### PR TITLE
🐛 FIX: `NeedImport` logic

### DIFF
--- a/sphinx_needs/directives/need.py
+++ b/sphinx_needs/directives/need.py
@@ -548,7 +548,7 @@ def remove_hidden_needs(app: Sphinx, doctree: nodes.document, fromdocname: str) 
     """Remove hidden needs from the doctree, before it is rendered."""
     if fromdocname not in SphinxNeedsData(app.env).get_or_create_docs().get("all", []):
         return
-    for node_need in doctree.findall(Need):
+    for node_need in list(doctree.findall(Need)):
         if node_need.get("hidden"):
             node_need.parent.remove(node_need)  # type: ignore
 


### PR DESCRIPTION
@danwos unless I am missing something (?) I think this is broken, since `getattr` is used on a dictionary, instead of `dict.get`, so they will always return the default `None`.

Also improved efficiency, by using `json.load` instead of `json.loads`, and not recreating the `known_options` list within a loop