### PR TITLE
✨ Add `border_color` option for `needflow`

### DIFF
--- a/docs/directives/needflow.rst
+++ b/docs/directives/needflow.rst
@@ -282,6 +282,26 @@ sets the border for each need of the needflow to **red** if the need also passes
       :link_types: tests, blocks
       :highlight: id in ['spec_flow_002', 'subspec_2'] or type == 'req'
 
+.. _needflow_border_color:
+
+border_color
+~~~~~~~~~~~~
+
+.. versionadded:: 3.0.0
+
+The ``:border_color:`` allows for setting per need border colors, based on the need data.
+The value should be written with the :ref:`variant syntax <needs_variant_support>`, and each return value should be a hex (RGB) color.
+
+.. need-example::
+
+   .. needflow:: Engineering plan to develop a car
+      :tags: flow_example
+      :link_types: tests, blocks
+      :border_color:
+         [type == 'req']:FF0000,
+         [type == 'spec']:0000FF,
+         [type == 'test']:00FF00
+
 .. _needflow_align:
 
 align

--- a/sphinx_needs/data.py
+++ b/sphinx_needs/data.py
@@ -328,6 +328,9 @@ class NeedsFlowType(NeedsFilteredDiagramBaseType):
     root_depth: int | None
     """How many levels to include from the root node (if set)."""
 
+    border_color: str | None
+    """Color of the outline of the needs, specified using the variant syntax."""
+
 
 class NeedsGanttType(NeedsFilteredDiagramBaseType):
     """Data for a single (filtered) gantt chart."""

--- a/sphinx_needs/directives/needflow.py
+++ b/sphinx_needs/directives/needflow.py
@@ -26,6 +26,7 @@ from sphinx_needs.logging import get_logger
 from sphinx_needs.utils import (
     add_doc,
     get_scale,
+    match_variants,
     remove_node_from_tree,
     split_link_types,
 )
@@ -60,6 +61,7 @@ class NeedflowDirective(FilterBase):
         "config": directives.unchanged_required,
         "scale": directives.unchanged_required,
         "highlight": directives.unchanged_required,
+        "border_color": directives.unchanged_required,
         "align": directives.unchanged_required,
         "debug": directives.flag,
     }
@@ -108,6 +110,7 @@ class NeedflowDirective(FilterBase):
             "config_names": config_names,
             "scale": get_scale(self.options, location),
             "highlight": self.options.get("highlight", ""),
+            "border_color": self.options.get("border_color", None),
             "align": self.options.get("align"),
             "debug": "debug" in self.options,
             "caption": self.arguments[0] if self.arguments else None,
@@ -151,6 +154,16 @@ def get_need_node_rep_for_plantuml(
         need_info, needs_config, current_needflow["highlight"], all_needs
     ):
         node_colors.append("line:FF0000")
+
+    elif current_needflow["border_color"]:
+        color = match_variants(
+            current_needflow["border_color"],
+            {**need_info},
+            needs_config.variants,
+            location=(current_needflow["docname"], current_needflow["lineno"]),
+        )
+        if color:
+            node_colors.append(f"line:{color}")
 
     # need parts style use default "rectangle"
     if need_info["is_need"]:


### PR DESCRIPTION
The ``:border_color:`` option allows for setting per need border colors, based on the need data.
The value should be written with the variant syntax, and each return value should be a hex (RGB) color.

See: https://sphinx-needs--1194.org.readthedocs.build/en/1194/directives/needflow.html#border-color