### PR TITLE
🐛 Fix creation of need title nodes

### DIFF
--- a/sphinx_needs/layout.py
+++ b/sphinx_needs/layout.py
@@ -493,7 +493,6 @@ class LayoutHandler:
         :param show_empty: If false and requested need-value is None or '', no output is returned. Default: false
         :return: docutils node
         """
-
         data_container = nodes.inline(classes=["needs_" + name])
         if prefix:
             prefix_node = self._parse(prefix)
@@ -513,16 +512,16 @@ class LayoutHandler:
         if isinstance(data, str):
             if len(data) == 0 and not show_empty:
                 return []
-            # data_node = nodes.inline(classes=["needs_data"])
-            # data_node.append(nodes.Text(data)
-            # data_container.append(data_node)
+
             needs_string_links_option: List[str] = []
             for v in self.needs_config.string_links.values():
                 needs_string_links_option.extend(v["options"])
 
-            if name in needs_string_links_option:
-                data = re.split(r",|;", data)
-                data = [i.strip() for i in data if len(i) != 0]
+            data_list: List[str] = (
+                [i.strip() for i in re.split(r",|;", data) if len(i) != 0]
+                if name in needs_string_links_option
+                else [data]
+            )
 
             matching_link_confs = []
             for link_conf in self.string_links.values():
@@ -530,7 +529,7 @@ class LayoutHandler:
                     matching_link_confs.append(link_conf)
 
             data_node = nodes.inline(classes=["needs_data"])
-            for index, datum in enumerate(data):
+            for index, datum in enumerate(data_list):
                 if matching_link_confs:
                     data_node += match_string_link(
                         text_item=datum,
@@ -544,7 +543,7 @@ class LayoutHandler:
                     ref_item = nodes.Text(datum)
                     data_node += ref_item
 
-                if (isinstance(data, list) and index + 1 < len(data)) or index + 1 < len([data]):
+                if (name in needs_string_links_option and index + 1 < len(data)) or index + 1 < len([data]):
                     data_node += nodes.emphasis("; ", "; ")
 
             data_container.append(data_node)


### PR DESCRIPTION
Previously the logic was mistakenly looping over every character of the string, and so creating a `Text` node per character, rather than a single `Text` node for the full title string.