### PR TITLE
♻️ Refactor needs post-processing function signatures

### DIFF
--- a/sphinx_needs/api/need.py
+++ b/sphinx_needs/api/need.py
@@ -746,6 +746,7 @@ def _merge_global_options(app: Sphinx, needs_info, global_options) -> None:
     """Add all global defined options to needs_info"""
     if global_options is None:
         return
+    config = NeedsSphinxConfig(app.config)
     for key, value in global_options.items():
         # If key already exists in needs_info, this global_option got overwritten manually in current need
         if key in needs_info and needs_info[key]:
@@ -762,7 +763,7 @@ def _merge_global_options(app: Sphinx, needs_info, global_options) -> None:
         for single_value in values:
             if len(single_value) < 2 or len(single_value) > 3:
                 raise NeedsInvalidException(f"global option tuple has wrong amount of parameters: {key}")
-            if filter_single_need(app, needs_info, single_value[1]):
+            if filter_single_need(needs_info, config, single_value[1]):
                 # Set value, if filter has matched
                 needs_info[key] = single_value[0]
             elif len(single_value) == 3 and (key not in needs_info.keys() or len(str(needs_info[key])) > 0):

--- a/sphinx_needs/builder.py
+++ b/sphinx_needs/builder.py
@@ -48,7 +48,9 @@ class NeedsBuilder(Builder):
         from sphinx_needs.filter_common import filter_needs
 
         filter_string = needs_config.builder_filter
-        filtered_needs: List[NeedsInfoType] = filter_needs(self.app, data.get_or_create_needs().values(), filter_string)
+        filtered_needs: List[NeedsInfoType] = filter_needs(
+            data.get_or_create_needs().values(), needs_config, filter_string
+        )
 
         for need in filtered_needs:
             needs_list.add_need(version, need)
@@ -181,7 +183,7 @@ class NeedsIdBuilder(Builder):
         filter_string = needs_config.builder_filter
         from sphinx_needs.filter_common import filter_needs
 
-        filtered_needs = filter_needs(self.app, needs, filter_string)
+        filtered_needs = filter_needs(needs, needs_config, filter_string)
         needs_build_json_per_id_path = needs_config.build_json_per_id_path
         needs_dir = os.path.join(self.outdir, needs_build_json_per_id_path)
         if not os.path.exists(needs_dir):

--- a/sphinx_needs/config.py
+++ b/sphinx_needs/config.py
@@ -87,6 +87,8 @@ class NeedsSphinxConfig:
         super().__setattr__("_config", config)
 
     def __getattribute__(self, name: str) -> Any:
+        if name.startswith("__"):
+            return super().__getattribute__(name)
         return getattr(super().__getattribute__("_config"), f"needs_{name}")
 
     def __setattr__(self, name: str, value: Any) -> None:

--- a/sphinx_needs/directives/needbar.py
+++ b/sphinx_needs/directives/needbar.py
@@ -271,7 +271,7 @@ def process_needbar(app: Sphinx, doctree: nodes.document, fromdocname: str, foun
                 if element.isdigit():
                     line_number.append(float(element))
                 else:
-                    result = len(filter_needs(app, need_list, element))
+                    result = len(filter_needs(need_list, needs_config, element))
                     line_number.append(float(result))
             local_data_number.append(line_number)
 

--- a/sphinx_needs/directives/needflow.py
+++ b/sphinx_needs/directives/needflow.py
@@ -130,7 +130,9 @@ def get_need_node_rep_for_plantuml(
         # We set # later, as the user may not have given a color and the node must get highlighted
         node_colors.append(need_info["type_color"].replace("#", ""))
 
-    if current_needflow["highlight"] and filter_single_need(app, need_info, current_needflow["highlight"], all_needs):
+    if current_needflow["highlight"] and filter_single_need(
+        need_info, needs_config, current_needflow["highlight"], all_needs
+    ):
         node_colors.append("line:FF0000")
 
     # need parts style use default "rectangle"

--- a/sphinx_needs/directives/needgantt.py
+++ b/sphinx_needs/directives/needgantt.py
@@ -214,7 +214,7 @@ def process_needgantt(app: Sphinx, doctree: nodes.document, fromdocname: str, fo
             complete = None
 
             if current_needgantt["milestone_filter"]:
-                is_milestone = filter_single_need(app, need, current_needgantt["milestone_filter"])
+                is_milestone = filter_single_need(need, needs_config, current_needgantt["milestone_filter"])
             else:
                 is_milestone = False
 
@@ -259,7 +259,7 @@ def process_needgantt(app: Sphinx, doctree: nodes.document, fromdocname: str, fo
         puml_node["uml"] += "\n' Constraints definition \n\n"
         for need in found_needs:
             if current_needgantt["milestone_filter"]:
-                is_milestone = filter_single_need(app, need, current_needgantt["milestone_filter"])
+                is_milestone = filter_single_need(need, needs_config, current_needgantt["milestone_filter"])
             else:
                 is_milestone = False
             for con_type in ("starts_with_links", "starts_after_links", "ends_with_links"):

--- a/sphinx_needs/directives/needimport.py
+++ b/sphinx_needs/directives/needimport.py
@@ -123,6 +123,7 @@ class NeedimportDirective(SphinxDirective):
         if version not in needs_import_list["versions"].keys():
             raise VersionNotFound(f"Version {version} not found in needs import file {correct_need_import_path}")
 
+        needs_config = NeedsSphinxConfig(self.config)
         # TODO this is not exactly NeedsInfoType, because the export removes/adds some keys
         needs_list: Dict[str, NeedsInfoType] = needs_import_list["versions"][version]["needs"]
 
@@ -138,7 +139,7 @@ class NeedimportDirective(SphinxDirective):
                 # "content" is the sphinx internal name for this kind of information
                 filter_context["content"] = need["description"]  # type: ignore[typeddict-item]
                 try:
-                    if filter_single_need(self.env.app, filter_context, filter_string):
+                    if filter_single_need(filter_context, needs_config, filter_string):
                         needs_list_filtered[key] = need
                 except Exception as e:
                     logger.warning(
@@ -152,7 +153,7 @@ class NeedimportDirective(SphinxDirective):
         needs_list = needs_list_filtered
 
         # If we need to set an id prefix, we also need to manipulate all used ids in the imported data.
-        extra_links = NeedsSphinxConfig(self.config).extra_links
+        extra_links = needs_config.extra_links
         if id_prefix:
             for need in needs_list.values():
                 for id in needs_list:

--- a/sphinx_needs/directives/needpie.py
+++ b/sphinx_needs/directives/needpie.py
@@ -111,9 +111,10 @@ class NeedpieDirective(FilterBase):
 def process_needpie(app: Sphinx, doctree: nodes.document, fromdocname: str, found_nodes: List[nodes.Element]) -> None:
     env = app.env
     needs_data = SphinxNeedsData(env)
+    needs_config = NeedsSphinxConfig(env.config)
 
     # NEEDFLOW
-    include_needs = NeedsSphinxConfig(env.config).include_needs
+    include_needs = needs_config.include_needs
     # for node in doctree.findall(Needpie):
     for node in found_nodes:
         if not include_needs:
@@ -146,7 +147,7 @@ def process_needpie(app: Sphinx, doctree: nodes.document, fromdocname: str, foun
                 if line.isdigit():
                     sizes.append(abs(float(line)))
                 else:
-                    result = len(filter_needs(app, need_list, line))
+                    result = len(filter_needs(need_list, needs_config, line))
                     sizes.append(result)
         elif current_needpie["filter_func"] and not content:
             try:

--- a/sphinx_needs/directives/needsequence.py
+++ b/sphinx_needs/directives/needsequence.py
@@ -259,7 +259,9 @@ def get_message_needs(
                 if filter:
                     from sphinx_needs.filter_common import filter_single_need
 
-                    if not filter_single_need(app, all_needs_dict[rec_id], filter, needs=all_needs_dict.values()):
+                    if not filter_single_need(
+                        all_needs_dict[rec_id], NeedsSphinxConfig(app.config), filter, needs=all_needs_dict.values()
+                    ):
                         continue
 
                 rec_data = {"id": rec_id, "title": all_needs_dict[rec_id]["title"], "messages": []}

--- a/sphinx_needs/directives/needuml.py
+++ b/sphinx_needs/directives/needuml.py
@@ -350,8 +350,9 @@ class JinjaFunctions:
         """
         Return a list of found needs that pass the given filter string.
         """
+        needs_config = NeedsSphinxConfig(self.app.config)
 
-        return filter_needs(self.app, list(self.needs.values()), filter_string=filter_string)
+        return filter_needs(list(self.needs.values()), needs_config, filter_string=filter_string)
 
     def imports(self, *args):
         if not self.parent_need_id:

--- a/sphinx_needs/filter_common.py
+++ b/sphinx_needs/filter_common.py
@@ -102,6 +102,7 @@ def process_filters(
 
     :return: list of needs, which passed the filters
     """
+    needs_config = NeedsSphinxConfig(app.config)
     found_needs: list[NeedsPartsInfoType]
     sort_key = filter_data["sort_by"]
     if sort_key:
@@ -156,13 +157,13 @@ def process_filters(
                 if status_filter_passed and tags_filter_passed and type_filter_passed:
                     found_needs_by_options.append(need_info)
             # Get need by filter string
-            found_needs_by_string = filter_needs(app, all_needs_incl_parts, filter_data["filter"])
+            found_needs_by_string = filter_needs(all_needs_incl_parts, needs_config, filter_data["filter"])
             # Make an intersection of both lists
             found_needs = intersection_of_need_results(found_needs_by_options, found_needs_by_string)
         else:
             # There is no other config as the one for filter string.
             # So we only need this result.
-            found_needs = filter_needs(app, all_needs_incl_parts, filter_data["filter"])
+            found_needs = filter_needs(all_needs_incl_parts, needs_config, filter_data["filter"])
     else:
         # Provides only a copy of needs to avoid data manipulations.
         context = {
@@ -192,7 +193,7 @@ def process_filters(
         found_needs = []
 
         # Check if config allow unsafe filters
-        if NeedsSphinxConfig(app.config).allow_unsafe_filters:
+        if needs_config.allow_unsafe_filters:
             found_needs = found_dirty_needs
         else:
             # Just take the ids from search result and use the related, but original need
@@ -203,8 +204,7 @@ def process_filters(
 
     # Store basic filter configuration and result global list.
     # Needed mainly for exporting the result to needs.json (if builder "needs" is used).
-    env = app.env
-    filter_list = SphinxNeedsData(env).get_or_create_filters()
+    filter_list = SphinxNeedsData(app.env).get_or_create_filters()
     found_needs_ids = [need["id_complete"] for need in found_needs]
 
     filter_list[filter_data["target_id"]] = {
@@ -258,8 +258,8 @@ V = TypeVar("V", bound=NeedsInfoType)
 
 @measure_time("filtering")
 def filter_needs(
-    app: Sphinx,
     needs: Iterable[V],
+    config: NeedsSphinxConfig,
     filter_string: None | str = "",
     current_need: NeedsInfoType | None = None,
 ) -> list[V]:
@@ -267,14 +267,13 @@ def filter_needs(
     Filters given needs based on a given filter string.
     Returns all needs, which pass the given filter.
 
-    :param app: Sphinx application object
     :param needs: list of needs, which shall be filtered
+    :param config: NeedsSphinxConfig object
     :param filter_string: strings, which gets evaluated against each need
     :param current_need: current need, which uses the filter.
 
     :return: list of found needs
     """
-
     if not filter_string:
         return list(needs)
 
@@ -286,7 +285,7 @@ def filter_needs(
     for filter_need in needs:
         try:
             if filter_single_need(
-                app, filter_need, filter_string, needs, current_need, filter_compiled=filter_compiled
+                filter_need, config, filter_string, needs, current_need, filter_compiled=filter_compiled
             ):
                 found_needs.append(filter_need)
         except Exception as e:
@@ -300,8 +299,8 @@ def filter_needs(
 
 @measure_time("filtering")
 def filter_single_need(
-    app: Sphinx,
     need: NeedsInfoType,
+    config: NeedsSphinxConfig,
     filter_string: str = "",
     needs: Iterable[NeedsInfoType] | None = None,
     current_need: NeedsInfoType | None = None,
@@ -310,8 +309,8 @@ def filter_single_need(
     """
     Checks if a single need/need_part passes a filter_string
 
-    :param app: Sphinx application object
-    :param current_need:
+    :param need: the data for a single need
+    :param config: NeedsSphinxConfig object
     :param filter_compiled: An already compiled filter_string to safe time
     :param need: need or need_part
     :param filter_string: string, which is used as input for eval()
@@ -327,7 +326,7 @@ def filter_single_need(
         filter_context["current_need"] = need
 
     # Get needs external filter data and merge to filter_context
-    filter_context.update(NeedsSphinxConfig(app.config).filter_data)
+    filter_context.update(config.filter_data)
 
     filter_context["search"] = re.search
     result = False

--- a/sphinx_needs/roles/need_count.py
+++ b/sphinx_needs/roles/need_count.py
@@ -10,6 +10,7 @@ from docutils import nodes
 from sphinx.application import Sphinx
 
 from sphinx_needs.api.exceptions import NeedsInvalidFilter
+from sphinx_needs.config import NeedsSphinxConfig
 from sphinx_needs.data import SphinxNeedsData
 from sphinx_needs.filter_common import filter_needs, prepare_need_list
 from sphinx_needs.logging import get_logger
@@ -24,21 +25,20 @@ class NeedCount(nodes.Inline, nodes.Element):  # type: ignore
 def process_need_count(
     app: Sphinx, doctree: nodes.document, _fromdocname: str, found_nodes: List[nodes.Element]
 ) -> None:
-    env = app.env
-    # for node_need_count in doctree.findall(NeedCount):
+    needs_config = NeedsSphinxConfig(app.config)
     for node_need_count in found_nodes:
-        all_needs = list(SphinxNeedsData(env).get_or_create_needs().values())
+        all_needs = list(SphinxNeedsData(app.env).get_or_create_needs().values())
         filter = node_need_count["reftarget"]
 
         if filter:
             filters = filter.split(" ? ")
             if len(filters) == 1:
                 need_list = prepare_need_list(all_needs)  # adds parts to need_list
-                amount = str(len(filter_needs(app, need_list, filters[0])))
+                amount = str(len(filter_needs(need_list, needs_config, filters[0])))
             elif len(filters) == 2:
                 need_list = prepare_need_list(all_needs)  # adds parts to need_list
-                amount_1 = len(filter_needs(app, need_list, filters[0]))
-                amount_2 = len(filter_needs(app, need_list, filters[1]))
+                amount_1 = len(filter_needs(need_list, needs_config, filters[0]))
+                amount_2 = len(filter_needs(need_list, needs_config, filters[1]))
                 amount = f"{amount_1 / amount_2 * 100:2.1f}"
             elif len(filters) > 2:
                 raise NeedsInvalidFilter(


### PR DESCRIPTION
This PR refactors the functions that post-process needs data, to only get passed what they actually require (rather than just `app` or `env`).
This makes it clearer what they are doing, and in all cases except `resolve_dynamic_values` effectively de-couples the post-processing from Sphinx, since you just need to pass them the needs data and needs configuration.
