### PR TITLE
🔧 Centralise sphinx `env` data access (and add schemas)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,7 @@ warn_unused_ignores = false
 module = [
   'sphinx_needs.api.need',
   'sphinx_needs.builder',
+  'sphinx_needs.data',
   'sphinx_needs.diagrams_common',
   'sphinx_needs.directives.need',
   'sphinx_needs.directives.needbar',
@@ -116,6 +117,7 @@ module = [
   'sphinx_needs.needs',
   'sphinx_needs.needsfile',
   'sphinx_needs.roles.need_incoming',
+  'sphinx_needs.roles.need_outgoing',
   'sphinx_needs.roles.need_part',
   'sphinx_needs.roles.need_ref',
   'sphinx_needs.services.github',

--- a/sphinx_needs/builder.py
+++ b/sphinx_needs/builder.py
@@ -7,6 +7,7 @@ from sphinx.application import Sphinx
 from sphinx.builders import Builder
 
 from sphinx_needs.config import NeedsSphinxConfig
+from sphinx_needs.data import SphinxNeedsData
 from sphinx_needs.logging import get_logger
 from sphinx_needs.needsfile import NeedsList
 from sphinx_needs.utils import unwrap
@@ -25,8 +26,9 @@ class NeedsBuilder(Builder):
 
     def finish(self) -> None:
         env = unwrap(self.env)
-        needs = env.needs_all_needs.values()  # We need a list of needs for later filter checks
-        filters = env.needs_all_filters
+        data = SphinxNeedsData(env)
+        needs = data.get_or_create_needs().values()  # We need a list of needs for later filter checks
+        filters = data.get_or_create_filters()
         version = getattr(env.config, "version", "unset")
         needs_list = NeedsList(env.config, self.outdir, self.srcdir)
         needs_config = NeedsSphinxConfig(env.config)
@@ -107,7 +109,7 @@ class NeedumlsBuilder(Builder):
 
     def finish(self) -> None:
         env = unwrap(self.env)
-        needumls = env.needs_all_needumls.values()
+        needumls = SphinxNeedsData(env).get_or_create_umls().values()
 
         for needuml in needumls:
             if needuml["save"]:

--- a/sphinx_needs/data.py
+++ b/sphinx_needs/data.py
@@ -179,12 +179,31 @@ class NeedsInfoType(NeedsBaseDataType):
     hidden: str
     duration: str
     completion: str
-    # constraints: str
+    # constraints: str  # this is already set in create_need
     # these are updated in process_need_nodes (-> check_links) transform
     has_dead_links: str | bool
     has_forbidden_dead_links: str | bool
-    # TODO also options from `BaseService.options`` get added to every need,
-    # via `ServiceManager.register`, which adds them to extra_options
+    # options from `BaseService.options` get added to every need,
+    # via `ServiceManager.register`, which adds them to `extra_options``
+    # GithubService
+    avatar: str
+    closed_at: str
+    created_at: str
+    max_amount: str
+    service: str
+    specific: str
+    type: str
+    updated_at: str
+    user: str
+    # OpenNeedsService
+    params: str
+    prefix: str
+    url_postfix: str
+    # shared GithubService and OpenNeedsService
+    max_content_lines: str
+    id_prefix: str
+    query: str
+    url: str
 
     # Note there are also:
     # - dynamic default options that can be set by needs_extra_options config

--- a/sphinx_needs/data.py
+++ b/sphinx_needs/data.py
@@ -1,0 +1,618 @@
+"""Module to control access to sphinx-needs data,
+which is stored in the Sphinx environment.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+try:
+    from typing import Literal, TypedDict
+except ImportError:
+    # introduced in python 3.8
+    from typing_extensions import Literal, TypedDict
+
+if TYPE_CHECKING:
+    from docutils.nodes import Element, Text
+    from sphinx.application import Sphinx
+    from sphinx.environment import BuildEnvironment
+
+    from sphinx_needs.services.manager import ServiceManager
+
+
+class NeedsFilterType(TypedDict):
+    filter: str
+    """Filter string."""
+    status: list[str]
+    tags: list[str]
+    types: list[str]
+    export_id: str
+    result: list[str]
+    amount: int
+
+
+class NeedsWorkflowType(TypedDict):
+    """
+    Used to store workflow status information for already executed tasks.
+    Some tasks like backlink_creation need be performed only once.
+    But most sphinx-events get called several times (for each single document file),
+    which would also execute our code several times...
+    """
+
+    backlink_creation_links: bool
+    dynamic_values_resolved: bool
+    links_checked: bool
+    add_sections: bool
+    variant_option_resolved: bool
+    needs_extended: bool
+
+
+class NeedsBaseDataType(TypedDict):
+    """A base type for all data."""
+
+    docname: str
+    """Name of the document where the need is defined."""
+    lineno: int
+    """Line number where the need is defined."""
+    target_id: str
+    """ID of the data."""
+
+
+class NeedsPartType(TypedDict):
+    """Data for a single need part."""
+
+    id: str
+    """ID of the part"""
+
+    # TODO are these necessary? i.e. its always a part, not a need
+    is_part: bool
+    is_need: bool
+
+    content: str
+    """Content of the part."""
+    document: str
+    """docname where the part is defined."""
+    links_back: list[str]
+    """List of need IDs, which are referencing this part."""
+    links: list[str]
+    """List of need IDs, which are referenced by this part."""
+
+
+class NeedsInfoType(NeedsBaseDataType):
+    """Data for a single need."""
+
+    id: str
+    """ID of the data (same as target_id)"""
+
+    # meta information
+    full_title: str
+    """Title of the need, of unlimited length."""
+    title: str
+    """Title of the need, trimmed to a maximum length."""
+    status: None | str
+    tags: list[str]
+
+    # rendering information
+    collapse: bool
+    """hide the meta-data information of the need."""
+    hide: bool
+    """If true, the need is not rendered."""
+    delete: bool
+    """If true, the need is deleted entirely."""
+    layout: None | str
+    """Key of the layout, which is used to render the need."""
+    style: None | str
+    """Comma-separated list of CSS classes (all appended by `needs_style_`)."""
+
+    # TODO why is it called arch?
+    arch: dict[str, str]
+    """Mapping of uml key to uml content."""
+
+    # external reference information
+    is_external: bool
+    """If true, no node is created and need is referencing external url"""
+    external_url: None | str
+    """URL of the need, if it is an external need."""
+    external_css: str
+    """CSS class name, added to the external reference."""
+
+    # type information (based on needs_types config)
+    type: str
+    type_name: str
+    type_prefix: str
+    type_color: str
+    """Hexadecimal color code of the type."""
+    type_style: str
+
+    # Used by needextend
+    is_modified: bool
+    modifications: int
+
+    # parts information
+    parts: dict[str, NeedsPartType]
+    # TODO are these necessary? i.e. its always a need, not a part
+    is_need: bool
+    is_part: bool
+
+    # content creation information
+    jinja_content: bool
+    template: None | str
+    pre_template: None | str
+    post_template: None | str
+    content: str
+    pre_content: str
+    post_content: str
+    content_id: None | str
+    """ID of the content node."""
+    content_node: None | Element
+    """deep copy of the content node."""
+
+    # link information
+    links: list[str]
+    """List of need IDs, which are referenced by this need."""
+    # TODO there is a lot more dynamically added link information;
+    # for each item in needs_extra_links config,
+    # you end up with a key named by the "option" field,
+    # and then another key named by the "option" field + "_back"
+    # these all have value type `list[str]`
+
+    # constraints information
+    # set in process_need_nodes (-> process_constraints) transform
+    constraints: list[str]
+    constraints_passed: None | bool
+    constraints_results: dict[str, dict[str, bool]]
+
+    # additional source information
+    doctype: str
+    """Type of the document where the need is defined, e.g. '.rst'"""
+    # set in add_sections transform
+    sections: list[str]
+    section_name: str
+    """Simply the first section"""
+    signature: str | Text
+    """Derived from a docutils desc_name node"""
+    parent_needs: list[str]
+    parent_need: str
+    """Simply the first parent"""
+
+    # default extra options
+    # TODO these all default to "" which I don't think is good
+    hidden: str
+    duration: str
+    completion: str
+    # constraints: str
+    # these are updated in process_need_nodes (-> check_links) transform
+    has_dead_links: str | bool
+    has_forbidden_dead_links: str | bool
+    # TODO also options from `BaseService.options`` get added to every need,
+    # via `ServiceManager.register`, which adds them to extra_options
+
+    # Note there are also:
+    # - dynamic default options that can be set by needs_extra_options config
+    # - dynamic global options that can be set by needs_global_options config
+
+
+class NeedsBarType(NeedsBaseDataType):
+    """Data for a single (matplotlib) bar diagram."""
+
+    error_id: str
+    title: None | str
+    content: str
+    legend: bool
+    x_axis_title: str
+    xlabels: list[str]
+    xlabels_rotation: str
+    y_axis_title: str
+    ylabels: list[str]
+    ylabels_rotation: str
+    separator: str
+    stacked: bool
+    show_sum: bool
+    show_top_sum: bool
+    sum_rotation: bool
+    transpose: bool
+    horizontal: bool
+    style: str
+    colors: list[str]
+    text_color: str
+
+
+class NeedsExtendType(NeedsBaseDataType):
+    """Data to modify an existing need."""
+
+    filter: None | str
+    modifications: dict[str, str]
+    strict: bool
+
+
+class NeedsFilteredBaseType(NeedsBaseDataType):
+    """A base type for all filtered data."""
+
+    # Filter attributes
+    status: list[str]
+    tags: list[str]
+    types: list[str]
+    filter: None | str
+    sort_by: None | str
+    filter_code: str
+    filter_func: None | str
+    export_id: str
+
+
+class NeedsFilteredDiagramBaseType(NeedsFilteredBaseType):
+    """A base type for all filtered diagram data."""
+
+    show_legend: bool
+    show_filters: bool
+    show_link_names: bool
+    link_types: list[str]
+    config: str
+    config_names: str
+    scale: str
+    highlight: str
+    align: None | str
+    debug: bool
+    caption: None | str
+
+
+class NeedsExtractType(NeedsFilteredBaseType):
+    """Data to extract needs from a document."""
+
+    export_id: str
+    layout: str
+    style: str
+    show_filters: bool
+    filter_arg: None | str
+
+
+class _NeedsFilterType(NeedsFilteredBaseType):
+    """Data to present (filtered) needs inside a list, table or diagram
+
+    .. deprecated:: 0.2.0
+    """
+
+    show_tags: bool
+    show_status: bool
+    show_filters: bool
+    show_legend: bool
+    layout: Literal["list", "table", "diagram"]
+    export_id: str
+
+
+class NeedsFlowType(NeedsFilteredDiagramBaseType):
+    """Data for a single (filtered) flow chart."""
+
+    caption: None | str
+    show_filters: bool
+    show_legend: bool
+    show_link_names: bool
+    debug: bool
+    config_names: str
+    config: str
+    scale: str
+    highlight: str
+    align: str
+    link_types: list[str]
+
+
+class NeedsGanttType(NeedsFilteredDiagramBaseType):
+    """Data for a single (filtered) gantt chart."""
+
+    starts_with_links: list[str]
+    starts_after_links: list[str]
+    ends_with_links: list[str]
+    milestone_filter: str
+    start_date: None | str
+    timeline: Literal[None, "daily", "weekly", "monthly"]
+    no_color: bool
+    duration_option: str
+    completion_option: str
+
+
+class NeedsListType(NeedsFilteredBaseType):
+    """Data for a single (filtered) needs list."""
+
+    show_tags: bool
+    show_status: bool
+    show_filters: bool
+    export_id: str
+
+
+class NeedsPieType(NeedsBaseDataType):
+    """Data for a single (matplotlib) pie chart."""
+
+    title: str
+    content: str
+    legend: bool
+    explode: None | list[float]
+    style: None | str
+    labels: None | list[str]
+    colors: None | list[str]
+    text_color: None | str
+    shadow: bool
+    filter_func: None | str
+
+
+class NeedsSequenceType(NeedsFilteredDiagramBaseType):
+    """Data for a single (filtered) sequence diagram."""
+
+    start: str
+
+
+class NeedsTableType(NeedsFilteredBaseType):
+    """Data for a single (filtered) needs table."""
+
+    caption: None | str
+    classes: list[str]
+    columns: list[tuple[str, str]]
+    colwidths: list[int]
+    style: str
+    style_row: str
+    style_col: str
+    sort: str
+    show_filters: bool
+    show_parts: bool
+
+
+class NeedsUmlType(NeedsBaseDataType):
+    """Data for a single (filtered) uml diagram."""
+
+    caption: None | str
+    content: str
+    scale: str
+    align: str
+    config_names: None | str
+    config: str
+    debug: bool
+    extra: dict[str, str]
+    key: None | str
+    save: None | str
+    is_arch: bool
+
+
+class SphinxNeedsData:
+    """Centralised access to sphinx-needs data, stored within the Sphinx environment."""
+
+    def __init__(self, env: BuildEnvironment) -> None:
+        self.env = env
+
+    def get_or_create_needs(self) -> dict[str, NeedsInfoType]:
+        """Get all needs, mapped by ID.
+
+        This is lazily created and cached in the environment.
+        """
+        try:
+            return self.env.needs_all_needs
+        except AttributeError:
+            self.env.needs_all_needs = {}
+        return self.env.needs_all_needs
+
+    def get_or_create_filters(self) -> dict[str, NeedsFilterType]:
+        """Get all filters, mapped by ID.
+
+        This is lazily created and cached in the environment.
+        """
+        try:
+            return self.env.needs_all_filters
+        except AttributeError:
+            self.env.needs_all_filters = {}
+        return self.env.needs_all_filters
+
+    def get_or_create_docs(self) -> dict[str, list[str]]:
+        """Get mapping of need category to docnames containing the need.
+
+        This is lazily created and cached in the environment.
+        """
+        try:
+            return self.env.needs_all_docs
+        except AttributeError:
+            self.env.needs_all_docs = {"all": []}
+        return self.env.needs_all_docs
+
+    def get_or_create_workflow(self) -> NeedsWorkflowType:
+        """Get workflow information.
+
+        This is lazily created and cached in the environment.
+        """
+        try:
+            return self.env.needs_workflow
+        except AttributeError:
+            self.env.needs_workflow = {
+                "backlink_creation_links": False,
+                "dynamic_values_resolved": False,
+                "links_checked": False,
+                "add_sections": False,
+                "variant_option_resolved": False,
+                "needs_extended": False,
+            }
+            # TODO use needs_config here
+            for link_type in self.env.app.config.needs_extra_links:
+                self.env.needs_workflow["backlink_creation_{}".format(link_type["option"])] = False
+
+        return self.env.needs_workflow
+
+    def get_or_create_services(self) -> ServiceManager:
+        """Get information about services.
+
+        This is lazily created and cached in the environment.
+        """
+        from sphinx_needs.services.manager import ServiceManager
+
+        try:
+            return self.env.app.needs_services
+        except AttributeError:
+            self.env.app.needs_services = ServiceManager(self.env.app)
+        return self.env.app.needs_services
+
+    def get_or_create_bars(self) -> dict[str, NeedsBarType]:
+        """Get all bar charts, mapped by ID.
+
+        This is lazily created and cached in the environment.
+        """
+        try:
+            return self.env.need_all_needbar
+        except AttributeError:
+            self.env.need_all_needbar = {}
+        return self.env.need_all_needbar
+
+    def get_or_create_extends(self) -> dict[str, NeedsExtendType]:
+        """Get all need modifications, mapped by ID.
+
+        This is lazily created and cached in the environment.
+        """
+        try:
+            return self.env.need_all_needextend
+        except AttributeError:
+            self.env.need_all_needextend = {}
+        return self.env.need_all_needextend
+
+    def get_or_create_extracts(self) -> dict[str, NeedsExtractType]:
+        """Get all need extractions, mapped by ID.
+
+        This is lazily created and cached in the environment.
+        """
+        try:
+            return self.env.need_all_needextracts
+        except AttributeError:
+            self.env.need_all_needextracts = {}
+        return self.env.need_all_needextracts
+
+    def _get_or_create_filters(self) -> dict[str, _NeedsFilterType]:
+        """Get all need filters, mapped by ID.
+
+        .. deprecated:: 0.2.0
+
+        This is lazily created and cached in the environment.
+        """
+        try:
+            return self.env.need_all_needfilters
+        except AttributeError:
+            self.env.need_all_needfilters = {}
+        return self.env.need_all_needfilters
+
+    def get_or_create_flows(self) -> dict[str, NeedsFlowType]:
+        """Get all need flow charts, mapped by ID.
+
+        This is lazily created and cached in the environment.
+        """
+        try:
+            return self.env.need_all_needflows
+        except AttributeError:
+            self.env.need_all_needflows = {}
+        return self.env.need_all_needflows
+
+    def get_or_create_gantts(self) -> dict[str, NeedsGanttType]:
+        """Get all need gantt charts, mapped by ID.
+
+        This is lazily created and cached in the environment.
+        """
+        try:
+            return self.env.need_all_needgantts
+        except AttributeError:
+            self.env.need_all_needgantts = {}
+        return self.env.need_all_needgantts
+
+    def get_or_create_lists(self) -> dict[str, NeedsListType]:
+        """Get all need gantt charts, mapped by ID.
+
+        This is lazily created and cached in the environment.
+        """
+        try:
+            return self.env.need_all_needlists
+        except AttributeError:
+            self.env.need_all_needlists = {}
+        return self.env.need_all_needlists
+
+    def get_or_create_pies(self) -> dict[str, NeedsPieType]:
+        """Get all need gantt charts, mapped by ID.
+
+        This is lazily created and cached in the environment.
+        """
+        try:
+            return self.env.need_all_needpie
+        except AttributeError:
+            self.env.need_all_needpie = {}
+        return self.env.need_all_needpie
+
+    def get_or_create_sequences(self) -> dict[str, NeedsSequenceType]:
+        """Get all need sequence diagrams, mapped by ID.
+
+        This is lazily created and cached in the environment.
+        """
+        try:
+            return self.env.need_all_needsequences
+        except AttributeError:
+            self.env.need_all_needsequences = {}
+        return self.env.need_all_needsequences
+
+    def get_or_create_tables(self) -> dict[str, NeedsTableType]:
+        """Get all need tables, mapped by ID.
+
+        This is lazily created and cached in the environment.
+        """
+        try:
+            return self.env.need_all_needtables
+        except AttributeError:
+            self.env.need_all_needtables = {}
+        return self.env.need_all_needtables
+
+    def get_or_create_umls(self) -> dict[str, NeedsUmlType]:
+        """Get all need uml diagrams, mapped by ID.
+
+        This is lazily created and cached in the environment.
+        """
+        try:
+            return self.env.needs_all_needumls
+        except AttributeError:
+            self.env.needs_all_needumls = {}
+        return self.env.needs_all_needumls
+
+
+def merge_data(_app: Sphinx, env: BuildEnvironment, _docnames: list[str], other: BuildEnvironment) -> None:
+    """
+    Performs data merge of parallel executed workers.
+    Used only for parallel builds.
+
+    Needs to update env manually for all data Sphinx-Needs collect during read phase
+    """
+
+    # Update global needs dict
+    needs = SphinxNeedsData(env).get_or_create_needs()
+    other_needs = SphinxNeedsData(other).get_or_create_needs()
+    needs.update(other_needs)
+
+    def _merge(name: str, is_complex_dict: bool = False) -> None:
+        # Update global needs dict
+        if not hasattr(env, name):
+            setattr(env, name, {})
+        objects = getattr(env, name)
+        if hasattr(other, name):
+            other_objects = getattr(other, name)
+            if isinstance(other_objects, dict) and isinstance(objects, dict):
+                if not is_complex_dict:
+                    objects.update(other_objects)
+                else:
+                    for other_key, other_value in other_objects.items():
+                        # other_value is a list from here on!
+                        if other_key in objects:
+                            objects[other_key] = list(set(objects[other_key]) | set(other_value))
+                        else:
+                            objects[other_key] = other_value
+            elif isinstance(other_objects, list) and isinstance(objects, list):
+                objects = list(set(objects) | set(other_objects))
+            else:
+                raise TypeError(
+                    f'Objects to "merge" must be dict or list, ' f"not {type(other_objects)} and {type(objects)}"
+                )
+
+    _merge("needs_all_docs", is_complex_dict=True)
+    _merge("need_all_needbar")
+    _merge("need_all_needextend")
+    _merge("need_all_needextracts")
+    _merge("need_all_needfilters")
+    _merge("need_all_needflows")
+    _merge("need_all_needgantts")
+    _merge("need_all_needlists")
+    _merge("need_all_needpie")
+    _merge("need_all_needsequences")
+    _merge("need_all_needtables")
+    _merge("needs_all_needumls")

--- a/sphinx_needs/diagrams_common.py
+++ b/sphinx_needs/diagrams_common.py
@@ -5,7 +5,6 @@ diagram related directive. E.g. needflow and needsequence.
 
 import html
 import os
-import re
 import textwrap
 from typing import Any, Dict, List, Tuple
 from urllib.parse import urlparse
@@ -18,7 +17,7 @@ from sphinx.util.docutils import SphinxDirective
 from sphinx_needs.config import NeedsSphinxConfig
 from sphinx_needs.errors import NoUri
 from sphinx_needs.logging import get_logger
-from sphinx_needs.utils import unwrap
+from sphinx_needs.utils import get_scale, split_link_types, unwrap
 
 logger = get_logger(__name__)
 
@@ -38,17 +37,6 @@ class DiagramBase(SphinxDirective):
         "debug": directives.flag,
     }
 
-    def prepare_env(self, env_var: str) -> str:
-        env_var = "need_all_" + env_var
-        if not hasattr(self.env, env_var):
-            setattr(self.env, env_var, {})
-
-        # be sure, global var is available. If not, create it
-        if not hasattr(self.env, "needs_all_needs"):
-            self.env.needs_all_needs = {}
-
-        return env_var
-
     def create_target(self, target_name: str) -> Tuple[int, str, nodes.target]:
         id = self.env.new_serialno(target_name)
         targetid = f"{target_name}-{self.env.docname}-{id}"
@@ -57,18 +45,8 @@ class DiagramBase(SphinxDirective):
         return id, targetid, targetnode
 
     def collect_diagram_attributes(self) -> Dict[str, Any]:
-        link_types = self.options.get("link_types", "links")
-        if len(link_types) > 0:
-            link_types = [link_type.strip() for link_type in re.split(";|,", link_types)]
-            for i in range(len(link_types)):
-                if len(link_types[i]) == 0 or link_types[i].isspace():
-                    del link_types[i]
-                    logger.warning(
-                        "Scruffy link_type definition found in needsequence. "
-                        "Defined link_type contains spaces only. [needs]",
-                        type="needs",
-                        location=(self.env.docname, self.lineno),
-                    )
+        location = (self.env.docname, self.lineno)
+        link_types = split_link_types(self.options.get("link_types", "links"), location)
 
         needs_config = NeedsSphinxConfig(self.config)
         config_names = self.options.get("config")
@@ -76,20 +54,9 @@ class DiagramBase(SphinxDirective):
         if config_names:
             for config_name in config_names.split(","):
                 config_name = config_name.strip()
+                # TODO this is copied from NeedflowDirective, is it correct?
                 if config_name and config_name in needs_config.flow_configs:
                     configs.append(needs_config.flow_configs[config_name])
-
-        scale = self.options.get("scale", "100").replace("%", "")
-        if not scale.isdigit():
-            raise Exception(f'Needsequence scale value must be a number. "{scale}" found')
-        if int(scale) < 1 or int(scale) > 300:
-            raise Exception(f'Needsequence scale value must be between 1 and 300. "{scale}" found')
-
-        highlight = self.options.get("highlight", "")
-
-        caption = None
-        if self.arguments:
-            caption = self.arguments[0]
 
         collected_diagram_options = {
             "show_legend": "show_legend" in self.options,
@@ -98,11 +65,11 @@ class DiagramBase(SphinxDirective):
             "link_types": link_types,
             "config": "\n".join(configs),
             "config_names": config_names,
-            "scale": scale,
-            "highlight": highlight,
+            "scale": get_scale(self.options, location),
+            "highlight": self.options.get("highlight", ""),
             "align": self.options.get("align"),
             "debug": "debug" in self.options,
-            "caption": caption,
+            "caption": self.arguments[0] if self.arguments else None,
         }
         return collected_diagram_options
 

--- a/sphinx_needs/directives/needextend.py
+++ b/sphinx_needs/directives/needextend.py
@@ -12,6 +12,7 @@ from sphinx.util.docutils import SphinxDirective
 
 from sphinx_needs.api.exceptions import NeedsInvalidFilter
 from sphinx_needs.config import NeedsSphinxConfig
+from sphinx_needs.data import SphinxNeedsData
 from sphinx_needs.filter_common import filter_needs
 from sphinx_needs.logging import get_logger
 from sphinx_needs.utils import add_doc, unwrap
@@ -39,12 +40,6 @@ class NeedextendDirective(SphinxDirective):
 
     def run(self) -> Sequence[nodes.Node]:
         env = self.env
-        if not hasattr(env, "need_all_needextend"):
-            env.need_all_needextend = {}
-
-        # be sure, global var is available. If not, create it
-        if not hasattr(env, "needs_all_needs"):
-            env.needs_all_needs = {}
 
         id = env.new_serialno("needextend")
         targetid = f"needextend-{env.docname}-{id}"
@@ -61,7 +56,8 @@ class NeedextendDirective(SphinxDirective):
         elif strict_option.upper() == "FALSE":
             strict = False
 
-        env.need_all_needextend[targetid] = {
+        data = SphinxNeedsData(env).get_or_create_extends()
+        data[targetid] = {
             "docname": env.docname,
             "lineno": self.lineno,
             "target_id": targetid,
@@ -82,11 +78,11 @@ def process_needextend(app: Sphinx, doctree: nodes.document, fromdocname: str) -
     builder = unwrap(app.builder)
     env = unwrap(builder.env)
     needs_config = NeedsSphinxConfig(env.config)
-    if not hasattr(env, "need_all_needextend"):
-        env.need_all_needextend = {}
+    data = SphinxNeedsData(env)
+    workflow = data.get_or_create_workflow()
 
-    if not env.needs_workflow["needs_extended"]:
-        env.needs_workflow["needs_extended"] = True
+    if not workflow["needs_extended"]:
+        workflow["needs_extended"] = True
 
         list_names = (
             ["tags", "links"]
@@ -95,11 +91,13 @@ def process_needextend(app: Sphinx, doctree: nodes.document, fromdocname: str) -
         )  # back-links (incoming)
         link_names = [x["option"] for x in needs_config.extra_links]
 
-        for current_needextend in env.need_all_needextend.values():
+        all_needs = data.get_or_create_needs()
+
+        for current_needextend in data.get_or_create_extends().values():
             # Check if filter is just a need-id.
             # In this case create the needed filter string
             need_filter = current_needextend["filter"]
-            if need_filter in env.needs_all_needs:
+            if need_filter in all_needs:
                 need_filter = f'id == "{need_filter}"'
             # If it looks like a need id, but we haven't found one, raise an exception
             elif re.fullmatch(needs_config.id_regex, need_filter):
@@ -110,7 +108,7 @@ def process_needextend(app: Sphinx, doctree: nodes.document, fromdocname: str) -
                     logger.info(error)
                     continue
             try:
-                found_needs = filter_needs(app, env.needs_all_needs.values(), need_filter)
+                found_needs = filter_needs(app, all_needs.values(), need_filter)
             except NeedsInvalidFilter as e:
                 raise NeedsInvalidFilter(
                     f"Filter not valid for needextend on page {current_needextend['docname']}:\n{e}"
@@ -118,7 +116,7 @@ def process_needextend(app: Sphinx, doctree: nodes.document, fromdocname: str) -
 
             for found_need in found_needs:
                 # Work in the stored needs, not on the search result
-                need = env.needs_all_needs[found_need["id"]]
+                need = all_needs[found_need["id"]]
                 need["is_modified"] = True
                 need["modifications"] += 1
 
@@ -140,8 +138,8 @@ def process_needextend(app: Sphinx, doctree: nodes.document, fromdocname: str) -
                                 for ref_need in re.split(";|,", value):
                                     # Remove whitespaces
                                     ref_need = ref_need.strip()
-                                    if found_need["id"] not in env.needs_all_needs[ref_need][f"{option_name}_back"]:
-                                        env.needs_all_needs[ref_need][f"{option_name}_back"] += [found_need["id"]]
+                                    if found_need["id"] not in all_needs[ref_need][f"{option_name}_back"]:
+                                        all_needs[ref_need][f"{option_name}_back"] += [found_need["id"]]
 
                         # else it must be a normal string
                         else:
@@ -158,7 +156,7 @@ def process_needextend(app: Sphinx, doctree: nodes.document, fromdocname: str) -
                             # If we manipulate links, we need to delete the reference in the target need as well
                             if option_name in link_names:
                                 for ref_need in old_content:  # There may be several links
-                                    env.needs_all_needs[ref_need][f"{option_name}_back"].remove(found_need["id"])
+                                    all_needs[ref_need][f"{option_name}_back"].remove(found_need["id"])
 
                         else:
                             need[option_name] = ""
@@ -177,12 +175,12 @@ def process_needextend(app: Sphinx, doctree: nodes.document, fromdocname: str) -
                             if option in link_names:
                                 # Remove old links
                                 for ref_need in old_content:  # There may be several links
-                                    env.needs_all_needs[ref_need][f"{option}_back"].remove(found_need["id"])
+                                    all_needs[ref_need][f"{option}_back"].remove(found_need["id"])
 
                                 # Add new links
                                 for ref_need in need[option]:  # There may be several links
-                                    if found_need["id"] not in env.needs_all_needs[ref_need][f"{option}_back"]:
-                                        env.needs_all_needs[ref_need][f"{option}_back"] += [found_need["id"]]
+                                    if found_need["id"] not in all_needs[ref_need][f"{option}_back"]:
+                                        all_needs[ref_need][f"{option}_back"] += [found_need["id"]]
 
                         else:
                             need[option] = value

--- a/sphinx_needs/directives/needlist.py
+++ b/sphinx_needs/directives/needlist.py
@@ -9,6 +9,7 @@ from docutils.parsers.rst import directives
 from sphinx.application import Sphinx
 
 from sphinx_needs.config import NeedsSphinxConfig
+from sphinx_needs.data import SphinxNeedsData
 from sphinx_needs.directives.utils import (
     no_needs_found_paragraph,
     used_filter_paragraph,
@@ -37,36 +38,28 @@ class NeedlistDirective(FilterBase):
 
     def run(self) -> Sequence[nodes.Node]:
         env = self.env
-        if not hasattr(env, "need_all_needlists"):
-            env.need_all_needlists = {}
-
-        # be sure, global var is available. If not, create it
-        if not hasattr(env, "needs_all_needs"):
-            env.needs_all_needs = {}
 
         targetid = "needlist-{docname}-{id}".format(docname=env.docname, id=env.new_serialno("needlist"))
         targetnode = nodes.target("", "", ids=[targetid])
 
         # Add the need and all needed information
-        env.need_all_needlists[targetid] = {
+        SphinxNeedsData(env).get_or_create_lists()[targetid] = {
             "docname": env.docname,
             "lineno": self.lineno,
-            # "target_node": targetnode,
             "target_id": targetid,
             "show_tags": "show_tags" in self.options,
             "show_status": "show_status" in self.options,
             "show_filters": "show_filters" in self.options,
             "export_id": self.options.get("export_id", ""),
-            # "env": env,
+            **self.collect_filter_attributes(),
         }
-        env.need_all_needlists[targetid].update(self.collect_filter_attributes())
 
         add_doc(env, env.docname)
 
         return [targetnode, Needlist("")]
 
 
-def process_needlist(app: Sphinx, doctree: nodes.document, fromdocname: str, found_nodes: list) -> None:
+def process_needlist(app: Sphinx, doctree: nodes.document, fromdocname: str, found_nodes: List[nodes.Element]) -> None:
     """
     Replace all needlist nodes with a list of the collected needs.
     Augment each need with a backlink to the original location.
@@ -89,8 +82,8 @@ def process_needlist(app: Sphinx, doctree: nodes.document, fromdocname: str, fou
             continue
 
         id = node.attributes["ids"][0]
-        current_needfilter = env.need_all_needlists[id]
-        all_needs = env.needs_all_needs
+        current_needfilter = SphinxNeedsData(env).get_or_create_lists()[id]
+        all_needs = SphinxNeedsData(env).get_or_create_needs()
         content: List[nodes.Node] = []
         all_needs = list(all_needs.values())
         found_needs = process_filters(app, all_needs, current_needfilter)

--- a/sphinx_needs/directives/needtable.py
+++ b/sphinx_needs/directives/needtable.py
@@ -1,5 +1,5 @@
 import re
-from typing import Sequence
+from typing import List, Sequence
 
 from docutils import nodes
 from docutils.parsers.rst import directives
@@ -7,6 +7,7 @@ from sphinx.application import Sphinx
 
 from sphinx_needs.api.exceptions import NeedsInvalidException
 from sphinx_needs.config import NeedsSphinxConfig
+from sphinx_needs.data import SphinxNeedsData
 from sphinx_needs.debug import measure_time
 from sphinx_needs.directives.utils import (
     get_option_list,
@@ -48,12 +49,6 @@ class NeedtableDirective(FilterBase):
     @profile("NEEDTABLE_RUN")
     def run(self) -> Sequence[nodes.Node]:
         env = self.env
-        if not hasattr(env, "need_all_needtables"):
-            env.need_all_needtables = {}
-
-        # be sure, global var is available. If not, create it
-        if not hasattr(env, "needs_all_needs"):
-            env.needs_all_needs = {}
 
         targetid = "needtable-{docname}-{id}".format(docname=env.docname, id=env.new_serialno("needtable"))
         targetnode = nodes.target("", "", ids=[targetid])
@@ -89,7 +84,7 @@ class NeedtableDirective(FilterBase):
             title = self.arguments[0]
 
         # Add the need and all needed information
-        env.need_all_needtables[targetid] = {
+        SphinxNeedsData(env).get_or_create_tables()[targetid] = {
             "docname": env.docname,
             "lineno": self.lineno,
             "target_id": targetid,
@@ -105,8 +100,8 @@ class NeedtableDirective(FilterBase):
             # If not set, the options.get() method returns False
             "show_filters": "show_filters" in self.options,
             "show_parts": self.options.get("show_parts", False) is None,
+            **self.collect_filter_attributes(),
         }
-        env.need_all_needtables[targetid].update(self.collect_filter_attributes())
 
         add_doc(env, env.docname)
 
@@ -115,7 +110,9 @@ class NeedtableDirective(FilterBase):
 
 @measure_time("needtable")
 @profile("NEEDTABLE")
-def process_needtables(app: Sphinx, doctree: nodes.document, fromdocname: str, found_nodes: list) -> None:
+def process_needtables(
+    app: Sphinx, doctree: nodes.document, fromdocname: str, found_nodes: List[nodes.Element]
+) -> None:
     """
     Replace all needtables nodes with a table of filtered nodes.
 
@@ -127,6 +124,7 @@ def process_needtables(app: Sphinx, doctree: nodes.document, fromdocname: str, f
     builder = unwrap(app.builder)
     env = unwrap(builder.env)
     needs_config = NeedsSphinxConfig(app.config)
+    needs_data = SphinxNeedsData(env)
 
     # Create a link_type dictionary, which keys-list can be easily used to find columns
     link_type_list = {}
@@ -141,6 +139,8 @@ def process_needtables(app: Sphinx, doctree: nodes.document, fromdocname: str, f
         if link_type["option"] == "links":
             link_type_list["OUTGOING"] = link_type
             link_type_list["INCOMING"] = link_type
+
+    all_needs = needs_data.get_or_create_needs()
 
     # for node in doctree.findall(Needtable):
     for node in found_nodes:
@@ -157,8 +157,7 @@ def process_needtables(app: Sphinx, doctree: nodes.document, fromdocname: str, f
             continue
 
         id = node.attributes["ids"][0]
-        current_needtable = env.need_all_needtables[id]
-        all_needs = env.needs_all_needs
+        current_needtable = needs_data.get_or_create_tables()[id]
 
         if current_needtable["style"] == "" or current_needtable["style"].upper() not in ["TABLE", "DATATABLES"]:
             if needs_config.table_style == "":
@@ -208,11 +207,9 @@ def process_needtables(app: Sphinx, doctree: nodes.document, fromdocname: str, f
         # Add lineno to node
         table_node.line = current_needtable["lineno"]
 
-        all_needs = list(all_needs.values())
-
         # Perform filtering of needs
         try:
-            filtered_needs = process_filters(app, all_needs, current_needtable)
+            filtered_needs = process_filters(app, list(all_needs.values()), current_needtable)
         except Exception as e:
             raise e
 
@@ -255,28 +252,26 @@ def process_needtables(app: Sphinx, doctree: nodes.document, fromdocname: str, f
 
             for option, _title in current_needtable["columns"]:
                 if option == "ID":
-                    row += row_col_maker(
-                        app, fromdocname, env.needs_all_needs, temp_need, "id", make_ref=True, prefix=prefix
-                    )
+                    row += row_col_maker(app, fromdocname, all_needs, temp_need, "id", make_ref=True, prefix=prefix)
                 elif option == "TITLE":
-                    row += row_col_maker(app, fromdocname, env.needs_all_needs, temp_need, "title", prefix=prefix)
+                    row += row_col_maker(app, fromdocname, all_needs, temp_need, "title", prefix=prefix)
                 elif option in link_type_list:
                     link_type = link_type_list[option]
                     if option in ["INCOMING", link_type["option"].upper() + "_BACK", link_type["incoming"].upper()]:
                         row += row_col_maker(
                             app,
                             fromdocname,
-                            env.needs_all_needs,
+                            all_needs,
                             temp_need,
                             link_type["option"] + "_back",
                             ref_lookup=True,
                         )
                     else:
                         row += row_col_maker(
-                            app, fromdocname, env.needs_all_needs, temp_need, link_type["option"], ref_lookup=True
+                            app, fromdocname, all_needs, temp_need, link_type["option"], ref_lookup=True
                         )
                 else:
-                    row += row_col_maker(app, fromdocname, env.needs_all_needs, temp_need, option.lower())
+                    row += row_col_maker(app, fromdocname, all_needs, temp_need, option.lower())
             tbody += row
 
             # Need part rows
@@ -297,7 +292,7 @@ def process_needtables(app: Sphinx, doctree: nodes.document, fromdocname: str, f
                             row += row_col_maker(
                                 app,
                                 fromdocname,
-                                env.needs_all_needs,
+                                all_needs,
                                 temp_part,
                                 "id_complete",
                                 make_ref=True,
@@ -307,7 +302,7 @@ def process_needtables(app: Sphinx, doctree: nodes.document, fromdocname: str, f
                             row += row_col_maker(
                                 app,
                                 fromdocname,
-                                env.needs_all_needs,
+                                all_needs,
                                 temp_part,
                                 "content",
                                 prefix=needs_config.part_prefix,
@@ -323,13 +318,13 @@ def process_needtables(app: Sphinx, doctree: nodes.document, fromdocname: str, f
                             row += row_col_maker(
                                 app,
                                 fromdocname,
-                                env.needs_all_needs,
+                                all_needs,
                                 temp_part,
                                 link_type_list[option]["option"] + "_back",
                                 ref_lookup=True,
                             )
                         else:
-                            row += row_col_maker(app, fromdocname, env.needs_all_needs, temp_part, option.lower())
+                            row += row_col_maker(app, fromdocname, all_needs, temp_part, option.lower())
 
                     tbody += row
 

--- a/sphinx_needs/directives/needuml.py
+++ b/sphinx_needs/directives/needuml.py
@@ -1,13 +1,15 @@
 import html
 import os
-from typing import Sequence
+from typing import List, Sequence
 
 from docutils import nodes
 from docutils.parsers.rst import directives
 from jinja2 import BaseLoader, Environment, Template
+from sphinx.application import Sphinx
 from sphinx.util.docutils import SphinxDirective
 
 from sphinx_needs.config import NeedsSphinxConfig
+from sphinx_needs.data import SphinxNeedsData
 from sphinx_needs.debug import measure_time
 from sphinx_needs.diagrams_common import calculate_link
 from sphinx_needs.directives.needflow import make_entity_name
@@ -39,8 +41,6 @@ class NeedumlDirective(SphinxDirective):
 
     def run(self) -> Sequence[nodes.Node]:
         env = self.env
-        if not hasattr(env, "needs_all_needumls"):
-            env.needs_all_needumls = {}
 
         if self.name == "needarch":
             targetid = "needarch-{docname}-{id}".format(docname=env.docname, id=env.new_serialno("needarch"))
@@ -89,7 +89,7 @@ class NeedumlDirective(SphinxDirective):
             else:
                 plantuml_code_out_path = save_path
 
-        env.needs_all_needumls[targetid] = {
+        SphinxNeedsData(env).get_or_create_umls()[targetid] = {
             "docname": env.docname,
             "lineno": self.lineno,
             "target_id": targetid,
@@ -226,8 +226,8 @@ class JinjaFunctions:
     Provides access to sphinx-app and all Needs objects.
     """
 
-    def __init__(self, app, fromdocname, parent_need_id: str, processed_need_ids: {}):
-        self.needs = app.builder.env.needs_all_needs
+    def __init__(self, app: Sphinx, fromdocname, parent_need_id: str, processed_need_ids: dict):
+        self.needs = SphinxNeedsData(app.env).get_or_create_needs()
         self.app = app
         self.fromdocname = fromdocname
         self.parent_need_id = parent_need_id
@@ -403,13 +403,13 @@ def is_element_of_need(node: nodes.Element) -> str:
 
 
 @measure_time("needuml")
-def process_needuml(app, doctree, fromdocname, found_nodes):
+def process_needuml(app: Sphinx, doctree: nodes.document, fromdocname: str, found_nodes: List[nodes.Element]) -> None:
     env = app.builder.env
 
     # for node in doctree.findall(Needuml):
     for node in found_nodes:
         id = node.attributes["ids"][0]
-        current_needuml = env.needs_all_needumls[id]
+        current_needuml = SphinxNeedsData(env).get_or_create_umls()[id]
 
         parent_need_id = None
         # Check if current needuml is needarch

--- a/sphinx_needs/directives/utils.py
+++ b/sphinx_needs/directives/utils.py
@@ -5,6 +5,7 @@ from docutils import nodes
 from sphinx.environment import BuildEnvironment
 
 from sphinx_needs.config import NeedsSphinxConfig
+from sphinx_needs.data import SphinxNeedsData
 from sphinx_needs.defaults import TITLE_REGEX
 
 
@@ -95,7 +96,7 @@ def analyse_needs_metrics(env: BuildEnvironment) -> Dict[str, Any]:
     :param env: Sphinx build environment
     :return: Dictionary consisting of needs metrics.
     """
-    needs: Dict = env.needs_all_needs
+    needs = SphinxNeedsData(env).get_or_create_needs()
     metric_data = {"needs_amount": len(needs)}
     needs_types = {i["directive"]: 0 for i in NeedsSphinxConfig(env.config).types}
 

--- a/sphinx_needs/external_needs.py
+++ b/sphinx_needs/external_needs.py
@@ -10,6 +10,7 @@ from sphinx.environment import BuildEnvironment
 from sphinx_needs.api import add_external_need, del_need
 from sphinx_needs.api.exceptions import NeedsDuplicatedId
 from sphinx_needs.config import NeedsSphinxConfig
+from sphinx_needs.data import SphinxNeedsData
 from sphinx_needs.logging import get_logger
 from sphinx_needs.utils import clean_log, import_prefix_link_edit
 
@@ -112,12 +113,12 @@ def load_external_needs(app: Sphinx, env: BuildEnvironment, _docname: str) -> No
 
             # check if external needs already exist
             ext_need_id = need_params["id"]
-            if ext_need_id in env.needs_all_needs:
+
+            need = SphinxNeedsData(env).get_or_create_needs().get(ext_need_id)
+
+            if need is not None:
                 # check need_params for more detail
-                if (
-                    env.needs_all_needs[ext_need_id]["is_external"]
-                    and source["base_url"] in env.needs_all_needs[ext_need_id]["external_url"]
-                ):
+                if need["is_external"] and source["base_url"] in need["external_url"]:
                     # delete the already existing external need from api need
                     del_need(app, ext_need_id)
                 else:

--- a/sphinx_needs/functions/functions.py
+++ b/sphinx_needs/functions/functions.py
@@ -25,7 +25,7 @@ logger = get_logger(__name__)
 unicode = str
 ast_boolean = ast.NameConstant
 
-# this input args should actually be of type `Need` and `List[Need]`, however `Need` is *currently* untyped.
+# TODO this input args should actually be of type `Need` and `List[Need]`, however `Need` is *currently* untyped.
 DynamicFunction = Callable[[Sphinx, Any, Any], Union[str, int, float, List[Union[str, int, float]]]]
 
 

--- a/sphinx_needs/functions/functions.py
+++ b/sphinx_needs/functions/functions.py
@@ -16,6 +16,7 @@ from sphinx.environment import BuildEnvironment
 from sphinx.errors import SphinxError
 
 from sphinx_needs.config import NeedsSphinxConfig
+from sphinx_needs.data import SphinxNeedsData
 from sphinx_needs.debug import measure_time
 from sphinx_needs.logging import get_logger
 from sphinx_needs.utils import NEEDS_FUNCTIONS, match_variants  # noqa: F401
@@ -37,8 +38,6 @@ def register_func(need_function: DynamicFunction, name: Optional[str] = None):
     :return: None
     """
 
-    # if not hasattr(env, 'needs_functions'):
-    #     env.needs_functions = {}
     global NEEDS_FUNCTIONS
     if NEEDS_FUNCTIONS is None:
         NEEDS_FUNCTIONS = {}
@@ -54,7 +53,6 @@ def register_func(need_function: DynamicFunction, name: Optional[str] = None):
         # This is mostly the case during tet runs.
         logger.info(f"sphinx-needs: Function name {func_name} already registered. Ignoring the new one!")
 
-    # env.needs_functions[func_name] = {
     NEEDS_FUNCTIONS[func_name] = {"name": func_name, "function": need_function}
 
 
@@ -69,14 +67,11 @@ def execute_func(env: BuildEnvironment, need, func_string: str):
     global NEEDS_FUNCTIONS
     func_name, func_args, func_kwargs = _analyze_func_string(func_string, need)
 
-    # if func_name not in env.needs_functions.keys():
     if func_name not in NEEDS_FUNCTIONS.keys():
         raise SphinxError("Unknown dynamic sphinx-needs function: {}. Found in need: {}".format(func_name, need["id"]))
 
-    # func = env.needs_functions[func_name]['function']
-
     func = measure_time(category="dyn_func", source="user", func=NEEDS_FUNCTIONS[func_name]["function"])
-    func_return = func(env.app, need, env.needs_all_needs, *func_args, **func_kwargs)
+    func_return = func(env.app, need, SphinxNeedsData(env).get_or_create_needs(), *func_args, **func_kwargs)
 
     if not isinstance(func_return, (str, int, float, list, unicode)) and func_return:
         raise SphinxError(
@@ -170,11 +165,13 @@ def resolve_dynamic_values(env: BuildEnvironment):
     :param env: Sphinx environment
     :return: return value of given function
     """
+    data = SphinxNeedsData(env)
+    workflow = data.get_or_create_workflow()
     # Only perform calculation if not already done yet
-    if env.needs_workflow["dynamic_values_resolved"]:
+    if workflow["dynamic_values_resolved"]:
         return
 
-    needs = env.needs_all_needs
+    needs = data.get_or_create_needs()
     for need in needs.values():
         for need_option in need:
             if need_option in ["docname", "lineno", "target_node", "content", "content_node", "content_id"]:
@@ -233,7 +230,7 @@ def resolve_dynamic_values(env: BuildEnvironment):
                 need[need_option] = new_values
 
     # Finally set a flag so that this function gets not executed several times
-    env.needs_workflow["dynamic_values_resolved"] = True
+    workflow["dynamic_values_resolved"] = True
 
 
 def resolve_variants_options(env: BuildEnvironment):
@@ -247,15 +244,17 @@ def resolve_variants_options(env: BuildEnvironment):
     :param env: Sphinx environment
     :return: None
     """
+    data = SphinxNeedsData(env)
+    workflow = data.get_or_create_workflow()
     # Only perform calculation if not already done yet
-    if env.needs_workflow["variant_option_resolved"]:
+    if workflow["variant_option_resolved"]:
         return
 
     needs_config = NeedsSphinxConfig(env.config)
     variants_options = needs_config.variant_options
 
     if variants_options:
-        needs: Dict = env.needs_all_needs
+        needs = data.get_or_create_needs()
         for need in needs.values():
             # Data to use as filter context.
             need_context: Dict = {**need}
@@ -273,7 +272,7 @@ def resolve_variants_options(env: BuildEnvironment):
                         need[var_option] = match_variants(option_value, need_context, needs_config.variants)
 
     # Finally set a flag so that this function gets not executed several times
-    env.needs_workflow["variant_option_resolved"] = True
+    workflow["variant_option_resolved"] = True
 
 
 def check_and_get_content(content: str, need, env: BuildEnvironment) -> str:

--- a/sphinx_needs/layout.py
+++ b/sphinx_needs/layout.py
@@ -23,6 +23,7 @@ from sphinx.application import Sphinx
 from sphinx.environment.collectors.asset import DownloadFileCollector, ImageCollector
 
 from sphinx_needs.config import NeedsSphinxConfig
+from sphinx_needs.data import SphinxNeedsData
 from sphinx_needs.debug import measure_time
 from sphinx_needs.utils import INTERNALS, match_string_link, unwrap
 
@@ -42,7 +43,7 @@ def create_need(need_id: str, app: Sphinx, layout=None, style=None, docname: Opt
     :return:
     """
     env = app.builder.env
-    needs = env.needs_all_needs
+    needs = SphinxNeedsData(env).get_or_create_needs()
 
     if need_id not in needs.keys():
         raise SphinxNeedLayoutException(f"Given need id {need_id} does not exist.")
@@ -146,7 +147,7 @@ def build_need(layout, node, app: Sphinx, style=None, fromdocname: Optional[str]
     """
 
     env = app.builder.env
-    needs = env.needs_all_needs
+    needs = SphinxNeedsData(env).get_or_create_needs()
     node_container = nodes.container()
 
     need_layout = layout

--- a/sphinx_needs/needsfile.py
+++ b/sphinx_needs/needsfile.py
@@ -11,6 +11,7 @@ from typing import Any, List
 
 from jsonschema import Draft7Validator
 
+from sphinx_needs.data import NeedsFilterType
 from sphinx_needs.logging import get_logger
 
 log = get_logger(__name__)
@@ -83,7 +84,7 @@ class NeedsList:
         self.needs_list["versions"][version]["needs"][need_info["id"]] = writable_needs
         self.needs_list["versions"][version]["needs_amount"] = len(self.needs_list["versions"][version]["needs"])
 
-    def add_filter(self, version, need_filter) -> None:
+    def add_filter(self, version, need_filter: NeedsFilterType) -> None:
         self.update_or_add_version(version)
         writable_filters = {key: need_filter[key] for key in need_filter if key not in self.JSON_KEY_EXCLUSIONS_FILTERS}
         self.needs_list["versions"][version]["filters"][need_filter["export_id"].upper()] = writable_filters

--- a/sphinx_needs/roles/need_count.py
+++ b/sphinx_needs/roles/need_count.py
@@ -10,6 +10,7 @@ from docutils import nodes
 from sphinx.application import Sphinx
 
 from sphinx_needs.api.exceptions import NeedsInvalidFilter
+from sphinx_needs.data import SphinxNeedsData
 from sphinx_needs.filter_common import filter_needs, prepare_need_list
 from sphinx_needs.logging import get_logger
 from sphinx_needs.utils import unwrap
@@ -28,7 +29,7 @@ def process_need_count(
     env = unwrap(builder.env)
     # for node_need_count in doctree.findall(NeedCount):
     for node_need_count in found_nodes:
-        all_needs = list(getattr(env, "needs_all_needs", {}).values())
+        all_needs = list(SphinxNeedsData(env).get_or_create_needs().values())
         filter = node_need_count["reftarget"]
 
         if filter:

--- a/sphinx_needs/roles/need_outgoing.py
+++ b/sphinx_needs/roles/need_outgoing.py
@@ -5,6 +5,7 @@ from sphinx.application import Sphinx
 from sphinx.util.nodes import make_refnode
 
 from sphinx_needs.config import NeedsSphinxConfig
+from sphinx_needs.data import SphinxNeedsData
 from sphinx_needs.errors import NoUri
 from sphinx_needs.logging import get_logger
 from sphinx_needs.utils import check_and_calc_base_url_rel_path, unwrap
@@ -26,7 +27,7 @@ def process_need_outgoing(
     # for node_need_ref in doctree.findall(NeedOutgoing):
     for node_need_ref in found_nodes:
         node_link_container = nodes.inline()
-        needs_all_needs = getattr(env, "needs_all_needs", {})
+        needs_all_needs = SphinxNeedsData(env).get_or_create_needs()
         ref_need = needs_all_needs[node_need_ref["reftarget"]]
 
         # Let's check if NeedIncoming shall follow a specific link type

--- a/sphinx_needs/roles/need_part.py
+++ b/sphinx_needs/roles/need_part.py
@@ -24,7 +24,7 @@ class NeedPart(nodes.Inline, nodes.Element):
     pass
 
 
-def process_need_part(app: Sphinx, doctree: nodes.document, fromdocname: str, found_nodes: list) -> None:
+def process_need_part(app: Sphinx, doctree: nodes.document, fromdocname: str, found_nodes: List[nodes.Element]) -> None:
     pass
 
 

--- a/sphinx_needs/roles/need_ref.py
+++ b/sphinx_needs/roles/need_ref.py
@@ -1,12 +1,13 @@
 import contextlib
 from collections.abc import Iterable
-from typing import Dict
+from typing import Dict, List
 
 from docutils import nodes
 from sphinx.application import Sphinx
 from sphinx.util.nodes import make_refnode
 
 from sphinx_needs.config import NeedsSphinxConfig
+from sphinx_needs.data import SphinxNeedsData
 from sphinx_needs.errors import NoUri
 from sphinx_needs.logging import get_logger
 from sphinx_needs.nodes import Need
@@ -52,10 +53,11 @@ def transform_need_to_dict(need: Need) -> Dict[str, str]:
     return dict_need
 
 
-def process_need_ref(app: Sphinx, doctree: nodes.document, fromdocname: str, found_nodes) -> None:
+def process_need_ref(app: Sphinx, doctree: nodes.document, fromdocname: str, found_nodes: List[nodes.Element]) -> None:
     builder = unwrap(app.builder)
     env = unwrap(builder.env)
     needs_config = NeedsSphinxConfig(env.config)
+    all_needs = SphinxNeedsData(env).get_or_create_needs()
     # for node_need_ref in doctree.findall(NeedRef):
     for node_need_ref in found_nodes:
         # Let's create a dummy node, for the case we will not be able to create a real reference
@@ -80,8 +82,8 @@ def process_need_ref(app: Sphinx, doctree: nodes.document, fromdocname: str, fou
             ref_id = ref_id_complete
             part_id = None
 
-        if ref_id in env.needs_all_needs:
-            target_need = env.needs_all_needs[ref_id]
+        if ref_id in all_needs:
+            target_need = all_needs[ref_id]
 
             dict_need = transform_need_to_dict(target_need)  # Transform a dict in a dict of {str, str}
 

--- a/sphinx_needs/services/manager.py
+++ b/sphinx_needs/services/manager.py
@@ -21,9 +21,7 @@ class ServiceManager:
         try:
             config = NeedsSphinxConfig(self.app.config).services[name]
         except KeyError:
-            self.log.debug(
-                "No service config found for {}. " "Add it in your conf.py to needs_services dictionary.".format(name)
-            )
+            self.log.debug(f"No service config found for {name}. Add it in your conf.py to needs_services dictionary.")
             config = {}
 
         # Register options from service class

--- a/sphinx_needs/warnings.py
+++ b/sphinx_needs/warnings.py
@@ -8,6 +8,7 @@ from sphinx.application import Sphinx
 from sphinx.util import logging
 
 from sphinx_needs.config import NEEDS_CONFIG, NeedsSphinxConfig
+from sphinx_needs.data import SphinxNeedsData
 from sphinx_needs.filter_common import filter_needs
 from sphinx_needs.logging import get_logger
 from sphinx_needs.utils import unwrap
@@ -44,7 +45,7 @@ def process_warnings(app: Sphinx, exception: Optional[Exception]) -> None:
 
     env.needs_warnings_executed = True
 
-    needs = env.needs_all_needs
+    needs = SphinxNeedsData(env).get_or_create_needs()
 
     # Exclude external needs for warnings check
     checked_needs = {}


### PR DESCRIPTION
The sphinx-needs data stored on the Sphinx `BuildEnvironment` is currently difficult to interpret and work with,
since the dynamic nature of `BuildEnvironment` provides no type safety or static introspection.

This PR intends to centralise access to sphinx-needs data, via `sphinx_needs.data.SphinxNeedsData`, which is a thin wrapper around the sphinx `BuildEnvironment`, to define and provide type safe access to the sphinx-need specific data.

[TypedDict](https://docs.python.org/3/library/typing.html#typing.TypedDict) are used to type annotate the dictionary keys for the different data types,
and thus `sphinx_needs.data` essentially provides a schema for the data that sphinx-needs stores.

This is a non-breaking change, since all data can still be accessed via the sphinx `BuildEnvironment`, (although this is now discouraged).

---

Note, this is intended as a step toward making the package type checked, since at present, although mypy is used, almost every module is set to be ignored (see `pyproject.toml`)