### PR TITLE
Plantuml debug mode

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -17,6 +17,7 @@ Released: under development
 Released: under development
 
 * Improvement: Reduce document build time, by memoizing the inline parse in ``build_need`` (`#968 <https://github.com/useblocks/sphinx-needs/pull/968>`_)
+* Improvement: Adding :ref:`needs_plantuml_debug` option to get meaningful error messages of PlantUML problems.
 
 1.3.0
 -----

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,6 +19,7 @@ Released: under development
 * Improvement: Reduce document build time, by memoizing the inline parse in ``build_need`` (`#968 <https://github.com/useblocks/sphinx-needs/pull/968>`_)
 * Improvement: Adding :ref:`needs_plantuml_debug` option to get meaningful error messages of PlantUML problems.
 
+
 1.3.0
 -----
 Released: 16.08.2023

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,6 +59,7 @@ extensions = [
 ]
 
 # smartquotes = False
+needs_plantuml_debug = True
 
 needs_debug_measurement = True
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -390,7 +390,7 @@ language = "en"
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
-exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "needgantt.rst"]
 
 # Control extra excludes like the performance page via env-var.
 excludes = os.getenv("SPHINX_EXCLUDE", "").split(",")

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -488,13 +488,12 @@ needs_plantuml_debug
 
 .. versionadded:: 1.4.0
 
-Activates the debugging mode for all PlantUML related directives like :ref:`needflow`, :ref:`needuml` and :ref:`needarch`.
+Activates the debugging mode for all PlantUML related directives like :ref:`needflow`, :ref:`needuml`, :ref:`needarch`
+and others.
 This runs PlantUML directly in the scope of Sphinx-Needs and allows Sphinx-Needs to recognize
 and analyse syntax errors in advance.
 
-An error will lead to a detailed report on the command line.
-It also sets the :ref:`needflow_debug` option, so that the generated PlantUML code is printed
-below each ``needflow`` and Co.
+An error will lead to a report on the command line.
 
 Default value: ``False``
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -481,6 +481,26 @@ Use ``style_start`` and ``style_end`` like this:
    and orientation (`left`, `rigth`, `up` and `down`). We suggest to set the orientation
    in `style_end` like in the example above, as this is more often supported.
 
+.. _needs_plantuml_debug:
+
+needs_plantuml_debug
+~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 1.4.0
+
+Activates the debugging mode for all PlantUML related directives like :ref:`needflow`, :ref:`needuml` and :ref:`needarch`.
+This runs PlantUML directly in the scope of Sphinx-Needs and allows Sphinx-Needs to recognize
+and analyse syntax errors in advance.
+
+An error will lead to a detailed report on the command line.
+It also sets the :ref:`needflow_debug` option, so that the generated PlantUML code is printed
+below each ``needflow`` and Co.
+
+Default value: ``False``
+
+This options doubles the build time needed to generate a needflow diagram, as the PlantUML code gets generated twice.
+Use it only, when it is hard to identify the source of PlantUML related problems.
+
 
 .. _needs_filter_data:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ requests-file = "^1.5.1"  # external links
 requests = "^2.25.1"  # external_links
 jsonschema = ">=3.2.0"  # needsimport schema validation
 sphinx-data-viewer = "^0.1.1"  # needservice debug output
+sphinxcontrib-plantuml = "^0.24"  # all plantuml directives
 
 [tool.poetry.dev-dependencies]
 sphinxcontrib-plantuml = "^0"

--- a/sphinx_needs/directives/needflow.py
+++ b/sphinx_needs/directives/needflow.py
@@ -1,14 +1,12 @@
 import html
 import os
 import re
-import tempfile
 from typing import Iterable, Sequence
 
 from docutils import nodes
 from docutils.parsers.rst import directives
 from jinja2 import Template
 from sphinx.application import Sphinx
-from sphinxcontrib.plantuml import _split_cmdargs  # Needed for plantuml execution path
 from sphinxcontrib.plantuml import (
     generate_name,  # Needed for plantuml filename calculation
 )
@@ -17,7 +15,7 @@ from sphinx_needs.debug import measure_time
 from sphinx_needs.diagrams_common import calculate_link, create_legend
 from sphinx_needs.filter_common import FilterBase, filter_single_need, process_filters
 from sphinx_needs.logging import get_logger
-from sphinx_needs.utils import add_doc, unwrap
+from sphinx_needs.utils import add_doc, plantuml_debug, unwrap
 
 logger = get_logger(__name__)
 
@@ -494,11 +492,13 @@ def process_needflow(app: Sphinx, doctree: nodes.document, fromdocname: str, fou
         # If the central PlantUML Debug option is set, we need to generate the code already once in advance and
         # report any errors directly.
         if app.config.needs_plantuml_debug:
-            plantuml_args = _split_cmdargs(app.config.plantuml)
-            plantuml_args.extend(["-stdrpt:1"])
-            with tempfile.NamedTemporaryFile() as tmp:
-                tmp.write(puml_node["uml"])
-                plantuml_args.extend([tmp.name])
+            plantuml_debug(
+                "needflow",
+                app.config.plantuml,
+                puml_node.children[0]["uml"],
+                current_needflow["docname"],
+                current_needflow["lineno"],
+            )
 
         # We have to restrustructer the needflow
         # If this block should be organized differently

--- a/sphinx_needs/directives/needgantt.py
+++ b/sphinx_needs/directives/needgantt.py
@@ -19,7 +19,7 @@ from sphinx_needs.diagrams_common import (
 from sphinx_needs.directives.utils import get_link_type_option
 from sphinx_needs.filter_common import FilterBase, filter_single_need, process_filters
 from sphinx_needs.logging import get_logger
-from sphinx_needs.utils import MONTH_NAMES, add_doc
+from sphinx_needs.utils import MONTH_NAMES, add_doc, plantuml_debug
 
 logger = get_logger(__name__)
 
@@ -306,6 +306,15 @@ def process_needgantt(app, doctree, fromdocname, found_nodes):
             content.append(para)
         if current_needgantt["show_filters"]:
             content.append(get_filter_para(current_needgantt))
+
+        if app.config.needs_plantuml_debug:
+            plantuml_debug(
+                "needgant",
+                app.config.plantuml,
+                puml_node.children[0]["uml"],
+                current_needgantt["docname"],
+                current_needgantt["lineno"],
+            )
 
         if current_needgantt["debug"]:
             content += get_debug_container(puml_node)

--- a/sphinx_needs/directives/needsequence.py
+++ b/sphinx_needs/directives/needsequence.py
@@ -19,7 +19,7 @@ from sphinx_needs.diagrams_common import (
 )
 from sphinx_needs.filter_common import FilterBase
 from sphinx_needs.logging import get_logger
-from sphinx_needs.utils import add_doc, unwrap
+from sphinx_needs.utils import add_doc, plantuml_debug, unwrap
 
 logger = get_logger(__name__)
 
@@ -210,6 +210,15 @@ def process_needsequence(app: Sphinx, doctree: nodes.document, fromdocname: str,
             content.append(para)
         if current_needsequence["show_filters"]:
             content.append(get_filter_para(current_needsequence))
+
+        if app.config.needs_plantuml_debug:
+            plantuml_debug(
+                "needflow",
+                app.config.plantuml,
+                puml_node.children[0]["uml"],
+                current_needsequence["docname"],
+                current_needsequence["lineno"],
+            )
 
         if current_needsequence["debug"]:
             content += get_debug_container(puml_node)

--- a/sphinx_needs/directives/needuml.py
+++ b/sphinx_needs/directives/needuml.py
@@ -10,7 +10,7 @@ from sphinx_needs.debug import measure_time
 from sphinx_needs.diagrams_common import calculate_link
 from sphinx_needs.directives.needflow import make_entity_name
 from sphinx_needs.filter_common import filter_needs
-from sphinx_needs.utils import add_doc
+from sphinx_needs.utils import add_doc, plantuml_debug
 
 
 class Needuml(nodes.General, nodes.Element):
@@ -455,6 +455,11 @@ def process_needuml(app, doctree, fromdocname, found_nodes):
             title_text = current_needuml["caption"]
             title = nodes.title(title_text, "", nodes.Text(title_text))
             content.insert(0, title)
+
+        if app.config.needs_plantuml_debug:
+            plantuml_debug(
+                "needuml", app.config.plantuml, puml_node["uml"], current_needuml["docname"], current_needuml["lineno"]
+            )
 
         if current_needuml["debug"]:
             content += get_debug_node_from_puml_node(puml_node)

--- a/sphinx_needs/needs.py
+++ b/sphinx_needs/needs.py
@@ -192,6 +192,8 @@ def setup(app: Sphinx) -> Dict[str, Any]:
 
     app.add_config_value("needs_needextend_strict", True, "html", types=[bool])
 
+    app.add_config_value("needs_plantuml_debug", False, "html", types=[bool])
+
     # If given, only the defined status are allowed.
     # Values needed for each status:
     # * name


### PR DESCRIPTION
Tests all plantuml-related directives in advance and in the context of Sphinx-Needs, so that meaningful error messages get written and the problematic code is stored in a temporary file.

Tasks
* [x] Run and check plantuml
* [x] Store failed code in a temporary file
* [ ] docs (80%, file save missing)
* [ ] Test cases

Fixes #754 