### PR TITLE
🔧 Enforce type checking in `api/need.py`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,6 +45,8 @@ intersphinx_mapping = {
 
 nitpicky = True
 nitpick_ignore = [
+    ("py:class", "docutils.nodes.Node"),
+    ("py:class", "docutils.parsers.rst.states.RSTState"),
     ("py:class", "T"),
     ("py:class", "sphinx_needs.debug.T"),
     ("py:class", "sphinx_needs.data.NeedsInfoType"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,14 +138,9 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = [
-  'sphinx_needs.api.need',
-]
-ignore_errors = true
-
-[[tool.mypy.overrides]]
-module = [
   "sphinx_needs.directives.needextend",
   "sphinx_needs.functions.functions",
+  "sphinx_needs.api.need",
 ]
 # TODO dynamically overriding TypeDict keys is a bit tricky
 disable_error_code = "literal-required"

--- a/sphinx_needs/data.py
+++ b/sphinx_needs/data.py
@@ -26,17 +26,6 @@ class NeedsFilterType(TypedDict):
     """If set, the filter is exported with this ID in the needs.json file."""
 
 
-class NeedsBaseDataType(TypedDict):
-    """A base type for all data."""
-
-    docname: str
-    """Name of the document where the need is defined."""
-    lineno: int
-    """Line number where the need is defined."""
-    target_id: str
-    """ID of the data."""
-
-
 class NeedsPartType(TypedDict):
     """Data for a single need part."""
 
@@ -56,11 +45,20 @@ class NeedsPartType(TypedDict):
     """List of need IDs, which are referencing this part."""
 
 
-class NeedsInfoType(NeedsBaseDataType):
+class NeedsInfoType(TypedDict):
     """Data for a single need."""
 
+    target_id: str
+    """ID of the data."""
     id: str
     """ID of the data (same as target_id)"""
+
+    # TODO docname and lineno can be None, if the need is external,
+    # but currently this raises mypy errors for other parts of the code base
+    docname: str
+    """Name of the document where the need is defined."""
+    lineno: int
+    """Line number where the need is defined."""
 
     # meta information
     full_title: str
@@ -71,7 +69,7 @@ class NeedsInfoType(NeedsBaseDataType):
     tags: list[str]
 
     # rendering information
-    collapse: bool
+    collapse: None | bool
     """hide the meta-data information of the need."""
     hide: bool
     """If true, the need is not rendered."""
@@ -212,6 +210,17 @@ class NeedsPartsInfoType(NeedsInfoType):
     """docname where the part is defined."""
     id_parent: str
     id_complete: str
+
+
+class NeedsBaseDataType(TypedDict):
+    """A base type for data items collected from directives."""
+
+    docname: str
+    """Name of the document where the need is defined."""
+    lineno: int
+    """Line number where the need is defined."""
+    target_id: str
+    """ID of the data."""
 
 
 class NeedsBarType(NeedsBaseDataType):

--- a/sphinx_needs/directives/need.py
+++ b/sphinx_needs/directives/need.py
@@ -163,7 +163,7 @@ class NeedDirective(SphinxDirective):
             **need_extra_options,
         )
         add_doc(env, self.docname)
-        return need_nodes  # type: ignore[no-any-return]
+        return need_nodes
 
     def read_in_links(self, name: str) -> list[str]:
         # Get links


### PR DESCRIPTION
Note, I have made changes in a way to not breaking any existing logic / tests.
However, I've added a number of TODOs where I have "ignored" type incompatibilities that do look like they should be resolved.

For example, `add_external_need`, understandably sets `docname`/`lineno` to `None`, however, some parts of the code base appear to not account for this possibility.

Anyway, I'll look into these in later PRs