### PR TITLE
🔧 Remove release to test-pypi

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,38 +22,9 @@ jobs:
           name: poetry_build
           path: dist/
 
-  # Test-PyPi release
-  publish_test:
-    name: Publish on TestPyPi
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.9
-      - uses: actions/download-artifact@v4
-        with:
-          name: poetry_build
-          path: dist/
-      - name: Display structure of downloaded files
-        run: ls -R
-      - name: install Poetry
-        run: python -m pip install poetry
-      - name: poetry configure TestPyPI Repo
-        run: poetry config repositories.test-pypi https://test.pypi.org/legacy/
-      - name: poetry configure TestPyPI Token
-        run:  poetry config pypi-token.test-pypi ${{ secrets.PYPI_TEST }}
-
-      - name: poetry publish TestPyPi
-        run: poetry publish -r test-pypi
-
-  # Get calls only, if publish on Test-PyPi has worked.
   publish_oficial:
     name: Publish on PyPi
     runs-on: ubuntu-latest
-    needs: publish_test
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python 3.9


### PR DESCRIPTION
This failed in the last release and TBH it doesn't make sense to upload to test-pypi on the actual release workflow, because it is too late to test then; 
if we wanted to do this it should be e.g. on every commit to the `master` branch