### PR TITLE
🔧 Fix Docker deployment

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -12,8 +12,12 @@ on:
   push:
     tags:
       - '*.*.*'
+  pull_request:
+    paths: ['docker/**']
+
 env:
   NEEDS_VERSION: 2.0.0
+  DEPLOY_IMAGE: ${{ github.event_name != 'pull_request' }}
 
 jobs:
   build:
@@ -46,30 +50,27 @@ jobs:
             latest=true
           tags: |
             type=pep440,pattern={{version}}
-      -
-        # Check if deployment is needed (if no manual trigger was done, defaults to 'y')
-        name: Check if deployment is needed
-        id: deploycheck
+
+      - name: Check if deployment manually disabled
+        if: github.event.inputs.deploy == 'n'
         run: |
-          DEPLOY_CHECK=${{ github.event.inputs.deploy }}
-          echo "::set-output name=value::${DEPLOY_CHECK:-"y"}"
-      -
-        # Login to Docker Hub Docker Registry for deployment
-        name: Login to Docker Hub Docker Registry 🐸
+          echo "DEPLOY_IMAGE=false" >> "$GITHUB_ENV"
+
+      - name: Login to Docker Hub Docker Registry 🐸
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Build and push html image to Doker Hub Docker Registry 🐳
+
+      - name: Build and push html image to Doker Hub Docker Registry 🐳
         id: docker_build
         uses: docker/build-push-action@v5
         with:
-          push: ${{ github.event_name != 'pull_request' && steps.deploycheck.outputs.value == 'y' }}
+          push: ${{ env.DEPLOY_IMAGE == 'true' }}
           file: docker/Dockerfile
           platforms: linux/amd64,linux/arm64
           build-args: |
             NEEDS_VERSION=${{ env.NEEDS_VERSION }}
             BASE_IMAGE=${{ matrix.base-image }}
           tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -22,6 +22,7 @@ env:
 jobs:
   build:
     strategy:
+      fail-fast: ${{ github.event_name != 'pull_request' }}
       matrix:
         base-image: ["sphinxdoc/sphinx:latest", "sphinxdoc/sphinx-latexpdf:latest"]
         image: ["sphinxneeds", "sphinxneeds-latexpdf"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,6 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 # Install apt & make
 RUN \
-  sed -i 's/# \(.*multiverse$\)/\1/g' /etc/apt/sources.list && \
   apt-get update && \
   apt-get upgrade -y && \
   apt-get install -y --no-install-recommends sudo
@@ -48,11 +47,11 @@ RUN pip3 install --no-cache-dir \
 # Install Sphinx-Needs
 RUN \
     if [ -n "$NEEDS_VERSION" ] && [ "$NEEDS_VERSION" = "pre-release" ]; then \
-      pip3 install --no-cache-dir git+https://github.com/useblocks/sphinx-needs; \
+      pip3 install --no-cache-dir "sphinx-needs[plotting] @ git+https://github.com/useblocks/sphinx-needs"; \
     elif [ -n "$NEEDS_VERSION" ]; then \
-      pip3 install --no-cache-dir git+https://github.com/useblocks/sphinx-needs@$NEEDS_VERSION; \
+      pip3 install --no-cache-dir "sphinx-needs[plotting] @ git+https://github.com/useblocks/sphinx-needs@$NEEDS_VERSION"; \
     else \
-      pip3 install --no-cache-dir sphinx-needs; \
+      pip3 install --no-cache-dir sphinx-needs[plotting]; \
     fi
 
 ## Clean up


### PR DESCRIPTION
Fix the Docker build, which failed on the last deployment

Also 

- Add the new `plotting` extra, to install `matplotlib`
- Makes the docker build workflow run (without deployment) in PRs that modify the Docker files,
- fixes deprecation warning in workflow: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/