### PR TITLE
Fixed extra links example

### DIFF
--- a/docs/directives/need.rst
+++ b/docs/directives/need.rst
@@ -358,10 +358,12 @@ By using :ref:`needs_extra_links <needs_extra_links>`, you can use the configure
       {
          "option": "blocks",
          "incoming": "is blocked by",
+         "outgoing": "blocks"
       },
       {
          "option": "tests",
          "incoming": "is tested by",
+         "outgoing": "tests",
          "copy": False,
          "color": "#00AA00"
       }


### PR DESCRIPTION
## PR description
This PR fixes [extra links field example](https://sphinx-needs.readthedocs.io/en/latest/directives/need.html#extra-links) in the docs.

## Why is it needed?
Documentation describing [need/req's extra links](https://sphinx-needs.readthedocs.io/en/latest/directives/need.html#extra-links) has an incorrect example - `outgoing` dictionary entry is missing:

```
# conf.py
needs_extra_links = [
   {
      "option": "blocks",
      "incoming": "is blocked by",
   },
   {
      "option": "tests",
      "incoming": "is tested by",
      "copy": False,
      "color": "#00AA00"
   }
]
```

When used it causes this error:
```
Extension error (sphinx_needs.directives.need):
Handler <function process_need_nodes at 0x7f5d5123e9e0> for event 'doctree-resolved' threw an exception (exception: 'outgoing')
```
Documentation of `needs_extra_links` ([here](https://sphinx-needs.readthedocs.io/en/latest/configuration.html#needs-extra-links)) states that the `outgoing` field is necessary and the example above is unnecessarily misleading.
