### PR TITLE
needs_external_needs: Skip setting prefixes if no prefix was given

### DIFF
--- a/sphinx_needs/utils.py
+++ b/sphinx_needs/utils.py
@@ -229,6 +229,9 @@ def import_prefix_link_edit(needs: Dict[str, Any], id_prefix: str, needs_extra_l
     :param needs_extra_links: config var of all supported extra links. Normally coming from env.config.needs_extra_links
     :return:
     """
+    if not id_prefix:
+        return
+    
     needs_ids = needs.keys()
 
     for need in needs.values():

--- a/sphinx_needs/utils.py
+++ b/sphinx_needs/utils.py
@@ -231,7 +231,7 @@ def import_prefix_link_edit(needs: Dict[str, Any], id_prefix: str, needs_extra_l
     """
     if not id_prefix:
         return
-    
+
     needs_ids = needs.keys()
 
     for need in needs.values():


### PR DESCRIPTION
With the current implementation, `import_prefix_link_edit` always tries to set a prefix for external needs, even when no prefix is configured for them.
This leads to unnecessary performance problems, especially if the imported needs file is large.
This PR fixes the issue by checking if a `id_prefix` is set first.