### PR TITLE
🐛👌 Centralise need missing link reporting

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -90,7 +90,7 @@ DEFAULT_DIAGRAM_TEMPLATE = (
 # Absolute path to the needs_report_template_file based on the conf.py directory
 # needs_report_template = "/needs_templates/report_template.need"   # Use custom report template
 
-needs_report_dead_links = False
+suppress_warnings = ["needs.link_outgoing"]
 
 needs_types = [
     # Architecture types

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -294,7 +294,13 @@ In this cases, you can provide a list of tuples.
 needs_report_dead_links
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Deactivate/activate log messages of outgoing dead links. If set to ``False``, then deactivate.
+.. deprecated:: 2.1.0
+
+    Instead add ``needs.link_outgoing`` to the `suppress_warnings <https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-suppress_warnings>`__ list::
+
+        suppress_warnings = ["needs.link_outgoing"]
+
+Deactivate/activate log messages of disallowed outgoing dead links. If set to ``False``, then deactivate.
 
 Default value is ``True``.
 

--- a/sphinx_needs/config.py
+++ b/sphinx_needs/config.py
@@ -191,6 +191,7 @@ class NeedsSphinxConfig:
     Example: [{"name": "blocks, "incoming": "is blocked by", "copy_link": True, "color": "#ffcc00"}]
     """
     report_dead_links: bool = field(default=True, metadata={"rebuild": "html", "types": (bool,)})
+    """DEPRECATED: Use ``suppress_warnings = ["needs.link_outgoing"]`` instead."""
     filter_data: dict[str, Any] = field(default_factory=dict, metadata={"rebuild": "html", "types": ()})
     allow_unsafe_filters: bool = field(default=False, metadata={"rebuild": "html", "types": (bool,)})
     flow_show_links: bool = field(default=False, metadata={"rebuild": "html", "types": (bool,)})

--- a/sphinx_needs/directives/need.py
+++ b/sphinx_needs/directives/need.py
@@ -29,7 +29,7 @@ from sphinx_needs.need_constraints import process_constraints
 from sphinx_needs.nodes import Need
 from sphinx_needs.utils import add_doc, profile, remove_node_from_tree, split_need_id
 
-logger = get_logger(__name__)
+LOGGER = get_logger(__name__)
 
 NON_BREAKING_SPACE = re.compile("\xa0+")
 
@@ -156,7 +156,7 @@ class NeedDirective(SphinxDirective):
         if links_string:
             for link in re.split(r";|,", links_string):
                 if link.isspace():
-                    logger.warning(
+                    LOGGER.warning(
                         f"Grubby link definition found in need '{self.trimmed_title}'. "
                         "Defined link contains spaces only. [needs]",
                         type="needs",
@@ -436,10 +436,10 @@ def check_links(needs: Dict[str, NeedsInfoType], config: NeedsSphinxConfig) -> N
     the ``has_forbidden_dead_links`` field is also added.
     """
     extra_links = config.extra_links
+    report_dead_links = config.report_dead_links
     for need in needs.values():
         for link_type in extra_links:
-            dead_links_allowed = link_type.get("allow_dead_links", False)
-            need_link_value: List[str] = (
+            need_link_value = (
                 [need[link_type["option"]]] if isinstance(need[link_type["option"]], str) else need[link_type["option"]]  # type: ignore
             )
             for need_id_full in need_link_value:
@@ -449,9 +449,26 @@ def check_links(needs: Dict[str, NeedsInfoType], config: NeedsSphinxConfig) -> N
                     need_id_main in needs and need_id_part and need_id_part not in needs[need_id_main]["parts"]
                 ):
                     need["has_dead_links"] = True
-                    if not dead_links_allowed:
+                    if not link_type.get("allow_dead_links", False):
                         need["has_forbidden_dead_links"] = True
-                    break  # One found dead link is enough
+                        if report_dead_links:
+                            message = f"Need '{need['id']}' has unknown outgoing link '{link}' in field '{link_type['option']}'"
+                            # if the need has been imported from an external URL,
+                            # we want to provide that URL as the location of the warning,
+                            # otherwise we use the location of the need in the source file
+                            if need.get("is_external", False):
+                                LOGGER.warning(
+                                    f"{need['external_url']}: {message} [needs.external_link_outgoing]",
+                                    type="needs",
+                                    subtype="external_link_outgoing",
+                                )
+                            else:
+                                LOGGER.warning(
+                                    f"{message} [needs.link_outgoing]",
+                                    location=(need["docname"], need["lineno"]),
+                                    type="needs",
+                                    subtype="link_outgoing",
+                                )
 
 
 def create_back_links(needs: Dict[str, NeedsInfoType], config: NeedsSphinxConfig) -> None:

--- a/sphinx_needs/directives/need.py
+++ b/sphinx_needs/directives/need.py
@@ -452,7 +452,7 @@ def check_links(needs: Dict[str, NeedsInfoType], config: NeedsSphinxConfig) -> N
                     if not link_type.get("allow_dead_links", False):
                         need["has_forbidden_dead_links"] = True
                         if report_dead_links:
-                            message = f"Need '{need['id']}' has unknown outgoing link '{link}' in field '{link_type['option']}'"
+                            message = f"Need '{need['id']}' has unknown outgoing link '{need_id_full}' in field '{link_type['option']}'"
                             # if the need has been imported from an external URL,
                             # we want to provide that URL as the location of the warning,
                             # otherwise we use the location of the need in the source file

--- a/sphinx_needs/roles/need_ref.py
+++ b/sphinx_needs/roles/need_ref.py
@@ -141,8 +141,9 @@ def process_need_ref(app: Sphinx, doctree: nodes.document, fromdocname: str, fou
 
         else:
             log.warning(
-                f"linked need {node_need_ref['reftarget']} not found [needs]",
+                f"linked need {node_need_ref['reftarget']} not found [needs.link_ref]",
                 type="needs",
+                subtype="link_ref",
                 location=node_need_ref,
             )
 

--- a/tests/doc_test/doc_report_dead_links_false/conf.py
+++ b/tests/doc_test/doc_report_dead_links_false/conf.py
@@ -10,7 +10,7 @@ needs_types = [
     {"directive": "test", "title": "Test Case", "prefix": "TC_", "color": "#DCB239", "style": "node"},
 ]
 
-needs_report_dead_links = False
+suppress_warnings = ["needs.link_outgoing"]
 
 needs_extra_links = [
     {

--- a/tests/test_broken_links.py
+++ b/tests/test_broken_links.py
@@ -1,13 +1,18 @@
 import pytest
+from sphinx.util.console import strip_colors
 
 
-@pytest.mark.parametrize("test_app", [{"buildername": "html", "srcdir": "doc_test/broken_links"}], indirect=True)
+@pytest.mark.parametrize(
+    "test_app", [{"buildername": "html", "srcdir": "doc_test/broken_links", "no_plantuml": True}], indirect=True
+)
 def test_doc_build_html(test_app):
     app = test_app
     app.build()
 
-    warning = app._warning
-    # stdout warnings
-    warnings = warning.getvalue()
-
-    assert "linked need BROKEN_LINK not found" in warnings
+    # check there are expected warnings
+    warnings = strip_colors(app._warning.getvalue().replace(str(app.srcdir), "srcdir"))
+    print(warnings.splitlines())
+    assert warnings.splitlines() == [
+        "srcdir/index.rst:12: WARNING: Need 'SP_TOO_002' has unknown outgoing link 'NOT_WORKING_LINK' in field 'links' [needs.link_outgoing]",
+        "srcdir/index.rst:21: WARNING: linked need BROKEN_LINK not found [needs.link_ref]",
+    ]

--- a/tests/test_needs_external_needs_build.py
+++ b/tests/test_needs_external_needs_build.py
@@ -22,7 +22,10 @@ def test_doc_build_html(test_app, sphinx_test_tempdir):
     output = subprocess.run(
         ["sphinx-build", "-b", "html", "-D", rf"plantuml={plantuml}", src_dir, out_dir], capture_output=True
     )
-    assert not output.stderr, f"Build failed with stderr: {output.stderr}"
+    assert output.stderr.decode("utf-8").splitlines() == [
+        "WARNING: http://my_company.com/docs/v1/index.html#TEST_01: Need 'EXT_TEST_01' has unknown outgoing link 'SPEC_1' in field 'links' [needs.external_link_outgoing]",
+        "WARNING: ../../_build/html/index.html#TEST_01: Need 'EXT_REL_PATH_TEST_01' has unknown outgoing link 'SPEC_1' in field 'links' [needs.external_link_outgoing]",
+    ]
 
     # run second time and check
     output_second = subprocess.run(

--- a/tests/test_report_dead_links.py
+++ b/tests/test_report_dead_links.py
@@ -1,3 +1,4 @@
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -6,61 +7,52 @@ import pytest
 @pytest.mark.parametrize(
     "test_app", [{"buildername": "html", "srcdir": "doc_test/doc_report_dead_links_true"}], indirect=True
 )
-def test_needs_report_dead_links_true(test_app):
-    import subprocess
-
+def test_needs_dead_links_warnings(test_app):
     app = test_app
-
-    # Check config value of needs_report_dead_links
-    assert app.config.needs_report_dead_links
 
     src_dir = Path(app.srcdir)
     out_dir = Path(app.outdir)
     output = subprocess.run(["sphinx-build", "-M", "html", src_dir, out_dir], capture_output=True)
 
-    # Check log info msg of dead links
-    assert (
-        "outgoing linked need DEAD_LINK_ALLOWED not found (document: index, source need REQ_001 on line 7 ) [needs]"
-        in output.stdout.decode("utf-8")
-    )
-    # Check log warning msg of dead links
-    assert (
-        "WARNING: outgoing linked need ANOTHER_DEAD_LINK not found (document: index, "
-        "source need REQ_004 on line 17 ) [needs]" in output.stderr.decode("utf-8")
-    )
-    assert (
-        "WARNING: outgoing linked need REQ_005 not found (document: index, source need TEST_004 on line 45 ) [needs]"
-        in output.stderr.decode("utf-8")
-    )
+    # check there are expected warnings
+    stderr = output.stderr.decode("utf-8")
+    stderr = stderr.replace(str(src_dir), "srcdir")
+    assert stderr.splitlines() == [
+        "srcdir/index.rst:17: WARNING: Need 'REQ_004' has unknown outgoing link 'ANOTHER_DEAD_LINK' in field 'links' [needs.link_outgoing]",
+        "srcdir/index.rst:45: WARNING: Need 'TEST_004' has unknown outgoing link 'REQ_005.invalid' in field 'links' [needs.link_outgoing]",
+        "srcdir/index.rst:45: WARNING: Need 'TEST_004' has unknown outgoing link 'REQ_005.invalid' in field 'tests' [needs.link_outgoing]",
+    ]
+
+
+@pytest.mark.parametrize(
+    "test_app", [{"buildername": "needs", "srcdir": "doc_test/doc_report_dead_links_true"}], indirect=True
+)
+def test_needs_dead_links_warnings_needs_builder(test_app):
+    app = test_app
+
+    src_dir = Path(app.srcdir)
+    out_dir = Path(app.outdir)
+    output = subprocess.run(["sphinx-build", "-M", "needs", src_dir, out_dir], capture_output=True)
+
+    # check there are expected warnings
+    stderr = output.stderr.decode("utf-8")
+    stderr = stderr.replace(str(src_dir), "srcdir")
+    assert stderr.splitlines() == [
+        "srcdir/index.rst:17: WARNING: Need 'REQ_004' has unknown outgoing link 'ANOTHER_DEAD_LINK' in field 'links' [needs.link_outgoing]",
+        "srcdir/index.rst:45: WARNING: Need 'TEST_004' has unknown outgoing link 'REQ_005.invalid' in field 'links' [needs.link_outgoing]",
+        "srcdir/index.rst:45: WARNING: Need 'TEST_004' has unknown outgoing link 'REQ_005.invalid' in field 'tests' [needs.link_outgoing]",
+    ]
 
 
 @pytest.mark.parametrize(
     "test_app", [{"buildername": "html", "srcdir": "doc_test/doc_report_dead_links_false"}], indirect=True
 )
-def test_needs_report_dead_links_false(test_app):
-    import subprocess
-
+def test_needs_dead_links_suppress_warnings(test_app):
     app = test_app
-
-    # Check config value of needs_report_dead_links
-    assert not app.config.needs_report_dead_links
 
     src_dir = Path(app.srcdir)
     out_dir = Path(app.outdir)
     output = subprocess.run(["sphinx-build", "-M", "html", src_dir, out_dir], capture_output=True)
 
-    # Check log info msg of dead links deactivated
-    assert (
-        "outgoing linked need DEAD_LINK_ALLOWED not found (document: index, source need REQ_001 on line 7 ) [needs]"
-        not in output.stdout.decode("utf-8")
-    )
-    # Check log warning msg of dead links deactivated
-    assert (
-        "WARNING: outgoing linked need ANOTHER_DEAD_LINK not found (document: index, "
-        "source need REQ_004 on line 17 ) [needs]" not in output.stderr.decode("utf-8")
-    )
-    assert (
-        "WARNING: outgoing linked need REQ_005 not found (document: index, source need TEST_004 on line 45 ) [needs]"
-        not in output.stderr.decode("utf-8")
-    )
+    # check there are no warnings
     assert not output.stderr


### PR DESCRIPTION
Currently, warnings for need outgoing links that reference a non-existent ID, are only generated "indirectly" in the render phase; where  `NeedOutgoing` nodes are converted to nodes that are understood by sphinx builders (HTML, PDF, ...).

Since this render phase is no longer needed/run for simply creating the `needs.json`, using the `needs` builder, these warnings are not generated.

Additionally, any needs that are not explicitly rendered in the documentation, like externally imported needs, are also skipped.

The reporting of unknown links is now moved to the `check_links` function, meaning it is now run for all needs and all builders. The warnings have also been given a subtype `link_outgoing` or `external_link_outgoing`, e.g.

```
srcdir/index.rst:12: WARNING: Need 'SP_TOO_002' has unknown outgoing link 'NOT_WORKING_LINK' in field 'links' [needs.link_outgoing]
WARNING: http://my_company.com/docs/v1/index.html#TEST_01: Need 'EXT_TEST_01' has unknown outgoing link 'SPEC_1' in field 'links' [needs.external_link_outgoing]
```

This means they can be suppressed using the standard Sphinx config: 

```python
suppress_warnings = ["needs.link_outgoing", "needs.external_link_outgoing"]` 
```

This deprecates the need for the `needs_report_dead_links` configuration, which now emits a deprecation warning if set by the user.

@danwos, do you agree that `needs_report_dead_links` can be deprecated, and that warnings should be emitted for unknown ids in external need links?

closes #1038 
closes #1095