### PR TITLE
🔧 Make mypy pre-commit hook isolated

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,20 +50,9 @@ jobs:
     name: Lint
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3.5.3
-      - name: Set Up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.10"
-      - name: Install/Update  build dependencies
-        run: |
-          python -m pip install --upgrade setuptools
-          python -m pip install --upgrade pip
-      - name: Install Poetry
-        run: |
-          curl -sL https://install.python-poetry.org | python -
-      - name: Update Pip
-        run: poetry run pip install -U pip setuptools
-      - name: Install Dependencies
-        run: poetry install
-      - uses: pre-commit/action@v3.0.0
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.8'
+    - uses: pre-commit/action@v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,14 +26,16 @@ repos:
         args:
           - --py36-plus
 
-  - repo: local
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.5.1
     hooks:
-      - id: mypy
-        name: mypy
-        entry: poetry run mypy
-        language: system
-        require_serial: true
-        pass_filenames: false
+    - id: mypy
+      files: sphinx_needs/.*
+      args: []
+      additional_dependencies:
+      - sphinx==6
+      - types-docutils
+      - types-requests
 
   - repo: https://github.com/python-poetry/poetry
     rev: 1.5.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,13 +81,18 @@ line-length = 120
 profile = "black"
 
 [tool.mypy]
+files = "sphinx_needs"
 strict = true
 show_error_codes = true
 implicit_reexport = true
-files = "sphinx_needs"
-ignore_missing_imports = true
 namespace_packages = true
-warn_unused_ignores = false
+
+[[tool.mypy.overrides]]
+module = [
+  "requests_file",
+  "sphinx_data_viewer.*"
+]
+ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = [

--- a/sphinx_needs/directives/list2need.py
+++ b/sphinx_needs/directives/list2need.py
@@ -27,7 +27,7 @@ OPTION_AREA_REGEX = re.compile(r"\(\((.*)\)\)")
 OPTIONS_REGEX = re.compile(r"([^=,\s]*)=[\"']([^\"]*)[\"']")
 
 
-class List2Need(nodes.General, nodes.Element):  # type: ignore
+class List2Need(nodes.General, nodes.Element):
     pass
 
 

--- a/sphinx_needs/directives/needimport.py
+++ b/sphinx_needs/directives/needimport.py
@@ -18,7 +18,7 @@ from sphinx_needs.needsfile import check_needs_file
 from sphinx_needs.utils import add_doc, logger
 
 
-class Needimport(nodes.General, nodes.Element):  # type: ignore
+class Needimport(nodes.General, nodes.Element):
     pass
 
 

--- a/sphinx_needs/directives/needservice.py
+++ b/sphinx_needs/directives/needservice.py
@@ -15,7 +15,7 @@ from sphinx_needs.services.base import BaseService
 from sphinx_needs.utils import add_doc, unwrap
 
 
-class Needservice(nodes.General, nodes.Element):  # type: ignore
+class Needservice(nodes.General, nodes.Element):
     pass
 
 

--- a/sphinx_needs/nodes/__init__.py
+++ b/sphinx_needs/nodes/__init__.py
@@ -1,7 +1,7 @@
 from docutils import nodes
 
 
-class Need(nodes.General, nodes.Element):  # type: ignore
+class Need(nodes.General, nodes.Element):
     """
     Node for containing a complete need.
     Node structure:


### PR DESCRIPTION
This makes it easier to run pre-commit in isolation, with no system dependencies other than pre-commit itself.

It also means in principle we can set up https://pre-commit.ci/