### PR TITLE
👌 Performance: Memoize Inline parser for `build_need`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -35,3 +35,5 @@ Jörg Kreuzberger <j.kreuzberger@procitec.de>
 Duodu Randy <duodurandy19@gmail.com>
 
 Christian Wappler <chri.wapp@gmail.com>
+
+Chris Sewell <chrisj_sewell@hotmail.com>

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,6 +16,7 @@ Released: under development
 -----
 Released: under development
 
+* Improvement: Reduce document build time, by memoizing the inline parse in ``build_need`` (`#968 <https://github.com/useblocks/sphinx-needs/pull/968>`_)
 
 1.3.0
 -----

--- a/sphinx_needs/layout.py
+++ b/sphinx_needs/layout.py
@@ -3,12 +3,12 @@ Cares about the correct creation and handling of need layout.
 
 Based on https://github.com/useblocks/sphinxcontrib-needs/issues/102
 """
-from functools import lru_cache
-from optparse import Values
 import os
 import re
 import uuid
 from contextlib import suppress
+from functools import lru_cache
+from optparse import Values
 from typing import List, Optional, Tuple
 from urllib.parse import urlparse
 

--- a/sphinx_needs/layout.py
+++ b/sphinx_needs/layout.py
@@ -3,11 +3,13 @@ Cares about the correct creation and handling of need layout.
 
 Based on https://github.com/useblocks/sphinxcontrib-needs/issues/102
 """
+from functools import lru_cache
+from optparse import Values
 import os
 import re
 import uuid
 from contextlib import suppress
-from typing import List, Optional
+from typing import List, Optional, Tuple
 from urllib.parse import urlparse
 
 import requests
@@ -169,6 +171,14 @@ def build_need(layout, node, app: Sphinx, style=None, fromdocname: Optional[str]
     node.parent.replace(node, node_container)
 
 
+@lru_cache(1)
+def _generate_inline_parser() -> Tuple[Values, Inliner]:
+    doc_settings = OptionParser(components=(Parser,)).get_default_values()
+    inline_parser = Inliner()
+    inline_parser.init_customizations(doc_settings)
+    return doc_settings, inline_parser
+
+
 class LayoutHandler:
     """
     Cares about the correct layout handling
@@ -267,7 +277,7 @@ class LayoutHandler:
         }
 
         # Dummy Document setup
-        self.doc_settings = OptionParser(components=(Parser,)).get_default_values()
+        self.doc_settings, self.inline_parser = _generate_inline_parser()
         self.dummy_doc = new_document("dummy", self.doc_settings)
         self.doc_language = languages.get_language(self.dummy_doc.settings.language_code)
         self.doc_memo = Struct(
@@ -352,9 +362,7 @@ class LayoutHandler:
         :param line: string to parse
         :return: nodes
         """
-        inline_parser = Inliner()
-        inline_parser.init_customizations(self.doc_settings)
-        result, message = inline_parser.parse(line, 0, self.doc_memo, self.dummy_doc)
+        result, message = self.inline_parser.parse(line, 0, self.doc_memo, self.dummy_doc)
         if message:
             raise SphinxNeedLayoutException(message)
         return result


### PR DESCRIPTION
As discussed in #967, `build_need` (called from `print_need_nodes`) is currently taking a large amount of build times.

A key reason for this is that the initialisation of the inline parser, which requires compiling numerous regexes, is being run on every call.
This is not required, since the initialisation is invariant.

In this PR therefore, we move the initialisation to a cached function, which will only run once per build.

As shown when using `phinx-analysis  --project needs --pyinstrument --tree --tree-filter 0.01`, compared to #967, this significantly reduces the `print_need_nodes` component of the build time; from taking ~25% to ~8%

In this example it reduces the total build time from ~1.6 seconds to ~1.2 seconds

![image](https://github.com/useblocks/sphinx-needs/assets/2997570/0f873a62-e01c-496f-bdc7-41dd848ae6f3)
