### PR TITLE
👌 Make needtable titles more permissive

### DIFF
--- a/sphinx_needs/defaults.py
+++ b/sphinx_needs/defaults.py
@@ -199,7 +199,7 @@ NEEDFLOW_CONFIG_DEFAULTS = {
     """,
 }
 
-TITLE_REGEX = r'([\w]+) as "([\w ]+)"'
+TITLE_REGEX = r'([^\s]+) as "([^"]+)"'
 
 
 NEED_DEFAULT_OPTIONS: Dict[str, Any] = {

--- a/tests/doc_test/doc_needtable/conf.py
+++ b/tests/doc_test/doc_needtable/conf.py
@@ -23,6 +23,7 @@ needs_extra_options = [
     "github",
     "value",
     "unit",
+    "special-chars!",
 ]
 
 needs_string_links = {

--- a/tests/doc_test/doc_needtable/test_titles.rst
+++ b/tests/doc_test/doc_needtable/test_titles.rst
@@ -12,7 +12,8 @@ TEST Titles
 .. spec:: need 3
    :id: titles_003
    :links: titles_001
+   :special-chars!: special-chars value
 
 .. needtable::
-   :columns: id;title as "Headline" ;outgoing as "Links"; incoming as "To this need123";status;tags as "My Tags"
+   :columns: id;title as "Headline" ;outgoing as "Links"; incoming as "To this need123";status;tags as "My Tags";special-chars! as "Special Characters!"
    :style: table

--- a/tests/test_needtable.py
+++ b/tests/test_needtable.py
@@ -149,3 +149,5 @@ def test_doc_needtable_titles(test_app):
     html = Path(app.outdir, "test_titles.html").read_text()
     assert '<th class="head"><p>Headline</p></th>' in html
     assert '<th class="head"><p>To this need123</p></th>' in html
+    assert '<th class="head"><p>Special Characters!</p></th>' in html
+    assert '<td class="needs_special-chars!"><p>special-chars value</p></td>' in html


### PR DESCRIPTION
For `key as "title"` columns, the regex has been changed, to allow for the key to contain anything except whitespace characters, and the title to contain anything except the `"` character

closes #1089 