### PR TITLE
flatten an unnecessary exception

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,6 +53,8 @@ jobs:
       - name: Install Poetry
         run: |
           curl -sL https://install.python-poetry.org | python -
+      - name: Update Pip
+        run: poetry run pip install -U pip setuptools
       - name: Install Dependencies
         run: poetry install
       - uses: pre-commit/action@v3.0.0

--- a/sphinx_needs/directives/needflow.py
+++ b/sphinx_needs/directives/needflow.py
@@ -160,11 +160,7 @@ def process_needflow(app: Sphinx, doctree: nodes.document, fromdocname: str) -> 
                 )
 
         content = []
-        try:
-            if "sphinxcontrib.plantuml" not in app.config.extensions:
-                raise ImportError
-            from sphinxcontrib.plantuml import plantuml
-        except ImportError:
+        if "sphinxcontrib.plantuml" not in app.config.extensions:
             content = nodes.error()
             para = nodes.paragraph()
             text = nodes.Text("PlantUML is not available!", "PlantUML is not available!")
@@ -172,6 +168,8 @@ def process_needflow(app: Sphinx, doctree: nodes.document, fromdocname: str) -> 
             content.append(para)
             node.replace_self(content)
             continue
+
+        from sphinxcontrib.plantuml import plantuml
 
         plantuml_block_text = ".. plantuml::\n" "\n" "   @startuml" "   @enduml"
         puml_node = plantuml(plantuml_block_text)


### PR DESCRIPTION
this exception is immediately caught and handled, so might as well be a simple if statement.

@danwos i'm not sure this is reachable anyway, since `sphinxcontrib.plantuml` is already imported right at the top of the file. If the extension wasn't available in the build environment, you'd have already thrown an `ImportError` by this point.

This exception can only fire if you have installed the extension, but haven't included it in your config.

What are the intended semantics?