### PR TITLE
Allow to specify a part separator other than dot "."

### DIFF
--- a/sphinx_needs/config.py
+++ b/sphinx_needs/config.py
@@ -317,6 +317,10 @@ class NeedsSphinxConfig:
         default="→\xa0", metadata={"rebuild": "html", "types": (str,)}
     )
     """Prefix for need_part output in tables"""
+    part_separator: str = field(
+        default=".", metadata={"rebuild": "html", "types": (str,)}
+    )
+    """Separator character between a need and a need_part"""
     extra_links: list[LinkOptionsType] = field(
         default_factory=list, metadata={"rebuild": "html", "types": ()}
     )

--- a/sphinx_needs/directives/need.py
+++ b/sphinx_needs/directives/need.py
@@ -474,7 +474,9 @@ def check_links(needs: dict[str, NeedsInfoType], config: NeedsSphinxConfig) -> N
             _value = need[link_type["option"]]  # type: ignore[literal-required]
             need_link_value = [_value] if isinstance(_value, str) else _value
             for need_id_full in need_link_value:
-                need_id_main, need_id_part = split_need_id(need_id_full, config.part_separator)
+                need_id_main, need_id_part = split_need_id(
+                    need_id_full, config.part_separator
+                )
 
                 if need_id_main not in needs or (
                     need_id_main in needs
@@ -521,7 +523,9 @@ def create_back_links(
                 [need[option]] if isinstance(need[option], str) else need[option]  # type: ignore[literal-required]
             )
             for need_id_full in need_link_value:
-                need_id_main, need_id_part = split_need_id(need_id_full, config.part_separator)
+                need_id_main, need_id_part = split_need_id(
+                    need_id_full, config.part_separator
+                )
 
                 if need_id_main in needs:
                     if key not in needs[need_id_main][option_back]:  # type: ignore[literal-required]

--- a/sphinx_needs/directives/need.py
+++ b/sphinx_needs/directives/need.py
@@ -474,7 +474,7 @@ def check_links(needs: dict[str, NeedsInfoType], config: NeedsSphinxConfig) -> N
             _value = need[link_type["option"]]  # type: ignore[literal-required]
             need_link_value = [_value] if isinstance(_value, str) else _value
             for need_id_full in need_link_value:
-                need_id_main, need_id_part = split_need_id(need_id_full)
+                need_id_main, need_id_part = split_need_id(need_id_full, config.part_separator)
 
                 if need_id_main not in needs or (
                     need_id_main in needs
@@ -521,7 +521,7 @@ def create_back_links(
                 [need[option]] if isinstance(need[option], str) else need[option]  # type: ignore[literal-required]
             )
             for need_id_full in need_link_value:
-                need_id_main, need_id_part = split_need_id(need_id_full)
+                need_id_main, need_id_part = split_need_id(need_id_full, config.part_separator)
 
                 if need_id_main in needs:
                     if key not in needs[need_id_main][option_back]:  # type: ignore[literal-required]

--- a/sphinx_needs/roles/need_outgoing.py
+++ b/sphinx_needs/roles/need_outgoing.py
@@ -46,7 +46,7 @@ def process_need_outgoing(
         link_list = [links] if isinstance(links, str) else links
 
         for index, need_id_full in enumerate(link_list):
-            need_id_main, need_id_part = split_need_id(need_id_full)
+            need_id_main, need_id_part = split_need_id(need_id_full, needs_config.part_separator)
 
             # If the need target exists, let's create the reference
             if (need_id_main in needs_all_needs and not need_id_part) or (

--- a/sphinx_needs/roles/need_outgoing.py
+++ b/sphinx_needs/roles/need_outgoing.py
@@ -46,7 +46,9 @@ def process_need_outgoing(
         link_list = [links] if isinstance(links, str) else links
 
         for index, need_id_full in enumerate(link_list):
-            need_id_main, need_id_part = split_need_id(need_id_full, needs_config.part_separator)
+            need_id_main, need_id_part = split_need_id(
+                need_id_full, needs_config.part_separator
+            )
 
             # If the need target exists, let's create the reference
             if (need_id_main in needs_all_needs and not need_id_part) or (

--- a/sphinx_needs/roles/need_ref.py
+++ b/sphinx_needs/roles/need_ref.py
@@ -78,7 +78,7 @@ def process_need_ref(
         postfix = "]]"
 
         need_id_full = node_need_ref["reftarget"]
-        need_id_main, need_id_part = split_need_id(need_id_full)
+        need_id_main, need_id_part = split_need_id(need_id_full, needs_config.part_separator)
 
         if need_id_main in all_needs:
             target_need = all_needs[need_id_main]

--- a/sphinx_needs/roles/need_ref.py
+++ b/sphinx_needs/roles/need_ref.py
@@ -78,7 +78,9 @@ def process_need_ref(
         postfix = "]]"
 
         need_id_full = node_need_ref["reftarget"]
-        need_id_main, need_id_part = split_need_id(need_id_full, needs_config.part_separator)
+        need_id_main, need_id_part = split_need_id(
+            need_id_full, needs_config.part_separator
+        )
 
         if need_id_main in all_needs:
             target_need = all_needs[need_id_main]

--- a/sphinx_needs/utils.py
+++ b/sphinx_needs/utils.py
@@ -100,16 +100,16 @@ MONTH_NAMES = [
 ]
 
 
-def split_need_id(need_id_full: str) -> tuple[str, str | None]:
+def split_need_id(need_id_full: str, part_separator: str) -> tuple[str, str | None]:
     """A need id can be a combination of a main id and a part id,
-    split by a dot.
+    split by a separator, by default a dot.
     This function splits them:
-    If there is no dot, the part id is None,
-    otherwise everything before the first dot is the main id,
-    and everything after the first dot is the part id.
+    If there is no separator character, the part id is None,
+    otherwise everything before the first separator is the main id,
+    and everything after the first separator is the part id.
     """
-    if "." in need_id_full:
-        need_id, need_part_id = need_id_full.split(".", maxsplit=1)
+    if part_separator in need_id_full:
+        need_id, need_part_id = need_id_full.split(part_separator, maxsplit=1)
     else:
         need_id = need_id_full
         need_part_id = None


### PR DESCRIPTION
This (partly?) solves #1160.

With this patch you can refer to a need containing a dot, an example:

```
:need:`A5.1`
```

Before this patch:

```
Traceback (most recent call last):
  File "/home/nn/.local/pipx/venvs/sphinx/lib/python3.10/site-packages/sphinx/cmd/build.py", line 298, in build_main
    app.build(args.force_all, args.filenames)
  File "/home/nn/.local/pipx/venvs/sphinx/lib/python3.10/site-packages/sphinx/application.py", line 351, in build
    self.builder.build_all()
  File "/home/nn/.local/pipx/venvs/sphinx/lib/python3.10/site-packages/sphinx/builders/__init__.py", line 252, in build_all
    self.build(None, summary=__('all source files'), method='all')
  File "/home/nn/.local/pipx/venvs/sphinx/lib/python3.10/site-packages/sphinx/builders/__init__.py", line 363, in build
    self.write(docnames, list(updated_docnames), method)
  File "/home/nn/.local/pipx/venvs/sphinx/lib/python3.10/site-packages/sphinx/builders/latex/__init__.py", line 299, in write
    doctree = self.assemble_doctree(
  File "/home/nn/.local/pipx/venvs/sphinx/lib/python3.10/site-packages/sphinx/builders/latex/__init__.py", line 365, in assemble_doctree
    self.env.resolve_references(largetree, indexfile, self)
  File "/home/nn/.local/pipx/venvs/sphinx/lib/python3.10/site-packages/sphinx/environment/__init__.py", line 676, in resolve_references
    self.apply_post_transforms(doctree, fromdocname)
  File "/home/nn/.local/pipx/venvs/sphinx/lib/python3.10/site-packages/sphinx/environment/__init__.py", line 693, in apply_post_transforms
    self.events.emit('doctree-resolved', doctree, docname)
  File "/home/nn/.local/pipx/venvs/sphinx/lib/python3.10/site-packages/sphinx/events.py", line 97, in emit
    results.append(listener.handler(self.app, *args))
  File "/home/nn/code/github.com/holmboe/sphinx-needs/sphinx_needs/needs.py", line 350, in process_caller
    check_func(app, doctree, fromdocname, current_nodes[check_node])
  File "/home/nn/code/github.com/holmboe/sphinx-needs/sphinx_needs/roles/need_ref.py", line 95, in process_need_ref
    dict_need["title"] = target_need["parts"][need_id_part]["content"]
KeyError: '1'
> /home/nn/code/github.com/holmboe/sphinx-needs/sphinx_needs/roles/need_ref.py(95)process_need_ref()
-> dict_need["title"] = target_need["parts"][need_id_part]["content"]
```