### PR TITLE
👌 Optimize needextend filter_needs usage

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,12 +16,13 @@ Released: under development
 -----
 Released: under development
 * Improvement: Added Builder :ref:`needs_id_builder` added and config option :ref:`needs_build_json_per_id` in `conf.py`. 
-
-* Improvement: Reduce document build time, by memoizing the inline parse in ``build_need`` (`#968 <https://github.com/useblocks/sphinx-needs/pull/968>`_)
-
-* Change `NeedsBuilder` format to `needs` (`#978 <https://github.com/useblocks/sphinx-needs/pull/978>`_)
-
-* Improvement: Suffix all warnings with ``[needs]``, and allow them to be suppressed (`#975 <https://github.com/useblocks/sphinx-needs/pull/975>`_)
+* Improvement: Reduce document build time, by memoizing the inline parse in ``build_need``
+  (`#968 <https://github.com/useblocks/sphinx-needs/pull/968>`_)
+* Change `NeedsBuilder` format to `needs`
+  (`#978 <https://github.com/useblocks/sphinx-needs/pull/978>`_)
+* Improvement: Suffix all warnings with ``[needs]``, and allow them to be suppressed
+  (`#975 <https://github.com/useblocks/sphinx-needs/pull/975>`_)
+* Improvement: :ref:`needextend` for single needs is much faster.
 
 1.3.0
 -----

--- a/sphinx_needs/directives/needextend.py
+++ b/sphinx_needs/directives/needextend.py
@@ -97,7 +97,7 @@ def process_needextend(app: Sphinx, doctree: nodes.document, fromdocname: str) -
             # In this case create the needed filter string
             need_filter = current_needextend["filter"]
             if need_filter in all_needs:
-                need_filter = f'id == "{need_filter}"'
+                found_needs = [all_needs[need_filter]]
             # If it looks like a need id, but we haven't found one, raise an exception
             elif need_filter is not None and re.fullmatch(needs_config.id_regex, need_filter):
                 error = f"Provided id {need_filter} for needextend does not exist."
@@ -106,12 +106,13 @@ def process_needextend(app: Sphinx, doctree: nodes.document, fromdocname: str) -
                 else:
                     logger.info(error)
                     continue
-            try:
-                found_needs = filter_needs(app, all_needs.values(), need_filter)
-            except NeedsInvalidFilter as e:
-                raise NeedsInvalidFilter(
-                    f"Filter not valid for needextend on page {current_needextend['docname']}:\n{e}"
-                )
+            else:
+                try:
+                    found_needs = filter_needs(app, all_needs.values(), need_filter)
+                except NeedsInvalidFilter as e:
+                    raise NeedsInvalidFilter(
+                        f"Filter not valid for needextend on page {current_needextend['docname']}:\n{e}"
+                    )
 
             for found_need in found_needs:
                 # Work in the stored needs, not on the search result


### PR DESCRIPTION
Instead of using `filter_needs()` for a single need (`id == ""XY`) , the need is taken directly from `all_needs`, so that we do not need to perform any filtering.