### PR TITLE
[#743] update documentation for custom css files

### DIFF
--- a/docs/layout_styles.rst
+++ b/docs/layout_styles.rst
@@ -572,8 +572,7 @@ Own CSS file on sphinx level
 If you want to use most of the sphinx-needs internal styles but only need some specific changes for single elements, you
 can provide your own CSS file by register it inside your conf.py::
 
-    def setup(app):
-        app.add_stylesheet('css/my_custom.css')  # may also be an URL
+    html_css_files = ['css/my_custom.css'])  # may also be an tuple, see `html_css_files <https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_css_files>`_
 
 .. hint::
 

--- a/docs/layout_styles.rst
+++ b/docs/layout_styles.rst
@@ -572,7 +572,9 @@ Own CSS file on sphinx level
 If you want to use most of the sphinx-needs internal styles but only need some specific changes for single elements, you
 can provide your own CSS file by register it inside your conf.py::
 
-    html_css_files = ['css/my_custom.css'])  # may also be an tuple, see `html_css_files <https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_css_files>`_
+    html_css_files = ['css/my_custom.css'])  # may also be an tuple
+    
+See `html_css_files <https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_css_files>`_ for changing priority or media type.
 
 .. hint::
 


### PR DESCRIPTION
Instead of using `app.add_css_files` the better way seems to use `html_css_files` cause the files will be added **after** the extension css files by default.

Fix for #743