### PR TITLE
🔧  Remove `constraints` from `extra_options`

### DIFF
--- a/sphinx_needs/data.py
+++ b/sphinx_needs/data.py
@@ -179,7 +179,6 @@ class NeedsInfoType(TypedDict):
     # TODO these all default to "" which I don't think is good
     duration: str
     completion: str
-    # constraints: str  # this is already set in create_need
     # options from `BaseService.options` get added to every need,
     # via `ServiceManager.register`, which adds them to `extra_options``
     # GithubService

--- a/sphinx_needs/directives/need.py
+++ b/sphinx_needs/directives/need.py
@@ -130,6 +130,7 @@ class NeedDirective(SphinxDirective):
         post_template = self.options.get("post_template")
         duration = self.options.get("duration")
         completion = self.options.get("completion")
+        constraints = self.options.get("constraints", [])
 
         need_extra_options = {"duration": duration, "completion": completion}
         for extra_link in self.needs_config.extra_links:
@@ -160,6 +161,7 @@ class NeedDirective(SphinxDirective):
             layout=layout,
             delete=delete_opt,
             jinja_content=jinja_content,
+            constraints=constraints,
             **need_extra_options,
         )
         add_doc(env, self.docname)

--- a/sphinx_needs/directives/needimport.py
+++ b/sphinx_needs/directives/needimport.py
@@ -212,6 +212,7 @@ class NeedimportDirective(SphinxDirective):
             "style",
             "layout",
             "need_type",
+            "constraints",
             *[x["option"] for x in extra_links],
             *NEEDS_CONFIG.extra_options,
         )

--- a/sphinx_needs/external_needs.py
+++ b/sphinx_needs/external_needs.py
@@ -144,7 +144,7 @@ def load_external_needs(app: Sphinx, env: BuildEnvironment, _docname: str) -> No
             need_params["links"] = need.get("links", [])
             need_params["tags"] = ",".join(need.get("tags", []))
             need_params["status"] = need.get("status")
-            need_params["constraints"] = ",".join(need.get("constraints", []))
+            need_params["constraints"] = need.get("constraints", [])
 
             del need_params["description"]
 

--- a/sphinx_needs/needs.py
+++ b/sphinx_needs/needs.py
@@ -516,7 +516,6 @@ def prepare_env(app: Sphinx, env: BuildEnvironment, _docname: str) -> None:
     for option in [
         "duration",
         "completion",
-        "constraints",
     ]:
         # Check if not already set by user
         if option not in NEEDS_CONFIG.extra_options:


### PR DESCRIPTION
`constraints` is a core sphinx-need option, and so it is not necessary to add it to the `extra_options`

(this change was made as a result of #1122)