### PR TITLE
FIX: Use `re.fullmatch` for `needs_id_regex` in need creation

### DIFF
--- a/sphinx_needs/api/need.py
+++ b/sphinx_needs/api/need.py
@@ -216,7 +216,7 @@ def add_need(
     if (
         needs_config.id_regex
         and not is_external
-        and not re.match(needs_config.id_regex, need_id)
+        and not re.fullmatch(needs_config.id_regex, need_id)
     ):
         raise NeedsInvalidException(
             f"Given ID '{need_id}' does not match configured regex '{needs_config.id_regex}'"


### PR DESCRIPTION
The regex supplied should be assumed to match the entire string, rather than be a partial match (as is the case currently using `re.match`).

This is then consistent with the usage of `needs_id_regex` in:

- https://github.com/useblocks/sphinx-needs/blob/1de1a7a047bfc7912ea0aa779ffb187def7a5254/sphinx_needs/directives/needextend.py#L111
- - https://github.com/useblocks/sphinx-needs/blob/1de1a7a047bfc7912ea0aa779ffb187def7a5254/sphinx_needs/directives/needextract.py#L103
