### PR TITLE
needs: Remove some of the extra IDs in the output

### DIFF
--- a/sphinx_needs/api/need.py
+++ b/sphinx_needs/api/need.py
@@ -197,7 +197,7 @@ def add_need(
     if is_external:
         target_node = None
     else:
-        target_node = nodes.target("", "", ids=[need_id], refid=need_id)
+        target_node = nodes.target("", "", ids=[need_id], refid=need_id, anonymous="")
         external_url = None
 
     # Handle status

--- a/tests/test_doc_build_latex.py
+++ b/tests/test_doc_build_latex.py
@@ -19,3 +19,7 @@ def test_doc_build_latex(test_app):
         "\\sphinxcaption{Table from sphinxneeds\\sphinxhyphen{}contrib \\textquotesingle"
         "{}needtable\\textquotesingle{} directive}" in latex_content
     )
+
+    # Check that the USER_STORY_001 label is only created once in the LaTeX output.  Split
+    # on the string, which should split latex_content into two.
+    assert len(latex_content.split(r"\label{\detokenize{index:USER_STORY_001}}")) == 2


### PR DESCRIPTION
Inside the LaTeX generator, it looks for the attributes ids and refid for creating link targets.  When a new layer with a <container> wrapper was added in commit e51fc1f, for an unknown reason this triggered these additional IDs to generate links within the LaTeX output.

A test case has been added to ensure only one hyperref within LaTeX is encountered as well.

(https://github.com/useblocks/sphinx-needs/issues/808)