### PR TITLE
🔧 Consolidate needs data post-processing

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -257,7 +257,7 @@ The following is an outline of the build events which this extension adds to the
    - Check for dead links (``process_need_nodes -> check_links``)
    - Generate back links (``process_need_nodes -> create_back_links``)
    - Process constraints, for each ``Need`` node (``process_need_nodes -> process_constraints``)
-   - Perform all modifications on need data items, due to ``Needextend`` nodes (``process_need_nodes -> process_needextend``)
+   - Perform all modifications on need data items, due to ``Needextend`` nodes (``process_need_nodes -> extend_needs_data``)
    - Format each ``Need`` node to give the desired visual output (``process_need_nodes -> print_need_nodes``)
    - Process all other need specific nodes, replacing them with the desired visual output (``process_creator``)
 

--- a/sphinx_needs/data.py
+++ b/sphinx_needs/data.py
@@ -30,23 +30,6 @@ class NeedsFilterType(TypedDict):
     amount: int
 
 
-class NeedsWorkflowType(TypedDict):
-    """
-    Used to store workflow status information for already executed tasks.
-    Some tasks like backlink_creation need be performed only once.
-    But most sphinx-events get called several times (for each single document file),
-    which would also execute our code several times...
-    """
-
-    backlink_creation_links: bool
-    dynamic_values_resolved: bool
-    links_checked: bool
-    add_sections: bool
-    variant_option_resolved: bool
-    needs_extended: bool
-    needs_constraints: bool
-
-
 class NeedsBaseDataType(TypedDict):
     """A base type for all data."""
 
@@ -448,27 +431,18 @@ class SphinxNeedsData:
             self.env.needs_all_docs = {"all": []}
         return self.env.needs_all_docs
 
-    def get_or_create_workflow(self) -> NeedsWorkflowType:
-        """Get workflow information.
-
-        This is lazily created and cached in the environment.
-        """
+    @property
+    def needs_is_post_processed(self) -> bool:
+        """Whether needs have been post-processed."""
         try:
-            return self.env.needs_workflow
+            return self.env.needs_is_post_processed
         except AttributeError:
-            self.env.needs_workflow = {
-                "backlink_creation_links": False,
-                "dynamic_values_resolved": False,
-                "links_checked": False,
-                "add_sections": False,
-                "variant_option_resolved": False,
-                "needs_extended": False,
-                "needs_constraints": False,
-            }
-            for link_type in self.env.app.config.needs_extra_links:
-                self.env.needs_workflow["backlink_creation_{}".format(link_type["option"])] = False
+            self.env.needs_is_post_processed = False
+        return self.env.needs_is_post_processed
 
-        return self.env.needs_workflow  # type: ignore[return-value]
+    @needs_is_post_processed.setter
+    def needs_is_post_processed(self, value: bool) -> None:
+        self.env.needs_is_post_processed = value
 
     def get_or_create_services(self) -> ServiceManager:
         """Get information about services.

--- a/sphinx_needs/directives/needextend.py
+++ b/sphinx_needs/directives/needextend.py
@@ -71,132 +71,119 @@ class NeedextendDirective(SphinxDirective):
         return [targetnode, Needextend("")]
 
 
-def process_needextend(app: Sphinx, doctree: nodes.document, fromdocname: str) -> None:
-    """
-    Perform all modifications on needs
-    """
+def extend_needs_data(app: Sphinx) -> None:
+    """Use data gathered from needextend directives to modify fields of existing needs."""
     env = app.env
     needs_config = NeedsSphinxConfig(env.config)
     data = SphinxNeedsData(env)
-    workflow = data.get_or_create_workflow()
 
-    if not workflow["needs_extended"]:
-        workflow["needs_extended"] = True
+    list_values = (
+        ["tags", "links"]
+        + [x["option"] for x in needs_config.extra_links]
+        + [f"{x['option']}_back" for x in needs_config.extra_links]
+    )  # back-links (incoming)
+    link_names = [x["option"] for x in needs_config.extra_links]
 
-        list_values = (
-            ["tags", "links"]
-            + [x["option"] for x in needs_config.extra_links]
-            + [f"{x['option']}_back" for x in needs_config.extra_links]
-        )  # back-links (incoming)
-        link_names = [x["option"] for x in needs_config.extra_links]
+    all_needs = data.get_or_create_needs()
 
-        all_needs = data.get_or_create_needs()
-
-        for current_needextend in data.get_or_create_extends().values():
-            need_filter = current_needextend["filter"]
-            if need_filter in all_needs:
-                # a single known ID
-                found_needs = [all_needs[need_filter]]
-            elif need_filter is not None and re.fullmatch(needs_config.id_regex, need_filter):
-                # an unknown ID
-                error = f"Provided id {need_filter} for needextend does not exist."
-                if current_needextend["strict"]:
-                    raise NeedsInvalidFilter(error)
-                else:
-                    logger.info(error)
-                    continue
+    for current_needextend in data.get_or_create_extends().values():
+        need_filter = current_needextend["filter"]
+        if need_filter in all_needs:
+            # a single known ID
+            found_needs = [all_needs[need_filter]]
+        elif need_filter is not None and re.fullmatch(needs_config.id_regex, need_filter):
+            # an unknown ID
+            error = f"Provided id {need_filter} for needextend does not exist."
+            if current_needextend["strict"]:
+                raise NeedsInvalidFilter(error)
             else:
-                # a filter string
-                try:
-                    found_needs = filter_needs(app, all_needs.values(), need_filter)
-                except NeedsInvalidFilter as e:
-                    raise NeedsInvalidFilter(
-                        f"Filter not valid for needextend on page {current_needextend['docname']}:\n{e}"
-                    )
+                logger.info(error)
+                continue
+        else:
+            # a filter string
+            try:
+                found_needs = filter_needs(app, all_needs.values(), need_filter)
+            except NeedsInvalidFilter as e:
+                raise NeedsInvalidFilter(
+                    f"Filter not valid for needextend on page {current_needextend['docname']}:\n{e}"
+                )
 
-            for found_need in found_needs:
-                # Work in the stored needs, not on the search result
-                need = all_needs[found_need["id"]]
-                need["is_modified"] = True
-                need["modifications"] += 1
+        for found_need in found_needs:
+            # Work in the stored needs, not on the search result
+            need = all_needs[found_need["id"]]
+            need["is_modified"] = True
+            need["modifications"] += 1
 
-                for option, value in current_needextend["modifications"].items():
-                    if option.startswith("+"):
-                        option_name = option[1:]
-                        if option_name in link_names:
-                            # If we add links, then add all corresponding back links
-                            for ref_need in [i.strip() for i in re.split(";|,", value)]:
-                                if ref_need not in all_needs:
-                                    logger.warning(
-                                        f"Provided link id {ref_need} for needextend does not exist. [needs]",
-                                        type="needs",
-                                        location=(current_needextend["docname"], current_needextend["lineno"]),
-                                    )
-                                    continue
-                                if ref_need not in need[option_name]:
-                                    need[option_name].append(ref_need)
-                                if found_need["id"] not in all_needs[ref_need][f"{option_name}_back"]:
-                                    all_needs[ref_need][f"{option_name}_back"] += [found_need["id"]]
-                        elif option_name in list_values:
-                            for item in [i.strip() for i in re.split(";|,", value)]:
-                                if item not in need[option_name]:
-                                    need[option_name].append(item)
-                        else:
-                            if need[option_name]:
-                                # If content is already stored, we need to add some whitespace
-                                need[option_name] += " "
-                            need[option_name] += value
-
-                    elif option.startswith("-"):
-                        option_name = option[1:]
-                        if option_name in link_names:
-                            # If we remove links, then remove all corresponding back links
-                            for ref_need in (i for i in need[option_name] if i in all_needs):
-                                all_needs[ref_need][f"{option_name}_back"].remove(found_need["id"])
-                            need[option_name] = []
-                        if option_name in list_values:
-                            need[option_name] = []
-                        else:
-                            need[option_name] = ""
+            for option, value in current_needextend["modifications"].items():
+                if option.startswith("+"):
+                    option_name = option[1:]
+                    if option_name in link_names:
+                        # If we add links, then add all corresponding back links
+                        for ref_need in [i.strip() for i in re.split(";|,", value)]:
+                            if ref_need not in all_needs:
+                                logger.warning(
+                                    f"Provided link id {ref_need} for needextend does not exist. [needs]",
+                                    type="needs",
+                                    location=(current_needextend["docname"], current_needextend["lineno"]),
+                                )
+                                continue
+                            if ref_need not in need[option_name]:
+                                need[option_name].append(ref_need)
+                            if found_need["id"] not in all_needs[ref_need][f"{option_name}_back"]:
+                                all_needs[ref_need][f"{option_name}_back"] += [found_need["id"]]
+                    elif option_name in list_values:
+                        for item in [i.strip() for i in re.split(";|,", value)]:
+                            if item not in need[option_name]:
+                                need[option_name].append(item)
                     else:
-                        if option in link_names:
-                            # If we change links, then modify all corresponding back links
-                            for ref_need in (i for i in need[option] if i in all_needs):
-                                all_needs[ref_need][f"{option}_back"].remove(found_need["id"])
-                            need[option] = []
-                            for ref_need in [i.strip() for i in re.split(";|,", value)]:
-                                if ref_need not in all_needs:
-                                    logger.warning(
-                                        f"Provided link id {ref_need} for needextend does not exist. [needs]",
-                                        type="needs",
-                                        location=(current_needextend["docname"], current_needextend["lineno"]),
-                                    )
-                                    continue
-                                need[option].append(ref_need)
-                            for ref_need in need[option]:
-                                if found_need["id"] not in all_needs[ref_need][f"{option}_back"]:
-                                    all_needs[ref_need][f"{option}_back"] += [found_need["id"]]
-                        elif option in list_values:
-                            need[option] = [i.strip() for i in re.split(";|,", value)]
-                        else:
-                            need[option] = value
+                        if need[option_name]:
+                            # If content is already stored, we need to add some whitespace
+                            need[option_name] += " "
+                        need[option_name] += value
 
-    for node in doctree.findall(Needextend):
-        # No printouts for needextend
-        removed_needextend_node(node)
+                elif option.startswith("-"):
+                    option_name = option[1:]
+                    if option_name in link_names:
+                        # If we remove links, then remove all corresponding back links
+                        for ref_need in (i for i in need[option_name] if i in all_needs):
+                            all_needs[ref_need][f"{option_name}_back"].remove(found_need["id"])
+                        need[option_name] = []
+                    if option_name in list_values:
+                        need[option_name] = []
+                    else:
+                        need[option_name] = ""
+                else:
+                    if option in link_names:
+                        # If we change links, then modify all corresponding back links
+                        for ref_need in (i for i in need[option] if i in all_needs):
+                            all_needs[ref_need][f"{option}_back"].remove(found_need["id"])
+                        need[option] = []
+                        for ref_need in [i.strip() for i in re.split(";|,", value)]:
+                            if ref_need not in all_needs:
+                                logger.warning(
+                                    f"Provided link id {ref_need} for needextend does not exist. [needs]",
+                                    type="needs",
+                                    location=(current_needextend["docname"], current_needextend["lineno"]),
+                                )
+                                continue
+                            need[option].append(ref_need)
+                        for ref_need in need[option]:
+                            if found_need["id"] not in all_needs[ref_need][f"{option}_back"]:
+                                all_needs[ref_need][f"{option}_back"] += [found_need["id"]]
+                    elif option in list_values:
+                        need[option] = [i.strip() for i in re.split(";|,", value)]
+                    else:
+                        need[option] = value
 
 
-def removed_needextend_node(node: Needextend) -> None:
+def remove_needextend_node(node: Needextend) -> None:
     """
-    # Remove needextend from docutils node-tree, so that no output gets generated for it.
-    # Ok, this is really dirty.
-    # If we replace a node, docutils checks, if it will not lose any attributes.
-    # But this is here the case, because we are using the attribute "ids" of a node.
-    # However, I do not understand, why losing an attribute is such a big deal, so we delete everything
-    # before docutils claims about it.
-
-    :param node:
-    :return:
+    Remove needextend from docutils node-tree, so that no output gets generated for it.
+    Ok, this is really dirty.
+    If we replace a node, docutils checks, if it will not lose any attributes.
+    But this is here the case, because we are using the attribute "ids" of a node.
+    However, I do not understand, why losing an attribute is such a big deal, so we delete everything
+    before docutils claims about it.
     """
 
     for att in ("ids", "names", "classes", "dupnames"):

--- a/sphinx_needs/need_constraints.py
+++ b/sphinx_needs/need_constraints.py
@@ -13,19 +13,17 @@ logger = get_logger(__name__)
 
 
 def process_constraints(app: Sphinx) -> None:
-    """Analyse constraints of a single need,
-    and set corresponding fields on the need data item.
+    """Analyse constraints of all needs,
+    and set corresponding fields on the need data item:
+    ``constraints_passed`` and ``constraints_results``.
+
+    The ``style`` field may also be changed, if a constraint fails
+    (depending on the config value ``constraint_failed_options``)
     """
     env = app.env
     needs_config = NeedsSphinxConfig(env.config)
     config_constraints = needs_config.constraints
     needs = SphinxNeedsData(env).get_or_create_needs()
-    workflow = SphinxNeedsData(env).get_or_create_workflow()
-
-    if workflow["needs_constraints"]:
-        return
-
-    workflow["needs_constraints"] = True
 
     error_templates_cache: Dict[str, jinja2.Template] = {}
 

--- a/sphinx_needs/needs.py
+++ b/sphinx_needs/needs.py
@@ -489,8 +489,6 @@ def prepare_env(app: Sphinx, env: BuildEnvironment, _docname: str) -> None:
 
     needs_config.flow_configs.update(NEEDFLOW_CONFIG_DEFAULTS)
 
-    data.get_or_create_workflow()
-
     # Set time measurement flag
     if needs_config.debug_measurement:
         debug.START_TIME = timer()  # Store the rough start time of Sphinx build


### PR DESCRIPTION
This PR is a step towards #1018, and being able to generate the `needs.json` without running the Sphinx `BUILD` phase.

Here we consolidate all functions that post-process the needs data, after it has been fully extracted from all documents and external sources.
We remove the individual logic from within these functions, to check if the post-processing has already been done, and instead check before running all the functions.

This refactor does not actually change the sphinx-needs process in any way, this will come in later PRs
