### PR TITLE
CI: Docker build arm images as well...

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -67,6 +67,8 @@ jobs:
         with:
           push: ${{ github.event_name != 'pull_request' && steps.deploycheck.outputs.value == 'y' }}
           file: docker/Dockerfile
+          context: ci
+          platforms: linux/amd64,linux/arm64
           build-args: |
             NEEDS_VERSION=${{ env.NEEDS_VERSION }}
             BASE_IMAGE=${{ matrix.base-image }}


### PR DESCRIPTION
Hello,

working on my ARM Macbook, i quickly discoverd that the sphinx-needs docker image is not usable , for example as a devcontainer in VSCode.

In context of the [sphinx docker pipeline](https://github.com/sphinx-doc/sphinx-docker-images/blob/4cd233f9c5222ab726439354bdc626248b948c1b/.github/workflows/build-ci.yml#LL40C9-L40C45), i thought this might be the correct solution, but was not able to test it as the main branch build is not working out of the box within my fork.

Anyhow, I hope we somehow get enabled to consume arm based docker images.

Regards!