### PR TITLE
♻️ Change `NeedsBuilder` format to `needs`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,6 +18,8 @@ Released: under development
 
 * Improvement: Reduce document build time, by memoizing the inline parse in ``build_need`` (`#968 <https://github.com/useblocks/sphinx-needs/pull/968>`_)
 
+* Change `NeedsBuilder` format to `needs` (`#978 <https://github.com/useblocks/sphinx-needs/pull/978>`_)
+
 1.3.0
 -----
 Released: 16.08.2023

--- a/sphinx_needs/builder.py
+++ b/sphinx_needs/builder.py
@@ -15,7 +15,7 @@ log = get_logger(__name__)
 
 class NeedsBuilder(Builder):
     name = "needs"
-    format = "json"
+    format = "needs"
     file_suffix = ".txt"
     links_suffix = None
 


### PR DESCRIPTION
Changing the format from `json` to `needs` will make it more specific to target the `NeedsBuilder`, and any derivatives such as in #960, #961, #962

The `format` attribute of the sphinx builder is perhaps a bit misleading, since it is mainly used to target a "class" of builders, rather than a specific output format,
see: https://www.sphinx-doc.org/en/master/usage/builders/index.html

This will allow for logic in other parts of the sphinx-needs pipeline, e.g. to skip certain build steps not required by the needs builders.