### PR TITLE
🧪 Add headless java to test builds

### DIFF
--- a/tests/doc_test/add_sections/conf.py
+++ b/tests/doc_test/add_sections/conf.py
@@ -40,7 +40,7 @@ needs_extra_options = {
     "impacts": directives.unchanged,
 }
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/add_sections/conf.py
+++ b/tests/doc_test/add_sections/conf.py
@@ -40,7 +40,9 @@ needs_extra_options = {
     "impacts": directives.unchanged,
 }
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/api_doc/conf.py
+++ b/tests/doc_test/api_doc/conf.py
@@ -40,7 +40,9 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/api_doc/conf.py
+++ b/tests/doc_test/api_doc/conf.py
@@ -40,7 +40,7 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/api_doc_awesome/conf.py
+++ b/tests/doc_test/api_doc_awesome/conf.py
@@ -40,7 +40,9 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/api_doc_awesome/conf.py
+++ b/tests/doc_test/api_doc_awesome/conf.py
@@ -40,7 +40,7 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/arch_doc/conf.py
+++ b/tests/doc_test/arch_doc/conf.py
@@ -40,7 +40,9 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/arch_doc/conf.py
+++ b/tests/doc_test/arch_doc/conf.py
@@ -40,7 +40,7 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/broken_doc/conf.py
+++ b/tests/doc_test/broken_doc/conf.py
@@ -40,7 +40,9 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/broken_doc/conf.py
+++ b/tests/doc_test/broken_doc/conf.py
@@ -40,7 +40,7 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/broken_links/conf.py
+++ b/tests/doc_test/broken_links/conf.py
@@ -40,7 +40,9 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/broken_links/conf.py
+++ b/tests/doc_test/broken_links/conf.py
@@ -40,7 +40,7 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/broken_statuses/conf.py
+++ b/tests/doc_test/broken_statuses/conf.py
@@ -45,7 +45,7 @@ needs_statuses = [
     {"name": "implemented", "description": "Implemented status"},
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/broken_statuses/conf.py
+++ b/tests/doc_test/broken_statuses/conf.py
@@ -45,7 +45,9 @@ needs_statuses = [
     {"name": "implemented", "description": "Implemented status"},
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/broken_syntax_doc/conf.py
+++ b/tests/doc_test/broken_syntax_doc/conf.py
@@ -40,7 +40,9 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/broken_syntax_doc/conf.py
+++ b/tests/doc_test/broken_syntax_doc/conf.py
@@ -40,7 +40,7 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/broken_tags/conf.py
+++ b/tests/doc_test/broken_tags/conf.py
@@ -45,7 +45,7 @@ needs_tags = [
     {"name": "security", "description": "tag for security needs"},
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/broken_tags/conf.py
+++ b/tests/doc_test/broken_tags/conf.py
@@ -45,7 +45,9 @@ needs_tags = [
     {"name": "security", "description": "tag for security needs"},
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/broken_tags_2/conf.py
+++ b/tests/doc_test/broken_tags_2/conf.py
@@ -45,7 +45,7 @@ needs_tags = [
     {"name": "security", "description": "tag for security needs"},
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/broken_tags_2/conf.py
+++ b/tests/doc_test/broken_tags_2/conf.py
@@ -45,7 +45,9 @@ needs_tags = [
     {"name": "security", "description": "tag for security needs"},
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_basic/conf.py
+++ b/tests/doc_test/doc_basic/conf.py
@@ -38,7 +38,7 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_basic/conf.py
+++ b/tests/doc_test/doc_basic/conf.py
@@ -38,7 +38,9 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_basic_latex/conf.py
+++ b/tests/doc_test/doc_basic_latex/conf.py
@@ -38,7 +38,7 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_basic_latex/conf.py
+++ b/tests/doc_test/doc_basic_latex/conf.py
@@ -38,7 +38,9 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_build_latex/conf.py
+++ b/tests/doc_test/doc_build_latex/conf.py
@@ -46,7 +46,9 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_build_latex/conf.py
+++ b/tests/doc_test/doc_build_latex/conf.py
@@ -46,7 +46,7 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_df_calc_sum/conf.py
+++ b/tests/doc_test/doc_df_calc_sum/conf.py
@@ -44,7 +44,9 @@ needs_types = [
 
 needs_extra_options = {"test_func": directives.unchanged, "hours": directives.unchanged, "amount": directives.unchanged}
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_df_calc_sum/conf.py
+++ b/tests/doc_test/doc_df_calc_sum/conf.py
@@ -44,7 +44,7 @@ needs_types = [
 
 needs_extra_options = {"test_func": directives.unchanged, "hours": directives.unchanged, "amount": directives.unchanged}
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_df_check_linked_values/conf.py
+++ b/tests/doc_test/doc_df_check_linked_values/conf.py
@@ -44,7 +44,9 @@ needs_types = [
 
 needs_extra_options = {"test_func": directives.unchanged, "hours": directives.unchanged}
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_df_check_linked_values/conf.py
+++ b/tests/doc_test/doc_df_check_linked_values/conf.py
@@ -44,7 +44,7 @@ needs_types = [
 
 needs_extra_options = {"test_func": directives.unchanged, "hours": directives.unchanged}
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_df_user_functions/conf.py
+++ b/tests/doc_test/doc_df_user_functions/conf.py
@@ -51,7 +51,7 @@ def my_own_function(app, need, needs):
 
 needs_functions = [my_own_function]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_df_user_functions/conf.py
+++ b/tests/doc_test/doc_df_user_functions/conf.py
@@ -51,7 +51,9 @@ def my_own_function(app, need, needs):
 
 needs_functions = [my_own_function]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_dynamic_functions/conf.py
+++ b/tests/doc_test/doc_dynamic_functions/conf.py
@@ -44,7 +44,9 @@ needs_types = [
 
 needs_extra_options = {"test_func": directives.unchanged}
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_dynamic_functions/conf.py
+++ b/tests/doc_test/doc_dynamic_functions/conf.py
@@ -44,7 +44,7 @@ needs_types = [
 
 needs_extra_options = {"test_func": directives.unchanged}
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_export_id/conf.py
+++ b/tests/doc_test/doc_export_id/conf.py
@@ -67,7 +67,7 @@ needs_extra_links = [
 
 needs_flow_link_types = ["links", "tests"]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_export_id/conf.py
+++ b/tests/doc_test/doc_export_id/conf.py
@@ -67,7 +67,9 @@ needs_extra_links = [
 
 needs_flow_link_types = ["links", "tests"]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_extra_links/conf.py
+++ b/tests/doc_test/doc_extra_links/conf.py
@@ -68,7 +68,9 @@ needs_extra_links = [
 
 needs_flow_link_types = ["links", "tests"]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_extra_links/conf.py
+++ b/tests/doc_test/doc_extra_links/conf.py
@@ -68,7 +68,7 @@ needs_extra_links = [
 
 needs_flow_link_types = ["links", "tests"]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_github_issue_160/conf.py
+++ b/tests/doc_test/doc_github_issue_160/conf.py
@@ -33,7 +33,9 @@ sys.path.insert(0, os.path.abspath("../../sphinxcontrib"))
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 needs_id_regex = "^[A-Z0-9]-[A-Z0-9]+"
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_github_issue_160/conf.py
+++ b/tests/doc_test/doc_github_issue_160/conf.py
@@ -33,7 +33,7 @@ sys.path.insert(0, os.path.abspath("../../sphinxcontrib"))
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 needs_id_regex = "^[A-Z0-9]-[A-Z0-9]+"
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_github_issue_21/conf.py
+++ b/tests/doc_test/doc_github_issue_21/conf.py
@@ -40,7 +40,9 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_github_issue_21/conf.py
+++ b/tests/doc_test/doc_github_issue_21/conf.py
@@ -40,7 +40,7 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_github_issue_44/conf.py
+++ b/tests/doc_test/doc_github_issue_44/conf.py
@@ -41,7 +41,9 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_github_issue_44/conf.py
+++ b/tests/doc_test/doc_github_issue_44/conf.py
@@ -41,7 +41,7 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_github_issue_61/conf.py
+++ b/tests/doc_test/doc_github_issue_61/conf.py
@@ -33,7 +33,9 @@ sys.path.insert(0, os.path.abspath("../../sphinxcontrib"))
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 needs_id_regex = "^[A-Z0-9]-[A-Z0-9]+"
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_github_issue_61/conf.py
+++ b/tests/doc_test/doc_github_issue_61/conf.py
@@ -33,7 +33,7 @@ sys.path.insert(0, os.path.abspath("../../sphinxcontrib"))
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 needs_id_regex = "^[A-Z0-9]-[A-Z0-9]+"
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_global_options/conf.py
+++ b/tests/doc_test/doc_global_options/conf.py
@@ -48,7 +48,9 @@ needs_global_options = {
     "global_5": ("STATUS_CLOSED", 'status == "closed"', "STATUS_UNKNOWN"),
 }
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_global_options/conf.py
+++ b/tests/doc_test/doc_global_options/conf.py
@@ -48,7 +48,7 @@ needs_global_options = {
     "global_5": ("STATUS_CLOSED", 'status == "closed"', "STATUS_UNKNOWN"),
 }
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_layout/conf.py
+++ b/tests/doc_test/doc_layout/conf.py
@@ -67,7 +67,9 @@ needs_layouts = {
 }
 
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_layout/conf.py
+++ b/tests/doc_test/doc_layout/conf.py
@@ -67,7 +67,7 @@ needs_layouts = {
 }
 
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_list2need/conf.py
+++ b/tests/doc_test/doc_list2need/conf.py
@@ -48,7 +48,7 @@ needs_extra_links = [
     {"option": "triggers", "incoming": "is triggered by", "outgoing": "triggers"},
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_list2need/conf.py
+++ b/tests/doc_test/doc_list2need/conf.py
@@ -48,7 +48,9 @@ needs_extra_links = [
     {"option": "triggers", "incoming": "is triggered by", "outgoing": "triggers"},
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_measure_time/conf.py
+++ b/tests/doc_test/doc_measure_time/conf.py
@@ -61,7 +61,7 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_measure_time/conf.py
+++ b/tests/doc_test/doc_measure_time/conf.py
@@ -61,7 +61,9 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_need_count/conf.py
+++ b/tests/doc_test/doc_need_count/conf.py
@@ -40,7 +40,9 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_need_count/conf.py
+++ b/tests/doc_test/doc_need_count/conf.py
@@ -40,7 +40,7 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_need_delete/conf.py
+++ b/tests/doc_test/doc_need_delete/conf.py
@@ -38,7 +38,7 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_need_delete/conf.py
+++ b/tests/doc_test/doc_need_delete/conf.py
@@ -38,7 +38,9 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_need_id_from_title/conf.py
+++ b/tests/doc_test/doc_need_id_from_title/conf.py
@@ -45,7 +45,9 @@ needs_title_optional = True
 needs_title_from_content = True
 needs_id_from_title = True
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_need_id_from_title/conf.py
+++ b/tests/doc_test/doc_need_id_from_title/conf.py
@@ -45,7 +45,7 @@ needs_title_optional = True
 needs_title_from_content = True
 needs_id_from_title = True
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_need_jinja_content/conf.py
+++ b/tests/doc_test/doc_need_jinja_content/conf.py
@@ -38,7 +38,9 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 

--- a/tests/doc_test/doc_need_jinja_content/conf.py
+++ b/tests/doc_test/doc_need_jinja_content/conf.py
@@ -38,7 +38,7 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 

--- a/tests/doc_test/doc_need_parts/conf.py
+++ b/tests/doc_test/doc_need_parts/conf.py
@@ -40,7 +40,9 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_need_parts/conf.py
+++ b/tests/doc_test/doc_need_parts/conf.py
@@ -40,7 +40,7 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_needarch/conf.py
+++ b/tests/doc_test/doc_needarch/conf.py
@@ -67,7 +67,7 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_needarch/conf.py
+++ b/tests/doc_test/doc_needarch/conf.py
@@ -67,7 +67,9 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_needarch_jinja_func_import/conf.py
+++ b/tests/doc_test/doc_needarch_jinja_func_import/conf.py
@@ -64,7 +64,9 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_needarch_jinja_func_import/conf.py
+++ b/tests/doc_test/doc_needarch_jinja_func_import/conf.py
@@ -64,7 +64,7 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_needarch_jinja_func_need/conf.py
+++ b/tests/doc_test/doc_needarch_jinja_func_need/conf.py
@@ -67,7 +67,7 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_needarch_jinja_func_need/conf.py
+++ b/tests/doc_test/doc_needarch_jinja_func_need/conf.py
@@ -67,7 +67,9 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_needarch_negative_tests/conf.py
+++ b/tests/doc_test/doc_needarch_negative_tests/conf.py
@@ -67,7 +67,7 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_needarch_negative_tests/conf.py
+++ b/tests/doc_test/doc_needarch_negative_tests/conf.py
@@ -67,7 +67,9 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_needextend/conf.py
+++ b/tests/doc_test/doc_needextend/conf.py
@@ -40,7 +40,9 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_needextend/conf.py
+++ b/tests/doc_test/doc_needextend/conf.py
@@ -40,7 +40,7 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_needextend_strict/conf.py
+++ b/tests/doc_test/doc_needextend_strict/conf.py
@@ -40,7 +40,9 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_needextend_strict/conf.py
+++ b/tests/doc_test/doc_needextend_strict/conf.py
@@ -40,7 +40,7 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_needextract/conf.py
+++ b/tests/doc_test/doc_needextract/conf.py
@@ -46,7 +46,9 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_needextract/conf.py
+++ b/tests/doc_test/doc_needextract/conf.py
@@ -46,7 +46,7 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_needflow/conf.py
+++ b/tests/doc_test/doc_needflow/conf.py
@@ -43,7 +43,9 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_needflow/conf.py
+++ b/tests/doc_test/doc_needflow/conf.py
@@ -43,7 +43,7 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_needflow_incl_child_needs/conf.py
+++ b/tests/doc_test/doc_needflow_incl_child_needs/conf.py
@@ -59,7 +59,7 @@ needs_types = [
 # ]
 
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_needflow_incl_child_needs/conf.py
+++ b/tests/doc_test/doc_needflow_incl_child_needs/conf.py
@@ -59,7 +59,9 @@ needs_types = [
 # ]
 
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_needimport_download_needs_json/conf.py
+++ b/tests/doc_test/doc_needimport_download_needs_json/conf.py
@@ -42,7 +42,7 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_needimport_download_needs_json/conf.py
+++ b/tests/doc_test/doc_needimport_download_needs_json/conf.py
@@ -42,7 +42,9 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_needimport_download_needs_json_negative/conf.py
+++ b/tests/doc_test/doc_needimport_download_needs_json_negative/conf.py
@@ -42,7 +42,7 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_needimport_download_needs_json_negative/conf.py
+++ b/tests/doc_test/doc_needimport_download_needs_json_negative/conf.py
@@ -42,7 +42,9 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_needimport_noindex/conf.py
+++ b/tests/doc_test/doc_needimport_noindex/conf.py
@@ -36,7 +36,7 @@ extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 numfig = True
 
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_needimport_noindex/conf.py
+++ b/tests/doc_test/doc_needimport_noindex/conf.py
@@ -36,7 +36,9 @@ extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 numfig = True
 
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_needlist/conf.py
+++ b/tests/doc_test/doc_needlist/conf.py
@@ -42,7 +42,7 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_needlist/conf.py
+++ b/tests/doc_test/doc_needlist/conf.py
@@ -42,7 +42,9 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_needpie/conf.py
+++ b/tests/doc_test/doc_needpie/conf.py
@@ -45,7 +45,7 @@ needs_types = [
 
 needs_extra_options = ["author"]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_needpie/conf.py
+++ b/tests/doc_test/doc_needpie/conf.py
@@ -45,7 +45,9 @@ needs_types = [
 
 needs_extra_options = ["author"]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_needs_builder/conf.py
+++ b/tests/doc_test/doc_needs_builder/conf.py
@@ -42,7 +42,7 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 needs_file = "custom_needs_test.json"

--- a/tests/doc_test/doc_needs_builder/conf.py
+++ b/tests/doc_test/doc_needs_builder/conf.py
@@ -42,7 +42,9 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 needs_file = "custom_needs_test.json"

--- a/tests/doc_test/doc_needs_builder_negative_tests/conf.py
+++ b/tests/doc_test/doc_needs_builder_negative_tests/conf.py
@@ -42,7 +42,7 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_needs_builder_negative_tests/conf.py
+++ b/tests/doc_test/doc_needs_builder_negative_tests/conf.py
@@ -42,7 +42,9 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_needs_builder_parallel/conf.py
+++ b/tests/doc_test/doc_needs_builder_parallel/conf.py
@@ -44,7 +44,9 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 needs_file = "custom_needs_test.json"

--- a/tests/doc_test/doc_needs_builder_parallel/conf.py
+++ b/tests/doc_test/doc_needs_builder_parallel/conf.py
@@ -44,7 +44,7 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 needs_file = "custom_needs_test.json"

--- a/tests/doc_test/doc_needs_external_needs/conf.py
+++ b/tests/doc_test/doc_needs_external_needs/conf.py
@@ -42,7 +42,7 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 needs_external_needs = [

--- a/tests/doc_test/doc_needs_external_needs/conf.py
+++ b/tests/doc_test/doc_needs_external_needs/conf.py
@@ -42,7 +42,9 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 needs_external_needs = [

--- a/tests/doc_test/doc_needs_external_needs_remote/conf.py
+++ b/tests/doc_test/doc_needs_external_needs_remote/conf.py
@@ -42,7 +42,7 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 needs_external_needs = [

--- a/tests/doc_test/doc_needs_external_needs_remote/conf.py
+++ b/tests/doc_test/doc_needs_external_needs_remote/conf.py
@@ -42,7 +42,9 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 needs_external_needs = [

--- a/tests/doc_test/doc_needs_external_needs_with_target_url/conf.py
+++ b/tests/doc_test/doc_needs_external_needs_with_target_url/conf.py
@@ -42,7 +42,7 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 needs_external_needs = [

--- a/tests/doc_test/doc_needs_external_needs_with_target_url/conf.py
+++ b/tests/doc_test/doc_needs_external_needs_with_target_url/conf.py
@@ -42,7 +42,9 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 needs_external_needs = [

--- a/tests/doc_test/doc_needs_filter_data/conf.py
+++ b/tests/doc_test/doc_needs_filter_data/conf.py
@@ -60,7 +60,9 @@ needs_warnings = {
 
 needs_warnings_always_warn = True
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_needs_filter_data/conf.py
+++ b/tests/doc_test/doc_needs_filter_data/conf.py
@@ -60,7 +60,7 @@ needs_warnings = {
 
 needs_warnings_always_warn = True
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_needs_warnings/conf.py
+++ b/tests/doc_test/doc_needs_warnings/conf.py
@@ -42,7 +42,7 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 needs_external_needs = [

--- a/tests/doc_test/doc_needs_warnings/conf.py
+++ b/tests/doc_test/doc_needs_warnings/conf.py
@@ -42,7 +42,9 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 needs_external_needs = [

--- a/tests/doc_test/doc_needs_warnings_return_status_code/conf.py
+++ b/tests/doc_test/doc_needs_warnings_return_status_code/conf.py
@@ -42,7 +42,7 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 

--- a/tests/doc_test/doc_needs_warnings_return_status_code/conf.py
+++ b/tests/doc_test/doc_needs_warnings_return_status_code/conf.py
@@ -42,7 +42,9 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 

--- a/tests/doc_test/doc_needsfile/conf.py
+++ b/tests/doc_test/doc_needsfile/conf.py
@@ -41,7 +41,9 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_needsfile/conf.py
+++ b/tests/doc_test/doc_needsfile/conf.py
@@ -41,7 +41,7 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_needtable/conf.py
+++ b/tests/doc_test/doc_needtable/conf.py
@@ -72,7 +72,7 @@ needs_string_links = {
     },
 }
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_needtable/conf.py
+++ b/tests/doc_test/doc_needtable/conf.py
@@ -72,7 +72,9 @@ needs_string_links = {
     },
 }
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_needuml/conf.py
+++ b/tests/doc_test/doc_needuml/conf.py
@@ -67,7 +67,7 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_needuml/conf.py
+++ b/tests/doc_test/doc_needuml/conf.py
@@ -67,7 +67,9 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_needuml_diagram_allowmixing/conf.py
+++ b/tests/doc_test/doc_needuml_diagram_allowmixing/conf.py
@@ -67,7 +67,7 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_needuml_diagram_allowmixing/conf.py
+++ b/tests/doc_test/doc_needuml_diagram_allowmixing/conf.py
@@ -67,7 +67,9 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_needuml_duplicate_key/conf.py
+++ b/tests/doc_test/doc_needuml_duplicate_key/conf.py
@@ -67,7 +67,7 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_needuml_duplicate_key/conf.py
+++ b/tests/doc_test/doc_needuml_duplicate_key/conf.py
@@ -67,7 +67,9 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_needuml_filter/conf.py
+++ b/tests/doc_test/doc_needuml_filter/conf.py
@@ -67,7 +67,7 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_needuml_filter/conf.py
+++ b/tests/doc_test/doc_needuml_filter/conf.py
@@ -67,7 +67,9 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_needuml_jinja_func_flow/conf.py
+++ b/tests/doc_test/doc_needuml_jinja_func_flow/conf.py
@@ -67,7 +67,7 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_needuml_jinja_func_flow/conf.py
+++ b/tests/doc_test/doc_needuml_jinja_func_flow/conf.py
@@ -67,7 +67,9 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_needuml_jinja_func_import_negative_tests/conf.py
+++ b/tests/doc_test/doc_needuml_jinja_func_import_negative_tests/conf.py
@@ -64,7 +64,9 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_needuml_jinja_func_import_negative_tests/conf.py
+++ b/tests/doc_test/doc_needuml_jinja_func_import_negative_tests/conf.py
@@ -64,7 +64,7 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_needuml_jinja_func_need_removed/conf.py
+++ b/tests/doc_test/doc_needuml_jinja_func_need_removed/conf.py
@@ -67,7 +67,7 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_needuml_jinja_func_need_removed/conf.py
+++ b/tests/doc_test/doc_needuml_jinja_func_need_removed/conf.py
@@ -67,7 +67,9 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_needuml_jinja_func_ref/conf.py
+++ b/tests/doc_test/doc_needuml_jinja_func_ref/conf.py
@@ -67,7 +67,7 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_needuml_jinja_func_ref/conf.py
+++ b/tests/doc_test/doc_needuml_jinja_func_ref/conf.py
@@ -67,7 +67,9 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_needuml_key_name_diagram/conf.py
+++ b/tests/doc_test/doc_needuml_key_name_diagram/conf.py
@@ -67,7 +67,7 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_needuml_key_name_diagram/conf.py
+++ b/tests/doc_test/doc_needuml_key_name_diagram/conf.py
@@ -67,7 +67,9 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_needuml_save/conf.py
+++ b/tests/doc_test/doc_needuml_save/conf.py
@@ -67,7 +67,9 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 needs_build_needumls = "my_needumls"

--- a/tests/doc_test/doc_needuml_save/conf.py
+++ b/tests/doc_test/doc_needuml_save/conf.py
@@ -67,7 +67,7 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 needs_build_needumls = "my_needumls"

--- a/tests/doc_test/doc_needuml_save_with_abs_path/conf.py
+++ b/tests/doc_test/doc_needuml_save_with_abs_path/conf.py
@@ -67,7 +67,7 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_needuml_save_with_abs_path/conf.py
+++ b/tests/doc_test/doc_needuml_save_with_abs_path/conf.py
@@ -67,7 +67,9 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_open_needs_service/conf.py
+++ b/tests/doc_test/doc_open_needs_service/conf.py
@@ -62,7 +62,9 @@ needs_services = {
 }
 
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_open_needs_service/conf.py
+++ b/tests/doc_test/doc_open_needs_service/conf.py
@@ -62,7 +62,7 @@ needs_services = {
 }
 
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_report_dead_links_false/conf.py
+++ b/tests/doc_test/doc_report_dead_links_false/conf.py
@@ -60,7 +60,7 @@ needs_extra_links = [
     },
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_report_dead_links_false/conf.py
+++ b/tests/doc_test/doc_report_dead_links_false/conf.py
@@ -60,7 +60,9 @@ needs_extra_links = [
     },
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_report_dead_links_true/conf.py
+++ b/tests/doc_test/doc_report_dead_links_true/conf.py
@@ -58,7 +58,7 @@ needs_extra_links = [
     },
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_report_dead_links_true/conf.py
+++ b/tests/doc_test/doc_report_dead_links_true/conf.py
@@ -58,7 +58,9 @@ needs_extra_links = [
     },
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_role_need_max_title_length/conf.py
+++ b/tests/doc_test/doc_role_need_max_title_length/conf.py
@@ -44,7 +44,9 @@ needs_role_need_template = "[{id}] {title} ({status}) {type_name}/{type} - {tags
 
 needs_role_need_max_title_length = 10
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_role_need_max_title_length/conf.py
+++ b/tests/doc_test/doc_role_need_max_title_length/conf.py
@@ -44,7 +44,7 @@ needs_role_need_template = "[{id}] {title} ({status}) {type_name}/{type} - {tags
 
 needs_role_need_max_title_length = 10
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_role_need_max_title_length_unlimited/conf.py
+++ b/tests/doc_test/doc_role_need_max_title_length_unlimited/conf.py
@@ -44,7 +44,7 @@ needs_role_need_template = "[{id}] {title} ({status}) {type_name}/{type} - {tags
 
 needs_role_need_max_title_length = -1
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_role_need_max_title_length_unlimited/conf.py
+++ b/tests/doc_test/doc_role_need_max_title_length_unlimited/conf.py
@@ -44,7 +44,9 @@ needs_role_need_template = "[{id}] {title} ({status}) {type_name}/{type} - {tags
 
 needs_role_need_max_title_length = -1
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_role_need_template/conf.py
+++ b/tests/doc_test/doc_role_need_template/conf.py
@@ -42,7 +42,7 @@ needs_types = [
 
 needs_role_need_template = "[{id}] {title} ({status}) {type_name}/{type} - {tags} - {links} - {links_back} - {content}"
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_role_need_template/conf.py
+++ b/tests/doc_test/doc_role_need_template/conf.py
@@ -42,7 +42,9 @@ needs_types = [
 
 needs_role_need_template = "[{id}] {title} ({status}) {type_name}/{type} - {tags} - {links} - {links_back} - {content}"
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_style_blank/conf.py
+++ b/tests/doc_test/doc_style_blank/conf.py
@@ -42,7 +42,9 @@ needs_types = [
 
 needs_css = "blank.css"
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_style_blank/conf.py
+++ b/tests/doc_test/doc_style_blank/conf.py
@@ -42,7 +42,7 @@ needs_types = [
 
 needs_css = "blank.css"
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_style_custom/conf.py
+++ b/tests/doc_test/doc_style_custom/conf.py
@@ -42,7 +42,9 @@ needs_types = [
 
 needs_css = os.path.join(os.path.dirname(__file__), "my_custom.css")
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_style_custom/conf.py
+++ b/tests/doc_test/doc_style_custom/conf.py
@@ -42,7 +42,7 @@ needs_types = [
 
 needs_css = os.path.join(os.path.dirname(__file__), "my_custom.css")
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_style_modern/conf.py
+++ b/tests/doc_test/doc_style_modern/conf.py
@@ -42,7 +42,9 @@ needs_types = [
 
 needs_css = "modern.css"
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_style_modern/conf.py
+++ b/tests/doc_test/doc_style_modern/conf.py
@@ -42,7 +42,7 @@ needs_types = [
 
 needs_css = "modern.css"
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_style_unknown/conf.py
+++ b/tests/doc_test/doc_style_unknown/conf.py
@@ -42,7 +42,9 @@ needs_types = [
 
 needs_css = "UNKNOWN.css"
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/doc_style_unknown/conf.py
+++ b/tests/doc_test/doc_style_unknown/conf.py
@@ -42,7 +42,7 @@ needs_types = [
 
 needs_css = "UNKNOWN.css"
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/external_doc/conf.py
+++ b/tests/doc_test/external_doc/conf.py
@@ -53,7 +53,9 @@ needs_external_needs = [
 # Needed to export really ALL needs. The default entry would filter out all needs coming from external
 needs_builder_filter = "True"
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/external_doc/conf.py
+++ b/tests/doc_test/external_doc/conf.py
@@ -53,7 +53,7 @@ needs_external_needs = [
 # Needed to export really ALL needs. The default entry would filter out all needs coming from external
 needs_builder_filter = "True"
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/extra_options/conf.py
+++ b/tests/doc_test/extra_options/conf.py
@@ -47,7 +47,9 @@ def setup(app):
     add_extra_option(app, "introduced")
 
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/extra_options/conf.py
+++ b/tests/doc_test/extra_options/conf.py
@@ -47,7 +47,7 @@ def setup(app):
     add_extra_option(app, "introduced")
 
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/filter_doc/conf.py
+++ b/tests/doc_test/filter_doc/conf.py
@@ -42,7 +42,7 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/filter_doc/conf.py
+++ b/tests/doc_test/filter_doc/conf.py
@@ -42,7 +42,9 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/generic_doc/conf.py
+++ b/tests/doc_test/generic_doc/conf.py
@@ -40,7 +40,9 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/generic_doc/conf.py
+++ b/tests/doc_test/generic_doc/conf.py
@@ -40,7 +40,7 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/import_doc/conf.py
+++ b/tests/doc_test/import_doc/conf.py
@@ -60,7 +60,7 @@ needs_template = """
 {% endif -%}
 """
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/import_doc/conf.py
+++ b/tests/doc_test/import_doc/conf.py
@@ -60,7 +60,9 @@ needs_template = """
 {% endif -%}
 """
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/import_doc_empty/conf.py
+++ b/tests/doc_test/import_doc_empty/conf.py
@@ -60,7 +60,7 @@ needs_template = """
 {% endif -%}
 """
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/import_doc_empty/conf.py
+++ b/tests/doc_test/import_doc_empty/conf.py
@@ -60,7 +60,9 @@ needs_template = """
 {% endif -%}
 """
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/import_doc_invalid/conf.py
+++ b/tests/doc_test/import_doc_invalid/conf.py
@@ -60,7 +60,7 @@ needs_template = """
 {% endif -%}
 """
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/import_doc_invalid/conf.py
+++ b/tests/doc_test/import_doc_invalid/conf.py
@@ -60,7 +60,9 @@ needs_template = """
 {% endif -%}
 """
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/multiple_link_backs/conf.py
+++ b/tests/doc_test/multiple_link_backs/conf.py
@@ -32,7 +32,9 @@ sys.path.insert(0, os.path.abspath("../../sphinxcontrib-needs"))
 
 extensions = ["sphinx_needs"]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/multiple_link_backs/conf.py
+++ b/tests/doc_test/multiple_link_backs/conf.py
@@ -32,7 +32,7 @@ sys.path.insert(0, os.path.abspath("../../sphinxcontrib-needs"))
 
 extensions = ["sphinx_needs"]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/need_constraints/conf.py
+++ b/tests/doc_test/need_constraints/conf.py
@@ -42,7 +42,7 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 needs_external_needs = [

--- a/tests/doc_test/need_constraints/conf.py
+++ b/tests/doc_test/need_constraints/conf.py
@@ -42,7 +42,9 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 needs_external_needs = [

--- a/tests/doc_test/need_constraints_failed/conf.py
+++ b/tests/doc_test/need_constraints_failed/conf.py
@@ -42,7 +42,7 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "../need_constraints", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "../need_constraints", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 needs_external_needs = [

--- a/tests/doc_test/need_constraints_failed/conf.py
+++ b/tests/doc_test/need_constraints_failed/conf.py
@@ -42,7 +42,9 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "../need_constraints", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "../need_constraints", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 needs_external_needs = [

--- a/tests/doc_test/needextract_with_nested_needs/conf.py
+++ b/tests/doc_test/needextract_with_nested_needs/conf.py
@@ -41,7 +41,9 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/needextract_with_nested_needs/conf.py
+++ b/tests/doc_test/needextract_with_nested_needs/conf.py
@@ -41,7 +41,7 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/needpie_with_zero_needs/conf.py
+++ b/tests/doc_test/needpie_with_zero_needs/conf.py
@@ -41,7 +41,9 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/needpie_with_zero_needs/conf.py
+++ b/tests/doc_test/needpie_with_zero_needs/conf.py
@@ -41,7 +41,7 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/non_exists_file_import/conf.py
+++ b/tests/doc_test/non_exists_file_import/conf.py
@@ -60,7 +60,7 @@ needs_template = """
 {% endif -%}
 """
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/non_exists_file_import/conf.py
+++ b/tests/doc_test/non_exists_file_import/conf.py
@@ -60,7 +60,9 @@ needs_template = """
 {% endif -%}
 """
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/parallel_doc/conf.py
+++ b/tests/doc_test/parallel_doc/conf.py
@@ -42,7 +42,7 @@ needs_variants = {"change_author": "assignee == 'Randy Duodu'"}
 needs_variant_options = ["status", "author"]
 needs_filter_data = {"assignee": "Randy Duodu"}
 needs_extra_options = ["my_extra_option", "another_option", "author", "comment"]
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/parallel_doc/conf.py
+++ b/tests/doc_test/parallel_doc/conf.py
@@ -42,7 +42,9 @@ needs_variants = {"change_author": "assignee == 'Randy Duodu'"}
 needs_variant_options = ["status", "author"]
 needs_filter_data = {"assignee": "Randy Duodu"}
 needs_extra_options = ["my_extra_option", "another_option", "author", "comment"]
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/role_need_doc/conf.py
+++ b/tests/doc_test/role_need_doc/conf.py
@@ -53,7 +53,9 @@ needs_external_needs = [
 # Needed to export really ALL needs. The default entry would filter out all needs coming from external
 needs_builder_filter = "True"
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/role_need_doc/conf.py
+++ b/tests/doc_test/role_need_doc/conf.py
@@ -53,7 +53,7 @@ needs_external_needs = [
 # Needed to export really ALL needs. The default entry would filter out all needs coming from external
 needs_builder_filter = "True"
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/service_doc/conf.py
+++ b/tests/doc_test/service_doc/conf.py
@@ -60,7 +60,9 @@ needs_services = {
 }
 
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/service_doc/conf.py
+++ b/tests/doc_test/service_doc/conf.py
@@ -60,7 +60,7 @@ needs_services = {
 }
 
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/title_from_content/conf.py
+++ b/tests/doc_test/title_from_content/conf.py
@@ -35,7 +35,7 @@ needs_title_from_content = True
 needs_max_title_length = 50
 smartquotes_action = "qD"
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/title_from_content/conf.py
+++ b/tests/doc_test/title_from_content/conf.py
@@ -35,7 +35,9 @@ needs_title_from_content = True
 needs_max_title_length = 50
 smartquotes_action = "qD"
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/title_optional/conf.py
+++ b/tests/doc_test/title_optional/conf.py
@@ -35,7 +35,7 @@ needs_title_optional = True
 needs_max_title_length = 50
 smartquotes_action = "qD"
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/title_optional/conf.py
+++ b/tests/doc_test/title_optional/conf.py
@@ -35,7 +35,9 @@ needs_title_optional = True
 needs_max_title_length = 50
 smartquotes_action = "qD"
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/unicode_support/conf.py
+++ b/tests/doc_test/unicode_support/conf.py
@@ -42,7 +42,7 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/unicode_support/conf.py
+++ b/tests/doc_test/unicode_support/conf.py
@@ -42,7 +42,9 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/variant_doc/conf.py
+++ b/tests/doc_test/variant_doc/conf.py
@@ -55,7 +55,7 @@ needs_extra_options = [
 ]
 
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/variant_doc/conf.py
+++ b/tests/doc_test/variant_doc/conf.py
@@ -55,7 +55,9 @@ needs_extra_options = [
 ]
 
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/variant_options/conf.py
+++ b/tests/doc_test/variant_options/conf.py
@@ -55,7 +55,7 @@ needs_extra_options = [
 ]
 
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/doc_test/variant_options/conf.py
+++ b/tests/doc_test/variant_options/conf.py
@@ -55,7 +55,9 @@ needs_extra_options = [
 ]
 
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(os.path.dirname(__file__), "..", "utils", "plantuml.jar")
+plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
+    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
+)
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
This makes it easier to run the test suite,
since it inhibits window focus switching