### PR TITLE
✨ Allow creating a `needflow` from a `root_id`

### DIFF
--- a/docs/directives/needflow.rst
+++ b/docs/directives/needflow.rst
@@ -45,6 +45,71 @@ Options
    **needflow** supports the full filtering possibilities of **Sphinx-Needs**.
    Please see :ref:`filter` for more information.
 
+.. _needflow_root_id:
+.. _needflow_root_direction:
+.. _needflow_root_depth:
+
+root_id
+~~~~~~~
+
+.. versionadded:: 2.2.0
+
+To select a root need for the flowchart and its connected needs, you can use the ``:root_id:`` option.
+This takes the id of the need you want to use as the root,
+and then traverses the tree of connected needs, to create an initial selection of needs to show in the flowchart.
+
+Connections are limited by the link types you have defined in the ``:link_types:`` option, or all link types if not defined.
+The direction of connections can be set with the ``:root_direction:`` option:
+``both`` (default), ``incoming`` or ``outgoing``.
+
+If ``:root_depth:`` is set, only needs with a distance of ``root_depth`` to the root need are shown.
+
+Other need filters are applied on this initial selection of connected needs.
+
+|ex|
+
+.. code-block:: rst
+
+   .. needflow::
+      :root_id: spec_flow_002
+      :root_direction: incoming
+      :link_types: tests, blocks
+      :show_link_names:
+
+   .. needflow::
+      :root_id: spec_flow_002
+      :root_direction: outgoing
+      :link_types: tests, blocks
+      :show_link_names:
+
+   .. needflow::
+      :root_id: spec_flow_002
+      :root_direction: outgoing
+      :root_depth: 1
+      :link_types: tests, blocks
+      :show_link_names:
+
+|out|
+
+.. needflow::
+   :root_id: spec_flow_002
+   :root_direction: incoming
+   :link_types: tests, blocks
+   :show_link_names:
+
+.. needflow::
+   :root_id: spec_flow_002
+   :root_direction: outgoing
+   :link_types: tests, blocks
+   :show_link_names:
+
+.. needflow::
+   :root_id: spec_flow_002
+   :root_direction: outgoing
+   :root_depth: 1
+   :link_types: tests, blocks
+   :show_link_names:
+
 .. _needflow_show_filters:
 
 show_filters

--- a/sphinx_needs/data.py
+++ b/sphinx_needs/data.py
@@ -319,6 +319,15 @@ class _NeedsFilterType(NeedsFilteredBaseType):
 class NeedsFlowType(NeedsFilteredDiagramBaseType):
     """Data for a single (filtered) flow chart."""
 
+    root_id: str | None
+    """need ID to use as a root node."""
+
+    root_direction: Literal["both", "incoming", "outgoing"]
+    """Which link directions to include from the root node (if set)."""
+
+    root_depth: int | None
+    """How many levels to include from the root node (if set)."""
+
 
 class NeedsGanttType(NeedsFilteredDiagramBaseType):
     """Data for a single (filtered) gantt chart."""

--- a/tests/doc_test/doc_needflow/index.rst
+++ b/tests/doc_test/doc_needflow/index.rst
@@ -4,7 +4,8 @@ TEST DOCUMENT NEEDFLOW
 .. toctree::
 
    page
-   empty_needflow_with_debug.rst
+   empty_needflow_with_debug
+   needflow_with_root_id
 
 
 .. spec:: Command line interface

--- a/tests/doc_test/doc_needflow/needflow_with_root_id.rst
+++ b/tests/doc_test/doc_needflow/needflow_with_root_id.rst
@@ -1,0 +1,8 @@
+needflow with root ID
+=====================
+
+
+.. needflow::
+   :root_id: SPEC_1
+   :root_direction: incoming
+   :debug:

--- a/tests/test_needflow.py
+++ b/tests/test_needflow.py
@@ -10,11 +10,6 @@ from docutils import __version__ as doc_ver
     indirect=True,
 )
 def test_doc_build_html(test_app):
-    import sphinx
-
-    if sphinx.__version__.startswith("3.5"):
-        return
-
     app = test_app
     app.build()
 
@@ -50,6 +45,12 @@ def test_doc_build_html(test_app):
     assert "STORY_1.subspec [[../index.html#STORY_1.subspec]]" in page_html
     assert "STORY_2 [[../index.html#STORY_2]]" in page_html
     assert "STORY_2.another_one [[../index.html#STORY_2.another_one]]" in page_html
+
+    with_rootid = Path(app.outdir, "needflow_with_root_id.html").read_text()
+    assert "SPEC_1" in with_rootid
+    assert "STORY_1" in with_rootid
+    assert "STORY_2" in with_rootid
+    assert "SPEC_2" not in with_rootid
 
     empty_needflow_with_debug = Path(
         app.outdir, "empty_needflow_with_debug.html"


### PR DESCRIPTION
A classic use-case for visualising a graph, is to select a root node and visualise the sub-tree of all ancestor / decendant nodes.
Here we add the capability to the `needflow` directive, via new `root_id`, `root_direction` and `root_depth` options