### PR TITLE
👌 Better typing for `needs_types` and allow default style/color

### DIFF
--- a/sphinx_needs/api/need.py
+++ b/sphinx_needs/api/need.py
@@ -177,10 +177,8 @@ def add_need(
         if ntype["directive"] == need_type:
             type_name = ntype["title"]
             type_prefix = ntype["prefix"]
-            type_color = (
-                ntype["color"] or "#000000"
-            )  # if no color set up user in config
-            type_style = ntype["style"] or "node"  # if no style set up user in config
+            type_color = ntype.get("color") or "#000000"
+            type_style = ntype.get("style") or "node"
             found = True
             break
 

--- a/sphinx_needs/config.py
+++ b/sphinx_needs/config.py
@@ -10,7 +10,7 @@ from sphinx_needs.defaults import DEFAULT_DIAGRAM_TEMPLATE
 
 if TYPE_CHECKING:
     from sphinx.util.logging import SphinxLoggerAdapter
-    from typing_extensions import Required
+    from typing_extensions import NotRequired, Required
 
     from sphinx_needs.data import NeedsInfoType
 
@@ -141,6 +141,21 @@ class LinkOptionsType(TypedDict, total=False):
     """If True, add a 'forbidden' class to dead links"""
 
 
+class NeedType(TypedDict):
+    """Defines a need type"""
+
+    directive: str
+    """The directive name."""
+    title: str
+    """A human readable title."""
+    prefix: str
+    """The prefix to use for the need ID."""
+    color: NotRequired[str]
+    """The default color to use in diagrams (default: "#000000")."""
+    style: NotRequired[str]
+    """The default node style to use in diagrams (default: "node")."""
+
+
 @dataclass
 class NeedsSphinxConfig:
     """A wrapper around the Sphinx configuration,
@@ -164,7 +179,7 @@ class NeedsSphinxConfig:
     def __setattr__(self, name: str, value: Any) -> None:
         return setattr(super().__getattribute__("_config"), f"needs_{name}", value)
 
-    types: list[dict[str, Any]] = field(
+    types: list[NeedType] = field(
         default_factory=lambda: [
             {
                 "directive": "req",

--- a/sphinx_needs/diagrams_common.py
+++ b/sphinx_needs/diagrams_common.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import html
 import os
 import textwrap
-from typing import Any, TypedDict
+from typing import TypedDict
 from urllib.parse import urlparse
 
 from docutils import nodes
@@ -16,7 +16,7 @@ from docutils.parsers.rst import directives
 from sphinx.application import Sphinx
 from sphinx.util.docutils import SphinxDirective
 
-from sphinx_needs.config import NeedsSphinxConfig
+from sphinx_needs.config import NeedsSphinxConfig, NeedType
 from sphinx_needs.data import NeedsFilteredBaseType, NeedsInfoType
 from sphinx_needs.errors import NoUri
 from sphinx_needs.logging import get_logger
@@ -208,8 +208,8 @@ def calculate_link(
     return link
 
 
-def create_legend(need_types: list[dict[str, Any]]) -> str:
-    def create_row(need_type: dict[str, Any]) -> str:
+def create_legend(need_types: list[NeedType]) -> str:
+    def create_row(need_type: NeedType) -> str:
         return "\n|<back:{color}> {color} </back>| {name} |".format(
             color=need_type["color"], name=need_type["title"]
         )

--- a/tests/doc_test/doc_basic/conf.py
+++ b/tests/doc_test/doc_basic/conf.py
@@ -11,27 +11,23 @@ needs_types = [
         "title": "User Story",
         "prefix": "US_",
         "color": "#BFD8D2",
-        "style": "node",
     },
     {
         "directive": "spec",
         "title": "Specification",
         "prefix": "SP_",
         "color": "#FEDCD2",
-        "style": "node",
     },
     {
         "directive": "impl",
         "title": "Implementation",
         "prefix": "IM_",
         "color": "#DF744A",
-        "style": "node",
     },
     {
         "directive": "test",
         "title": "Test Case",
         "prefix": "TC_",
         "color": "#DCB239",
-        "style": "node",
     },
 ]


### PR DESCRIPTION
Add typing for `needs_types`  items, and allow for the `style` and `color` keys to use defaults when undefined.