### PR TITLE
🐛 fix warnings for duplicate needs in parallel builds

### DIFF
--- a/sphinx_needs/api/exceptions.py
+++ b/sphinx_needs/api/exceptions.py
@@ -19,10 +19,6 @@ class NeedsNoIdException(SphinxError):
     pass
 
 
-class NeedsDuplicatedId(SphinxError):
-    pass
-
-
 class NeedsStatusNotAllowed(SphinxError):
     pass
 

--- a/sphinx_needs/data.py
+++ b/sphinx_needs/data.py
@@ -678,7 +678,6 @@ def merge_data(
 
     _merge("needs_all_docs")
     _merge("need_all_needbar")
-    _merge("need_all_needbar")
     _merge("need_all_needextend")
     _merge("need_all_needextracts")
     _merge("need_all_needfilters")

--- a/sphinx_needs/data.py
+++ b/sphinx_needs/data.py
@@ -652,7 +652,7 @@ def merge_data(
 
     # update other data
 
-    def _merge(name: str) -> None:
+    def _merge(name: str, is_complex_dict: bool = False) -> None:
         # Update global needs dict
         if not hasattr(env, name):
             setattr(env, name, {})
@@ -660,14 +660,17 @@ def merge_data(
         if hasattr(other, name):
             other_objects = getattr(other, name)
             if isinstance(other_objects, dict) and isinstance(objects, dict):
-                for other_key, other_value in other_objects.items():
-                    # other_value is a list from here on!
-                    if other_key in objects:
-                        objects[other_key] = list(
-                            set(objects[other_key]) | set(other_value)
-                        )
-                    else:
-                        objects[other_key] = other_value
+                if not is_complex_dict:
+                    objects.update(other_objects)
+                else:
+                    for other_key, other_value in other_objects.items():
+                        # other_value is a list from here on!
+                        if other_key in objects:
+                            objects[other_key] = list(
+                                set(objects[other_key]) | set(other_value)
+                            )
+                        else:
+                            objects[other_key] = other_value
             elif isinstance(other_objects, list) and isinstance(objects, list):
                 objects = list(set(objects) | set(other_objects))
             else:
@@ -676,7 +679,7 @@ def merge_data(
                     f"not {type(other_objects)} and {type(objects)}"
                 )
 
-    _merge("needs_all_docs")
+    _merge("needs_all_docs", is_complex_dict=True)
     _merge("need_all_needbar")
     _merge("need_all_needextend")
     _merge("need_all_needextracts")

--- a/sphinx_needs/external_needs.py
+++ b/sphinx_needs/external_needs.py
@@ -11,7 +11,6 @@ from sphinx.application import Sphinx
 from sphinx.environment import BuildEnvironment
 
 from sphinx_needs.api import add_external_need, del_need
-from sphinx_needs.api.exceptions import NeedsDuplicatedId
 from sphinx_needs.config import NeedsSphinxConfig
 from sphinx_needs.data import SphinxNeedsData
 from sphinx_needs.logging import get_logger
@@ -30,7 +29,7 @@ def get_target_template(target_url: str) -> Template:
     return mem_template
 
 
-def load_external_needs(app: Sphinx, env: BuildEnvironment, _docname: str) -> None:
+def load_external_needs(app: Sphinx, env: BuildEnvironment, docname: str) -> None:
     """Load needs from configured external sources."""
     needs_config = NeedsSphinxConfig(app.config)
     for source in needs_config.external_needs:
@@ -159,10 +158,14 @@ def load_external_needs(app: Sphinx, env: BuildEnvironment, _docname: str) -> No
                     # delete the already existing external need from api need
                     del_need(app, ext_need_id)
                 else:
-                    raise NeedsDuplicatedId(
-                        f'During external needs handling, an identical ID was detected: {ext_need_id} \
-                            from needs_external_needs url: {source["base_url"]}'
+                    log.warning(
+                        f'During external needs handling, an identical ID was detected: {ext_need_id} '
+                        f'from needs_external_needs url: {source["base_url"]} [needs.duplicate_id]',
+                        type="needs",
+                        subtype="duplicate_id",
+                        location=docname if docname else None,
                     )
+                    return None
 
             add_external_need(app, **need_params)
 

--- a/tests/doc_test/parallel_doc/index.rst
+++ b/tests/doc_test/parallel_doc/index.rst
@@ -7,6 +7,7 @@ PARALLEL TEST DOCUMENT
    page_2
    page_3
    page_4
+   page_5
 
 .. spec:: Command line interface
     :id: SP_TOO_001

--- a/tests/doc_test/parallel_doc/page_5.rst
+++ b/tests/doc_test/parallel_doc/page_5.rst
@@ -1,0 +1,5 @@
+Page 5
+======
+
+.. story:: duplicate
+   :id: STORY_PAGE_1

--- a/tests/test_broken_doc.py
+++ b/tests/test_broken_doc.py
@@ -1,18 +1,26 @@
-import pytest
+import os
 
-from sphinx_needs.api.need import NeedsDuplicatedId
+import pytest
+from sphinx.testing.util import SphinxTestApp
+from sphinx.util.console import strip_colors
 
 
 @pytest.mark.parametrize(
     "test_app",
-    [{"buildername": "html", "srcdir": "doc_test/broken_doc"}],
+    [{"buildername": "html", "srcdir": "doc_test/broken_doc", "no_plantuml": True}],
     indirect=True,
 )
-def test_doc_build_html(test_app):
-    with pytest.raises(NeedsDuplicatedId):
-        app = test_app
-
-        app.build()
-        html = (app.outdir / "index.html").read_text()
-        assert "<h1>BROKEN DOCUMENT" in html
-        assert "SP_TOO_001" in html
+def test_doc_build_html(test_app: SphinxTestApp):
+    test_app.build()
+    warnings = (
+        strip_colors(test_app._warning.getvalue())
+        .replace(str(test_app.srcdir) + os.path.sep, "<srcdir>/")
+        .strip()
+    )
+    assert (
+        warnings
+        == "<srcdir>/index.rst:11: WARNING: A need with ID SP_TOO_001 already exists, title: 'Command line interface'. [needs.duplicate_id]"
+    )
+    html = (test_app.outdir / "index.html").read_text()
+    assert "<h1>BROKEN DOCUMENT" in html
+    assert "SP_TOO_001" in html


### PR DESCRIPTION
Change duplicate need feedback from raising exceptions to emitting Sphinx warnings, e.g.

```
path/to/page.rst:4: WARNING: A need with ID STORY_PAGE_1 already exists, title: 'duplicate'. [needs.duplicate_id]
```

and ensure warning is also emitted during parallel builds

Note, although there was already a parallel build test in the test suite, 
actually it was not running parallel because there were not enough documents in the test project (see https://github.com/sphinx-doc/sphinx/pull/12796),
so one more is added and now the warning is correct.
