### PR TITLE
Fix unbounded memory usage in pickle environment

### DIFF
--- a/sphinx_needs/needs.py
+++ b/sphinx_needs/needs.py
@@ -739,11 +739,11 @@ def merge_data(_app: Sphinx, env: BuildEnvironment, _docnames: List[str], other:
                     for other_key, other_value in other_objects.items():
                         # other_value is a list from here on!
                         if other_key in objects:
-                            objects[other_key] += other_value
+                            objects[other_key] = list(set(objects[other_key]) | set(other_value))
                         else:
                             objects[other_key] = other_value
             elif isinstance(other_objects, list) and isinstance(objects, list):
-                objects += other_objects
+                objects = list(set(objects) | set(other_objects))
             else:
                 raise TypeError(
                     f'Objects to "merge" must be dict or list, ' f"not {type(other_objects)} and {type(objects)}"


### PR DESCRIPTION
In my project we are using incremental builds and building often in parallel with `sphinx-build -j auto`. We use sphinx-needs a lot and we've noticed in this configuration huge memory usage during compilation, sometimes so high (30+ GB) that it crashes my laptop. After some debugging, it turns out it comes from the size of the pickled environment that's used to store information between incremental builds.

This file is typically found in your build directory as `environment.pickle`. The problem is that it grows after every incremental parallel build. This can be seen by rebuilding our project with something like:

```sh
grep -Rl "\.\. need" | xargs touch
sphinx-build -j auto [...]
```

When doing this, we notice that the file size of `environment.pickle` increases every time. Of course when a build is run, this file is unpickled in RAM by each sphinx-build process. Looking more closely at the cause, it comes from `env.needs_all_docs["all"]`. This list is correctly appended to only if the element is not already in it in `add_doc()` :

https://github.com/useblocks/sphinx-needs/blob/6d7740f0c13aa4c089a4a2747c1ae91cd305131a/sphinx_needs/utils.py#L575-L576

However, `merge_data()` appends both lists without checking for duplicates. This can result in unbounded increase in the size of the list in the build environment:

https://github.com/useblocks/sphinx-needs/blob/6d7740f0c13aa4c089a4a2747c1ae91cd305131a/sphinx_needs/needs.py#L730-L731

This can also be seen by running this simple script in your build directory:

```py
import pickle

with open("path/to/your/environment.pickle", "rb") as f:
    env = pickle.load(f)

print("{} = {}".format('len(env.needs_all_docs["all"])', len(env.needs_all_docs["all"])))
```

This PR fixes this issue by merging lists without duplicates in `merge_data()`.