### PR TITLE
♻️ Make matplotlib dependency optional

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,7 +79,7 @@ jobs:
           python -m pytest -v --ignore=tests/benchmarks -m "jstest" tests
 
   tests-no-mpl:
-    name: Docs no matplotlib
+    name: Test matplotlib uninstalled
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,6 +78,27 @@ jobs:
         run: |
           python -m pytest -v --ignore=tests/benchmarks -m "jstest" tests
 
+  docs-no-mpl:
+    # the docs should build without matplotlib (just issuing warnings)
+    name: Docs no matplotlib
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set Up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Update pip
+        run: python -m pip install --upgrade pip
+      - name: Install Dependencies
+        run: |
+          python -m pip install -e .[docs]
+          python -m pip uninstall -y matplotlib numpy
+          python -m pip freeze
+      - name: Run HTML build
+        run: sphinx-build -b html . _build 
+        working-directory: docs
+
   check:
   
     # This job does nothing and is only used for the branch protection
@@ -89,6 +110,7 @@ jobs:
     - lint
     - tests-core
     - tests-js
+    - docs-no-mpl
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,8 +78,7 @@ jobs:
         run: |
           python -m pytest -v --ignore=tests/benchmarks -m "jstest" tests
 
-  docs-no-mpl:
-    # the docs should build without matplotlib (just issuing warnings)
+  tests-no-mpl:
     name: Docs no matplotlib
     runs-on: ubuntu-latest
     steps:
@@ -92,10 +91,14 @@ jobs:
         run: python -m pip install --upgrade pip
       - name: Install Dependencies
         run: |
-          python -m pip install -e .[docs]
+          python -m pip install -e .[test,docs]
           python -m pip uninstall -y matplotlib numpy
           python -m pip freeze
+      - name: Run pytest
+        run: |
+          python -m pytest -v tests/no_mpl_tests.py
       - name: Run HTML build
+        # the docs should build without matplotlib (just issuing warnings)
         run: sphinx-build -b html . _build 
         working-directory: docs
 
@@ -110,7 +113,7 @@ jobs:
     - lint
     - tests-core
     - tests-js
-    - docs-no-mpl
+    - tests-no-mpl
 
     runs-on: ubuntu-latest
 

--- a/README.rst
+++ b/README.rst
@@ -61,6 +61,12 @@ Using pip
 
     pip install sphinx-needs
 
+If you wish to also use the plotting features of sphinx-needs (see :ref:`needbar` and :ref:`needpie`), you need to also install ``matplotlib``, which is available *via* the ``plotting`` extra:
+
+.. code-block:: bash
+
+    pip install sphinx-needs[plotting]
+
 .. note::
 
    Prior version **1.0.1** the package was named ``sphinxcontrib-needs``.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,7 +49,6 @@ extensions = [
     "sphinxcontrib.plantuml",
     "sphinx_needs",
     "sphinx.ext.autodoc",
-    "matplotlib.sphinxext.plot_directive",
     "sphinx_copybutton",
     "sphinxcontrib.programoutput",
     "sphinx_design",

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -15,6 +15,12 @@ Using pip
 
     pip install sphinx-needs
 
+If you wish to also use the plotting features of sphinx-needs (see :ref:`needbar` and :ref:`needpie`), you need to also install ``matplotlib``, which is available *via* the ``plotting`` extra:
+
+.. code-block:: bash
+
+    pip install sphinx-needs[plotting]
+
 .. note::
 
    Prior version **1.0.1** the package was named ``sphinxcontrib-needs``.

--- a/noxfile.py
+++ b/noxfile.py
@@ -21,6 +21,16 @@ def tests(session, sphinx):
     session.run("pytest", "--ignore", "tests/benchmarks", *posargs, external=True)
 
 
+@session(python=PYTHON_VERSIONS)
+def tests_no_mpl(session):
+    session.install(".[test]")
+    session.run("pip", "uninstall", "-y", "matplotlib", "numpy", silent=True)
+    session.run("echo", "TEST FINAL PACKAGE LIST")
+    session.run("pip", "freeze")
+    posargs = session.posargs or ["tests/no_mpl_tests.py"]
+    session.run("pytest", *posargs, external=True)
+
+
 @session(python="3.10")
 def benchmark_time(session):
     session.install(".[test,benchmark,docs]")

--- a/noxfile.py
+++ b/noxfile.py
@@ -27,8 +27,7 @@ def tests_no_mpl(session):
     session.run("pip", "uninstall", "-y", "matplotlib", "numpy", silent=True)
     session.run("echo", "TEST FINAL PACKAGE LIST")
     session.run("pip", "freeze")
-    posargs = session.posargs or ["tests/no_mpl_tests.py"]
-    session.run("pytest", *posargs, external=True)
+    session.run("pytest", "tests/no_mpl_tests.py", *session.posargs, external=True)
 
 
 @session(python="3.10")

--- a/poetry.lock
+++ b/poetry.lock
@@ -218,7 +218,7 @@ files = [
 name = "contourpy"
 version = "1.1.0"
 description = "Python library for calculating contours of 2D quadrilateral grids"
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "contourpy-1.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:89f06eff3ce2f4b3eb24c1055a26981bffe4e7264acd86f15b97e40530b794bc"},
@@ -276,7 +276,7 @@ test-no-images = ["pytest", "pytest-cov", "wurlitzer"]
 name = "contourpy"
 version = "1.1.1"
 description = "Python library for calculating contours of 2D quadrilateral grids"
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "contourpy-1.1.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:46e24f5412c948d81736509377e255f6040e94216bf1a9b5ea1eaa9d29f6ec1b"},
@@ -347,7 +347,7 @@ test-no-images = ["pytest", "pytest-cov", "wurlitzer"]
 name = "cycler"
 version = "0.12.1"
 description = "Composable style cycles"
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "cycler-0.12.1-py3-none-any.whl", hash = "sha256:85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30"},
@@ -428,7 +428,7 @@ typing = ["typing-extensions (>=4.8)"]
 name = "fonttools"
 version = "4.44.0"
 description = "Tools to manipulate font files"
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "fonttools-4.44.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:e1cd1c6bb097e774d68402499ff66185190baaa2629ae2f18515a2c50b93db0c"},
@@ -632,7 +632,7 @@ referencing = ">=0.28.0"
 name = "kiwisolver"
 version = "1.4.5"
 description = "A fast implementation of the Cassowary constraint solver"
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "kiwisolver-1.4.5-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:05703cf211d585109fcd72207a31bb170a0f22144d68298dc5e61b3c946518af"},
@@ -935,7 +935,7 @@ files = [
 name = "matplotlib"
 version = "3.7.3"
 description = "Python plotting package"
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "matplotlib-3.7.3-cp310-cp310-macosx_10_12_universal2.whl", hash = "sha256:085c33b27561d9c04386789d5aa5eb4a932ddef43cfcdd0e01735f9a6e85ce0c"},
@@ -1084,7 +1084,7 @@ setuptools = "*"
 name = "numpy"
 version = "1.24.4"
 description = "Fundamental package for array computing in Python"
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "numpy-1.24.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c0bfb52d2169d58c1cdb8cc1f16989101639b34c7d3ce60ed70b19c63eba0b64"},
@@ -1132,7 +1132,7 @@ files = [
 name = "pillow"
 version = "10.1.0"
 description = "Python Imaging Library (Fork)"
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "Pillow-10.1.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:1ab05f3db77e98f93964697c8efc49c7954b08dd61cff526b7f2531a22410106"},
@@ -1476,7 +1476,7 @@ plugins = ["importlib-metadata"]
 name = "pyparsing"
 version = "3.1.1"
 description = "pyparsing module - Classes and methods to define and execute parsing grammars"
-optional = false
+optional = true
 python-versions = ">=3.6.8"
 files = [
     {file = "pyparsing-3.1.1-py3-none-any.whl", hash = "sha256:32c7c0b711493c72ff18a981d24f28aaf9c1fb7ed5e9667c9e84e3db623bdbfb"},
@@ -1568,7 +1568,7 @@ pytest = ">=2.8"
 name = "python-dateutil"
 version = "2.8.2"
 description = "Extensions to the standard Python datetime module"
-optional = false
+optional = true
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 files = [
     {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
@@ -1875,7 +1875,7 @@ testing-integration = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "jar
 name = "setuptools-scm"
 version = "8.0.4"
 description = "the blessed package to manage your versions by scm tags"
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "setuptools-scm-8.0.4.tar.gz", hash = "sha256:b5f43ff6800669595193fd09891564ee9d1d7dcb196cab4b2506d53a2e1c95c7"},
@@ -2194,7 +2194,7 @@ files = [
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
@@ -2216,7 +2216,7 @@ files = [
 name = "typing-extensions"
 version = "4.8.0"
 description = "Backported and Experimental Type Hints for Python 3.8+"
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "typing_extensions-4.8.0-py3-none-any.whl", hash = "sha256:8f92fc8806f9a6b641eaa5318da32b44d401efaac0f6678c9bc448ba3605faa0"},
@@ -2277,11 +2277,12 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 
 [extras]
 benchmark = ["memray", "pytest-benchmark"]
-docs = ["sphinx-copybutton", "sphinx-design", "sphinx-immaterial", "sphinxcontrib-plantuml", "sphinxcontrib-programoutput"]
-test = ["lxml", "pytest", "pytest-xprocess", "requests-mock", "responses", "sphinxcontrib-plantuml", "syrupy"]
+docs = ["matplotlib", "sphinx-copybutton", "sphinx-design", "sphinx-immaterial", "sphinxcontrib-plantuml", "sphinxcontrib-programoutput"]
+plotting = ["matplotlib"]
+test = ["lxml", "matplotlib", "pytest", "pytest-xprocess", "requests-mock", "responses", "sphinxcontrib-plantuml", "syrupy"]
 test-parallel = ["pytest-xdist"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4"
-content-hash = "2f246358b9845b557c46285d283af6507dcafec6035170b97b2447e062821218"
+content-hash = "845318ae7fcc4a246470671ea7ca0f05ed79189ea68152f609a0184044980487"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,12 +34,15 @@ packages = [
 [tool.poetry.dependencies]
 python = ">=3.8,<4"
 sphinx = ">=5.0,<8"
-matplotlib = ">=3.3.0"  # needpie
 requests-file = "^1.5.1"  # external links
 requests = "^2.25.1"  # external_links
 jsonschema = ">=3.2.0"  # needsimport schema validation
 sphinx-data-viewer = "^0.1.1"  # needservice debug output
 sphinxcontrib-jquery = "^4"  # needed for datatables in sphinx>=6
+
+# [project.optional-dependencies.plotting]
+# for needpie / needbar
+matplotlib = { version = ">=3.3.0", optional = true }
 
 # [project.optional-dependencies.test]
 pytest = { version = "^7", optional = true }
@@ -64,10 +67,12 @@ sphinx-design = { version="^0.5", optional = true }
 sphinx-immaterial = { version="0.11.7", optional = true }
 
 [tool.poetry.extras]
-test = ["pytest", "syrupy", "sphinxcontrib-plantuml", "requests-mock", "lxml", "responses", "pytest-xprocess"]
+plotting = ["matplotlib"]
+test = ["matplotlib", "pytest", "syrupy", "sphinxcontrib-plantuml", "requests-mock", "lxml", "responses", "pytest-xprocess"]
 test-parallel = ["pytest-xdist"]
 benchmark = ["pytest-benchmark", "memray"]
 docs = [
+  "matplotlib",
   "sphinxcontrib-plantuml",
   "sphinx-copybutton",
   "sphinxcontrib-programoutput",

--- a/sphinx_needs/directives/needbar.py
+++ b/sphinx_needs/directives/needbar.py
@@ -184,12 +184,19 @@ def process_needbar(app: Sphinx, doctree: nodes.document, fromdocname: str, foun
     # NEEDFLOW
     # for node in doctree.findall(Needbar):
     for node in found_nodes:
-        if matplotlib is None or not needs_config.include_needs:
+        if not needs_config.include_needs:
             remove_node_from_tree(node)
             continue
 
         id = node.attributes["ids"][0]
         current_needbar = needs_data.get_or_create_bars()[id]
+
+        if matplotlib is None:
+            message = "Matplotlib missing for needbar plot"
+            if current_needbar["title"]:
+                message += f" {current_needbar['title']!r}"
+            node.replace_self(nodes.error("", nodes.paragraph(text=message)))
+            continue
 
         # 1. define constants
         error_id = current_needbar["error_id"]

--- a/sphinx_needs/directives/needpie.py
+++ b/sphinx_needs/directives/needpie.py
@@ -120,12 +120,19 @@ def process_needpie(app: Sphinx, doctree: nodes.document, fromdocname: str, foun
     # NEEDFLOW
     # for node in doctree.findall(Needpie):
     for node in found_nodes:
-        if matplotlib is None or not needs_config.include_needs:
+        if not needs_config.include_needs:
             remove_node_from_tree(node)
             continue
 
         id = node.attributes["ids"][0]
         current_needpie = needs_data.get_or_create_pies()[id]
+
+        if matplotlib is None:
+            message = "Matplotlib missing for needpie plot"
+            if current_needpie["title"]:
+                message += f" {current_needpie['title']!r}"
+            node.replace_self(nodes.error("", nodes.paragraph(text=message)))
+            continue
 
         # Set matplotlib style
         style_previous_to_script_execution = matplotlib.rcParams

--- a/tests/doc_test/doc_needbar/conf.py
+++ b/tests/doc_test/doc_needbar/conf.py
@@ -1,0 +1,8 @@
+extensions = ["sphinx_needs"]
+
+needs_id_regex = "^[A-Za-z0-9_]"
+
+needs_types = [
+    {"directive": "req", "title": "Requirement", "prefix": "RQ_", "color": "#FEDCD2", "style": "node"},
+    {"directive": "spec", "title": "Specification", "prefix": "SP_", "color": "#FEDCD2", "style": "node"},
+]

--- a/tests/doc_test/doc_needbar/index.rst
+++ b/tests/doc_test/doc_needbar/index.rst
@@ -1,0 +1,35 @@
+TEST DOCUMENT Needbar
+=====================
+
+.. req:: Req 1
+    :id: REQ_1
+    :tags: a
+
+.. req:: Req 2
+    :id: REQ_2
+    :tags: b
+
+.. req:: Req 3
+    :id: REQ_3
+    :tags: b
+
+.. spec:: Spec 1
+    :id: SPEC_1
+    :tags: a
+
+.. spec:: Spec 2
+    :id: SPEC_2
+    :tags: a
+
+.. spec:: Spec 3
+    :id: SPEC_3
+    :tags: b
+
+.. needbar:: Bar Title
+    :legend:
+    :xlabels: FROM_DATA
+    :ylabels: FROM_DATA
+
+         , A                           , B
+    Req  , type=='req' and 'a' in tags , type=='req' and 'a' in tags
+    Spec , type=='spec' and 'b' in tags, type=='spec' and 'b' in tags

--- a/tests/no_mpl_tests.py
+++ b/tests/no_mpl_tests.py
@@ -1,0 +1,18 @@
+"""These tests should only be run in an environment without matplotlib installed."""
+import pytest
+
+
+@pytest.mark.parametrize("test_app", [{"buildername": "html", "srcdir": "doc_test/doc_needbar"}], indirect=True)
+def test_needbar(test_app):
+    """Test the build fails correctly, if matplotlib is not installed."""
+    test_app.build()
+    expected = "WARNING: Matplotlib is not installed and required by needbar. Install with `sphinx-needs[plotting]` to use. [needs.mpl]"
+    assert expected in test_app._warning.getvalue()
+
+
+@pytest.mark.parametrize("test_app", [{"buildername": "html", "srcdir": "doc_test/doc_needpie"}], indirect=True)
+def test_needpie(test_app):
+    """Test the build fails correctly, if matplotlib is not installed."""
+    test_app.build()
+    expected = "WARNING: Matplotlib is not installed and required by needpie. Install with `sphinx-needs[plotting]` to use. [needs.mpl]"
+    assert expected in test_app._warning.getvalue()

--- a/tests/test_needbar.py
+++ b/tests/test_needbar.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.parametrize("test_app", [{"buildername": "html", "srcdir": "doc_test/doc_needbar"}], indirect=True)
+def test_doc_build_html(test_app):
+    app = test_app
+    app.build()
+    html = Path(app.outdir, "index.html").read_text()
+    assert "SPEC_1" in html
+    assert '<img alt="Bar Title"' in html


### PR DESCRIPTION
This PR supercedes #493

It makes matplotlib and numpy optional dependencies, using `pip install sphinx-needs[plotting]`, by:

1. Removing direct uses of numpy
2. Moving the matplotlib import to a function, which can return `None`
3. Handling the `None` case in the `needbar`/`needpie` post-processing, by emmiting a warning and replacing the nodes with error admonitions.

A seperate test job and related test file is added for testing builds with needbar/needpie directives, when matplotlib is uninstalled.