### PR TITLE
🧪 Run CI also on pushes to master

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,8 @@
 name: CI
-on: [pull_request]
+on:
+  push:
+    branches: [master]
+  pull_request:
 jobs:
 
   lint:


### PR DESCRIPTION
This is mainly because it is required by codecov, for comparing coverage of PRs