### PR TITLE
👌 Improve need link tooltips

### DIFF
--- a/sphinx_needs/layout.py
+++ b/sphinx_needs/layout.py
@@ -692,7 +692,7 @@ class LayoutHandler:
                 todocname=_docname,
                 targetid=self.need["id"],
                 child=nodes_id_text.deepcopy(),
-                title=self.need["id"],
+                title=None,
             )
             id_container += id_ref
         return id_container

--- a/sphinx_needs/roles/need_incoming.py
+++ b/sphinx_needs/roles/need_incoming.py
@@ -66,7 +66,7 @@ def process_need_incoming(
                             _docname,
                             target_need["target_id"],
                             node_need_backref[0].deepcopy(),
-                            node_need_backref["reftarget"],
+                            target_need["title"],
                         )
                     else:
                         assert (

--- a/sphinx_needs/roles/need_outgoing.py
+++ b/sphinx_needs/roles/need_outgoing.py
@@ -90,7 +90,7 @@ def process_need_outgoing(
                             _docname,
                             target_id,
                             node_need_ref[0].deepcopy(),
-                            node_need_ref["reftarget"],
+                            target_need["title"],
                         )
                     else:
                         assert (


### PR DESCRIPTION
Currently, the tooltips in needs, for links to need IDs is a bit odd, it just says the current need ID with no context:
 
![need-hover-now](https://github.com/useblocks/sphinx-needs/assets/2997570/feb3ee65-5824-4381-992b-f4c4690cbedb)

This seems not useful, so here I have changed them to provide a tooltip of the title of the linked need:

![need-hover-after](https://github.com/useblocks/sphinx-needs/assets/2997570/36b4d879-0681-4e2e-b2f6-3ae4765e333c)
