### PR TITLE
🔧 Fix typing of need docname/lineno

### DIFF
--- a/sphinx_needs/api/need.py
+++ b/sphinx_needs/api/need.py
@@ -326,8 +326,8 @@ def add_need(
 
     # Add the need and all needed information
     needs_info: NeedsInfoType = {
-        "docname": docname,  # type: ignore[typeddict-item]
-        "lineno": lineno,  # type: ignore[typeddict-item]
+        "docname": docname,
+        "lineno": lineno,
         "doctype": doctype,
         "target_id": need_id,
         "content_node": None,

--- a/sphinx_needs/data.py
+++ b/sphinx_needs/data.py
@@ -48,12 +48,10 @@ class NeedsInfoType(TypedDict, total=False):
     id: Required[str]
     """ID of the data (same as target_id)"""
 
-    # TODO docname and lineno can be None, if the need is external,
-    # but currently this raises mypy errors for other parts of the code base
-    docname: Required[str]
-    """Name of the document where the need is defined."""
-    lineno: Required[int]
-    """Line number where the need is defined."""
+    docname: Required[str | None]
+    """Name of the document where the need is defined (None if external)"""
+    lineno: Required[int | None]
+    """Line number where the need is defined (None if external)"""
 
     # meta information
     full_title: Required[str]

--- a/sphinx_needs/diagrams_common.py
+++ b/sphinx_needs/diagrams_common.py
@@ -195,12 +195,9 @@ def calculate_link(
             if not parsed_url.scheme and not os.path.isabs(need_info["external_url"]):
                 # only need to add ../ or ..\ to get out of the image folder
                 link = ".." + os.path.sep + need_info["external_url"]
-        else:
+        elif _docname := need_info["docname"]:
             link = (
-                "../"
-                + builder.get_target_uri(need_info["docname"])
-                + "#"
-                + need_info["target_id"]
+                "../" + builder.get_target_uri(_docname) + "#" + need_info["target_id"]
             )
             if need_info["is_part"]:
                 link = f"{link}.{need_info['id']}"

--- a/sphinx_needs/directives/needlist.py
+++ b/sphinx_needs/directives/needlist.py
@@ -121,13 +121,11 @@ def process_needlist(
                     ref["classes"].append(need_info["external_css"])
                     ref.append(title)
                     para += ref
-                else:
+                elif _docname := need_info["docname"]:
                     target_id = need_info["target_id"]
                     ref = nodes.reference("", "")
-                    ref["refdocname"] = need_info["docname"]
-                    ref["refuri"] = builder.get_relative_uri(
-                        fromdocname, need_info["docname"]
-                    )
+                    ref["refdocname"] = _docname
+                    ref["refuri"] = builder.get_relative_uri(fromdocname, _docname)
                     ref["refuri"] += "#" + target_id
                     ref.append(title)
                     para += ref

--- a/sphinx_needs/functions/common.py
+++ b/sphinx_needs/functions/common.py
@@ -170,7 +170,7 @@ def copy(
             NeedsSphinxConfig(app.config),
             filter,
             need,
-            location=(need["docname"], need["lineno"]),
+            location=(need["docname"], need["lineno"]) if need["docname"] else None,
         )
         if result:
             need = result[0]

--- a/sphinx_needs/roles/need_incoming.py
+++ b/sphinx_needs/roles/need_incoming.py
@@ -57,11 +57,13 @@ def process_need_incoming(
                     #     link_text += ", "
                     node_need_backref[0] = nodes.Text(link_text)
 
-                    if not target_need["is_external"]:
+                    if not target_need["is_external"] and (
+                        _docname := target_need["docname"]
+                    ):
                         new_node_ref = make_refnode(
                             builder,
                             fromdocname,
-                            target_need["docname"],
+                            _docname,
                             target_need["target_id"],
                             node_need_backref[0].deepcopy(),
                             node_need_backref["reftarget"],

--- a/sphinx_needs/roles/need_outgoing.py
+++ b/sphinx_needs/roles/need_outgoing.py
@@ -81,11 +81,13 @@ def process_need_outgoing(
 
                     node_need_ref[0] = nodes.Text(link_text)
 
-                    if not target_need["is_external"]:
+                    if not target_need["is_external"] and (
+                        _docname := target_need["docname"]
+                    ):
                         new_node_ref = make_refnode(
                             builder,
                             fromdocname,
-                            target_need["docname"],
+                            _docname,
                             target_id,
                             node_need_ref[0].deepcopy(),
                             node_need_ref["reftarget"],

--- a/sphinx_needs/roles/need_ref.py
+++ b/sphinx_needs/roles/need_ref.py
@@ -133,11 +133,13 @@ def process_need_ref(
             node_need_ref[0].children[0] = nodes.Text(link_text)  # type: ignore[index]
 
             with contextlib.suppress(NoUri):
-                if not target_need.get("is_external", False):
+                if not target_need.get("is_external", False) and (
+                    _docname := target_need["docname"]
+                ):
                     new_node_ref = make_refnode(
                         builder,
                         fromdocname,
-                        target_need["docname"],
+                        _docname,
                         node_need_ref["reftarget"],
                         node_need_ref[0].deepcopy(),
                         node_need_ref["reftarget"],

--- a/sphinx_needs/utils.py
+++ b/sphinx_needs/utils.py
@@ -215,9 +215,9 @@ def row_col_maker(
                             )
                             ref_col["classes"].append(need_info["external_css"])
                             row_col["classes"].append(need_info["external_css"])
-                        else:
+                        elif _docname := need_info["docname"]:
                             ref_col["refuri"] = builder.get_relative_uri(
-                                fromdocname, need_info["docname"]
+                                fromdocname, _docname
                             )
                             ref_col["refuri"] += "#" + datum
                     elif ref_lookup:
@@ -231,9 +231,9 @@ def row_col_maker(
                             )
                             ref_col["classes"].append(temp_need["external_css"])
                             row_col["classes"].append(temp_need["external_css"])
-                        else:
+                        elif _docname := temp_need["docname"]:
                             ref_col["refuri"] = builder.get_relative_uri(
-                                fromdocname, temp_need["docname"]
+                                fromdocname, _docname
                             )
                             ref_col["refuri"] += "#" + temp_need["id"]
                             if link_part:


### PR DESCRIPTION
Account for these being `None` for external needs, that have no source mapping within the project

Practically, if `is_external is False` then `docname/lineno` are`str`, but if `is_external is True` then `docname/lineno` are `None`.
This internal relationship is difficult to encode in the type system though.
So here we always account for  `docname is None`, even if we have already checked for `is_external is False`