### PR TITLE
latex output: Fix LaTeX output format for needs tables

### DIFF
--- a/sphinx_needs/css/common.css
+++ b/sphinx_needs/css/common.css
@@ -21,6 +21,10 @@ div.needstable_wrapper {
     padding: 0;
 }
 
+p.needs_table_row {
+    margin: 0 auto;
+}
+
 /* We need not line-block margin:24 px here, which is coming from sphinx theme */
 table.need td div.needs_side.line-block{
     margin-bottom: 0;

--- a/sphinx_needs/layout.py
+++ b/sphinx_needs/layout.py
@@ -187,6 +187,7 @@ class LayoutHandler:
             classes.append("needs_style_none")
 
         classes.append("needs_type_" + "".join(self.need["type"].split()))
+        classes.append("colwidths-given")
 
         self.node_table = nodes.table(classes=classes, ids=[self.need["id"]])
         self.node_tbody = nodes.tbody()
@@ -309,11 +310,10 @@ class LayoutHandler:
         if len(lines) == 0:
             return None
 
-        lines_container = nodes.line_block(classes=[f"needs_{section}"])
+        lines_container = nodes.inline()
 
         for line in lines:
-            # line_block_node = nodes.line_block()
-            line_node = nodes.line()
+            line_node = nodes.inline()
 
             line_parsed = self._parse(line)
             line_ready = self._func_replace(line_parsed)
@@ -608,7 +608,7 @@ class LayoutHandler:
             if data in exclude:
                 continue
 
-            data_line = nodes.line()
+            data_line = nodes.paragraph(classes=["needs_table_row"])
             label = prefix + f"{data}:" + postfix + " "
             result = self.meta(data, label, show_empty)
             if not (show_empty or result):
@@ -665,7 +665,7 @@ class LayoutHandler:
         for link_type in self.app.config.needs_extra_links:
             type_key = link_type["option"]
             if self.need[type_key] and type_key not in exclude:
-                outgoing_line = nodes.line()
+                outgoing_line = nodes.paragraph(classes=["needs_table_row"])
                 outgoing_label = prefix + "{}:".format(link_type["outgoing"]) + postfix + " "
                 outgoing_line += self._parse(outgoing_label)
                 outgoing_line += self.meta_links(link_type["option"], incoming=False)
@@ -673,7 +673,7 @@ class LayoutHandler:
 
             type_key = link_type["option"] + "_back"
             if self.need[type_key] and type_key not in exclude:
-                incoming_line = nodes.line()
+                incoming_line = nodes.paragraph(classes=["needs_table_row"])
                 incoming_label = prefix + "{}:".format(link_type["incoming"]) + postfix + " "
                 incoming_line += self._parse(incoming_label)
                 incoming_line += self.meta_links(link_type["option"], incoming=True)

--- a/sphinx_needs/layout.py
+++ b/sphinx_needs/layout.py
@@ -310,15 +310,11 @@ class LayoutHandler:
         if len(lines) == 0:
             return None
 
-        lines_container = nodes.inline()
-
+        lines_container = []
         for line in lines:
-            line_node = nodes.inline()
-
             line_parsed = self._parse(line)
             line_ready = self._func_replace(line_parsed)
-            line_node += line_ready
-            lines_container.append(line_node)
+            lines_container += line_ready
 
         return lines_container
 
@@ -603,7 +599,7 @@ class LayoutHandler:
             link_names = [x["option"] for x in self.app.config.needs_extra_links]
             link_names += [x["option"] + "_back" for x in self.app.config.needs_extra_links]
             exclude += link_names
-        data_container = nodes.inline()
+        data_container = []
         for data in self.need.keys():
             if data in exclude:
                 continue


### PR DESCRIPTION
This adds the `colwidths-given` class to the table generated with a simple needs table.  The LaTeX output then actually checks the <colspec> blocks for each column and respects the widths specified.

Additionally, the need table was originally generating a <line-block> context and populating it with <line> elements.  This ends up adding extra spacing into the output for whatever reason and took up a lot of vertical space for each need in the rendered LaTeX PDF output.  This has been removed and instead each line is placed into a new paragraph context via nodes.paragraph().  This renders the output correctly, and the HTML side is captured via CSS to ensure that there are no margins around the paragraph.

Other attempts to solve the rendering didn't work.  If I moved the class into a nodes.inline(...) element, the LaTeX renderer doesn't like having a nested paragraph inside of a class defined via `inline(...)`.  Placing a pair of newlines, defining a new paragraph that way, also yielded the same error from the LaTeX renderer.  (I also tried using `nodes.container(...)` in lieu of `nodes.inline(...)`, but this added an extra trailing line in each section of the simple table.)

Note: Currently this breaks some of the test cases, and I haven't investigated these.  (I was more interested in figuring out how to fix the LaTeX output.)

Potentially fixes https://github.com/useblocks/sphinx-needs/issues/278.