### PR TITLE
Add `check` CI job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,3 +62,17 @@ jobs:
       with:
         python-version: '3.8'
     - uses: pre-commit/action@v3.0.0
+
+  check:
+    # This job does nothing and is only used for the branch protection
+    # see https://github.com/marketplace/actions/alls-green#why
+    if: always()
+    needs:
+    - lint
+    - tests
+    runs-on: ubuntu-latest
+    steps:
+    - name: Decide whether the needed jobs succeeded or failed
+      uses: re-actors/alls-green@release/v1
+      with:
+        jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
This job simply passes if all other jobs pass.
This means that it can be used as a singlular "required" for branch protection rules, rather than having to change every time the test matrix changes