### PR TITLE
🐛 Fix gantt chart rendering

### DIFF
--- a/sphinx_needs/directives/needgantt.py
+++ b/sphinx_needs/directives/needgantt.py
@@ -149,9 +149,9 @@ def process_needgantt(app, doctree, fromdocname, found_nodes):
             no_plantuml(node)
             continue
 
-        plantuml_block_text = ".. plantuml::\n" "\n" "   @startuml" "   @enduml"
+        plantuml_block_text = ".. plantuml::\n" "\n" "   @startgantt" "   @endgantt"
         puml_node = plantuml(plantuml_block_text)
-        puml_node["uml"] = "@startuml\n"
+        puml_node["uml"] = "@startgantt\n"
 
         # Adding config
         config = current_needgantt["config"]
@@ -265,7 +265,7 @@ def process_needgantt(app, doctree, fromdocname, found_nodes):
         if current_needgantt["show_legend"]:
             puml_node["uml"] += create_legend(app.config.needs_types)
 
-        puml_node["uml"] += "\n@enduml"
+        puml_node["uml"] += "\n@endgantt"
         puml_node["incdir"] = os.path.dirname(current_needgantt["docname"])
         puml_node["filename"] = os.path.split(current_needgantt["docname"])[1]  # Needed for plantuml >= 0.9
 


### PR DESCRIPTION
In plantuml V1.2022.12 (23 Oct, 2022), it became a syntax error not to use `@startgantt`: https://plantuml.com/changes

fixes #977 