### PR TITLE
👌 Remove hard-coding of `completion` and `duration` need fields

### DIFF
--- a/sphinx_needs/config.py
+++ b/sphinx_needs/config.py
@@ -257,9 +257,11 @@ class NeedsSphinxConfig:
     duration_option: str = field(
         default="duration", metadata={"rebuild": "html", "types": (str,)}
     )
+    """Added to options on need directives, and key on need data items, for use by ``needgantt``"""
     completion_option: str = field(
         default="completion", metadata={"rebuild": "html", "types": (str,)}
     )
+    """Added to options on need directives, and key on need data items, for use by ``needgantt``"""
     needextend_strict: bool = field(
         default=True, metadata={"rebuild": "html", "types": (bool,)}
     )

--- a/sphinx_needs/data.py
+++ b/sphinx_needs/data.py
@@ -175,35 +175,35 @@ class NeedsInfoType(TypedDict):
     parent_need: str
     """Simply the first parent id"""
 
-    # default extra options
-    # TODO these all default to "" which I don't think is good
-    duration: str
-    completion: str
-    # options from `BaseService.options` get added to every need,
-    # via `ServiceManager.register`, which adds them to `extra_options``
-    # GithubService
+    # Fields added dynamically by services:
+    # options from ``BaseService.options`` get added to ``NEEDS_CONFIG.extra_options``,
+    # via `ServiceManager.register`,
+    # which in turn means they are added to every need via ``add_need``
+    # ``GithubService.options``
     avatar: str
     closed_at: str
     created_at: str
     max_amount: str
     service: str
     specific: str
-    # _type: str  # type is already set in create_need
+    ## type: str  # although this is already an internal field
     updated_at: str
     user: str
-    # OpenNeedsService
+    # ``OpenNeedsService.options``
     params: str
     prefix: str
     url_postfix: str
-    # shared GithubService and OpenNeedsService
+    # shared ``GithubService.options`` and ``OpenNeedsService.options``
     max_content_lines: str
     id_prefix: str
     query: str
     url: str
 
-    # Note there are also:
-    # - dynamic default options that can be set by needs_extra_options config
-    # - dynamic global options that can be set by needs_global_options config
+    # Note there are also these dynamic keys:
+    # - items in ``needs_extra_options`` + ``needs_duration_option`` + ``needs_completion_option``,
+    #   which get added to ``NEEDS_CONFIG.extra_options``,
+    #   and in turn means they are added to every need via ``add_need``
+    # - keys in ``needs_global_options`` config are added to every need via ``add_need``
 
 
 class NeedsPartsInfoType(NeedsInfoType):

--- a/sphinx_needs/data.py
+++ b/sphinx_needs/data.py
@@ -202,7 +202,7 @@ class NeedsInfoType(TypedDict):
     # Note there are also these dynamic keys:
     # - items in ``needs_extra_options`` + ``needs_duration_option`` + ``needs_completion_option``,
     #   which get added to ``NEEDS_CONFIG.extra_options``,
-    #   and in turn means they are added to every need via ``add_need``
+    #   and in turn means they are added to every need via ``add_need`` (as strings)
     # - keys in ``needs_global_options`` config are added to every need via ``add_need``
 
 

--- a/sphinx_needs/defaults.py
+++ b/sphinx_needs/defaults.py
@@ -219,8 +219,6 @@ NEED_DEFAULT_OPTIONS: dict[str, Any] = {
     "template": directives.unchanged_required,
     "pre_template": directives.unchanged_required,
     "post_template": directives.unchanged_required,
-    "duration": directives.unchanged_required,
-    "completion": directives.unchanged_required,
     "constraints": directives.unchanged_required,
     "constraints_passed": directives.unchanged_required,
     "constraints_results": directives.unchanged_required,

--- a/sphinx_needs/directives/need.py
+++ b/sphinx_needs/directives/need.py
@@ -128,11 +128,9 @@ class NeedDirective(SphinxDirective):
         template = self.options.get("template")
         pre_template = self.options.get("pre_template")
         post_template = self.options.get("post_template")
-        duration = self.options.get("duration")
-        completion = self.options.get("completion")
         constraints = self.options.get("constraints", [])
 
-        need_extra_options = {"duration": duration, "completion": completion}
+        need_extra_options = {}
         for extra_link in self.needs_config.extra_links:
             need_extra_options[extra_link["option"]] = self.options.get(
                 extra_link["option"], ""


### PR DESCRIPTION
As discussed in https://github.com/useblocks/sphinx-needs/issues/1122#issuecomment-1958004054,
These fields are used by `needgantt` but their name can be configured by `needs_duration_option` and `needs_completion_option`.

So here we remove the hard-coding and dynamically use these configuration options to set what option/key names are added.
 