### PR TITLE
👌 Remove some unnecessary keys from `needs.json`

### DIFF
--- a/tests/__snapshots__/test_basic_doc.ambr
+++ b/tests/__snapshots__/test_basic_doc.ambr
@@ -34,8 +34,6 @@
             'has_forbidden_dead_links': '',
             'hidden': '',
             'id': 'ST_001',
-            'id_complete': 'ST_001',
-            'id_parent': 'ST_001',
             'id_prefix': '',
             'is_external': False,
             'is_modified': False,
@@ -51,8 +49,6 @@
             'params': '',
             'parent_need': '',
             'parent_needs': list([
-            ]),
-            'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
@@ -106,8 +102,6 @@
             'has_forbidden_dead_links': '',
             'hidden': '',
             'id': 'US_38823',
-            'id_complete': 'US_38823',
-            'id_parent': 'US_38823',
             'id_prefix': '',
             'is_external': False,
             'is_modified': False,
@@ -123,8 +117,6 @@
             'params': '',
             'parent_need': '',
             'parent_needs': list([
-            ]),
-            'parent_needs_back': list([
             ]),
             'parts': dict({
             }),

--- a/tests/__snapshots__/test_export_id.ambr
+++ b/tests/__snapshots__/test_export_id.ambr
@@ -119,9 +119,6 @@
             'blocks': list([
               'REQ_003',
             ]),
-            'blocks_back': list([
-              'REQ_005',
-            ]),
             'closed_at': '',
             'completion': '',
             'constraints': list([
@@ -143,8 +140,6 @@
             'has_forbidden_dead_links': '',
             'hidden': '',
             'id': 'REQ_001',
-            'id_complete': 'REQ_001',
-            'id_parent': 'REQ_001',
             'id_prefix': '',
             'is_external': False,
             'is_modified': False,
@@ -163,8 +158,6 @@
             'params': '',
             'parent_need': '',
             'parent_needs': list([
-            ]),
-            'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
@@ -188,10 +181,6 @@
             'template': None,
             'tests': list([
             ]),
-            'tests_back': list([
-              'TEST_001',
-              'TEST_002',
-            ]),
             'title': 'My requirement',
             'type': 'story',
             'type_name': 'User Story',
@@ -205,8 +194,6 @@
             }),
             'avatar': '',
             'blocks': list([
-            ]),
-            'blocks_back': list([
             ]),
             'closed_at': '',
             'completion': '',
@@ -229,8 +216,6 @@
             'has_forbidden_dead_links': '',
             'hidden': '',
             'id': 'REQ_002',
-            'id_complete': 'REQ_002',
-            'id_parent': 'REQ_002',
             'id_prefix': '',
             'is_external': False,
             'is_modified': False,
@@ -246,8 +231,6 @@
             'params': '',
             'parent_need': '',
             'parent_needs': list([
-            ]),
-            'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
@@ -271,8 +254,6 @@
             'template': None,
             'tests': list([
             ]),
-            'tests_back': list([
-            ]),
             'title': 'My requirement 2',
             'type': 'story',
             'type_name': 'User Story',
@@ -286,9 +267,6 @@
             }),
             'avatar': '',
             'blocks': list([
-            ]),
-            'blocks_back': list([
-              'REQ_001',
             ]),
             'closed_at': '',
             'completion': '',
@@ -311,8 +289,6 @@
             'has_forbidden_dead_links': '',
             'hidden': '',
             'id': 'REQ_003',
-            'id_complete': 'REQ_003',
-            'id_parent': 'REQ_003',
             'id_prefix': '',
             'is_external': False,
             'is_modified': False,
@@ -328,8 +304,6 @@
             'params': '',
             'parent_need': '',
             'parent_needs': list([
-            ]),
-            'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
@@ -353,9 +327,6 @@
             'template': None,
             'tests': list([
             ]),
-            'tests_back': list([
-              'TEST_001',
-            ]),
             'title': 'My requirement 3',
             'type': 'story',
             'type_name': 'User Story',
@@ -369,8 +340,6 @@
             }),
             'avatar': '',
             'blocks': list([
-            ]),
-            'blocks_back': list([
             ]),
             'closed_at': '',
             'completion': '',
@@ -393,8 +362,6 @@
             'has_forbidden_dead_links': '',
             'hidden': '',
             'id': 'REQ_004',
-            'id_complete': 'REQ_004',
-            'id_parent': 'REQ_004',
             'id_prefix': '',
             'is_external': False,
             'is_modified': False,
@@ -410,8 +377,6 @@
             'params': '',
             'parent_need': '',
             'parent_needs': list([
-            ]),
-            'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
@@ -435,8 +400,6 @@
             'template': None,
             'tests': list([
             ]),
-            'tests_back': list([
-            ]),
             'title': 'My requirement 4',
             'type': 'story',
             'type_name': 'User Story',
@@ -451,8 +414,6 @@
             'avatar': '',
             'blocks': list([
               'REQ_001',
-            ]),
-            'blocks_back': list([
             ]),
             'closed_at': '',
             'completion': '',
@@ -479,8 +440,6 @@
             'has_forbidden_dead_links': '',
             'hidden': '',
             'id': 'REQ_005',
-            'id_complete': 'REQ_005',
-            'id_parent': 'REQ_005',
             'id_prefix': '',
             'is_external': False,
             'is_modified': False,
@@ -498,8 +457,6 @@
             'params': '',
             'parent_need': '',
             'parent_needs': list([
-            ]),
-            'parent_needs_back': list([
             ]),
             'parts': dict({
               '1': dict({
@@ -552,9 +509,6 @@
             'template': None,
             'tests': list([
             ]),
-            'tests_back': list([
-              'TEST_003',
-            ]),
             'title': 'Req 5',
             'type': 'story',
             'type_name': 'User Story',
@@ -568,8 +522,6 @@
             }),
             'avatar': '',
             'blocks': list([
-            ]),
-            'blocks_back': list([
             ]),
             'closed_at': '',
             'completion': '',
@@ -592,8 +544,6 @@
             'has_forbidden_dead_links': '',
             'hidden': '',
             'id': 'TEST_001',
-            'id_complete': 'TEST_001',
-            'id_parent': 'TEST_001',
             'id_prefix': '',
             'is_external': False,
             'is_modified': False,
@@ -609,8 +559,6 @@
             'params': '',
             'parent_need': '',
             'parent_needs': list([
-            ]),
-            'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
@@ -636,8 +584,6 @@
               'REQ_001',
               'REQ_003',
             ]),
-            'tests_back': list([
-            ]),
             'title': 'Test of requirements',
             'type': 'test',
             'type_name': 'Test Case',
@@ -651,8 +597,6 @@
             }),
             'avatar': '',
             'blocks': list([
-            ]),
-            'blocks_back': list([
             ]),
             'closed_at': '',
             'completion': '',
@@ -675,8 +619,6 @@
             'has_forbidden_dead_links': '',
             'hidden': '',
             'id': 'TEST_002',
-            'id_complete': 'TEST_002',
-            'id_parent': 'TEST_002',
             'id_prefix': '',
             'is_external': False,
             'is_modified': False,
@@ -693,8 +635,6 @@
             'params': '',
             'parent_need': '',
             'parent_needs': list([
-            ]),
-            'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
@@ -719,8 +659,6 @@
             'tests': list([
               'REQ_001',
             ]),
-            'tests_back': list([
-            ]),
             'title': 'Test of requirements2',
             'type': 'test',
             'type_name': 'Test Case',
@@ -734,8 +672,6 @@
             }),
             'avatar': '',
             'blocks': list([
-            ]),
-            'blocks_back': list([
             ]),
             'closed_at': '',
             'completion': '',
@@ -758,8 +694,6 @@
             'has_forbidden_dead_links': '',
             'hidden': '',
             'id': 'TEST_003',
-            'id_complete': 'TEST_003',
-            'id_parent': 'TEST_003',
             'id_prefix': '',
             'is_external': False,
             'is_modified': False,
@@ -776,8 +710,6 @@
             'params': '',
             'parent_need': '',
             'parent_needs': list([
-            ]),
-            'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
@@ -802,8 +734,6 @@
             'tests': list([
               'REQ_005.1',
               'REQ_005.cool',
-            ]),
-            'tests_back': list([
             ]),
             'title': 'Test of requirements 5',
             'type': 'test',

--- a/tests/__snapshots__/test_external.ambr
+++ b/tests/__snapshots__/test_external.ambr
@@ -34,8 +34,6 @@
             'has_forbidden_dead_links': '',
             'hidden': '',
             'id': 'EXT_TEST_01',
-            'id_complete': 'EXT_TEST_01',
-            'id_parent': 'EXT_TEST_01',
             'id_prefix': '',
             'is_external': True,
             'is_modified': False,
@@ -52,8 +50,6 @@
             'params': '',
             'parent_need': '',
             'parent_needs': list([
-            ]),
-            'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
@@ -106,8 +102,6 @@
             'has_forbidden_dead_links': '',
             'hidden': '',
             'id': 'EXT_TEST_02',
-            'id_complete': 'EXT_TEST_02',
-            'id_parent': 'EXT_TEST_02',
             'id_prefix': '',
             'is_external': True,
             'is_modified': False,
@@ -125,8 +119,6 @@
             'params': '',
             'parent_need': '',
             'parent_needs': list([
-            ]),
-            'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
@@ -181,8 +173,6 @@
             'has_forbidden_dead_links': '',
             'hidden': '',
             'id': 'REQ_1',
-            'id_complete': 'REQ_1',
-            'id_parent': 'REQ_1',
             'id_prefix': '',
             'is_external': False,
             'is_modified': False,
@@ -198,8 +188,6 @@
             'params': '',
             'parent_need': '',
             'parent_needs': list([
-            ]),
-            'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
@@ -253,8 +241,6 @@
             'has_forbidden_dead_links': '',
             'hidden': '',
             'id': 'SPEC_1',
-            'id_complete': 'SPEC_1',
-            'id_parent': 'SPEC_1',
             'id_prefix': '',
             'is_external': False,
             'is_modified': False,
@@ -272,8 +258,6 @@
             'params': '',
             'parent_need': '',
             'parent_needs': list([
-            ]),
-            'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
@@ -327,8 +311,6 @@
             'has_forbidden_dead_links': '',
             'hidden': '',
             'id': 'SUB_002',
-            'id_complete': 'SUB_002',
-            'id_parent': 'SUB_002',
             'id_prefix': '',
             'is_external': False,
             'is_modified': False,
@@ -344,8 +326,6 @@
             'params': '',
             'parent_need': '',
             'parent_needs': list([
-            ]),
-            'parent_needs_back': list([
             ]),
             'parts': dict({
             }),

--- a/tests/__snapshots__/test_import.ambr
+++ b/tests/__snapshots__/test_import.ambr
@@ -51,8 +51,6 @@
             'parent_need': '',
             'parent_needs': list([
             ]),
-            'parent_needs_back': list([
-            ]),
             'parts': dict({
             }),
             'post_template': None,
@@ -121,8 +119,6 @@
             'params': '',
             'parent_need': '',
             'parent_needs': list([
-            ]),
-            'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
@@ -195,8 +191,6 @@
             'parent_need': '',
             'parent_needs': list([
             ]),
-            'parent_needs_back': list([
-            ]),
             'parts': dict({
             }),
             'post_template': None,
@@ -265,8 +259,6 @@
             'params': '',
             'parent_need': '',
             'parent_needs': list([
-            ]),
-            'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
@@ -337,8 +329,6 @@
             'parent_need': '',
             'parent_needs': list([
             ]),
-            'parent_needs_back': list([
-            ]),
             'parts': dict({
             }),
             'post_template': None,
@@ -408,8 +398,6 @@
             'parent_need': '',
             'parent_needs': list([
             ]),
-            'parent_needs_back': list([
-            ]),
             'parts': dict({
             }),
             'post_template': None,
@@ -477,8 +465,6 @@
             'params': '',
             'parent_need': '',
             'parent_needs': list([
-            ]),
-            'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
@@ -549,8 +535,6 @@
             'params': '',
             'parent_need': '',
             'parent_needs': list([
-            ]),
-            'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
@@ -626,8 +610,6 @@
             'parent_need': '',
             'parent_needs': list([
             ]),
-            'parent_needs_back': list([
-            ]),
             'parts': dict({
             }),
             'post_template': None,
@@ -699,8 +681,6 @@
             'parent_need': '',
             'parent_needs': list([
             ]),
-            'parent_needs_back': list([
-            ]),
             'parts': dict({
             }),
             'post_template': None,
@@ -769,8 +749,6 @@
             'params': '',
             'parent_need': '',
             'parent_needs': list([
-            ]),
-            'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
@@ -849,8 +827,6 @@
             'parent_need': '',
             'parent_needs': list([
             ]),
-            'parent_needs_back': list([
-            ]),
             'parts': dict({
             }),
             'post_template': None,
@@ -920,8 +896,6 @@
             'params': '',
             'parent_need': '',
             'parent_needs': list([
-            ]),
-            'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
@@ -993,8 +967,6 @@
             'parent_need': '',
             'parent_needs': list([
             ]),
-            'parent_needs_back': list([
-            ]),
             'parts': dict({
             }),
             'post_template': None,
@@ -1062,9 +1034,6 @@
             'params': '',
             'parent_need': '',
             'parent_needs': list([
-            ]),
-            'parent_needs_back': list([
-              'T_C3893',
             ]),
             'parts': dict({
             }),
@@ -1142,8 +1111,6 @@
             'parent_needs': list([
               'T_5CCAA',
             ]),
-            'parent_needs_back': list([
-            ]),
             'parts': dict({
             }),
             'post_template': None,
@@ -1215,8 +1182,6 @@
             'params': '',
             'parent_need': '',
             'parent_needs': list([
-            ]),
-            'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
@@ -1290,8 +1255,6 @@
             'params': '',
             'parent_need': '',
             'parent_needs': list([
-            ]),
-            'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
@@ -1368,8 +1331,6 @@
             'parent_need': '',
             'parent_needs': list([
             ]),
-            'parent_needs_back': list([
-            ]),
             'parts': dict({
             }),
             'post_template': None,
@@ -1442,8 +1403,6 @@
             'params': '',
             'parent_need': '',
             'parent_needs': list([
-            ]),
-            'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
@@ -1518,8 +1477,6 @@
             'parent_need': '',
             'parent_needs': list([
             ]),
-            'parent_needs_back': list([
-            ]),
             'parts': dict({
             }),
             'post_template': None,
@@ -1591,8 +1548,6 @@
             'params': '',
             'parent_need': '',
             'parent_needs': list([
-            ]),
-            'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
@@ -1667,8 +1622,6 @@
             'params': '',
             'parent_need': '',
             'parent_needs': list([
-            ]),
-            'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
@@ -1748,8 +1701,6 @@
             'parent_need': '',
             'parent_needs': list([
             ]),
-            'parent_needs_back': list([
-            ]),
             'parts': dict({
             }),
             'post_template': None,
@@ -1824,8 +1775,6 @@
             'params': '',
             'parent_need': '',
             'parent_needs': list([
-            ]),
-            'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
@@ -1908,8 +1857,6 @@
             'parent_need': '',
             'parent_needs': list([
             ]),
-            'parent_needs_back': list([
-            ]),
             'parts': dict({
             }),
             'post_template': None,
@@ -1983,8 +1930,6 @@
             'params': '',
             'parent_need': '',
             'parent_needs': list([
-            ]),
-            'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
@@ -2060,8 +2005,6 @@
             'parent_need': '',
             'parent_needs': list([
             ]),
-            'parent_needs_back': list([
-            ]),
             'parts': dict({
             }),
             'post_template': None,
@@ -2133,9 +2076,6 @@
             'params': '',
             'parent_need': '',
             'parent_needs': list([
-            ]),
-            'parent_needs_back': list([
-              'collapsed_T_C3893',
             ]),
             'parts': dict({
             }),
@@ -2217,8 +2157,6 @@
             'parent_needs': list([
               'collapsed_T_5CCAA',
             ]),
-            'parent_needs_back': list([
-            ]),
             'parts': dict({
             }),
             'post_template': None,
@@ -2296,9 +2234,6 @@
             'parent_needs': list([
               'hidden_TEST_01',
             ]),
-            'parent_needs_back': list([
-              'hidden_OWN_ID_123',
-            ]),
             'parts': dict({
             }),
             'post_template': None,
@@ -2370,9 +2305,6 @@
             'parent_need': 'hidden_IMPL_01',
             'parent_needs': list([
               'hidden_IMPL_01',
-            ]),
-            'parent_needs_back': list([
-              'hidden_REQ_001',
             ]),
             'parts': dict({
             }),
@@ -2448,9 +2380,6 @@
             'parent_needs': list([
               'hidden_OWN_ID_123',
             ]),
-            'parent_needs_back': list([
-              'hidden_ROLES_REQ_1',
-            ]),
             'parts': dict({
             }),
             'post_template': None,
@@ -2522,9 +2451,6 @@
             'parent_need': 'hidden_REQ_001',
             'parent_needs': list([
               'hidden_REQ_001',
-            ]),
-            'parent_needs_back': list([
-              'hidden_ROLES_REQ_2',
             ]),
             'parts': dict({
             }),
@@ -2598,9 +2524,6 @@
             'parent_needs': list([
               'hidden_ROLES_REQ_1',
             ]),
-            'parent_needs_back': list([
-              'hidden_R_22EB2',
-            ]),
             'parts': dict({
             }),
             'post_template': None,
@@ -2671,9 +2594,6 @@
             'parent_need': 'hidden_ROLES_REQ_2',
             'parent_needs': list([
               'hidden_ROLES_REQ_2',
-            ]),
-            'parent_needs_back': list([
-              'hidden_R_2A9D0',
             ]),
             'parts': dict({
             }),
@@ -2747,9 +2667,6 @@
             'parent_need': 'hidden_R_22EB2',
             'parent_needs': list([
               'hidden_R_22EB2',
-            ]),
-            'parent_needs_back': list([
-              'hidden_R_F4722',
             ]),
             'parts': dict({
             }),
@@ -2828,9 +2745,6 @@
             'parent_needs': list([
               'hidden_R_2A9D0',
             ]),
-            'parent_needs_back': list([
-              'hidden_S_01A67',
-            ]),
             'parts': dict({
             }),
             'post_template': None,
@@ -2904,9 +2818,6 @@
             'parent_need': 'hidden_R_F4722',
             'parent_needs': list([
               'hidden_R_F4722',
-            ]),
-            'parent_needs_back': list([
-              'hidden_S_503A1',
             ]),
             'parts': dict({
             }),
@@ -2988,9 +2899,6 @@
             'parent_needs': list([
               'hidden_S_01A67',
             ]),
-            'parent_needs_back': list([
-              'hidden_S_D70B0',
-            ]),
             'parts': dict({
             }),
             'post_template': None,
@@ -3064,9 +2972,6 @@
             'parent_needs': list([
               'hidden_S_503A1',
             ]),
-            'parent_needs_back': list([
-              'hidden_T_5CCAA',
-            ]),
             'parts': dict({
             }),
             'post_template': None,
@@ -3139,9 +3044,6 @@
             'parent_need': '',
             'parent_needs': list([
             ]),
-            'parent_needs_back': list([
-              'hidden_IMPL_01',
-            ]),
             'parts': dict({
             }),
             'post_template': None,
@@ -3212,9 +3114,6 @@
             'parent_need': 'hidden_S_D70B0',
             'parent_needs': list([
               'hidden_S_D70B0',
-            ]),
-            'parent_needs_back': list([
-              'hidden_T_C3893',
             ]),
             'parts': dict({
             }),
@@ -3294,8 +3193,6 @@
             'parent_needs': list([
               'hidden_T_5CCAA',
             ]),
-            'parent_needs_back': list([
-            ]),
             'parts': dict({
             }),
             'post_template': None,
@@ -3369,8 +3266,6 @@
             'parent_need': '',
             'parent_needs': list([
             ]),
-            'parent_needs_back': list([
-            ]),
             'parts': dict({
             }),
             'post_template': None,
@@ -3438,8 +3333,6 @@
             'params': '',
             'parent_need': '',
             'parent_needs': list([
-            ]),
-            'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
@@ -3511,8 +3404,6 @@
             'parent_need': '',
             'parent_needs': list([
             ]),
-            'parent_needs_back': list([
-            ]),
             'parts': dict({
             }),
             'post_template': None,
@@ -3583,8 +3474,6 @@
             'parent_need': '',
             'parent_needs': list([
             ]),
-            'parent_needs_back': list([
-            ]),
             'parts': dict({
             }),
             'post_template': None,
@@ -3652,8 +3541,6 @@
             'params': '',
             'parent_need': '',
             'parent_needs': list([
-            ]),
-            'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
@@ -3723,8 +3610,6 @@
             'params': '',
             'parent_need': '',
             'parent_needs': list([
-            ]),
-            'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
@@ -3797,8 +3682,6 @@
             'params': '',
             'parent_need': '',
             'parent_needs': list([
-            ]),
-            'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
@@ -3874,8 +3757,6 @@
             'parent_need': '',
             'parent_needs': list([
             ]),
-            'parent_needs_back': list([
-            ]),
             'parts': dict({
             }),
             'post_template': None,
@@ -3947,8 +3828,6 @@
             'params': '',
             'parent_need': '',
             'parent_needs': list([
-            ]),
-            'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
@@ -4022,8 +3901,6 @@
             'parent_need': '',
             'parent_needs': list([
             ]),
-            'parent_needs_back': list([
-            ]),
             'parts': dict({
             }),
             'post_template': None,
@@ -4094,8 +3971,6 @@
             'params': '',
             'parent_need': '',
             'parent_needs': list([
-            ]),
-            'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
@@ -4169,8 +4044,6 @@
             'params': '',
             'parent_need': '',
             'parent_needs': list([
-            ]),
-            'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
@@ -4249,8 +4122,6 @@
             'parent_need': '',
             'parent_needs': list([
             ]),
-            'parent_needs_back': list([
-            ]),
             'parts': dict({
             }),
             'post_template': None,
@@ -4324,8 +4195,6 @@
             'params': '',
             'parent_need': '',
             'parent_needs': list([
-            ]),
-            'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
@@ -4407,8 +4276,6 @@
             'parent_need': '',
             'parent_needs': list([
             ]),
-            'parent_needs_back': list([
-            ]),
             'parts': dict({
             }),
             'post_template': None,
@@ -4481,8 +4348,6 @@
             'params': '',
             'parent_need': '',
             'parent_needs': list([
-            ]),
-            'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
@@ -4557,8 +4422,6 @@
             'parent_need': '',
             'parent_needs': list([
             ]),
-            'parent_needs_back': list([
-            ]),
             'parts': dict({
             }),
             'post_template': None,
@@ -4629,9 +4492,6 @@
             'params': '',
             'parent_need': '',
             'parent_needs': list([
-            ]),
-            'parent_needs_back': list([
-              'test_T_C3893',
             ]),
             'parts': dict({
             }),
@@ -4711,8 +4571,6 @@
             'parent_need': 'test_T_5CCAA',
             'parent_needs': list([
               'test_T_5CCAA',
-            ]),
-            'parent_needs_back': list([
             ]),
             'parts': dict({
             }),

--- a/tests/__snapshots__/test_need_constraints.ambr
+++ b/tests/__snapshots__/test_need_constraints.ambr
@@ -50,8 +50,6 @@
             'parent_need': '',
             'parent_needs': list([
             ]),
-            'parent_needs_back': list([
-            ]),
             'parts': dict({
             }),
             'post_template': None,
@@ -124,8 +122,6 @@
             'params': '',
             'parent_need': '',
             'parent_needs': list([
-            ]),
-            'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
@@ -202,8 +198,6 @@
             'parent_need': '',
             'parent_needs': list([
             ]),
-            'parent_needs_back': list([
-            ]),
             'parts': dict({
             }),
             'post_template': None,
@@ -276,8 +270,6 @@
             'parent_need': '',
             'parent_needs': list([
             ]),
-            'parent_needs_back': list([
-            ]),
             'parts': dict({
             }),
             'post_template': None,
@@ -345,8 +337,6 @@
             'params': '',
             'parent_need': '',
             'parent_needs': list([
-            ]),
-            'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
@@ -423,8 +413,6 @@
             'parent_need': '',
             'parent_needs': list([
             ]),
-            'parent_needs_back': list([
-            ]),
             'parts': dict({
             }),
             'post_template': None,
@@ -500,8 +488,6 @@
             'parent_need': '',
             'parent_needs': list([
             ]),
-            'parent_needs_back': list([
-            ]),
             'parts': dict({
             }),
             'post_template': None,
@@ -573,8 +559,6 @@
             'params': '',
             'parent_need': '',
             'parent_needs': list([
-            ]),
-            'parent_needs_back': list([
             ]),
             'parts': dict({
             }),

--- a/tests/__snapshots__/test_needextend.ambr
+++ b/tests/__snapshots__/test_needextend.ambr
@@ -52,8 +52,6 @@
             'parent_need': '',
             'parent_needs': list([
             ]),
-            'parent_needs_back': list([
-            ]),
             'parts': dict({
             }),
             'post_template': None,
@@ -121,8 +119,6 @@
             'params': '',
             'parent_need': '',
             'parent_needs': list([
-            ]),
-            'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
@@ -192,8 +188,6 @@
             'parent_need': '',
             'parent_needs': list([
             ]),
-            'parent_needs_back': list([
-            ]),
             'parts': dict({
             }),
             'post_template': None,
@@ -261,8 +255,6 @@
             'params': '',
             'parent_need': '',
             'parent_needs': list([
-            ]),
-            'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
@@ -352,8 +344,6 @@
             'parent_need': '',
             'parent_needs': list([
             ]),
-            'parent_needs_back': list([
-            ]),
             'parts': dict({
             }),
             'post_template': None,
@@ -424,8 +414,6 @@
             'params': '',
             'parent_need': '',
             'parent_needs': list([
-            ]),
-            'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
@@ -498,8 +486,6 @@
             'parent_need': '',
             'parent_needs': list([
             ]),
-            'parent_needs_back': list([
-            ]),
             'parts': dict({
             }),
             'post_template': None,
@@ -569,8 +555,6 @@
             'params': '',
             'parent_need': '',
             'parent_needs': list([
-            ]),
-            'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
@@ -643,8 +627,6 @@
             'parent_need': '',
             'parent_needs': list([
             ]),
-            'parent_needs_back': list([
-            ]),
             'parts': dict({
             }),
             'post_template': None,
@@ -712,8 +694,6 @@
             'params': '',
             'parent_need': '',
             'parent_needs': list([
-            ]),
-            'parent_needs_back': list([
             ]),
             'parts': dict({
             }),

--- a/tests/__snapshots__/test_needs_builder.ambr
+++ b/tests/__snapshots__/test_needs_builder.ambr
@@ -50,8 +50,6 @@
             'parent_need': '',
             'parent_needs': list([
             ]),
-            'parent_needs_back': list([
-            ]),
             'parts': dict({
             }),
             'post_template': None,
@@ -120,8 +118,6 @@
             'parent_need': '',
             'parent_needs': list([
             ]),
-            'parent_needs_back': list([
-            ]),
             'parts': dict({
             }),
             'post_template': None,
@@ -189,8 +185,6 @@
             'params': '',
             'parent_need': '',
             'parent_needs': list([
-            ]),
-            'parent_needs_back': list([
             ]),
             'parts': dict({
             }),


### PR DESCRIPTION
Remove additional keys from the `needs.json`, that are not intended to be exposed to the user:
- back links for user defined link types (standard back links are already ommited),
- `id_parent` and `id_complete`, which are only relevant to parts expansion.

(Note, this is relevant for #957)