### PR TITLE
👌 Improve plantuml warnings

### DIFF
--- a/sphinx_needs/directives/needfilter.py
+++ b/sphinx_needs/directives/needfilter.py
@@ -122,6 +122,11 @@ def process_needfilters(app: Sphinx, doctree: nodes.document, fromdocname: str, 
 
             plantuml_block_text = ".. plantuml::\n" "\n" "   @startuml" "   @enduml"
             puml_node = plantuml(plantuml_block_text)
+
+            # Add source origin
+            puml_node.line = current_needfilter["lineno"]
+            puml_node.source = env.doc2path(current_needfilter["docname"])
+
             puml_node["uml"] = "@startuml\n"
             puml_connections = ""
 

--- a/sphinx_needs/directives/needflow.py
+++ b/sphinx_needs/directives/needflow.py
@@ -341,6 +341,11 @@ def process_needflow(app: Sphinx, doctree: nodes.document, fromdocname: str, fou
         if found_needs:
             plantuml_block_text = ".. plantuml::\n" "\n" "   @startuml" "   @enduml"
             puml_node = plantuml(plantuml_block_text)
+
+            # Add source origin
+            puml_node.line = current_needflow["lineno"]
+            puml_node.source = env.doc2path(current_needflow["docname"])
+
             puml_node["uml"] = "@startuml\n"
             puml_connections = ""
 

--- a/sphinx_needs/directives/needgantt.py
+++ b/sphinx_needs/directives/needgantt.py
@@ -151,6 +151,11 @@ def process_needgantt(app, doctree, fromdocname, found_nodes):
 
         plantuml_block_text = ".. plantuml::\n" "\n" "   @startuml" "   @enduml"
         puml_node = plantuml(plantuml_block_text)
+
+        # Add source origin
+        puml_node.line = current_needgantt["lineno"]
+        puml_node.source = env.doc2path(current_needgantt["docname"])
+
         puml_node["uml"] = "@startuml\n"
 
         # Adding config
@@ -293,9 +298,6 @@ def process_needgantt(app, doctree, fromdocname, found_nodes):
             img_location = "../" * subfolder_amount + "_images/" + gen_flow_link[0].split("/")[-1]
             flow_ref = nodes.reference("t", current_needgantt["caption"], refuri=img_location)
             puml_node += nodes.caption("", "", flow_ref)
-
-        # Add lineno to node
-        puml_node.line = current_needgantt["lineno"]
 
         content.append(puml_node)
 

--- a/sphinx_needs/directives/needsequence.py
+++ b/sphinx_needs/directives/needsequence.py
@@ -121,6 +121,11 @@ def process_needsequence(app: Sphinx, doctree: nodes.document, fromdocname: str,
 
         plantuml_block_text = ".. plantuml::\n" "\n" "   @startuml" "   @enduml"
         puml_node = plantuml(plantuml_block_text)
+
+        # Add source origin
+        puml_node.line = current_needsequence["lineno"]
+        puml_node.source = env.doc2path(current_needsequence["docname"])
+
         puml_node["uml"] = "@startuml\n"
 
         # Adding config

--- a/sphinx_needs/directives/needuml.py
+++ b/sphinx_needs/directives/needuml.py
@@ -431,6 +431,10 @@ def process_needuml(app, doctree, fromdocname, found_nodes):
             config=config,
         )
 
+        # Add source origin
+        puml_node.line = current_needuml["lineno"]
+        puml_node.source = env.doc2path(current_needuml["docname"])
+
         # Add calculated needuml content
         current_needuml["content_calculated"] = puml_node["uml"]
 


### PR DESCRIPTION
This commit adds source origin  information to plantuml nodes, so that they can be reported by Sphinx warnings (for example if the render fails).

For example from #974, this now reports:

```
/Users/chrisjsewell/Documents/GitHub/sphinx-needs/docs/directives/needgantt.rst:20: WARNING: error while running plantuml
```

rather than just:

```
WARNING: error while running plantuml
```

Note, that this change also requires https://github.com/sphinx-contrib/plantuml/pull/79, to actually emit the source positions during sphinx builds