### PR TITLE
🧪 Remove plantuml config from test builds conf.py

### DIFF
--- a/tests/doc_test/add_sections/conf.py
+++ b/tests/doc_test/add_sections/conf.py
@@ -1,13 +1,6 @@
-import os
-
 from docutils.parsers.rst import directives
 
 extensions = ["sphinx_needs"]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"
 
 needs_extra_options = {
     "introduced": directives.unchanged,

--- a/tests/doc_test/api_doc/conf.py
+++ b/tests/doc_test/api_doc/conf.py
@@ -1,11 +1,4 @@
-import os
-
 extensions = ["sphinx_needs", "dummy_extension.dummy"]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"
 
 needs_types = [
     {"directive": "story", "title": "User Story", "prefix": "US_", "color": "#BFD8D2", "style": "node"},

--- a/tests/doc_test/api_doc_awesome/conf.py
+++ b/tests/doc_test/api_doc_awesome/conf.py
@@ -1,11 +1,4 @@
-import os
-
 extensions = ["sphinx_needs", "dummy_extension.dummy"]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"
 
 needs_types = [
     {"directive": "story", "title": "User Story", "prefix": "US_", "color": "#BFD8D2", "style": "node"},

--- a/tests/doc_test/arch_doc/conf.py
+++ b/tests/doc_test/arch_doc/conf.py
@@ -1,10 +1,5 @@
-import os
-
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
+# note, the plantuml executable command is set globally in the test suite
 plantuml_output_format = "svg"
 
 needs_types = [

--- a/tests/doc_test/broken_doc/conf.py
+++ b/tests/doc_test/broken_doc/conf.py
@@ -1,11 +1,4 @@
-import os
-
 extensions = ["sphinx_needs"]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"
 
 needs_types = [
     {"directive": "story", "title": "User Story", "prefix": "US_", "color": "#BFD8D2", "style": "node"},

--- a/tests/doc_test/broken_links/conf.py
+++ b/tests/doc_test/broken_links/conf.py
@@ -1,11 +1,4 @@
-import os
-
 extensions = ["sphinx_needs"]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"
 
 needs_types = [
     {"directive": "story", "title": "User Story", "prefix": "US_", "color": "#BFD8D2", "style": "node"},

--- a/tests/doc_test/broken_statuses/conf.py
+++ b/tests/doc_test/broken_statuses/conf.py
@@ -1,11 +1,4 @@
-import os
-
 extensions = ["sphinx_needs"]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"
 
 needs_types = [
     {"directive": "story", "title": "User Story", "prefix": "US_", "color": "#BFD8D2", "style": "node"},

--- a/tests/doc_test/broken_syntax_doc/conf.py
+++ b/tests/doc_test/broken_syntax_doc/conf.py
@@ -1,11 +1,4 @@
-import os
-
 extensions = ["sphinx_needs"]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"
 
 needs_types = [
     {"directive": "story", "title": "User Story", "prefix": "US_", "color": "#BFD8D2", "style": "node"},

--- a/tests/doc_test/broken_tags/conf.py
+++ b/tests/doc_test/broken_tags/conf.py
@@ -1,11 +1,4 @@
-import os
-
 extensions = ["sphinx_needs"]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"
 
 needs_types = [
     {"directive": "story", "title": "User Story", "prefix": "US_", "color": "#BFD8D2", "style": "node"},

--- a/tests/doc_test/broken_tags_2/conf.py
+++ b/tests/doc_test/broken_tags_2/conf.py
@@ -1,11 +1,4 @@
-import os
-
 extensions = ["sphinx_needs"]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"
 
 needs_types = [
     {"directive": "story", "title": "User Story", "prefix": "US_", "color": "#BFD8D2", "style": "node"},

--- a/tests/doc_test/doc_basic/conf.py
+++ b/tests/doc_test/doc_basic/conf.py
@@ -1,10 +1,6 @@
-import os
-
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
+# note, the plantuml executable command is set globally in the test suite
 plantuml_output_format = "svg"
 
 needs_id_regex = "^[A-Za-z0-9_]"

--- a/tests/doc_test/doc_basic_latex/conf.py
+++ b/tests/doc_test/doc_basic_latex/conf.py
@@ -1,12 +1,8 @@
-import os
-
 project = "basic test"
 
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
+# note, the plantuml executable command is set globally in the test suite
 plantuml_output_format = "svg"
 
 needs_id_regex = "^[A-Za-z0-9_]"

--- a/tests/doc_test/doc_build_latex/conf.py
+++ b/tests/doc_test/doc_build_latex/conf.py
@@ -1,12 +1,8 @@
-import os
-
 project = "needs test docs"
 
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
+# note, the plantuml executable command is set globally in the test suite
 plantuml_output_format = "svg"
 
 # figures, tables and code-blocks are automatically numbered if they have a caption

--- a/tests/doc_test/doc_df_calc_sum/conf.py
+++ b/tests/doc_test/doc_df_calc_sum/conf.py
@@ -1,13 +1,6 @@
-import os
-
 from docutils.parsers.rst import directives
 
 extensions = ["sphinx_needs"]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"
 
 needs_types = [
     {"directive": "story", "title": "User Story", "prefix": "US_", "color": "#BFD8D2", "style": "node"},

--- a/tests/doc_test/doc_df_check_linked_values/conf.py
+++ b/tests/doc_test/doc_df_check_linked_values/conf.py
@@ -1,13 +1,6 @@
-import os
-
 from docutils.parsers.rst import directives
 
 extensions = ["sphinx_needs"]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"
 
 needs_types = [
     {"directive": "story", "title": "User Story", "prefix": "US_", "color": "#BFD8D2", "style": "node"},

--- a/tests/doc_test/doc_df_user_functions/conf.py
+++ b/tests/doc_test/doc_df_user_functions/conf.py
@@ -1,13 +1,6 @@
-import os
-
 from docutils.parsers.rst import directives
 
 extensions = ["sphinx_needs"]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"
 
 needs_types = [
     {"directive": "story", "title": "User Story", "prefix": "US_", "color": "#BFD8D2", "style": "node"},

--- a/tests/doc_test/doc_dynamic_functions/conf.py
+++ b/tests/doc_test/doc_dynamic_functions/conf.py
@@ -1,13 +1,6 @@
-import os
-
 from docutils.parsers.rst import directives
 
 extensions = ["sphinx_needs"]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"
 
 needs_types = [
     {"directive": "story", "title": "User Story", "prefix": "US_", "color": "#BFD8D2", "style": "node"},

--- a/tests/doc_test/doc_export_id/conf.py
+++ b/tests/doc_test/doc_export_id/conf.py
@@ -1,12 +1,8 @@
-import os
-
 version = "1.0"
 
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
+# note, the plantuml executable command is set globally in the test suite
 plantuml_output_format = "svg"
 
 needs_types = [

--- a/tests/doc_test/doc_extra_links/conf.py
+++ b/tests/doc_test/doc_extra_links/conf.py
@@ -1,12 +1,8 @@
-import os
-
 project = "needs test docs"
 
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
+# note, the plantuml executable command is set globally in the test suite
 plantuml_output_format = "svg"
 
 needs_types = [

--- a/tests/doc_test/doc_github_issue_160/conf.py
+++ b/tests/doc_test/doc_github_issue_160/conf.py
@@ -1,10 +1,6 @@
-import os
-
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
+# note, the plantuml executable command is set globally in the test suite
 plantuml_output_format = "svg"
 
 needs_id_regex = "^[A-Z0-9]-[A-Z0-9]+"

--- a/tests/doc_test/doc_github_issue_21/conf.py
+++ b/tests/doc_test/doc_github_issue_21/conf.py
@@ -1,11 +1,4 @@
-import os
-
 extensions = ["sphinx_needs"]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"
 
 needs_types = [
     {"directive": "story", "title": "User Story", "prefix": "US_", "color": "#BFD8D2", "style": "node"},

--- a/tests/doc_test/doc_github_issue_44/conf.py
+++ b/tests/doc_test/doc_github_issue_44/conf.py
@@ -1,11 +1,4 @@
-import os
-
 extensions = ["sphinx_needs"]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"
 
 needs_id_regex = "^[A-Za-z0-9_]"
 

--- a/tests/doc_test/doc_github_issue_61/conf.py
+++ b/tests/doc_test/doc_github_issue_61/conf.py
@@ -1,10 +1,6 @@
-import os
-
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
+# note, the plantuml executable command is set globally in the test suite
 plantuml_output_format = "svg"
 
 needs_id_regex = "^[A-Z0-9]-[A-Z0-9]+"

--- a/tests/doc_test/doc_global_options/conf.py
+++ b/tests/doc_test/doc_global_options/conf.py
@@ -1,11 +1,4 @@
-import os
-
 extensions = ["sphinx_needs"]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"
 
 needs_types = [
     {"directive": "story", "title": "User Story", "prefix": "US_", "color": "#BFD8D2", "style": "node"},

--- a/tests/doc_test/doc_layout/conf.py
+++ b/tests/doc_test/doc_layout/conf.py
@@ -1,13 +1,6 @@
-import os
-
 from docutils.parsers.rst import directives
 
 extensions = ["sphinx_needs"]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"
 
 needs_types = [
     {"directive": "story", "title": "User Story", "prefix": "US_", "color": "#BFD8D2", "style": "node"},

--- a/tests/doc_test/doc_list2need/conf.py
+++ b/tests/doc_test/doc_list2need/conf.py
@@ -1,10 +1,6 @@
-import os
-
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
+# note, the plantuml executable command is set globally in the test suite
 plantuml_output_format = "svg"
 
 needs_table_style = "TABLE"

--- a/tests/doc_test/doc_measure_time/conf.py
+++ b/tests/doc_test/doc_measure_time/conf.py
@@ -9,9 +9,7 @@ sys.path.insert(0, os.path.abspath("."))
 
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
+# note, the plantuml executable command is set globally in the test suite
 plantuml_output_format = "svg"
 
 needs_debug_measurement = True

--- a/tests/doc_test/doc_need_count/conf.py
+++ b/tests/doc_test/doc_need_count/conf.py
@@ -1,11 +1,4 @@
-import os
-
 extensions = ["sphinx_needs"]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"
 
 needs_types = [
     {"directive": "story", "title": "User Story", "prefix": "US_", "color": "#BFD8D2", "style": "node"},

--- a/tests/doc_test/doc_need_delete/conf.py
+++ b/tests/doc_test/doc_need_delete/conf.py
@@ -1,10 +1,6 @@
-import os
-
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
+# note, the plantuml executable command is set globally in the test suite
 plantuml_output_format = "svg"
 
 needs_id_regex = "^[A-Za-z0-9_]"

--- a/tests/doc_test/doc_need_id_from_title/conf.py
+++ b/tests/doc_test/doc_need_id_from_title/conf.py
@@ -1,11 +1,4 @@
-import os
-
 extensions = ["sphinx_needs"]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"
 
 needs_types = [
     {"directive": "story", "title": "User Story", "prefix": "US_", "color": "#BFD8D2", "style": "node"},

--- a/tests/doc_test/doc_need_jinja_content/conf.py
+++ b/tests/doc_test/doc_need_jinja_content/conf.py
@@ -1,10 +1,6 @@
-import os
-
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
+# note, the plantuml executable command is set globally in the test suite
 plantuml_output_format = "svg"
 
 needs_id_regex = "^[A-Za-z0-9_]"

--- a/tests/doc_test/doc_need_parts/conf.py
+++ b/tests/doc_test/doc_need_parts/conf.py
@@ -1,11 +1,4 @@
-import os
-
 extensions = ["sphinx_needs"]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"
 
 needs_types = [
     {"directive": "story", "title": "User Story", "prefix": "US_", "color": "#BFD8D2", "style": "node"},

--- a/tests/doc_test/doc_needarch/conf.py
+++ b/tests/doc_test/doc_needarch/conf.py
@@ -1,10 +1,6 @@
-import os
-
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
+# note, the plantuml executable command is set globally in the test suite
 plantuml_output_format = "svg"
 
 needs_table_style = "TABLE"

--- a/tests/doc_test/doc_needarch_jinja_func_import/conf.py
+++ b/tests/doc_test/doc_needarch_jinja_func_import/conf.py
@@ -1,10 +1,6 @@
-import os
-
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
+# note, the plantuml executable command is set globally in the test suite
 plantuml_output_format = "svg"
 
 needs_types = [

--- a/tests/doc_test/doc_needarch_jinja_func_need/conf.py
+++ b/tests/doc_test/doc_needarch_jinja_func_need/conf.py
@@ -1,10 +1,6 @@
-import os
-
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
+# note, the plantuml executable command is set globally in the test suite
 plantuml_output_format = "svg"
 
 needs_table_style = "TABLE"

--- a/tests/doc_test/doc_needarch_negative_tests/conf.py
+++ b/tests/doc_test/doc_needarch_negative_tests/conf.py
@@ -1,10 +1,6 @@
-import os
-
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
+# note, the plantuml executable command is set globally in the test suite
 plantuml_output_format = "svg"
 
 needs_table_style = "TABLE"

--- a/tests/doc_test/doc_needextend/conf.py
+++ b/tests/doc_test/doc_needextend/conf.py
@@ -1,5 +1,3 @@
-import os
-
 extensions = ["sphinx_needs"]
 
 needs_build_json = True
@@ -10,8 +8,3 @@ needs_types = [
     {"directive": "impl", "title": "Implementation", "prefix": "IM_", "color": "#DF744A", "style": "node"},
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"

--- a/tests/doc_test/doc_needextend_strict/conf.py
+++ b/tests/doc_test/doc_needextend_strict/conf.py
@@ -1,5 +1,3 @@
-import os
-
 extensions = ["sphinx_needs"]
 
 needs_id_regex = "^[A-Za-z0-9_]*"
@@ -9,8 +7,3 @@ needs_types = [
     {"directive": "impl", "title": "Implementation", "prefix": "IM_", "color": "#DF744A", "style": "node"},
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"

--- a/tests/doc_test/doc_needextract/conf.py
+++ b/tests/doc_test/doc_needextract/conf.py
@@ -1,5 +1,3 @@
-import os
-
 extensions = ["sphinx_needs"]
 
 rst_prolog = """
@@ -15,8 +13,3 @@ needs_types = [
     {"directive": "impl", "title": "Implementation", "prefix": "IM_", "color": "#DF744A", "style": "node"},
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"

--- a/tests/doc_test/doc_needflow/conf.py
+++ b/tests/doc_test/doc_needflow/conf.py
@@ -1,6 +1,7 @@
-import os
-
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
+
+# note, the plantuml executable command is set globally in the test suite
+plantuml_output_format = "svg"
 
 needs_table_style = "TABLE"
 
@@ -12,8 +13,3 @@ needs_types = [
     {"directive": "impl", "title": "Implementation", "prefix": "IM_", "color": "#DF744A", "style": "node"},
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"

--- a/tests/doc_test/doc_needflow_incl_child_needs/conf.py
+++ b/tests/doc_test/doc_needflow_incl_child_needs/conf.py
@@ -1,6 +1,7 @@
-import os
-
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
+
+# note, the plantuml executable command is set globally in the test suite
+plantuml_output_format = "svg"
 
 needs_table_style = "TABLE"
 
@@ -27,9 +28,3 @@ needs_types = [
 #         "allow_dead_links": True,
 #     },
 # ]
-
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"

--- a/tests/doc_test/doc_needimport_download_needs_json/conf.py
+++ b/tests/doc_test/doc_needimport_download_needs_json/conf.py
@@ -1,5 +1,3 @@
-import os
-
 extensions = ["sphinx_needs"]
 
 needs_table_style = "TABLE"
@@ -10,8 +8,3 @@ needs_types = [
     {"directive": "impl", "title": "Implementation", "prefix": "IM_", "color": "#DF744A", "style": "node"},
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"

--- a/tests/doc_test/doc_needimport_download_needs_json_negative/conf.py
+++ b/tests/doc_test/doc_needimport_download_needs_json_negative/conf.py
@@ -1,5 +1,3 @@
-import os
-
 extensions = ["sphinx_needs"]
 
 needs_table_style = "TABLE"
@@ -10,8 +8,3 @@ needs_types = [
     {"directive": "impl", "title": "Implementation", "prefix": "IM_", "color": "#DF744A", "style": "node"},
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"

--- a/tests/doc_test/doc_needimport_noindex/conf.py
+++ b/tests/doc_test/doc_needimport_noindex/conf.py
@@ -1,5 +1,3 @@
-import os
-
 project = "needs test docs"
 master_doc = "intro"
 
@@ -8,8 +6,5 @@ extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 # figures, tables and code-blocks are automatically numbered if they have a caption
 numfig = True
 
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
+# note, the plantuml executable command is set globally in the test suite
 plantuml_output_format = "svg"

--- a/tests/doc_test/doc_needlist/conf.py
+++ b/tests/doc_test/doc_needlist/conf.py
@@ -1,5 +1,3 @@
-import os
-
 extensions = ["sphinx_needs"]
 
 needs_table_style = "TABLE"
@@ -10,8 +8,3 @@ needs_types = [
     {"directive": "impl", "title": "Implementation", "prefix": "IM_", "color": "#DF744A", "style": "node"},
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"

--- a/tests/doc_test/doc_needpie/conf.py
+++ b/tests/doc_test/doc_needpie/conf.py
@@ -1,6 +1,7 @@
-import os
-
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
+
+# note, the plantuml executable command is set globally in the test suite
+plantuml_output_format = "svg"
 
 needs_table_style = "TABLE"
 
@@ -14,8 +15,3 @@ needs_types = [
 ]
 
 needs_extra_options = ["author"]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"

--- a/tests/doc_test/doc_needs_builder/conf.py
+++ b/tests/doc_test/doc_needs_builder/conf.py
@@ -1,5 +1,3 @@
-import os
-
 version = "1.0"
 
 extensions = ["sphinx_needs"]
@@ -12,10 +10,5 @@ needs_types = [
     {"directive": "impl", "title": "Implementation", "prefix": "IM_", "color": "#DF744A", "style": "node"},
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"
 
 needs_file = "custom_needs_test.json"

--- a/tests/doc_test/doc_needs_builder_negative_tests/conf.py
+++ b/tests/doc_test/doc_needs_builder_negative_tests/conf.py
@@ -1,5 +1,3 @@
-import os
-
 extensions = ["sphinx_needs"]
 
 needs_table_style = "TABLE"
@@ -10,8 +8,3 @@ needs_types = [
     {"directive": "impl", "title": "Implementation", "prefix": "IM_", "color": "#DF744A", "style": "node"},
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"

--- a/tests/doc_test/doc_needs_builder_parallel/conf.py
+++ b/tests/doc_test/doc_needs_builder_parallel/conf.py
@@ -1,5 +1,3 @@
-import os
-
 version = "1.0"
 
 extensions = ["sphinx_needs"]
@@ -14,10 +12,5 @@ needs_types = [
     {"directive": "impl", "title": "Implementation", "prefix": "IM_", "color": "#DF744A", "style": "node"},
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"
 
 needs_file = "custom_needs_test.json"

--- a/tests/doc_test/doc_needs_external_needs/conf.py
+++ b/tests/doc_test/doc_needs_external_needs/conf.py
@@ -1,6 +1,7 @@
-import os
-
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
+
+# note, the plantuml executable command is set globally in the test suite
+plantuml_output_format = "svg"
 
 needs_table_style = "TABLE"
 
@@ -10,11 +11,6 @@ needs_types = [
     {"directive": "impl", "title": "Implementation", "prefix": "IM_", "color": "#DF744A", "style": "node"},
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"
 
 needs_external_needs = [
     {"base_url": "http://my_company.com/docs/v1/", "json_path": "needs_test_small.json", "id_prefix": "ext_"},

--- a/tests/doc_test/doc_needs_external_needs_remote/conf.py
+++ b/tests/doc_test/doc_needs_external_needs_remote/conf.py
@@ -1,6 +1,7 @@
-import os
-
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
+
+# note, the plantuml executable command is set globally in the test suite
+plantuml_output_format = "svg"
 
 needs_table_style = "TABLE"
 
@@ -10,11 +11,6 @@ needs_types = [
     {"directive": "impl", "title": "Implementation", "prefix": "IM_", "color": "#DF744A", "style": "node"},
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"
 
 needs_external_needs = [
     {

--- a/tests/doc_test/doc_needs_external_needs_with_target_url/conf.py
+++ b/tests/doc_test/doc_needs_external_needs_with_target_url/conf.py
@@ -1,6 +1,7 @@
-import os
-
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
+
+# note, the plantuml executable command is set globally in the test suite
+plantuml_output_format = "svg"
 
 needs_table_style = "TABLE"
 
@@ -10,11 +11,6 @@ needs_types = [
     {"directive": "impl", "title": "Implementation", "prefix": "IM_", "color": "#DF744A", "style": "node"},
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"
 
 needs_external_needs = [
     {

--- a/tests/doc_test/doc_needs_filter_data/conf.py
+++ b/tests/doc_test/doc_needs_filter_data/conf.py
@@ -7,6 +7,9 @@ sys.path.insert(0, os.path.abspath("./"))
 
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 
+# note, the plantuml executable command is set globally in the test suite
+plantuml_output_format = "svg"
+
 needs_id_regex = "^[A-Za-z0-9_]*"
 needs_types = [
     {"directive": "story", "title": "User Story", "prefix": "US_", "color": "#BFD8D2", "style": "node"},
@@ -31,8 +34,3 @@ needs_warnings = {
 }
 
 needs_warnings_always_warn = True
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"

--- a/tests/doc_test/doc_needs_warnings/conf.py
+++ b/tests/doc_test/doc_needs_warnings/conf.py
@@ -1,5 +1,3 @@
-import os
-
 extensions = ["sphinx_needs"]
 
 needs_table_style = "TABLE"
@@ -10,11 +8,6 @@ needs_types = [
     {"directive": "impl", "title": "Implementation", "prefix": "IM_", "color": "#DF744A", "style": "node"},
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"
 
 needs_external_needs = [
     {"base_url": "http://my_company.com/docs/v1/", "json_path": "needs_test_small.json", "id_prefix": "ext_"}

--- a/tests/doc_test/doc_needs_warnings_return_status_code/conf.py
+++ b/tests/doc_test/doc_needs_warnings_return_status_code/conf.py
@@ -1,5 +1,3 @@
-import os
-
 extensions = ["sphinx_needs"]
 
 needs_table_style = "TABLE"
@@ -10,11 +8,6 @@ needs_types = [
     {"directive": "impl", "title": "Implementation", "prefix": "IM_", "color": "#DF744A", "style": "node"},
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"
 
 
 def my_custom_warning_check(need, log):

--- a/tests/doc_test/doc_needsfile/conf.py
+++ b/tests/doc_test/doc_needsfile/conf.py
@@ -1,5 +1,3 @@
-import os
-
 extensions = ["sphinx_needs"]
 
 needs_file = "needs_errors.json"
@@ -10,8 +8,3 @@ needs_types = [
     {"directive": "impl", "title": "Implementation", "prefix": "IM_", "color": "#DF744A", "style": "node"},
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"

--- a/tests/doc_test/doc_needtable/conf.py
+++ b/tests/doc_test/doc_needtable/conf.py
@@ -1,5 +1,3 @@
-import os
-
 extensions = ["sphinx_needs"]
 
 needs_table_style = "TABLE"
@@ -41,8 +39,3 @@ needs_string_links = {
         "options": ["github"],
     },
 }
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"

--- a/tests/doc_test/doc_needuml/conf.py
+++ b/tests/doc_test/doc_needuml/conf.py
@@ -1,6 +1,7 @@
-import os
-
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
+
+# note, the plantuml executable command is set globally in the test suite
+plantuml_output_format = "svg"
 
 needs_table_style = "TABLE"
 
@@ -35,8 +36,3 @@ needs_types = [
     {"directive": "impl", "title": "Implementation", "prefix": "IM_", "color": "#DF744A", "style": "node"},
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"

--- a/tests/doc_test/doc_needuml_diagram_allowmixing/conf.py
+++ b/tests/doc_test/doc_needuml_diagram_allowmixing/conf.py
@@ -1,6 +1,7 @@
-import os
-
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
+
+# note, the plantuml executable command is set globally in the test suite
+plantuml_output_format = "svg"
 
 needs_table_style = "TABLE"
 
@@ -35,8 +36,3 @@ needs_types = [
     {"directive": "impl", "title": "Implementation", "prefix": "IM_", "color": "#DF744A", "style": "node"},
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"

--- a/tests/doc_test/doc_needuml_duplicate_key/conf.py
+++ b/tests/doc_test/doc_needuml_duplicate_key/conf.py
@@ -1,6 +1,7 @@
-import os
-
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
+
+# note, the plantuml executable command is set globally in the test suite
+plantuml_output_format = "svg"
 
 needs_table_style = "TABLE"
 
@@ -35,8 +36,3 @@ needs_types = [
     {"directive": "impl", "title": "Implementation", "prefix": "IM_", "color": "#DF744A", "style": "node"},
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"

--- a/tests/doc_test/doc_needuml_filter/conf.py
+++ b/tests/doc_test/doc_needuml_filter/conf.py
@@ -1,6 +1,7 @@
-import os
-
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
+
+# note, the plantuml executable command is set globally in the test suite
+plantuml_output_format = "svg"
 
 needs_table_style = "TABLE"
 
@@ -35,8 +36,3 @@ needs_types = [
     {"directive": "impl", "title": "Implementation", "prefix": "IM_", "color": "#DF744A", "style": "node"},
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"

--- a/tests/doc_test/doc_needuml_jinja_func_flow/conf.py
+++ b/tests/doc_test/doc_needuml_jinja_func_flow/conf.py
@@ -1,6 +1,7 @@
-import os
-
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
+
+# note, the plantuml executable command is set globally in the test suite
+plantuml_output_format = "svg"
 
 needs_table_style = "TABLE"
 
@@ -35,8 +36,3 @@ needs_types = [
     {"directive": "impl", "title": "Implementation", "prefix": "IM_", "color": "#DF744A", "style": "node"},
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"

--- a/tests/doc_test/doc_needuml_jinja_func_import_negative_tests/conf.py
+++ b/tests/doc_test/doc_needuml_jinja_func_import_negative_tests/conf.py
@@ -1,6 +1,7 @@
-import os
-
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
+
+# note, the plantuml executable command is set globally in the test suite
+plantuml_output_format = "svg"
 
 needs_types = [
     {
@@ -33,11 +34,6 @@ needs_types = [
     {"directive": "impl", "title": "Implementation", "prefix": "IM_", "color": "#DF744A", "style": "node"},
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"
 
 needs_extra_links = [
     {

--- a/tests/doc_test/doc_needuml_jinja_func_need_removed/conf.py
+++ b/tests/doc_test/doc_needuml_jinja_func_need_removed/conf.py
@@ -1,6 +1,7 @@
-import os
-
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
+
+# note, the plantuml executable command is set globally in the test suite
+plantuml_output_format = "svg"
 
 needs_table_style = "TABLE"
 
@@ -35,8 +36,3 @@ needs_types = [
     {"directive": "impl", "title": "Implementation", "prefix": "IM_", "color": "#DF744A", "style": "node"},
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"

--- a/tests/doc_test/doc_needuml_jinja_func_ref/conf.py
+++ b/tests/doc_test/doc_needuml_jinja_func_ref/conf.py
@@ -1,6 +1,7 @@
-import os
-
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
+
+# note, the plantuml executable command is set globally in the test suite
+plantuml_output_format = "svg"
 
 needs_table_style = "TABLE"
 
@@ -35,8 +36,3 @@ needs_types = [
     {"directive": "impl", "title": "Implementation", "prefix": "IM_", "color": "#DF744A", "style": "node"},
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"

--- a/tests/doc_test/doc_needuml_key_name_diagram/conf.py
+++ b/tests/doc_test/doc_needuml_key_name_diagram/conf.py
@@ -1,6 +1,7 @@
-import os
-
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
+
+# note, the plantuml executable command is set globally in the test suite
+plantuml_output_format = "svg"
 
 needs_table_style = "TABLE"
 
@@ -35,8 +36,3 @@ needs_types = [
     {"directive": "impl", "title": "Implementation", "prefix": "IM_", "color": "#DF744A", "style": "node"},
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"

--- a/tests/doc_test/doc_needuml_save/conf.py
+++ b/tests/doc_test/doc_needuml_save/conf.py
@@ -1,6 +1,7 @@
-import os
-
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
+
+# note, the plantuml executable command is set globally in the test suite
+plantuml_output_format = "svg"
 
 needs_table_style = "TABLE"
 
@@ -35,10 +36,5 @@ needs_types = [
     {"directive": "impl", "title": "Implementation", "prefix": "IM_", "color": "#DF744A", "style": "node"},
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"
 
 needs_build_needumls = "my_needumls"

--- a/tests/doc_test/doc_needuml_save_with_abs_path/conf.py
+++ b/tests/doc_test/doc_needuml_save_with_abs_path/conf.py
@@ -1,6 +1,7 @@
-import os
-
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
+
+# note, the plantuml executable command is set globally in the test suite
+plantuml_output_format = "svg"
 
 needs_table_style = "TABLE"
 
@@ -35,8 +36,3 @@ needs_types = [
     {"directive": "impl", "title": "Implementation", "prefix": "IM_", "color": "#DF744A", "style": "node"},
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"

--- a/tests/doc_test/doc_open_needs_service/conf.py
+++ b/tests/doc_test/doc_open_needs_service/conf.py
@@ -29,9 +29,3 @@ needs_services = {
         },
     },
 }
-
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"

--- a/tests/doc_test/doc_report_dead_links_false/conf.py
+++ b/tests/doc_test/doc_report_dead_links_false/conf.py
@@ -1,6 +1,7 @@
-import os
-
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
+
+# note, the plantuml executable command is set globally in the test suite
+plantuml_output_format = "svg"
 
 needs_types = [
     {"directive": "story", "title": "User Story", "prefix": "US_", "color": "#BFD8D2", "style": "node"},
@@ -29,8 +30,3 @@ needs_extra_links = [
         "style_part": "dotted,#00AA00",
     },
 ]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"

--- a/tests/doc_test/doc_report_dead_links_true/conf.py
+++ b/tests/doc_test/doc_report_dead_links_true/conf.py
@@ -1,6 +1,7 @@
-import os
-
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
+
+# note, the plantuml executable command is set globally in the test suite
+plantuml_output_format = "svg"
 
 needs_types = [
     {"directive": "story", "title": "User Story", "prefix": "US_", "color": "#BFD8D2", "style": "node"},
@@ -27,8 +28,3 @@ needs_extra_links = [
         "style_part": "dotted,#00AA00",
     },
 ]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"

--- a/tests/doc_test/doc_role_need_max_title_length/conf.py
+++ b/tests/doc_test/doc_role_need_max_title_length/conf.py
@@ -1,5 +1,3 @@
-import os
-
 extensions = ["sphinx_needs"]
 
 needs_types = [
@@ -12,8 +10,3 @@ needs_types = [
 needs_role_need_template = "[{id}] {title} ({status}) {type_name}/{type} - {tags} - {links} - {links_back} - {content}"
 
 needs_role_need_max_title_length = 10
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"

--- a/tests/doc_test/doc_role_need_max_title_length_unlimited/conf.py
+++ b/tests/doc_test/doc_role_need_max_title_length_unlimited/conf.py
@@ -1,5 +1,3 @@
-import os
-
 extensions = ["sphinx_needs"]
 
 needs_types = [
@@ -12,8 +10,3 @@ needs_types = [
 needs_role_need_template = "[{id}] {title} ({status}) {type_name}/{type} - {tags} - {links} - {links_back} - {content}"
 
 needs_role_need_max_title_length = -1
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"

--- a/tests/doc_test/doc_role_need_template/conf.py
+++ b/tests/doc_test/doc_role_need_template/conf.py
@@ -1,5 +1,3 @@
-import os
-
 extensions = ["sphinx_needs"]
 
 needs_types = [
@@ -10,8 +8,3 @@ needs_types = [
 ]
 
 needs_role_need_template = "[{id}] {title} ({status}) {type_name}/{type} - {tags} - {links} - {links_back} - {content}"
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"

--- a/tests/doc_test/doc_style_blank/conf.py
+++ b/tests/doc_test/doc_style_blank/conf.py
@@ -1,5 +1,3 @@
-import os
-
 extensions = ["sphinx_needs"]
 
 needs_types = [
@@ -10,8 +8,3 @@ needs_types = [
 ]
 
 needs_css = "blank.css"
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"

--- a/tests/doc_test/doc_style_custom/conf.py
+++ b/tests/doc_test/doc_style_custom/conf.py
@@ -10,8 +10,3 @@ needs_types = [
 ]
 
 needs_css = os.path.join(os.path.dirname(__file__), "my_custom.css")
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"

--- a/tests/doc_test/doc_style_modern/conf.py
+++ b/tests/doc_test/doc_style_modern/conf.py
@@ -1,5 +1,3 @@
-import os
-
 extensions = ["sphinx_needs"]
 
 needs_types = [
@@ -10,8 +8,3 @@ needs_types = [
 ]
 
 needs_css = "modern.css"
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"

--- a/tests/doc_test/doc_style_unknown/conf.py
+++ b/tests/doc_test/doc_style_unknown/conf.py
@@ -1,5 +1,3 @@
-import os
-
 extensions = ["sphinx_needs"]
 
 needs_types = [
@@ -10,8 +8,3 @@ needs_types = [
 ]
 
 needs_css = "UNKNOWN.css"
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"

--- a/tests/doc_test/external_doc/conf.py
+++ b/tests/doc_test/external_doc/conf.py
@@ -4,6 +4,9 @@ version = "1.0"
 
 extensions = ["sphinxcontrib.plantuml", "sphinx_needs"]
 
+# note, the plantuml executable command is set globally in the test suite
+plantuml_output_format = "svg"
+
 needs_id_regex = "^[A-Za-z0-9_]"
 
 needs_types = [
@@ -25,8 +28,3 @@ needs_external_needs = [
 
 # Needed to export really ALL needs. The default entry would filter out all needs coming from external
 needs_builder_filter = "True"
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"

--- a/tests/doc_test/extra_options/conf.py
+++ b/tests/doc_test/extra_options/conf.py
@@ -1,13 +1,6 @@
-import os
-
 from docutils.parsers.rst import directives
 
 extensions = ["sphinx_needs"]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"
 
 needs_extra_options = {
     "introduced": directives.unchanged,

--- a/tests/doc_test/filter_doc/conf.py
+++ b/tests/doc_test/filter_doc/conf.py
@@ -1,5 +1,3 @@
-import os
-
 extensions = ["sphinx_needs"]
 
 needs_id_regex = "^[A-Za-z0-9_]"
@@ -11,8 +9,3 @@ needs_types = [
     {"directive": "impl", "title": "Implementation", "prefix": "IM_", "color": "#DF744A", "style": "node"},
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"

--- a/tests/doc_test/generic_doc/conf.py
+++ b/tests/doc_test/generic_doc/conf.py
@@ -1,5 +1,3 @@
-import os
-
 extensions = ["sphinx_needs"]
 
 needs_types = [
@@ -8,8 +6,3 @@ needs_types = [
     {"directive": "impl", "title": "Implementation", "prefix": "IM_", "color": "#DF744A", "style": "node"},
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"

--- a/tests/doc_test/import_doc/conf.py
+++ b/tests/doc_test/import_doc/conf.py
@@ -1,5 +1,3 @@
-import os
-
 version = "1.0"
 
 extensions = ["sphinx_needs"]
@@ -32,8 +30,3 @@ needs_template = """
 
 {% endif -%}
 """
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"

--- a/tests/doc_test/import_doc_empty/conf.py
+++ b/tests/doc_test/import_doc_empty/conf.py
@@ -1,5 +1,3 @@
-import os
-
 extensions = ["sphinx_needs"]
 
 needs_id_regex = "^[A-Za-z0-9_]"
@@ -30,8 +28,3 @@ needs_template = """
 
 {% endif -%}
 """
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"

--- a/tests/doc_test/import_doc_invalid/conf.py
+++ b/tests/doc_test/import_doc_invalid/conf.py
@@ -1,5 +1,3 @@
-import os
-
 extensions = ["sphinx_needs"]
 
 needs_id_regex = "^[A-Za-z0-9_]"
@@ -30,8 +28,3 @@ needs_template = """
 
 {% endif -%}
 """
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"

--- a/tests/doc_test/multiple_link_backs/conf.py
+++ b/tests/doc_test/multiple_link_backs/conf.py
@@ -1,8 +1,1 @@
-import os
-
 extensions = ["sphinx_needs"]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"

--- a/tests/doc_test/need_constraints/conf.py
+++ b/tests/doc_test/need_constraints/conf.py
@@ -1,5 +1,3 @@
-import os
-
 extensions = ["sphinx_needs"]
 
 needs_build_json = True
@@ -11,11 +9,6 @@ needs_types = [
     {"directive": "impl", "title": "Implementation", "prefix": "IM_", "color": "#DF744A", "style": "node"},
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"
 
 needs_external_needs = [
     {"base_url": "http://my_company.com/docs/v1/", "json_path": "needs_test_small.json", "id_prefix": "ext_"}

--- a/tests/doc_test/need_constraints_failed/conf.py
+++ b/tests/doc_test/need_constraints_failed/conf.py
@@ -1,5 +1,3 @@
-import os
-
 extensions = ["sphinx_needs"]
 
 needs_table_style = "TABLE"
@@ -10,11 +8,6 @@ needs_types = [
     {"directive": "impl", "title": "Implementation", "prefix": "IM_", "color": "#DF744A", "style": "node"},
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "../need_constraints", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"
 
 needs_external_needs = [
     {"base_url": "http://my_company.com/docs/v1/", "json_path": "needs_test_small.json", "id_prefix": "ext_"}

--- a/tests/doc_test/needextract_with_nested_needs/conf.py
+++ b/tests/doc_test/needextract_with_nested_needs/conf.py
@@ -1,5 +1,3 @@
-import os
-
 extensions = ["sphinx_needs"]
 
 needs_id_regex = "^[A-Za-z0-9_]"
@@ -10,8 +8,3 @@ needs_types = [
     {"directive": "impl", "title": "Implementation", "prefix": "IM_", "color": "#DF744A", "style": "node"},
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"

--- a/tests/doc_test/needpie_with_zero_needs/conf.py
+++ b/tests/doc_test/needpie_with_zero_needs/conf.py
@@ -1,5 +1,3 @@
-import os
-
 extensions = ["sphinx_needs"]
 
 needs_id_regex = "^[A-Za-z0-9_]"
@@ -10,8 +8,3 @@ needs_types = [
     {"directive": "impl", "title": "Implementation", "prefix": "IM_", "color": "#DF744A", "style": "node"},
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"

--- a/tests/doc_test/non_exists_file_import/conf.py
+++ b/tests/doc_test/non_exists_file_import/conf.py
@@ -1,5 +1,3 @@
-import os
-
 extensions = ["sphinx_needs"]
 
 needs_id_regex = "^[A-Za-z0-9_]"
@@ -30,8 +28,3 @@ needs_template = """
 
 {% endif -%}
 """
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"

--- a/tests/doc_test/parallel_doc/conf.py
+++ b/tests/doc_test/parallel_doc/conf.py
@@ -1,5 +1,3 @@
-import os
-
 extensions = ["sphinx_needs"]
 
 needs_types = [
@@ -12,7 +10,3 @@ needs_variants = {"change_author": "assignee == 'Randy Duodu'"}
 needs_variant_options = ["status", "author"]
 needs_filter_data = {"assignee": "Randy Duodu"}
 needs_extra_options = ["my_extra_option", "another_option", "author", "comment"]
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"

--- a/tests/doc_test/role_need_doc/conf.py
+++ b/tests/doc_test/role_need_doc/conf.py
@@ -2,6 +2,9 @@ import os
 
 extensions = ["sphinxcontrib.plantuml", "sphinx_needs"]
 
+# note, the plantuml executable command is set globally in the test suite
+plantuml_output_format = "svg"
+
 needs_id_regex = "^[A-Za-z0-9_]"
 
 needs_types = [
@@ -23,8 +26,3 @@ needs_external_needs = [
 
 # Needed to export really ALL needs. The default entry would filter out all needs coming from external
 needs_builder_filter = "True"
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"

--- a/tests/doc_test/service_doc/conf.py
+++ b/tests/doc_test/service_doc/conf.py
@@ -1,5 +1,3 @@
-import os
-
 from tests.test_services.test_service_basics import NoDebugService, ServiceTest
 
 extensions = ["sphinx_needs"]
@@ -27,9 +25,3 @@ needs_services = {
         },
     },
 }
-
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"

--- a/tests/doc_test/title_from_content/conf.py
+++ b/tests/doc_test/title_from_content/conf.py
@@ -1,11 +1,4 @@
-import os
-
 extensions = ["sphinx_needs"]
 needs_title_from_content = True
 needs_max_title_length = 50
 smartquotes_action = "qD"
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"

--- a/tests/doc_test/title_optional/conf.py
+++ b/tests/doc_test/title_optional/conf.py
@@ -1,11 +1,4 @@
-import os
-
 extensions = ["sphinx_needs"]
 needs_title_optional = True
 needs_max_title_length = 50
 smartquotes_action = "qD"
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"

--- a/tests/doc_test/unicode_support/conf.py
+++ b/tests/doc_test/unicode_support/conf.py
@@ -1,5 +1,3 @@
-import os
-
 extensions = ["sphinx_needs"]
 
 needs_table_style = "TABLE"
@@ -10,8 +8,3 @@ needs_types = [
     {"directive": "impl", "title": "Implementation", "prefix": "IM_", "color": "#DF744A", "style": "node"},
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"

--- a/tests/doc_test/variant_doc/conf.py
+++ b/tests/doc_test/variant_doc/conf.py
@@ -1,8 +1,9 @@
-import os
-
 tags.add("tag_b")  # noqa: F821
 
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
+
+# note, the plantuml executable command is set globally in the test suite
+plantuml_output_format = "svg"
 
 needs_id_regex = "^[A-Za-z0-9_]"
 
@@ -28,9 +29,3 @@ needs_extra_options = [
     "value",
     "unit",
 ]
-
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"

--- a/tests/doc_test/variant_options/conf.py
+++ b/tests/doc_test/variant_options/conf.py
@@ -1,8 +1,9 @@
-import os
-
 tags.add("tag_b")  # noqa: F821
 
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
+
+# note, the plantuml executable command is set globally in the test suite
+plantuml_output_format = "svg"
 
 needs_id_regex = "^[A-Za-z0-9_]"
 
@@ -28,8 +29,3 @@ needs_extra_options = [
     "value",
     "unit",
 ]
-
-plantuml = "java -Djava.awt.headless=true -jar %s" % os.path.join(
-    os.path.dirname(__file__), "..", "utils", "plantuml.jar"
-)
-plantuml_output_format = "svg"


### PR DESCRIPTION
In #1051 setting of the `plantuml` config option was moved centrally into `test_app`.
Thats fine, but then it should also be removed from individual `conf.py`