### PR TITLE
👌 Add `needs_json_remove_defaults` configuration

### DIFF
--- a/docs/builders.rst
+++ b/docs/builders.rst
@@ -58,6 +58,8 @@ This allows to export specified filter results only.
       :export_id: filter_01
 
 
+.. _needs_builder_format:
+
 Format
 ++++++
 
@@ -65,6 +67,8 @@ As well as the ``filters`` and ``needs`` data, the **needs.json** file also cont
 This is a JSON schema of for the data structure of a single need,
 and also includes a ``field_type`` for each field, to denote the source of the field,
 and can be one of: ``core``, ``links``, ``extra``, ``global`` ``bool``.
+
+See also :ref:`needs_build_json_per_id` and :ref:`needs_json_remove_defaults` for more options on modifying the content of the ``needs.json`` file.
 
 .. code-block:: python
 

--- a/docs/builders.rst
+++ b/docs/builders.rst
@@ -66,7 +66,7 @@ Format
 As well as the ``filters`` and ``needs`` data, the **needs.json** file also contains the ``needs_schema``.
 This is a JSON schema of for the data structure of a single need,
 and also includes a ``field_type`` for each field, to denote the source of the field,
-and can be one of: ``core``, ``links``, ``extra``, ``global`` ``bool``.
+that can be one of: ``core``, ``links``, ``extra``, ``global``.
 
 See also :ref:`needs_build_json_per_id` and :ref:`needs_json_remove_defaults` for more options on modifying the content of the ``needs.json`` file.
 

--- a/docs/builders.rst
+++ b/docs/builders.rst
@@ -108,7 +108,8 @@ See also :ref:`needs_build_json_per_id` and :ref:`needs_json_remove_defaults` fo
                         "items": {
                             "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "default": []
                     },
                     "status": {
                         "description": "Status of the need.",
@@ -116,7 +117,8 @@ See also :ref:`needs_build_json_per_id` and :ref:`needs_json_remove_defaults` fo
                         "type": [
                             "string",
                             "null"
-                        ]
+                        ],
+                        "default": null
                     },
                     ...
                 }
@@ -161,7 +163,8 @@ See also :ref:`needs_build_json_per_id` and :ref:`needs_json_remove_defaults` fo
                     "items": {
                         "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "default": []
                 },
                 "status": {
                     "description": "Status of the need.",
@@ -169,7 +172,8 @@ See also :ref:`needs_build_json_per_id` and :ref:`needs_json_remove_defaults` fo
                     "type": [
                         "string",
                         "null"
-                    ]
+                    ],
+                    "default": null
                 },
                 ...
             },

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1725,8 +1725,8 @@ needs_json_remove_defaults
 
 .. versionadded:: 2.1.0
 
-Setting ``needs_json_remove_defaults = True`` will remove all need fields with default values, greatly reducing the size of the JSON file.
-The defaults are can be retrieved from the ``needs_schema`` now also output in the JSON file.
+Setting ``needs_json_remove_defaults = True`` will remove all need fields with default from ``needs.json``, greatly reducing its size.
+The defaults can be retrieved from the ``needs_schema`` now also output in the JSON file (see :ref:`this section <needs_builder_format>` for the format).
 
 .. _needs_build_json_per_id:
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1689,7 +1689,9 @@ Builds a ``needs.json`` file during other builds, like ``html``.
 
 This allows to have one single Sphinx-Build for two output formats, which may save some time.
 
-All other ``needs.json`` related configuration values, like :ref:`needs_file`, are taken into account.
+All other ``needs.json`` related configuration values, like :ref:`needs_file`,
+:ref:`needs_build_json_per_id` and :ref:`needs_json_remove_defaults` 
+are taken into account.
 
 Default: False
 
@@ -1704,15 +1706,27 @@ Example:
    The created ``needs.json`` file gets stored in the ``outdir`` of the current builder.
    So if ``html`` is used as builder, the final location is e.g. ``_build/html/needs.json``.
 
+   See :ref:`this section <needs_builder_format>`, for an explanation of the output format.
+
+.. _needs_reproducible_json:
+
+needs_reproducible_json 
+~~~~~~~~~~~~~~~~~~~~~~~
+
 .. versionadded:: 2.0.0
 
-    Setting ``needs_reproducible_json = True`` will ensure the JSON output is reproducible,
-    e.g. by removing timestamps from the output.
+Setting ``needs_reproducible_json = True`` will ensure the ``needs.json`` output is reproducible,
+e.g. by removing timestamps from the output.
+
+.. _needs_json_remove_defaults:
+
+needs_json_remove_defaults 
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. versionadded:: 2.1.0
 
-    Setting ``needs_json_remove_defaults = True`` will remove all need fields with default values, greatly reducing the size of the JSON file.
-    The defaults are can be retrieved from the ``needs_schema`` now also output in the JSON file.
+Setting ``needs_json_remove_defaults = True`` will remove all need fields with default values, greatly reducing the size of the JSON file.
+The defaults are can be retrieved from the ``needs_schema`` now also output in the JSON file.
 
 .. _needs_build_json_per_id:
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1709,6 +1709,10 @@ Example:
     Setting ``needs_reproducible_json = True`` will ensure the JSON output is reproducible,
     e.g. by removing timestamps from the output.
 
+.. versionadded:: 2.1.0
+
+    Setting ``needs_json_remove_defaults = True`` will remove all need fields with default values, greatly reducing the size of the JSON file.
+    The defaults are can be retrieved from the ``needs_schema`` now also output in the JSON file.
 
 .. _needs_build_json_per_id:
 

--- a/sphinx_needs/config.py
+++ b/sphinx_needs/config.py
@@ -435,6 +435,10 @@ class NeedsSphinxConfig:
         default=False, metadata={"rebuild": "html", "types": (bool,)}
     )
     """If True, the JSON needs file should be idempotent for multiple builds fo the same documentation."""
+    json_remove_defaults: bool = field(
+        default=False, metadata={"rebuild": "html", "types": (bool,)}
+    )
+    """If True, remove need fields with default values from the JSON needs file."""
     build_needumls: str = field(
         default="", metadata={"rebuild": "html", "types": (str,)}
     )

--- a/sphinx_needs/data.py
+++ b/sphinx_needs/data.py
@@ -63,21 +63,21 @@ NeedsCoreFields: Final[Mapping[str, CoreFieldParameters]] = {
     "id": {"description": "ID of the data.", "schema": {"type": "string"}},
     "docname": {
         "description": "Name of the document where the need is defined (None if external).",
-        "schema": {"type": ["string", "null"]},
+        "schema": {"type": ["string", "null"], "default": None},
     },
     "lineno": {
         "description": "Line number where the need is defined (None if external).",
-        "schema": {"type": ["integer", "null"]},
+        "schema": {"type": ["integer", "null"], "default": None},
         "exclude_json": True,
     },
     "lineno_content": {
         "description": "Line number on which the need content starts (None if external).",
-        "schema": {"type": ["integer", "null"]},
+        "schema": {"type": ["integer", "null"], "default": None},
         "exclude_json": True,
     },
     "full_title": {
         "description": "Title of the need, of unlimited length.",
-        "schema": {"type": "string"},
+        "schema": {"type": "string", "default": ""},
     },
     "title": {
         "description": "Title of the need, trimmed to a maximum length.",
@@ -85,139 +85,153 @@ NeedsCoreFields: Final[Mapping[str, CoreFieldParameters]] = {
     },
     "status": {
         "description": "Status of the need.",
-        "schema": {"type": ["string", "null"]},
+        "schema": {"type": ["string", "null"], "default": None},
         "show_in_layout": True,
     },
     "tags": {
         "description": "List of tags.",
-        "schema": {"type": "array", "items": {"type": "string"}},
+        "schema": {"type": "array", "items": {"type": "string"}, "default": []},
         "show_in_layout": True,
     },
     "collapse": {
         "description": "Hide the meta-data information of the need.",
-        "schema": {"type": ["boolean", "null"]},
+        "schema": {"type": ["boolean", "null"], "default": None},
         "exclude_json": True,
     },
     "hide": {
         "description": "If true, the need is not rendered.",
-        "schema": {"type": "boolean"},
+        "schema": {"type": "boolean", "default": False},
         "exclude_json": True,
     },
     "delete": {
         "description": "If true, the need is deleted entirely.",
-        "schema": {"type": "boolean"},
+        "schema": {"type": ["boolean", "null"], "default": None},
         "show_in_layout": True,
     },
     "layout": {
         "description": "Key of the layout, which is used to render the need.",
-        "schema": {"type": ["string", "null"]},
+        "schema": {"type": ["string", "null"], "default": None},
         "show_in_layout": True,
     },
     "style": {
         "description": "Comma-separated list of CSS classes (all appended by `needs_style_`).",
-        "schema": {"type": ["string", "null"]},
+        "schema": {"type": ["string", "null"], "default": None},
         "show_in_layout": True,
     },
     "arch": {
         "description": "Mapping of uml key to uml content.",
-        "schema": {"type": "object", "additionalProperties": {"type": "string"}},
+        "schema": {
+            "type": "object",
+            "additionalProperties": {"type": "string"},
+            "default": {},
+        },
     },
     "is_external": {
         "description": "If true, no node is created and need is referencing external url.",
-        "schema": {"type": "boolean"},
+        "schema": {"type": "boolean", "default": False},
     },
     "external_url": {
         "description": "URL of the need, if it is an external need.",
-        "schema": {"type": ["string", "null"]},
+        "schema": {"type": ["string", "null"], "default": None},
         "show_in_layout": True,
     },
     "external_css": {
         "description": "CSS class name, added to the external reference.",
-        "schema": {"type": "string"},
+        "schema": {"type": "string", "default": ""},
     },
-    "type": {"description": "Type of the need.", "schema": {"type": "string"}},
-    "type_name": {"description": "Name of the type.", "schema": {"type": "string"}},
+    "type": {
+        "description": "Type of the need.",
+        "schema": {"type": "string", "default": ""},
+    },
+    "type_name": {
+        "description": "Name of the type.",
+        "schema": {"type": "string", "default": ""},
+    },
     "type_prefix": {
         "description": "Prefix of the type.",
-        "schema": {"type": "string"},
+        "schema": {"type": "string", "default": ""},
         "exclude_json": True,
     },
     "type_color": {
         "description": "Hexadecimal color code of the type.",
-        "schema": {"type": "string"},
+        "schema": {"type": "string", "default": ""},
         "exclude_json": True,
     },
     "type_style": {
         "description": "Style of the type.",
-        "schema": {"type": "string"},
+        "schema": {"type": "string", "default": ""},
         "exclude_json": True,
     },
     "is_modified": {
         "description": "Whether the need was modified by needextend.",
-        "schema": {"type": "boolean"},
+        "schema": {"type": "boolean", "default": False},
     },
     "modifications": {
         "description": "Number of modifications by needextend.",
-        "schema": {"type": "integer"},
+        "schema": {"type": "integer", "default": 0},
     },
     "is_need": {
         "description": "Whether the need is a need.",
-        "schema": {"type": "boolean"},
+        "schema": {"type": "boolean", "default": True},
     },
     "is_part": {
         "description": "Whether the need is a part.",
-        "schema": {"type": "boolean"},
+        "schema": {"type": "boolean", "default": False},
     },
     "parts": {
         "description": "Mapping of parts, a.k.a. sub-needs, IDs to data that overrides the need's data",
-        "schema": {"type": "object", "additionalProperties": {"type": "object"}},
+        "schema": {
+            "type": "object",
+            "additionalProperties": {"type": "object"},
+            "default": {},
+        },
     },
     "id_parent": {
         "description": "<parent ID>, or <self ID> if not a part.",
         "exclude_json": True,
-        "schema": {"type": "string"},
+        "schema": {"type": "string", "default": ""},
     },
     "id_complete": {
         "description": "<parent ID>.<self ID>, or <self ID> if not a part.",
         "exclude_json": True,
-        "schema": {"type": "string"},
+        "schema": {"type": "string", "default": ""},
     },
     "jinja_content": {
         "description": "Whether the content should be pre-processed by jinja.",
-        "schema": {"type": "boolean"},
+        "schema": {"type": ["boolean", "null"], "default": None},
         "show_in_layout": True,
     },
     "template": {
         "description": "Template of the need.",
-        "schema": {"type": ["string", "null"]},
+        "schema": {"type": ["string", "null"], "default": None},
         "show_in_layout": True,
     },
     "pre_template": {
         "description": "Pre-template of the need.",
-        "schema": {"type": ["string", "null"]},
+        "schema": {"type": ["string", "null"], "default": None},
         "show_in_layout": True,
     },
     "post_template": {
         "description": "Post-template of the need.",
-        "schema": {"type": ["string", "null"]},
+        "schema": {"type": ["string", "null"], "default": None},
         "show_in_layout": True,
     },
     "content": {
         "description": "Content of the need.",
-        "schema": {"type": "string"},
+        "schema": {"type": "string", "default": ""},
         "exclude_json": True,
     },
     "pre_content": {
         "description": "Pre-content of the need.",
-        "schema": {"type": "string"},
+        "schema": {"type": "string", "default": ""},
     },
     "post_content": {
         "description": "Post-content of the need.",
-        "schema": {"type": "string"},
+        "schema": {"type": "string", "default": ""},
     },
     "content_id": {
         "description": "ID of the content node.",
-        "schema": {"type": ["string", "null"]},
+        "schema": {"type": ["string", "null"], "default": None},
     },
     "content_node": {
         "description": "Deep copy of the content node.",
@@ -226,49 +240,53 @@ NeedsCoreFields: Final[Mapping[str, CoreFieldParameters]] = {
     },
     "has_dead_links": {
         "description": "True if any links reference need ids that are not found in the need list.",
-        "schema": {"type": "boolean"},
+        "schema": {"type": "boolean", "default": False},
     },
     "has_forbidden_dead_links": {
         "description": "True if any links reference need ids that are not found in the need list, and the link type does not allow dead links.",
-        "schema": {"type": "boolean"},
+        "schema": {"type": "boolean", "default": False},
     },
     "constraints": {
         "description": "List of constraint names, which are defined for this need.",
-        "schema": {"type": "array", "items": {"type": "string"}},
+        "schema": {"type": "array", "items": {"type": "string"}, "default": []},
     },
     "constraints_results": {
         "description": "Mapping of constraint name, to check name, to result.",
-        "schema": {"type": "object", "additionalProperties": {"type": "object"}},
+        "schema": {
+            "type": "object",
+            "additionalProperties": {"type": "object"},
+            "default": {},
+        },
     },
     "constraints_passed": {
         "description": "True if all constraints passed, False if any failed, None if not yet checked.",
-        "schema": {"type": ["boolean", "null"]},
+        "schema": {"type": ["boolean", "null"], "default": True},
     },
     "constraints_error": {
         "description": "An error message set if any constraint failed, and `error_message` field is set in config.",
-        "schema": {"type": "string"},
+        "schema": {"type": "string", "default": ""},
         "show_in_layout": True,
     },
     "doctype": {
         "description": "Type of the document where the need is defined, e.g. '.rst'.",
-        "schema": {"type": "string"},
+        "schema": {"type": "string", "default": ".rst"},
     },
     "sections": {
         "description": "Sections of the need.",
-        "schema": {"type": "array", "items": {"type": "string"}},
+        "schema": {"type": "array", "items": {"type": "string"}, "default": []},
     },
     "section_name": {
         "description": "Simply the first section.",
-        "schema": {"type": ["string", "null"]},
+        "schema": {"type": ["string", "null"], "default": ""},
     },
     "signature": {
         "description": "Derived from a docutils desc_name node.",
-        "schema": {"type": "string"},
+        "schema": {"type": "string", "default": ""},
         "show_in_layout": True,
     },
     "parent_need": {
         "description": "Simply the first parent id.",
-        "schema": {"type": "string"},
+        "schema": {"type": "string", "default": ""},
     },
 }
 

--- a/sphinx_needs/directives/needimport.py
+++ b/sphinx_needs/directives/needimport.py
@@ -143,10 +143,19 @@ class NeedimportDirective(SphinxDirective):
             )
 
         needs_config = NeedsSphinxConfig(self.config)
+        data = needs_import_list["versions"][version]
         # TODO this is not exactly NeedsInfoType, because the export removes/adds some keys
-        needs_list: dict[str, NeedsInfoType] = needs_import_list["versions"][version][
-            "needs"
-        ]
+        needs_list: dict[str, NeedsInfoType] = data["needs"]
+        if schema := data.get("needs_schema"):
+            # Set defaults from schema
+            defaults = {
+                name: value["default"]
+                for name, value in schema["properties"].items()
+                if "default" in value
+            }
+            needs_list = {
+                key: {**defaults, **value} for key, value in needs_list.items()
+            }
 
         # Filter imported needs
         needs_list_filtered = {}

--- a/sphinx_needs/external_needs.py
+++ b/sphinx_needs/external_needs.py
@@ -95,9 +95,10 @@ def load_external_needs(app: Sphinx, env: BuildEnvironment, docname: str) -> Non
             data = needs_json["versions"][version]
             needs = data["needs"]
         except KeyError:
+            uri = source.get("json_url", source.get("json_path", "unknown"))
             raise NeedsExternalException(
                 clean_log(
-                    f"Version {version} not found in json file from {source['json_url']}"
+                    f"Version {version} not found in json file from {uri}: {list(needs_json.get('versions'))}"
                 )
             )
 

--- a/sphinx_needs/external_needs.py
+++ b/sphinx_needs/external_needs.py
@@ -92,7 +92,8 @@ def load_external_needs(app: Sphinx, env: BuildEnvironment, docname: str) -> Non
             )
 
         try:
-            needs = needs_json["versions"][version]["needs"]
+            data = needs_json["versions"][version]
+            needs = data["needs"]
         except KeyError:
             raise NeedsExternalException(
                 clean_log(
@@ -102,10 +103,20 @@ def load_external_needs(app: Sphinx, env: BuildEnvironment, docname: str) -> Non
 
         log.debug(f"Loading {len(needs)} needs.")
 
+        defaults = (
+            {
+                name: value["default"]
+                for name, value in schema["properties"].items()
+                if "default" in value
+            }
+            if (schema := data.get("needs_schema"))
+            else {}
+        )
+
         prefix = source.get("id_prefix", "").upper()
         import_prefix_link_edit(needs, prefix, needs_config.extra_links)
         for need in needs.values():
-            need_params = {**need}
+            need_params = {**defaults, **need}
 
             extra_links = [x["option"] for x in needs_config.extra_links]
             for key in list(need_params.keys()):

--- a/sphinx_needs/needsfile.py
+++ b/sphinx_needs/needsfile.py
@@ -106,14 +106,14 @@ class NeedsList:
         self.needs_config = NeedsSphinxConfig(config)
         self.outdir = outdir
         self.confdir = confdir
-        self._schema = generate_needs_schema(config) if add_schema else {}
+        self._schema = generate_needs_schema(config) if add_schema else None
         self._need_defaults = (
             {
                 name: value["default"]
                 for name, value in self._schema["properties"].items()
                 if "default" in value
             }
-            if add_schema
+            if self._schema
             else {}
         )
         self.current_version = config.version
@@ -139,7 +139,7 @@ class NeedsList:
                 "filters_amount": 0,
                 "filters": {},
             }
-            if self._schema is not None:
+            if self._schema:
                 self.needs_list["versions"][version]["needs_schema"] = self._schema
             if not self.needs_config.reproducible_json:
                 self.needs_list["versions"][version]["created"] = ""

--- a/sphinx_needs/needsfile.py
+++ b/sphinx_needs/needsfile.py
@@ -38,6 +38,7 @@ def generate_needs_schema(config: Config) -> dict[str, Any]:
             "type": "string",
             "description": extra_params.description,
             "field_type": "extra",
+            "default": "",
         }
 
     # TODO currently extra options can overlap with core fields,
@@ -59,6 +60,7 @@ def generate_needs_schema(config: Config) -> dict[str, Any]:
             "items": {"type": "string"},
             "description": "Link field",
             "field_type": "links",
+            "default": [],
         }
 
     for name in needs_config.global_options:
@@ -67,6 +69,7 @@ def generate_needs_schema(config: Config) -> dict[str, Any]:
                 "type": "string",
                 "description": "Added by needs_global_options configuration",
                 "field_type": "global",
+                "default": "",
             }
 
     return {
@@ -103,7 +106,16 @@ class NeedsList:
         self.needs_config = NeedsSphinxConfig(config)
         self.outdir = outdir
         self.confdir = confdir
-        self._add_schema = add_schema
+        self._schema = generate_needs_schema(config) if add_schema else {}
+        self._need_defaults = (
+            {
+                name: value["default"]
+                for name, value in self._schema["properties"].items()
+                if "default" in value
+            }
+            if add_schema
+            else {}
+        )
         self.current_version = config.version
         self.project = config.project
         self.needs_list = {
@@ -127,10 +139,8 @@ class NeedsList:
                 "filters_amount": 0,
                 "filters": {},
             }
-            if self._add_schema:
-                self.needs_list["versions"][version]["needs_schema"] = (
-                    generate_needs_schema(self.config)
-                )
+            if self._schema is not None:
+                self.needs_list["versions"][version]["needs_schema"] = self._schema
             if not self.needs_config.reproducible_json:
                 self.needs_list["versions"][version]["created"] = ""
 
@@ -143,11 +153,19 @@ class NeedsList:
     def add_need(self, version: str, need_info: NeedsInfoType) -> None:
         self.update_or_add_version(version)
         writable_needs = {
-            key: need_info[key]  # type: ignore[literal-required]
-            for key in need_info
+            key: value
+            for key, value in need_info.items()
             if key not in self._exclude_need_keys
         }
-        writable_needs["description"] = need_info["content"]
+        if self.needs_config.json_remove_defaults:
+            writable_needs = {
+                key: value
+                for key, value in writable_needs.items()
+                if not (
+                    key in self._need_defaults and value == self._need_defaults[key]
+                )
+            }
+        writable_needs["description"] = need_info["content"]  # TODO why this?
         self.needs_list["versions"][version]["needs"][need_info["id"]] = writable_needs
         self.needs_list["versions"][version]["needs_amount"] = len(
             self.needs_list["versions"][version]["needs"]

--- a/tests/__snapshots__/test_basic_doc.ambr
+++ b/tests/__snapshots__/test_basic_doc.ambr
@@ -150,26 +150,33 @@
               'additionalProperties': dict({
                 'type': 'string',
               }),
+              'default': dict({
+              }),
               'description': 'Mapping of uml key to uml content.',
               'field_type': 'core',
               'type': 'object',
             }),
             'avatar': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'closed_at': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'completion': dict({
+              'default': '',
               'description': 'Added for needgantt functionality',
               'field_type': 'extra',
               'type': 'string',
             }),
             'constraints': dict({
+              'default': list([
+              ]),
               'description': 'List of constraint names, which are defined for this need.',
               'field_type': 'core',
               'items': dict({
@@ -178,11 +185,13 @@
               'type': 'array',
             }),
             'constraints_error': dict({
+              'default': '',
               'description': 'An error message set if any constraint failed, and `error_message` field is set in config.',
               'field_type': 'core',
               'type': 'string',
             }),
             'constraints_passed': dict({
+              'default': True,
               'description': 'True if all constraints passed, False if any failed, None if not yet checked.',
               'field_type': 'core',
               'type': list([
@@ -194,11 +203,14 @@
               'additionalProperties': dict({
                 'type': 'object',
               }),
+              'default': dict({
+              }),
               'description': 'Mapping of constraint name, to check name, to result.',
               'field_type': 'core',
               'type': 'object',
             }),
             'content_id': dict({
+              'default': None,
               'description': 'ID of the content node.',
               'field_type': 'core',
               'type': list([
@@ -207,16 +219,22 @@
               ]),
             }),
             'created_at': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'delete': dict({
+              'default': None,
               'description': 'If true, the need is deleted entirely.',
               'field_type': 'core',
-              'type': 'boolean',
+              'type': list([
+                'boolean',
+                'null',
+              ]),
             }),
             'docname': dict({
+              'default': None,
               'description': 'Name of the document where the need is defined (None if external).',
               'field_type': 'core',
               'type': list([
@@ -225,21 +243,25 @@
               ]),
             }),
             'doctype': dict({
+              'default': '.rst',
               'description': "Type of the document where the need is defined, e.g. '.rst'.",
               'field_type': 'core',
               'type': 'string',
             }),
             'duration': dict({
+              'default': '',
               'description': 'Added for needgantt functionality',
               'field_type': 'extra',
               'type': 'string',
             }),
             'external_css': dict({
+              'default': '',
               'description': 'CSS class name, added to the external reference.',
               'field_type': 'core',
               'type': 'string',
             }),
             'external_url': dict({
+              'default': None,
               'description': 'URL of the need, if it is an external need.',
               'field_type': 'core',
               'type': list([
@@ -248,16 +270,19 @@
               ]),
             }),
             'full_title': dict({
+              'default': '',
               'description': 'Title of the need, of unlimited length.',
               'field_type': 'core',
               'type': 'string',
             }),
             'has_dead_links': dict({
+              'default': False,
               'description': 'True if any links reference need ids that are not found in the need list.',
               'field_type': 'core',
               'type': 'boolean',
             }),
             'has_forbidden_dead_links': dict({
+              'default': False,
               'description': 'True if any links reference need ids that are not found in the need list, and the link type does not allow dead links.',
               'field_type': 'core',
               'type': 'boolean',
@@ -268,36 +293,46 @@
               'type': 'string',
             }),
             'id_prefix': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'is_external': dict({
+              'default': False,
               'description': 'If true, no node is created and need is referencing external url.',
               'field_type': 'core',
               'type': 'boolean',
             }),
             'is_modified': dict({
+              'default': False,
               'description': 'Whether the need was modified by needextend.',
               'field_type': 'core',
               'type': 'boolean',
             }),
             'is_need': dict({
+              'default': True,
               'description': 'Whether the need is a need.',
               'field_type': 'core',
               'type': 'boolean',
             }),
             'is_part': dict({
+              'default': False,
               'description': 'Whether the need is a part.',
               'field_type': 'core',
               'type': 'boolean',
             }),
             'jinja_content': dict({
+              'default': None,
               'description': 'Whether the content should be pre-processed by jinja.',
               'field_type': 'core',
-              'type': 'boolean',
+              'type': list([
+                'boolean',
+                'null',
+              ]),
             }),
             'layout': dict({
+              'default': None,
               'description': 'Key of the layout, which is used to render the need.',
               'field_type': 'core',
               'type': list([
@@ -306,6 +341,8 @@
               ]),
             }),
             'links': dict({
+              'default': list([
+              ]),
               'description': 'Link field',
               'field_type': 'links',
               'items': dict({
@@ -314,31 +351,38 @@
               'type': 'array',
             }),
             'max_amount': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'max_content_lines': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'modifications': dict({
+              'default': 0,
               'description': 'Number of modifications by needextend.',
               'field_type': 'core',
               'type': 'integer',
             }),
             'params': dict({
+              'default': '',
               'description': 'Added by service open-needs',
               'field_type': 'extra',
               'type': 'string',
             }),
             'parent_need': dict({
+              'default': '',
               'description': 'Simply the first parent id.',
               'field_type': 'core',
               'type': 'string',
             }),
             'parent_needs': dict({
+              'default': list([
+              ]),
               'description': 'Link field',
               'field_type': 'links',
               'items': dict({
@@ -350,16 +394,20 @@
               'additionalProperties': dict({
                 'type': 'object',
               }),
+              'default': dict({
+              }),
               'description': "Mapping of parts, a.k.a. sub-needs, IDs to data that overrides the need's data",
               'field_type': 'core',
               'type': 'object',
             }),
             'post_content': dict({
+              'default': '',
               'description': 'Post-content of the need.',
               'field_type': 'core',
               'type': 'string',
             }),
             'post_template': dict({
+              'default': None,
               'description': 'Post-template of the need.',
               'field_type': 'core',
               'type': list([
@@ -368,11 +416,13 @@
               ]),
             }),
             'pre_content': dict({
+              'default': '',
               'description': 'Pre-content of the need.',
               'field_type': 'core',
               'type': 'string',
             }),
             'pre_template': dict({
+              'default': None,
               'description': 'Pre-template of the need.',
               'field_type': 'core',
               'type': list([
@@ -381,16 +431,19 @@
               ]),
             }),
             'prefix': dict({
+              'default': '',
               'description': 'Added by service open-needs',
               'field_type': 'extra',
               'type': 'string',
             }),
             'query': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'section_name': dict({
+              'default': '',
               'description': 'Simply the first section.',
               'field_type': 'core',
               'type': list([
@@ -399,6 +452,8 @@
               ]),
             }),
             'sections': dict({
+              'default': list([
+              ]),
               'description': 'Sections of the need.',
               'field_type': 'core',
               'items': dict({
@@ -407,21 +462,25 @@
               'type': 'array',
             }),
             'service': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'signature': dict({
+              'default': '',
               'description': 'Derived from a docutils desc_name node.',
               'field_type': 'core',
               'type': 'string',
             }),
             'specific': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'status': dict({
+              'default': None,
               'description': 'Status of the need.',
               'field_type': 'core',
               'type': list([
@@ -430,6 +489,7 @@
               ]),
             }),
             'style': dict({
+              'default': None,
               'description': 'Comma-separated list of CSS classes (all appended by `needs_style_`).',
               'field_type': 'core',
               'type': list([
@@ -438,6 +498,8 @@
               ]),
             }),
             'tags': dict({
+              'default': list([
+              ]),
               'description': 'List of tags.',
               'field_type': 'core',
               'items': dict({
@@ -451,6 +513,7 @@
               'type': 'string',
             }),
             'template': dict({
+              'default': None,
               'description': 'Template of the need.',
               'field_type': 'core',
               'type': list([
@@ -464,31 +527,37 @@
               'type': 'string',
             }),
             'type': dict({
+              'default': '',
               'description': 'Type of the need.',
               'field_type': 'core',
               'type': 'string',
             }),
             'type_name': dict({
+              'default': '',
               'description': 'Name of the type.',
               'field_type': 'core',
               'type': 'string',
             }),
             'updated_at': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'url': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'url_postfix': dict({
+              'default': '',
               'description': 'Added by service open-needs',
               'field_type': 'extra',
               'type': 'string',
             }),
             'user': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',

--- a/tests/__snapshots__/test_export_id.ambr
+++ b/tests/__snapshots__/test_export_id.ambr
@@ -736,16 +736,21 @@
               'additionalProperties': dict({
                 'type': 'string',
               }),
+              'default': dict({
+              }),
               'description': 'Mapping of uml key to uml content.',
               'field_type': 'core',
               'type': 'object',
             }),
             'avatar': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'blocks': dict({
+              'default': list([
+              ]),
               'description': 'Link field',
               'field_type': 'links',
               'items': dict({
@@ -754,16 +759,20 @@
               'type': 'array',
             }),
             'closed_at': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'completion': dict({
+              'default': '',
               'description': 'Added for needgantt functionality',
               'field_type': 'extra',
               'type': 'string',
             }),
             'constraints': dict({
+              'default': list([
+              ]),
               'description': 'List of constraint names, which are defined for this need.',
               'field_type': 'core',
               'items': dict({
@@ -772,11 +781,13 @@
               'type': 'array',
             }),
             'constraints_error': dict({
+              'default': '',
               'description': 'An error message set if any constraint failed, and `error_message` field is set in config.',
               'field_type': 'core',
               'type': 'string',
             }),
             'constraints_passed': dict({
+              'default': True,
               'description': 'True if all constraints passed, False if any failed, None if not yet checked.',
               'field_type': 'core',
               'type': list([
@@ -788,11 +799,14 @@
               'additionalProperties': dict({
                 'type': 'object',
               }),
+              'default': dict({
+              }),
               'description': 'Mapping of constraint name, to check name, to result.',
               'field_type': 'core',
               'type': 'object',
             }),
             'content_id': dict({
+              'default': None,
               'description': 'ID of the content node.',
               'field_type': 'core',
               'type': list([
@@ -801,16 +815,22 @@
               ]),
             }),
             'created_at': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'delete': dict({
+              'default': None,
               'description': 'If true, the need is deleted entirely.',
               'field_type': 'core',
-              'type': 'boolean',
+              'type': list([
+                'boolean',
+                'null',
+              ]),
             }),
             'docname': dict({
+              'default': None,
               'description': 'Name of the document where the need is defined (None if external).',
               'field_type': 'core',
               'type': list([
@@ -819,21 +839,25 @@
               ]),
             }),
             'doctype': dict({
+              'default': '.rst',
               'description': "Type of the document where the need is defined, e.g. '.rst'.",
               'field_type': 'core',
               'type': 'string',
             }),
             'duration': dict({
+              'default': '',
               'description': 'Added for needgantt functionality',
               'field_type': 'extra',
               'type': 'string',
             }),
             'external_css': dict({
+              'default': '',
               'description': 'CSS class name, added to the external reference.',
               'field_type': 'core',
               'type': 'string',
             }),
             'external_url': dict({
+              'default': None,
               'description': 'URL of the need, if it is an external need.',
               'field_type': 'core',
               'type': list([
@@ -842,16 +866,19 @@
               ]),
             }),
             'full_title': dict({
+              'default': '',
               'description': 'Title of the need, of unlimited length.',
               'field_type': 'core',
               'type': 'string',
             }),
             'has_dead_links': dict({
+              'default': False,
               'description': 'True if any links reference need ids that are not found in the need list.',
               'field_type': 'core',
               'type': 'boolean',
             }),
             'has_forbidden_dead_links': dict({
+              'default': False,
               'description': 'True if any links reference need ids that are not found in the need list, and the link type does not allow dead links.',
               'field_type': 'core',
               'type': 'boolean',
@@ -862,36 +889,46 @@
               'type': 'string',
             }),
             'id_prefix': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'is_external': dict({
+              'default': False,
               'description': 'If true, no node is created and need is referencing external url.',
               'field_type': 'core',
               'type': 'boolean',
             }),
             'is_modified': dict({
+              'default': False,
               'description': 'Whether the need was modified by needextend.',
               'field_type': 'core',
               'type': 'boolean',
             }),
             'is_need': dict({
+              'default': True,
               'description': 'Whether the need is a need.',
               'field_type': 'core',
               'type': 'boolean',
             }),
             'is_part': dict({
+              'default': False,
               'description': 'Whether the need is a part.',
               'field_type': 'core',
               'type': 'boolean',
             }),
             'jinja_content': dict({
+              'default': None,
               'description': 'Whether the content should be pre-processed by jinja.',
               'field_type': 'core',
-              'type': 'boolean',
+              'type': list([
+                'boolean',
+                'null',
+              ]),
             }),
             'layout': dict({
+              'default': None,
               'description': 'Key of the layout, which is used to render the need.',
               'field_type': 'core',
               'type': list([
@@ -900,6 +937,8 @@
               ]),
             }),
             'links': dict({
+              'default': list([
+              ]),
               'description': 'Link field',
               'field_type': 'links',
               'items': dict({
@@ -908,31 +947,38 @@
               'type': 'array',
             }),
             'max_amount': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'max_content_lines': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'modifications': dict({
+              'default': 0,
               'description': 'Number of modifications by needextend.',
               'field_type': 'core',
               'type': 'integer',
             }),
             'params': dict({
+              'default': '',
               'description': 'Added by service open-needs',
               'field_type': 'extra',
               'type': 'string',
             }),
             'parent_need': dict({
+              'default': '',
               'description': 'Simply the first parent id.',
               'field_type': 'core',
               'type': 'string',
             }),
             'parent_needs': dict({
+              'default': list([
+              ]),
               'description': 'Link field',
               'field_type': 'links',
               'items': dict({
@@ -944,16 +990,20 @@
               'additionalProperties': dict({
                 'type': 'object',
               }),
+              'default': dict({
+              }),
               'description': "Mapping of parts, a.k.a. sub-needs, IDs to data that overrides the need's data",
               'field_type': 'core',
               'type': 'object',
             }),
             'post_content': dict({
+              'default': '',
               'description': 'Post-content of the need.',
               'field_type': 'core',
               'type': 'string',
             }),
             'post_template': dict({
+              'default': None,
               'description': 'Post-template of the need.',
               'field_type': 'core',
               'type': list([
@@ -962,11 +1012,13 @@
               ]),
             }),
             'pre_content': dict({
+              'default': '',
               'description': 'Pre-content of the need.',
               'field_type': 'core',
               'type': 'string',
             }),
             'pre_template': dict({
+              'default': None,
               'description': 'Pre-template of the need.',
               'field_type': 'core',
               'type': list([
@@ -975,16 +1027,19 @@
               ]),
             }),
             'prefix': dict({
+              'default': '',
               'description': 'Added by service open-needs',
               'field_type': 'extra',
               'type': 'string',
             }),
             'query': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'section_name': dict({
+              'default': '',
               'description': 'Simply the first section.',
               'field_type': 'core',
               'type': list([
@@ -993,6 +1048,8 @@
               ]),
             }),
             'sections': dict({
+              'default': list([
+              ]),
               'description': 'Sections of the need.',
               'field_type': 'core',
               'items': dict({
@@ -1001,21 +1058,25 @@
               'type': 'array',
             }),
             'service': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'signature': dict({
+              'default': '',
               'description': 'Derived from a docutils desc_name node.',
               'field_type': 'core',
               'type': 'string',
             }),
             'specific': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'status': dict({
+              'default': None,
               'description': 'Status of the need.',
               'field_type': 'core',
               'type': list([
@@ -1024,6 +1085,7 @@
               ]),
             }),
             'style': dict({
+              'default': None,
               'description': 'Comma-separated list of CSS classes (all appended by `needs_style_`).',
               'field_type': 'core',
               'type': list([
@@ -1032,6 +1094,8 @@
               ]),
             }),
             'tags': dict({
+              'default': list([
+              ]),
               'description': 'List of tags.',
               'field_type': 'core',
               'items': dict({
@@ -1045,6 +1109,7 @@
               'type': 'string',
             }),
             'template': dict({
+              'default': None,
               'description': 'Template of the need.',
               'field_type': 'core',
               'type': list([
@@ -1053,6 +1118,8 @@
               ]),
             }),
             'tests': dict({
+              'default': list([
+              ]),
               'description': 'Link field',
               'field_type': 'links',
               'items': dict({
@@ -1066,31 +1133,37 @@
               'type': 'string',
             }),
             'type': dict({
+              'default': '',
               'description': 'Type of the need.',
               'field_type': 'core',
               'type': 'string',
             }),
             'type_name': dict({
+              'default': '',
               'description': 'Name of the type.',
               'field_type': 'core',
               'type': 'string',
             }),
             'updated_at': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'url': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'url_postfix': dict({
+              'default': '',
               'description': 'Added by service open-needs',
               'field_type': 'extra',
               'type': 'string',
             }),
             'user': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',

--- a/tests/__snapshots__/test_external.ambr
+++ b/tests/__snapshots__/test_external.ambr
@@ -356,26 +356,33 @@
               'additionalProperties': dict({
                 'type': 'string',
               }),
+              'default': dict({
+              }),
               'description': 'Mapping of uml key to uml content.',
               'field_type': 'core',
               'type': 'object',
             }),
             'avatar': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'closed_at': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'completion': dict({
+              'default': '',
               'description': 'Added for needgantt functionality',
               'field_type': 'extra',
               'type': 'string',
             }),
             'constraints': dict({
+              'default': list([
+              ]),
               'description': 'List of constraint names, which are defined for this need.',
               'field_type': 'core',
               'items': dict({
@@ -384,11 +391,13 @@
               'type': 'array',
             }),
             'constraints_error': dict({
+              'default': '',
               'description': 'An error message set if any constraint failed, and `error_message` field is set in config.',
               'field_type': 'core',
               'type': 'string',
             }),
             'constraints_passed': dict({
+              'default': True,
               'description': 'True if all constraints passed, False if any failed, None if not yet checked.',
               'field_type': 'core',
               'type': list([
@@ -400,11 +409,14 @@
               'additionalProperties': dict({
                 'type': 'object',
               }),
+              'default': dict({
+              }),
               'description': 'Mapping of constraint name, to check name, to result.',
               'field_type': 'core',
               'type': 'object',
             }),
             'content_id': dict({
+              'default': None,
               'description': 'ID of the content node.',
               'field_type': 'core',
               'type': list([
@@ -413,16 +425,22 @@
               ]),
             }),
             'created_at': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'delete': dict({
+              'default': None,
               'description': 'If true, the need is deleted entirely.',
               'field_type': 'core',
-              'type': 'boolean',
+              'type': list([
+                'boolean',
+                'null',
+              ]),
             }),
             'docname': dict({
+              'default': None,
               'description': 'Name of the document where the need is defined (None if external).',
               'field_type': 'core',
               'type': list([
@@ -431,21 +449,25 @@
               ]),
             }),
             'doctype': dict({
+              'default': '.rst',
               'description': "Type of the document where the need is defined, e.g. '.rst'.",
               'field_type': 'core',
               'type': 'string',
             }),
             'duration': dict({
+              'default': '',
               'description': 'Added for needgantt functionality',
               'field_type': 'extra',
               'type': 'string',
             }),
             'external_css': dict({
+              'default': '',
               'description': 'CSS class name, added to the external reference.',
               'field_type': 'core',
               'type': 'string',
             }),
             'external_url': dict({
+              'default': None,
               'description': 'URL of the need, if it is an external need.',
               'field_type': 'core',
               'type': list([
@@ -454,16 +476,19 @@
               ]),
             }),
             'full_title': dict({
+              'default': '',
               'description': 'Title of the need, of unlimited length.',
               'field_type': 'core',
               'type': 'string',
             }),
             'has_dead_links': dict({
+              'default': False,
               'description': 'True if any links reference need ids that are not found in the need list.',
               'field_type': 'core',
               'type': 'boolean',
             }),
             'has_forbidden_dead_links': dict({
+              'default': False,
               'description': 'True if any links reference need ids that are not found in the need list, and the link type does not allow dead links.',
               'field_type': 'core',
               'type': 'boolean',
@@ -474,36 +499,46 @@
               'type': 'string',
             }),
             'id_prefix': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'is_external': dict({
+              'default': False,
               'description': 'If true, no node is created and need is referencing external url.',
               'field_type': 'core',
               'type': 'boolean',
             }),
             'is_modified': dict({
+              'default': False,
               'description': 'Whether the need was modified by needextend.',
               'field_type': 'core',
               'type': 'boolean',
             }),
             'is_need': dict({
+              'default': True,
               'description': 'Whether the need is a need.',
               'field_type': 'core',
               'type': 'boolean',
             }),
             'is_part': dict({
+              'default': False,
               'description': 'Whether the need is a part.',
               'field_type': 'core',
               'type': 'boolean',
             }),
             'jinja_content': dict({
+              'default': None,
               'description': 'Whether the content should be pre-processed by jinja.',
               'field_type': 'core',
-              'type': 'boolean',
+              'type': list([
+                'boolean',
+                'null',
+              ]),
             }),
             'layout': dict({
+              'default': None,
               'description': 'Key of the layout, which is used to render the need.',
               'field_type': 'core',
               'type': list([
@@ -512,6 +547,8 @@
               ]),
             }),
             'links': dict({
+              'default': list([
+              ]),
               'description': 'Link field',
               'field_type': 'links',
               'items': dict({
@@ -520,31 +557,38 @@
               'type': 'array',
             }),
             'max_amount': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'max_content_lines': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'modifications': dict({
+              'default': 0,
               'description': 'Number of modifications by needextend.',
               'field_type': 'core',
               'type': 'integer',
             }),
             'params': dict({
+              'default': '',
               'description': 'Added by service open-needs',
               'field_type': 'extra',
               'type': 'string',
             }),
             'parent_need': dict({
+              'default': '',
               'description': 'Simply the first parent id.',
               'field_type': 'core',
               'type': 'string',
             }),
             'parent_needs': dict({
+              'default': list([
+              ]),
               'description': 'Link field',
               'field_type': 'links',
               'items': dict({
@@ -556,16 +600,20 @@
               'additionalProperties': dict({
                 'type': 'object',
               }),
+              'default': dict({
+              }),
               'description': "Mapping of parts, a.k.a. sub-needs, IDs to data that overrides the need's data",
               'field_type': 'core',
               'type': 'object',
             }),
             'post_content': dict({
+              'default': '',
               'description': 'Post-content of the need.',
               'field_type': 'core',
               'type': 'string',
             }),
             'post_template': dict({
+              'default': None,
               'description': 'Post-template of the need.',
               'field_type': 'core',
               'type': list([
@@ -574,11 +622,13 @@
               ]),
             }),
             'pre_content': dict({
+              'default': '',
               'description': 'Pre-content of the need.',
               'field_type': 'core',
               'type': 'string',
             }),
             'pre_template': dict({
+              'default': None,
               'description': 'Pre-template of the need.',
               'field_type': 'core',
               'type': list([
@@ -587,16 +637,19 @@
               ]),
             }),
             'prefix': dict({
+              'default': '',
               'description': 'Added by service open-needs',
               'field_type': 'extra',
               'type': 'string',
             }),
             'query': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'section_name': dict({
+              'default': '',
               'description': 'Simply the first section.',
               'field_type': 'core',
               'type': list([
@@ -605,6 +658,8 @@
               ]),
             }),
             'sections': dict({
+              'default': list([
+              ]),
               'description': 'Sections of the need.',
               'field_type': 'core',
               'items': dict({
@@ -613,21 +668,25 @@
               'type': 'array',
             }),
             'service': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'signature': dict({
+              'default': '',
               'description': 'Derived from a docutils desc_name node.',
               'field_type': 'core',
               'type': 'string',
             }),
             'specific': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'status': dict({
+              'default': None,
               'description': 'Status of the need.',
               'field_type': 'core',
               'type': list([
@@ -636,6 +695,7 @@
               ]),
             }),
             'style': dict({
+              'default': None,
               'description': 'Comma-separated list of CSS classes (all appended by `needs_style_`).',
               'field_type': 'core',
               'type': list([
@@ -644,6 +704,8 @@
               ]),
             }),
             'tags': dict({
+              'default': list([
+              ]),
               'description': 'List of tags.',
               'field_type': 'core',
               'items': dict({
@@ -657,6 +719,7 @@
               'type': 'string',
             }),
             'template': dict({
+              'default': None,
               'description': 'Template of the need.',
               'field_type': 'core',
               'type': list([
@@ -670,31 +733,37 @@
               'type': 'string',
             }),
             'type': dict({
+              'default': '',
               'description': 'Type of the need.',
               'field_type': 'core',
               'type': 'string',
             }),
             'type_name': dict({
+              'default': '',
               'description': 'Name of the type.',
               'field_type': 'core',
               'type': 'string',
             }),
             'updated_at': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'url': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'url_postfix': dict({
+              'default': '',
               'description': 'Added by service open-needs',
               'field_type': 'extra',
               'type': 'string',
             }),
             'user': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',

--- a/tests/__snapshots__/test_external.ambr
+++ b/tests/__snapshots__/test_external.ambr
@@ -1,3 +1,474 @@
+# name: test_export_import_round_trip
+  dict({
+    'current_version': '1.3',
+    'versions': dict({
+      '1.3': dict({
+        'filters': dict({
+        }),
+        'filters_amount': 0,
+        'needs': dict({
+          'EXT_REQ_01': dict({
+            'delete': False,
+            'description': '',
+            'doctype': '',
+            'external_css': 'external_link',
+            'external_url': 'http://my_company.com/docs/v1/index.html#REQ_01',
+            'full_title': 'REQ_01',
+            'id': 'EXT_REQ_01',
+            'is_external': True,
+            'jinja_content': False,
+            'target_id': 'EXT_REQ_01',
+            'title': 'REQ_01',
+            'type': 'req',
+            'type_name': 'Requirement',
+          }),
+          'IMP_REQ_01': dict({
+            'content_id': 'IMP_REQ_01',
+            'delete': False,
+            'description': '',
+            'docname': 'index',
+            'external_css': 'external_link',
+            'full_title': 'REQ_01',
+            'id': 'IMP_REQ_01',
+            'jinja_content': False,
+            'layout': '',
+            'section_name': 'Title',
+            'sections': list([
+              'Title',
+            ]),
+            'target_id': 'IMP_REQ_01',
+            'title': 'REQ_01',
+            'type': 'req',
+            'type_name': 'Requirement',
+          }),
+        }),
+        'needs_amount': 2,
+        'needs_schema': dict({
+          '$schema': 'http://json-schema.org/draft-07/schema#',
+          'properties': dict({
+            'arch': dict({
+              'additionalProperties': dict({
+                'type': 'string',
+              }),
+              'default': dict({
+              }),
+              'description': 'Mapping of uml key to uml content.',
+              'field_type': 'core',
+              'type': 'object',
+            }),
+            'avatar': dict({
+              'default': '',
+              'description': 'Added by service github-issues',
+              'field_type': 'extra',
+              'type': 'string',
+            }),
+            'closed_at': dict({
+              'default': '',
+              'description': 'Added by service github-issues',
+              'field_type': 'extra',
+              'type': 'string',
+            }),
+            'completion': dict({
+              'default': '',
+              'description': 'Added for needgantt functionality',
+              'field_type': 'extra',
+              'type': 'string',
+            }),
+            'constraints': dict({
+              'default': list([
+              ]),
+              'description': 'List of constraint names, which are defined for this need.',
+              'field_type': 'core',
+              'items': dict({
+                'type': 'string',
+              }),
+              'type': 'array',
+            }),
+            'constraints_error': dict({
+              'default': '',
+              'description': 'An error message set if any constraint failed, and `error_message` field is set in config.',
+              'field_type': 'core',
+              'type': 'string',
+            }),
+            'constraints_passed': dict({
+              'default': True,
+              'description': 'True if all constraints passed, False if any failed, None if not yet checked.',
+              'field_type': 'core',
+              'type': list([
+                'boolean',
+                'null',
+              ]),
+            }),
+            'constraints_results': dict({
+              'additionalProperties': dict({
+                'type': 'object',
+              }),
+              'default': dict({
+              }),
+              'description': 'Mapping of constraint name, to check name, to result.',
+              'field_type': 'core',
+              'type': 'object',
+            }),
+            'content_id': dict({
+              'default': None,
+              'description': 'ID of the content node.',
+              'field_type': 'core',
+              'type': list([
+                'string',
+                'null',
+              ]),
+            }),
+            'created_at': dict({
+              'default': '',
+              'description': 'Added by service github-issues',
+              'field_type': 'extra',
+              'type': 'string',
+            }),
+            'delete': dict({
+              'default': None,
+              'description': 'If true, the need is deleted entirely.',
+              'field_type': 'core',
+              'type': list([
+                'boolean',
+                'null',
+              ]),
+            }),
+            'docname': dict({
+              'default': None,
+              'description': 'Name of the document where the need is defined (None if external).',
+              'field_type': 'core',
+              'type': list([
+                'string',
+                'null',
+              ]),
+            }),
+            'doctype': dict({
+              'default': '.rst',
+              'description': "Type of the document where the need is defined, e.g. '.rst'.",
+              'field_type': 'core',
+              'type': 'string',
+            }),
+            'duration': dict({
+              'default': '',
+              'description': 'Added for needgantt functionality',
+              'field_type': 'extra',
+              'type': 'string',
+            }),
+            'external_css': dict({
+              'default': '',
+              'description': 'CSS class name, added to the external reference.',
+              'field_type': 'core',
+              'type': 'string',
+            }),
+            'external_url': dict({
+              'default': None,
+              'description': 'URL of the need, if it is an external need.',
+              'field_type': 'core',
+              'type': list([
+                'string',
+                'null',
+              ]),
+            }),
+            'full_title': dict({
+              'default': '',
+              'description': 'Title of the need, of unlimited length.',
+              'field_type': 'core',
+              'type': 'string',
+            }),
+            'has_dead_links': dict({
+              'default': False,
+              'description': 'True if any links reference need ids that are not found in the need list.',
+              'field_type': 'core',
+              'type': 'boolean',
+            }),
+            'has_forbidden_dead_links': dict({
+              'default': False,
+              'description': 'True if any links reference need ids that are not found in the need list, and the link type does not allow dead links.',
+              'field_type': 'core',
+              'type': 'boolean',
+            }),
+            'id': dict({
+              'description': 'ID of the data.',
+              'field_type': 'core',
+              'type': 'string',
+            }),
+            'id_prefix': dict({
+              'default': '',
+              'description': 'Added by service github-issues',
+              'field_type': 'extra',
+              'type': 'string',
+            }),
+            'is_external': dict({
+              'default': False,
+              'description': 'If true, no node is created and need is referencing external url.',
+              'field_type': 'core',
+              'type': 'boolean',
+            }),
+            'is_modified': dict({
+              'default': False,
+              'description': 'Whether the need was modified by needextend.',
+              'field_type': 'core',
+              'type': 'boolean',
+            }),
+            'is_need': dict({
+              'default': True,
+              'description': 'Whether the need is a need.',
+              'field_type': 'core',
+              'type': 'boolean',
+            }),
+            'is_part': dict({
+              'default': False,
+              'description': 'Whether the need is a part.',
+              'field_type': 'core',
+              'type': 'boolean',
+            }),
+            'jinja_content': dict({
+              'default': None,
+              'description': 'Whether the content should be pre-processed by jinja.',
+              'field_type': 'core',
+              'type': list([
+                'boolean',
+                'null',
+              ]),
+            }),
+            'layout': dict({
+              'default': None,
+              'description': 'Key of the layout, which is used to render the need.',
+              'field_type': 'core',
+              'type': list([
+                'string',
+                'null',
+              ]),
+            }),
+            'links': dict({
+              'default': list([
+              ]),
+              'description': 'Link field',
+              'field_type': 'links',
+              'items': dict({
+                'type': 'string',
+              }),
+              'type': 'array',
+            }),
+            'max_amount': dict({
+              'default': '',
+              'description': 'Added by service github-issues',
+              'field_type': 'extra',
+              'type': 'string',
+            }),
+            'max_content_lines': dict({
+              'default': '',
+              'description': 'Added by service github-issues',
+              'field_type': 'extra',
+              'type': 'string',
+            }),
+            'modifications': dict({
+              'default': 0,
+              'description': 'Number of modifications by needextend.',
+              'field_type': 'core',
+              'type': 'integer',
+            }),
+            'params': dict({
+              'default': '',
+              'description': 'Added by service open-needs',
+              'field_type': 'extra',
+              'type': 'string',
+            }),
+            'parent_need': dict({
+              'default': '',
+              'description': 'Simply the first parent id.',
+              'field_type': 'core',
+              'type': 'string',
+            }),
+            'parent_needs': dict({
+              'default': list([
+              ]),
+              'description': 'Link field',
+              'field_type': 'links',
+              'items': dict({
+                'type': 'string',
+              }),
+              'type': 'array',
+            }),
+            'parts': dict({
+              'additionalProperties': dict({
+                'type': 'object',
+              }),
+              'default': dict({
+              }),
+              'description': "Mapping of parts, a.k.a. sub-needs, IDs to data that overrides the need's data",
+              'field_type': 'core',
+              'type': 'object',
+            }),
+            'post_content': dict({
+              'default': '',
+              'description': 'Post-content of the need.',
+              'field_type': 'core',
+              'type': 'string',
+            }),
+            'post_template': dict({
+              'default': None,
+              'description': 'Post-template of the need.',
+              'field_type': 'core',
+              'type': list([
+                'string',
+                'null',
+              ]),
+            }),
+            'pre_content': dict({
+              'default': '',
+              'description': 'Pre-content of the need.',
+              'field_type': 'core',
+              'type': 'string',
+            }),
+            'pre_template': dict({
+              'default': None,
+              'description': 'Pre-template of the need.',
+              'field_type': 'core',
+              'type': list([
+                'string',
+                'null',
+              ]),
+            }),
+            'prefix': dict({
+              'default': '',
+              'description': 'Added by service open-needs',
+              'field_type': 'extra',
+              'type': 'string',
+            }),
+            'query': dict({
+              'default': '',
+              'description': 'Added by service github-issues',
+              'field_type': 'extra',
+              'type': 'string',
+            }),
+            'section_name': dict({
+              'default': '',
+              'description': 'Simply the first section.',
+              'field_type': 'core',
+              'type': list([
+                'string',
+                'null',
+              ]),
+            }),
+            'sections': dict({
+              'default': list([
+              ]),
+              'description': 'Sections of the need.',
+              'field_type': 'core',
+              'items': dict({
+                'type': 'string',
+              }),
+              'type': 'array',
+            }),
+            'service': dict({
+              'default': '',
+              'description': 'Added by service github-issues',
+              'field_type': 'extra',
+              'type': 'string',
+            }),
+            'signature': dict({
+              'default': '',
+              'description': 'Derived from a docutils desc_name node.',
+              'field_type': 'core',
+              'type': 'string',
+            }),
+            'specific': dict({
+              'default': '',
+              'description': 'Added by service github-issues',
+              'field_type': 'extra',
+              'type': 'string',
+            }),
+            'status': dict({
+              'default': None,
+              'description': 'Status of the need.',
+              'field_type': 'core',
+              'type': list([
+                'string',
+                'null',
+              ]),
+            }),
+            'style': dict({
+              'default': None,
+              'description': 'Comma-separated list of CSS classes (all appended by `needs_style_`).',
+              'field_type': 'core',
+              'type': list([
+                'string',
+                'null',
+              ]),
+            }),
+            'tags': dict({
+              'default': list([
+              ]),
+              'description': 'List of tags.',
+              'field_type': 'core',
+              'items': dict({
+                'type': 'string',
+              }),
+              'type': 'array',
+            }),
+            'target_id': dict({
+              'description': 'ID of the data.',
+              'field_type': 'core',
+              'type': 'string',
+            }),
+            'template': dict({
+              'default': None,
+              'description': 'Template of the need.',
+              'field_type': 'core',
+              'type': list([
+                'string',
+                'null',
+              ]),
+            }),
+            'title': dict({
+              'description': 'Title of the need, trimmed to a maximum length.',
+              'field_type': 'core',
+              'type': 'string',
+            }),
+            'type': dict({
+              'default': '',
+              'description': 'Type of the need.',
+              'field_type': 'core',
+              'type': 'string',
+            }),
+            'type_name': dict({
+              'default': '',
+              'description': 'Name of the type.',
+              'field_type': 'core',
+              'type': 'string',
+            }),
+            'updated_at': dict({
+              'default': '',
+              'description': 'Added by service github-issues',
+              'field_type': 'extra',
+              'type': 'string',
+            }),
+            'url': dict({
+              'default': '',
+              'description': 'Added by service github-issues',
+              'field_type': 'extra',
+              'type': 'string',
+            }),
+            'url_postfix': dict({
+              'default': '',
+              'description': 'Added by service open-needs',
+              'field_type': 'extra',
+              'type': 'string',
+            }),
+            'user': dict({
+              'default': '',
+              'description': 'Added by service github-issues',
+              'field_type': 'extra',
+              'type': 'string',
+            }),
+          }),
+          'type': 'object',
+        }),
+      }),
+    }),
+  })
+# ---
 # name: test_external_json[test_app0]
   dict({
     'current_version': '1.0',

--- a/tests/__snapshots__/test_import.ambr
+++ b/tests/__snapshots__/test_import.ambr
@@ -4549,26 +4549,33 @@
               'additionalProperties': dict({
                 'type': 'string',
               }),
+              'default': dict({
+              }),
               'description': 'Mapping of uml key to uml content.',
               'field_type': 'core',
               'type': 'object',
             }),
             'avatar': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'closed_at': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'completion': dict({
+              'default': '',
               'description': 'Added for needgantt functionality',
               'field_type': 'extra',
               'type': 'string',
             }),
             'constraints': dict({
+              'default': list([
+              ]),
               'description': 'List of constraint names, which are defined for this need.',
               'field_type': 'core',
               'items': dict({
@@ -4577,11 +4584,13 @@
               'type': 'array',
             }),
             'constraints_error': dict({
+              'default': '',
               'description': 'An error message set if any constraint failed, and `error_message` field is set in config.',
               'field_type': 'core',
               'type': 'string',
             }),
             'constraints_passed': dict({
+              'default': True,
               'description': 'True if all constraints passed, False if any failed, None if not yet checked.',
               'field_type': 'core',
               'type': list([
@@ -4593,11 +4602,14 @@
               'additionalProperties': dict({
                 'type': 'object',
               }),
+              'default': dict({
+              }),
               'description': 'Mapping of constraint name, to check name, to result.',
               'field_type': 'core',
               'type': 'object',
             }),
             'content_id': dict({
+              'default': None,
               'description': 'ID of the content node.',
               'field_type': 'core',
               'type': list([
@@ -4606,16 +4618,22 @@
               ]),
             }),
             'created_at': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'delete': dict({
+              'default': None,
               'description': 'If true, the need is deleted entirely.',
               'field_type': 'core',
-              'type': 'boolean',
+              'type': list([
+                'boolean',
+                'null',
+              ]),
             }),
             'docname': dict({
+              'default': None,
               'description': 'Name of the document where the need is defined (None if external).',
               'field_type': 'core',
               'type': list([
@@ -4624,21 +4642,25 @@
               ]),
             }),
             'doctype': dict({
+              'default': '.rst',
               'description': "Type of the document where the need is defined, e.g. '.rst'.",
               'field_type': 'core',
               'type': 'string',
             }),
             'duration': dict({
+              'default': '',
               'description': 'Added for needgantt functionality',
               'field_type': 'extra',
               'type': 'string',
             }),
             'external_css': dict({
+              'default': '',
               'description': 'CSS class name, added to the external reference.',
               'field_type': 'core',
               'type': 'string',
             }),
             'external_url': dict({
+              'default': None,
               'description': 'URL of the need, if it is an external need.',
               'field_type': 'core',
               'type': list([
@@ -4647,16 +4669,19 @@
               ]),
             }),
             'full_title': dict({
+              'default': '',
               'description': 'Title of the need, of unlimited length.',
               'field_type': 'core',
               'type': 'string',
             }),
             'has_dead_links': dict({
+              'default': False,
               'description': 'True if any links reference need ids that are not found in the need list.',
               'field_type': 'core',
               'type': 'boolean',
             }),
             'has_forbidden_dead_links': dict({
+              'default': False,
               'description': 'True if any links reference need ids that are not found in the need list, and the link type does not allow dead links.',
               'field_type': 'core',
               'type': 'boolean',
@@ -4667,36 +4692,46 @@
               'type': 'string',
             }),
             'id_prefix': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'is_external': dict({
+              'default': False,
               'description': 'If true, no node is created and need is referencing external url.',
               'field_type': 'core',
               'type': 'boolean',
             }),
             'is_modified': dict({
+              'default': False,
               'description': 'Whether the need was modified by needextend.',
               'field_type': 'core',
               'type': 'boolean',
             }),
             'is_need': dict({
+              'default': True,
               'description': 'Whether the need is a need.',
               'field_type': 'core',
               'type': 'boolean',
             }),
             'is_part': dict({
+              'default': False,
               'description': 'Whether the need is a part.',
               'field_type': 'core',
               'type': 'boolean',
             }),
             'jinja_content': dict({
+              'default': None,
               'description': 'Whether the content should be pre-processed by jinja.',
               'field_type': 'core',
-              'type': 'boolean',
+              'type': list([
+                'boolean',
+                'null',
+              ]),
             }),
             'layout': dict({
+              'default': None,
               'description': 'Key of the layout, which is used to render the need.',
               'field_type': 'core',
               'type': list([
@@ -4705,6 +4740,8 @@
               ]),
             }),
             'links': dict({
+              'default': list([
+              ]),
               'description': 'Link field',
               'field_type': 'links',
               'items': dict({
@@ -4713,31 +4750,38 @@
               'type': 'array',
             }),
             'max_amount': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'max_content_lines': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'modifications': dict({
+              'default': 0,
               'description': 'Number of modifications by needextend.',
               'field_type': 'core',
               'type': 'integer',
             }),
             'params': dict({
+              'default': '',
               'description': 'Added by service open-needs',
               'field_type': 'extra',
               'type': 'string',
             }),
             'parent_need': dict({
+              'default': '',
               'description': 'Simply the first parent id.',
               'field_type': 'core',
               'type': 'string',
             }),
             'parent_needs': dict({
+              'default': list([
+              ]),
               'description': 'Link field',
               'field_type': 'links',
               'items': dict({
@@ -4749,16 +4793,20 @@
               'additionalProperties': dict({
                 'type': 'object',
               }),
+              'default': dict({
+              }),
               'description': "Mapping of parts, a.k.a. sub-needs, IDs to data that overrides the need's data",
               'field_type': 'core',
               'type': 'object',
             }),
             'post_content': dict({
+              'default': '',
               'description': 'Post-content of the need.',
               'field_type': 'core',
               'type': 'string',
             }),
             'post_template': dict({
+              'default': None,
               'description': 'Post-template of the need.',
               'field_type': 'core',
               'type': list([
@@ -4767,11 +4815,13 @@
               ]),
             }),
             'pre_content': dict({
+              'default': '',
               'description': 'Pre-content of the need.',
               'field_type': 'core',
               'type': 'string',
             }),
             'pre_template': dict({
+              'default': None,
               'description': 'Pre-template of the need.',
               'field_type': 'core',
               'type': list([
@@ -4780,16 +4830,19 @@
               ]),
             }),
             'prefix': dict({
+              'default': '',
               'description': 'Added by service open-needs',
               'field_type': 'extra',
               'type': 'string',
             }),
             'query': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'section_name': dict({
+              'default': '',
               'description': 'Simply the first section.',
               'field_type': 'core',
               'type': list([
@@ -4798,6 +4851,8 @@
               ]),
             }),
             'sections': dict({
+              'default': list([
+              ]),
               'description': 'Sections of the need.',
               'field_type': 'core',
               'items': dict({
@@ -4806,21 +4861,25 @@
               'type': 'array',
             }),
             'service': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'signature': dict({
+              'default': '',
               'description': 'Derived from a docutils desc_name node.',
               'field_type': 'core',
               'type': 'string',
             }),
             'specific': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'status': dict({
+              'default': None,
               'description': 'Status of the need.',
               'field_type': 'core',
               'type': list([
@@ -4829,6 +4888,7 @@
               ]),
             }),
             'style': dict({
+              'default': None,
               'description': 'Comma-separated list of CSS classes (all appended by `needs_style_`).',
               'field_type': 'core',
               'type': list([
@@ -4837,6 +4897,8 @@
               ]),
             }),
             'tags': dict({
+              'default': list([
+              ]),
               'description': 'List of tags.',
               'field_type': 'core',
               'items': dict({
@@ -4850,6 +4912,7 @@
               'type': 'string',
             }),
             'template': dict({
+              'default': None,
               'description': 'Template of the need.',
               'field_type': 'core',
               'type': list([
@@ -4863,31 +4926,37 @@
               'type': 'string',
             }),
             'type': dict({
+              'default': '',
               'description': 'Type of the need.',
               'field_type': 'core',
               'type': 'string',
             }),
             'type_name': dict({
+              'default': '',
               'description': 'Name of the type.',
               'field_type': 'core',
               'type': 'string',
             }),
             'updated_at': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'url': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'url_postfix': dict({
+              'default': '',
               'description': 'Added by service open-needs',
               'field_type': 'extra',
               'type': 'string',
             }),
             'user': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',

--- a/tests/__snapshots__/test_need_constraints.ambr
+++ b/tests/__snapshots__/test_need_constraints.ambr
@@ -586,26 +586,33 @@
               'additionalProperties': dict({
                 'type': 'string',
               }),
+              'default': dict({
+              }),
               'description': 'Mapping of uml key to uml content.',
               'field_type': 'core',
               'type': 'object',
             }),
             'avatar': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'closed_at': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'completion': dict({
+              'default': '',
               'description': 'Added for needgantt functionality',
               'field_type': 'extra',
               'type': 'string',
             }),
             'constraints': dict({
+              'default': list([
+              ]),
               'description': 'List of constraint names, which are defined for this need.',
               'field_type': 'core',
               'items': dict({
@@ -614,11 +621,13 @@
               'type': 'array',
             }),
             'constraints_error': dict({
+              'default': '',
               'description': 'An error message set if any constraint failed, and `error_message` field is set in config.',
               'field_type': 'core',
               'type': 'string',
             }),
             'constraints_passed': dict({
+              'default': True,
               'description': 'True if all constraints passed, False if any failed, None if not yet checked.',
               'field_type': 'core',
               'type': list([
@@ -630,11 +639,14 @@
               'additionalProperties': dict({
                 'type': 'object',
               }),
+              'default': dict({
+              }),
               'description': 'Mapping of constraint name, to check name, to result.',
               'field_type': 'core',
               'type': 'object',
             }),
             'content_id': dict({
+              'default': None,
               'description': 'ID of the content node.',
               'field_type': 'core',
               'type': list([
@@ -643,16 +655,22 @@
               ]),
             }),
             'created_at': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'delete': dict({
+              'default': None,
               'description': 'If true, the need is deleted entirely.',
               'field_type': 'core',
-              'type': 'boolean',
+              'type': list([
+                'boolean',
+                'null',
+              ]),
             }),
             'docname': dict({
+              'default': None,
               'description': 'Name of the document where the need is defined (None if external).',
               'field_type': 'core',
               'type': list([
@@ -661,21 +679,25 @@
               ]),
             }),
             'doctype': dict({
+              'default': '.rst',
               'description': "Type of the document where the need is defined, e.g. '.rst'.",
               'field_type': 'core',
               'type': 'string',
             }),
             'duration': dict({
+              'default': '',
               'description': 'Added for needgantt functionality',
               'field_type': 'extra',
               'type': 'string',
             }),
             'external_css': dict({
+              'default': '',
               'description': 'CSS class name, added to the external reference.',
               'field_type': 'core',
               'type': 'string',
             }),
             'external_url': dict({
+              'default': None,
               'description': 'URL of the need, if it is an external need.',
               'field_type': 'core',
               'type': list([
@@ -684,16 +706,19 @@
               ]),
             }),
             'full_title': dict({
+              'default': '',
               'description': 'Title of the need, of unlimited length.',
               'field_type': 'core',
               'type': 'string',
             }),
             'has_dead_links': dict({
+              'default': False,
               'description': 'True if any links reference need ids that are not found in the need list.',
               'field_type': 'core',
               'type': 'boolean',
             }),
             'has_forbidden_dead_links': dict({
+              'default': False,
               'description': 'True if any links reference need ids that are not found in the need list, and the link type does not allow dead links.',
               'field_type': 'core',
               'type': 'boolean',
@@ -704,36 +729,46 @@
               'type': 'string',
             }),
             'id_prefix': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'is_external': dict({
+              'default': False,
               'description': 'If true, no node is created and need is referencing external url.',
               'field_type': 'core',
               'type': 'boolean',
             }),
             'is_modified': dict({
+              'default': False,
               'description': 'Whether the need was modified by needextend.',
               'field_type': 'core',
               'type': 'boolean',
             }),
             'is_need': dict({
+              'default': True,
               'description': 'Whether the need is a need.',
               'field_type': 'core',
               'type': 'boolean',
             }),
             'is_part': dict({
+              'default': False,
               'description': 'Whether the need is a part.',
               'field_type': 'core',
               'type': 'boolean',
             }),
             'jinja_content': dict({
+              'default': None,
               'description': 'Whether the content should be pre-processed by jinja.',
               'field_type': 'core',
-              'type': 'boolean',
+              'type': list([
+                'boolean',
+                'null',
+              ]),
             }),
             'layout': dict({
+              'default': None,
               'description': 'Key of the layout, which is used to render the need.',
               'field_type': 'core',
               'type': list([
@@ -742,6 +777,8 @@
               ]),
             }),
             'links': dict({
+              'default': list([
+              ]),
               'description': 'Link field',
               'field_type': 'links',
               'items': dict({
@@ -750,31 +787,38 @@
               'type': 'array',
             }),
             'max_amount': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'max_content_lines': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'modifications': dict({
+              'default': 0,
               'description': 'Number of modifications by needextend.',
               'field_type': 'core',
               'type': 'integer',
             }),
             'params': dict({
+              'default': '',
               'description': 'Added by service open-needs',
               'field_type': 'extra',
               'type': 'string',
             }),
             'parent_need': dict({
+              'default': '',
               'description': 'Simply the first parent id.',
               'field_type': 'core',
               'type': 'string',
             }),
             'parent_needs': dict({
+              'default': list([
+              ]),
               'description': 'Link field',
               'field_type': 'links',
               'items': dict({
@@ -786,16 +830,20 @@
               'additionalProperties': dict({
                 'type': 'object',
               }),
+              'default': dict({
+              }),
               'description': "Mapping of parts, a.k.a. sub-needs, IDs to data that overrides the need's data",
               'field_type': 'core',
               'type': 'object',
             }),
             'post_content': dict({
+              'default': '',
               'description': 'Post-content of the need.',
               'field_type': 'core',
               'type': 'string',
             }),
             'post_template': dict({
+              'default': None,
               'description': 'Post-template of the need.',
               'field_type': 'core',
               'type': list([
@@ -804,11 +852,13 @@
               ]),
             }),
             'pre_content': dict({
+              'default': '',
               'description': 'Pre-content of the need.',
               'field_type': 'core',
               'type': 'string',
             }),
             'pre_template': dict({
+              'default': None,
               'description': 'Pre-template of the need.',
               'field_type': 'core',
               'type': list([
@@ -817,16 +867,19 @@
               ]),
             }),
             'prefix': dict({
+              'default': '',
               'description': 'Added by service open-needs',
               'field_type': 'extra',
               'type': 'string',
             }),
             'query': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'section_name': dict({
+              'default': '',
               'description': 'Simply the first section.',
               'field_type': 'core',
               'type': list([
@@ -835,6 +888,8 @@
               ]),
             }),
             'sections': dict({
+              'default': list([
+              ]),
               'description': 'Sections of the need.',
               'field_type': 'core',
               'items': dict({
@@ -843,21 +898,25 @@
               'type': 'array',
             }),
             'service': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'signature': dict({
+              'default': '',
               'description': 'Derived from a docutils desc_name node.',
               'field_type': 'core',
               'type': 'string',
             }),
             'specific': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'status': dict({
+              'default': None,
               'description': 'Status of the need.',
               'field_type': 'core',
               'type': list([
@@ -866,6 +925,7 @@
               ]),
             }),
             'style': dict({
+              'default': None,
               'description': 'Comma-separated list of CSS classes (all appended by `needs_style_`).',
               'field_type': 'core',
               'type': list([
@@ -874,6 +934,8 @@
               ]),
             }),
             'tags': dict({
+              'default': list([
+              ]),
               'description': 'List of tags.',
               'field_type': 'core',
               'items': dict({
@@ -887,6 +949,7 @@
               'type': 'string',
             }),
             'template': dict({
+              'default': None,
               'description': 'Template of the need.',
               'field_type': 'core',
               'type': list([
@@ -900,31 +963,37 @@
               'type': 'string',
             }),
             'type': dict({
+              'default': '',
               'description': 'Type of the need.',
               'field_type': 'core',
               'type': 'string',
             }),
             'type_name': dict({
+              'default': '',
               'description': 'Name of the type.',
               'field_type': 'core',
               'type': 'string',
             }),
             'updated_at': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'url': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'url_postfix': dict({
+              'default': '',
               'description': 'Added by service open-needs',
               'field_type': 'extra',
               'type': 'string',
             }),
             'user': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',

--- a/tests/__snapshots__/test_needextend.ambr
+++ b/tests/__snapshots__/test_needextend.ambr
@@ -354,26 +354,33 @@
               'additionalProperties': dict({
                 'type': 'string',
               }),
+              'default': dict({
+              }),
               'description': 'Mapping of uml key to uml content.',
               'field_type': 'core',
               'type': 'object',
             }),
             'avatar': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'closed_at': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'completion': dict({
+              'default': '',
               'description': 'Added for needgantt functionality',
               'field_type': 'extra',
               'type': 'string',
             }),
             'constraints': dict({
+              'default': list([
+              ]),
               'description': 'List of constraint names, which are defined for this need.',
               'field_type': 'core',
               'items': dict({
@@ -382,11 +389,13 @@
               'type': 'array',
             }),
             'constraints_error': dict({
+              'default': '',
               'description': 'An error message set if any constraint failed, and `error_message` field is set in config.',
               'field_type': 'core',
               'type': 'string',
             }),
             'constraints_passed': dict({
+              'default': True,
               'description': 'True if all constraints passed, False if any failed, None if not yet checked.',
               'field_type': 'core',
               'type': list([
@@ -398,11 +407,14 @@
               'additionalProperties': dict({
                 'type': 'object',
               }),
+              'default': dict({
+              }),
               'description': 'Mapping of constraint name, to check name, to result.',
               'field_type': 'core',
               'type': 'object',
             }),
             'content_id': dict({
+              'default': None,
               'description': 'ID of the content node.',
               'field_type': 'core',
               'type': list([
@@ -411,16 +423,22 @@
               ]),
             }),
             'created_at': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'delete': dict({
+              'default': None,
               'description': 'If true, the need is deleted entirely.',
               'field_type': 'core',
-              'type': 'boolean',
+              'type': list([
+                'boolean',
+                'null',
+              ]),
             }),
             'docname': dict({
+              'default': None,
               'description': 'Name of the document where the need is defined (None if external).',
               'field_type': 'core',
               'type': list([
@@ -429,21 +447,25 @@
               ]),
             }),
             'doctype': dict({
+              'default': '.rst',
               'description': "Type of the document where the need is defined, e.g. '.rst'.",
               'field_type': 'core',
               'type': 'string',
             }),
             'duration': dict({
+              'default': '',
               'description': 'Added for needgantt functionality',
               'field_type': 'extra',
               'type': 'string',
             }),
             'external_css': dict({
+              'default': '',
               'description': 'CSS class name, added to the external reference.',
               'field_type': 'core',
               'type': 'string',
             }),
             'external_url': dict({
+              'default': None,
               'description': 'URL of the need, if it is an external need.',
               'field_type': 'core',
               'type': list([
@@ -452,16 +474,19 @@
               ]),
             }),
             'full_title': dict({
+              'default': '',
               'description': 'Title of the need, of unlimited length.',
               'field_type': 'core',
               'type': 'string',
             }),
             'has_dead_links': dict({
+              'default': False,
               'description': 'True if any links reference need ids that are not found in the need list.',
               'field_type': 'core',
               'type': 'boolean',
             }),
             'has_forbidden_dead_links': dict({
+              'default': False,
               'description': 'True if any links reference need ids that are not found in the need list, and the link type does not allow dead links.',
               'field_type': 'core',
               'type': 'boolean',
@@ -472,36 +497,46 @@
               'type': 'string',
             }),
             'id_prefix': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'is_external': dict({
+              'default': False,
               'description': 'If true, no node is created and need is referencing external url.',
               'field_type': 'core',
               'type': 'boolean',
             }),
             'is_modified': dict({
+              'default': False,
               'description': 'Whether the need was modified by needextend.',
               'field_type': 'core',
               'type': 'boolean',
             }),
             'is_need': dict({
+              'default': True,
               'description': 'Whether the need is a need.',
               'field_type': 'core',
               'type': 'boolean',
             }),
             'is_part': dict({
+              'default': False,
               'description': 'Whether the need is a part.',
               'field_type': 'core',
               'type': 'boolean',
             }),
             'jinja_content': dict({
+              'default': None,
               'description': 'Whether the content should be pre-processed by jinja.',
               'field_type': 'core',
-              'type': 'boolean',
+              'type': list([
+                'boolean',
+                'null',
+              ]),
             }),
             'layout': dict({
+              'default': None,
               'description': 'Key of the layout, which is used to render the need.',
               'field_type': 'core',
               'type': list([
@@ -510,6 +545,8 @@
               ]),
             }),
             'links': dict({
+              'default': list([
+              ]),
               'description': 'Link field',
               'field_type': 'links',
               'items': dict({
@@ -518,31 +555,38 @@
               'type': 'array',
             }),
             'max_amount': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'max_content_lines': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'modifications': dict({
+              'default': 0,
               'description': 'Number of modifications by needextend.',
               'field_type': 'core',
               'type': 'integer',
             }),
             'params': dict({
+              'default': '',
               'description': 'Added by service open-needs',
               'field_type': 'extra',
               'type': 'string',
             }),
             'parent_need': dict({
+              'default': '',
               'description': 'Simply the first parent id.',
               'field_type': 'core',
               'type': 'string',
             }),
             'parent_needs': dict({
+              'default': list([
+              ]),
               'description': 'Link field',
               'field_type': 'links',
               'items': dict({
@@ -554,16 +598,20 @@
               'additionalProperties': dict({
                 'type': 'object',
               }),
+              'default': dict({
+              }),
               'description': "Mapping of parts, a.k.a. sub-needs, IDs to data that overrides the need's data",
               'field_type': 'core',
               'type': 'object',
             }),
             'post_content': dict({
+              'default': '',
               'description': 'Post-content of the need.',
               'field_type': 'core',
               'type': 'string',
             }),
             'post_template': dict({
+              'default': None,
               'description': 'Post-template of the need.',
               'field_type': 'core',
               'type': list([
@@ -572,11 +620,13 @@
               ]),
             }),
             'pre_content': dict({
+              'default': '',
               'description': 'Pre-content of the need.',
               'field_type': 'core',
               'type': 'string',
             }),
             'pre_template': dict({
+              'default': None,
               'description': 'Pre-template of the need.',
               'field_type': 'core',
               'type': list([
@@ -585,16 +635,19 @@
               ]),
             }),
             'prefix': dict({
+              'default': '',
               'description': 'Added by service open-needs',
               'field_type': 'extra',
               'type': 'string',
             }),
             'query': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'section_name': dict({
+              'default': '',
               'description': 'Simply the first section.',
               'field_type': 'core',
               'type': list([
@@ -603,6 +656,8 @@
               ]),
             }),
             'sections': dict({
+              'default': list([
+              ]),
               'description': 'Sections of the need.',
               'field_type': 'core',
               'items': dict({
@@ -611,21 +666,25 @@
               'type': 'array',
             }),
             'service': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'signature': dict({
+              'default': '',
               'description': 'Derived from a docutils desc_name node.',
               'field_type': 'core',
               'type': 'string',
             }),
             'specific': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'status': dict({
+              'default': None,
               'description': 'Status of the need.',
               'field_type': 'core',
               'type': list([
@@ -634,6 +693,7 @@
               ]),
             }),
             'style': dict({
+              'default': None,
               'description': 'Comma-separated list of CSS classes (all appended by `needs_style_`).',
               'field_type': 'core',
               'type': list([
@@ -642,6 +702,8 @@
               ]),
             }),
             'tags': dict({
+              'default': list([
+              ]),
               'description': 'List of tags.',
               'field_type': 'core',
               'items': dict({
@@ -655,6 +717,7 @@
               'type': 'string',
             }),
             'template': dict({
+              'default': None,
               'description': 'Template of the need.',
               'field_type': 'core',
               'type': list([
@@ -668,31 +731,37 @@
               'type': 'string',
             }),
             'type': dict({
+              'default': '',
               'description': 'Type of the need.',
               'field_type': 'core',
               'type': 'string',
             }),
             'type_name': dict({
+              'default': '',
               'description': 'Name of the type.',
               'field_type': 'core',
               'type': 'string',
             }),
             'updated_at': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'url': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'url_postfix': dict({
+              'default': '',
               'description': 'Added by service open-needs',
               'field_type': 'extra',
               'type': 'string',
             }),
             'user': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
@@ -1142,26 +1211,33 @@
               'additionalProperties': dict({
                 'type': 'string',
               }),
+              'default': dict({
+              }),
               'description': 'Mapping of uml key to uml content.',
               'field_type': 'core',
               'type': 'object',
             }),
             'avatar': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'closed_at': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'completion': dict({
+              'default': '',
               'description': 'Added for needgantt functionality',
               'field_type': 'extra',
               'type': 'string',
             }),
             'constraints': dict({
+              'default': list([
+              ]),
               'description': 'List of constraint names, which are defined for this need.',
               'field_type': 'core',
               'items': dict({
@@ -1170,11 +1246,13 @@
               'type': 'array',
             }),
             'constraints_error': dict({
+              'default': '',
               'description': 'An error message set if any constraint failed, and `error_message` field is set in config.',
               'field_type': 'core',
               'type': 'string',
             }),
             'constraints_passed': dict({
+              'default': True,
               'description': 'True if all constraints passed, False if any failed, None if not yet checked.',
               'field_type': 'core',
               'type': list([
@@ -1186,11 +1264,14 @@
               'additionalProperties': dict({
                 'type': 'object',
               }),
+              'default': dict({
+              }),
               'description': 'Mapping of constraint name, to check name, to result.',
               'field_type': 'core',
               'type': 'object',
             }),
             'content_id': dict({
+              'default': None,
               'description': 'ID of the content node.',
               'field_type': 'core',
               'type': list([
@@ -1199,16 +1280,22 @@
               ]),
             }),
             'created_at': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'delete': dict({
+              'default': None,
               'description': 'If true, the need is deleted entirely.',
               'field_type': 'core',
-              'type': 'boolean',
+              'type': list([
+                'boolean',
+                'null',
+              ]),
             }),
             'docname': dict({
+              'default': None,
               'description': 'Name of the document where the need is defined (None if external).',
               'field_type': 'core',
               'type': list([
@@ -1217,21 +1304,25 @@
               ]),
             }),
             'doctype': dict({
+              'default': '.rst',
               'description': "Type of the document where the need is defined, e.g. '.rst'.",
               'field_type': 'core',
               'type': 'string',
             }),
             'duration': dict({
+              'default': '',
               'description': 'Added for needgantt functionality',
               'field_type': 'extra',
               'type': 'string',
             }),
             'external_css': dict({
+              'default': '',
               'description': 'CSS class name, added to the external reference.',
               'field_type': 'core',
               'type': 'string',
             }),
             'external_url': dict({
+              'default': None,
               'description': 'URL of the need, if it is an external need.',
               'field_type': 'core',
               'type': list([
@@ -1240,16 +1331,19 @@
               ]),
             }),
             'full_title': dict({
+              'default': '',
               'description': 'Title of the need, of unlimited length.',
               'field_type': 'core',
               'type': 'string',
             }),
             'has_dead_links': dict({
+              'default': False,
               'description': 'True if any links reference need ids that are not found in the need list.',
               'field_type': 'core',
               'type': 'boolean',
             }),
             'has_forbidden_dead_links': dict({
+              'default': False,
               'description': 'True if any links reference need ids that are not found in the need list, and the link type does not allow dead links.',
               'field_type': 'core',
               'type': 'boolean',
@@ -1260,36 +1354,46 @@
               'type': 'string',
             }),
             'id_prefix': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'is_external': dict({
+              'default': False,
               'description': 'If true, no node is created and need is referencing external url.',
               'field_type': 'core',
               'type': 'boolean',
             }),
             'is_modified': dict({
+              'default': False,
               'description': 'Whether the need was modified by needextend.',
               'field_type': 'core',
               'type': 'boolean',
             }),
             'is_need': dict({
+              'default': True,
               'description': 'Whether the need is a need.',
               'field_type': 'core',
               'type': 'boolean',
             }),
             'is_part': dict({
+              'default': False,
               'description': 'Whether the need is a part.',
               'field_type': 'core',
               'type': 'boolean',
             }),
             'jinja_content': dict({
+              'default': None,
               'description': 'Whether the content should be pre-processed by jinja.',
               'field_type': 'core',
-              'type': 'boolean',
+              'type': list([
+                'boolean',
+                'null',
+              ]),
             }),
             'layout': dict({
+              'default': None,
               'description': 'Key of the layout, which is used to render the need.',
               'field_type': 'core',
               'type': list([
@@ -1298,6 +1402,8 @@
               ]),
             }),
             'links': dict({
+              'default': list([
+              ]),
               'description': 'Link field',
               'field_type': 'links',
               'items': dict({
@@ -1306,31 +1412,38 @@
               'type': 'array',
             }),
             'max_amount': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'max_content_lines': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'modifications': dict({
+              'default': 0,
               'description': 'Number of modifications by needextend.',
               'field_type': 'core',
               'type': 'integer',
             }),
             'params': dict({
+              'default': '',
               'description': 'Added by service open-needs',
               'field_type': 'extra',
               'type': 'string',
             }),
             'parent_need': dict({
+              'default': '',
               'description': 'Simply the first parent id.',
               'field_type': 'core',
               'type': 'string',
             }),
             'parent_needs': dict({
+              'default': list([
+              ]),
               'description': 'Link field',
               'field_type': 'links',
               'items': dict({
@@ -1342,16 +1455,20 @@
               'additionalProperties': dict({
                 'type': 'object',
               }),
+              'default': dict({
+              }),
               'description': "Mapping of parts, a.k.a. sub-needs, IDs to data that overrides the need's data",
               'field_type': 'core',
               'type': 'object',
             }),
             'post_content': dict({
+              'default': '',
               'description': 'Post-content of the need.',
               'field_type': 'core',
               'type': 'string',
             }),
             'post_template': dict({
+              'default': None,
               'description': 'Post-template of the need.',
               'field_type': 'core',
               'type': list([
@@ -1360,11 +1477,13 @@
               ]),
             }),
             'pre_content': dict({
+              'default': '',
               'description': 'Pre-content of the need.',
               'field_type': 'core',
               'type': 'string',
             }),
             'pre_template': dict({
+              'default': None,
               'description': 'Pre-template of the need.',
               'field_type': 'core',
               'type': list([
@@ -1373,16 +1492,19 @@
               ]),
             }),
             'prefix': dict({
+              'default': '',
               'description': 'Added by service open-needs',
               'field_type': 'extra',
               'type': 'string',
             }),
             'query': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'section_name': dict({
+              'default': '',
               'description': 'Simply the first section.',
               'field_type': 'core',
               'type': list([
@@ -1391,6 +1513,8 @@
               ]),
             }),
             'sections': dict({
+              'default': list([
+              ]),
               'description': 'Sections of the need.',
               'field_type': 'core',
               'items': dict({
@@ -1399,21 +1523,25 @@
               'type': 'array',
             }),
             'service': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'signature': dict({
+              'default': '',
               'description': 'Derived from a docutils desc_name node.',
               'field_type': 'core',
               'type': 'string',
             }),
             'specific': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'status': dict({
+              'default': None,
               'description': 'Status of the need.',
               'field_type': 'core',
               'type': list([
@@ -1422,6 +1550,7 @@
               ]),
             }),
             'style': dict({
+              'default': None,
               'description': 'Comma-separated list of CSS classes (all appended by `needs_style_`).',
               'field_type': 'core',
               'type': list([
@@ -1430,6 +1559,8 @@
               ]),
             }),
             'tags': dict({
+              'default': list([
+              ]),
               'description': 'List of tags.',
               'field_type': 'core',
               'items': dict({
@@ -1443,6 +1574,7 @@
               'type': 'string',
             }),
             'template': dict({
+              'default': None,
               'description': 'Template of the need.',
               'field_type': 'core',
               'type': list([
@@ -1456,31 +1588,37 @@
               'type': 'string',
             }),
             'type': dict({
+              'default': '',
               'description': 'Type of the need.',
               'field_type': 'core',
               'type': 'string',
             }),
             'type_name': dict({
+              'default': '',
               'description': 'Name of the type.',
               'field_type': 'core',
               'type': 'string',
             }),
             'updated_at': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'url': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'url_postfix': dict({
+              'default': '',
               'description': 'Added by service open-needs',
               'field_type': 'extra',
               'type': 'string',
             }),
             'user': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',

--- a/tests/__snapshots__/test_needs_builder.ambr
+++ b/tests/__snapshots__/test_needs_builder.ambr
@@ -218,26 +218,33 @@
               'additionalProperties': dict({
                 'type': 'string',
               }),
+              'default': dict({
+              }),
               'description': 'Mapping of uml key to uml content.',
               'field_type': 'core',
               'type': 'object',
             }),
             'avatar': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'closed_at': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'completion': dict({
+              'default': '',
               'description': 'Added for needgantt functionality',
               'field_type': 'extra',
               'type': 'string',
             }),
             'constraints': dict({
+              'default': list([
+              ]),
               'description': 'List of constraint names, which are defined for this need.',
               'field_type': 'core',
               'items': dict({
@@ -246,11 +253,13 @@
               'type': 'array',
             }),
             'constraints_error': dict({
+              'default': '',
               'description': 'An error message set if any constraint failed, and `error_message` field is set in config.',
               'field_type': 'core',
               'type': 'string',
             }),
             'constraints_passed': dict({
+              'default': True,
               'description': 'True if all constraints passed, False if any failed, None if not yet checked.',
               'field_type': 'core',
               'type': list([
@@ -262,11 +271,14 @@
               'additionalProperties': dict({
                 'type': 'object',
               }),
+              'default': dict({
+              }),
               'description': 'Mapping of constraint name, to check name, to result.',
               'field_type': 'core',
               'type': 'object',
             }),
             'content_id': dict({
+              'default': None,
               'description': 'ID of the content node.',
               'field_type': 'core',
               'type': list([
@@ -275,16 +287,22 @@
               ]),
             }),
             'created_at': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'delete': dict({
+              'default': None,
               'description': 'If true, the need is deleted entirely.',
               'field_type': 'core',
-              'type': 'boolean',
+              'type': list([
+                'boolean',
+                'null',
+              ]),
             }),
             'docname': dict({
+              'default': None,
               'description': 'Name of the document where the need is defined (None if external).',
               'field_type': 'core',
               'type': list([
@@ -293,21 +311,25 @@
               ]),
             }),
             'doctype': dict({
+              'default': '.rst',
               'description': "Type of the document where the need is defined, e.g. '.rst'.",
               'field_type': 'core',
               'type': 'string',
             }),
             'duration': dict({
+              'default': '',
               'description': 'Added for needgantt functionality',
               'field_type': 'extra',
               'type': 'string',
             }),
             'external_css': dict({
+              'default': '',
               'description': 'CSS class name, added to the external reference.',
               'field_type': 'core',
               'type': 'string',
             }),
             'external_url': dict({
+              'default': None,
               'description': 'URL of the need, if it is an external need.',
               'field_type': 'core',
               'type': list([
@@ -316,16 +338,19 @@
               ]),
             }),
             'full_title': dict({
+              'default': '',
               'description': 'Title of the need, of unlimited length.',
               'field_type': 'core',
               'type': 'string',
             }),
             'has_dead_links': dict({
+              'default': False,
               'description': 'True if any links reference need ids that are not found in the need list.',
               'field_type': 'core',
               'type': 'boolean',
             }),
             'has_forbidden_dead_links': dict({
+              'default': False,
               'description': 'True if any links reference need ids that are not found in the need list, and the link type does not allow dead links.',
               'field_type': 'core',
               'type': 'boolean',
@@ -336,36 +361,46 @@
               'type': 'string',
             }),
             'id_prefix': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'is_external': dict({
+              'default': False,
               'description': 'If true, no node is created and need is referencing external url.',
               'field_type': 'core',
               'type': 'boolean',
             }),
             'is_modified': dict({
+              'default': False,
               'description': 'Whether the need was modified by needextend.',
               'field_type': 'core',
               'type': 'boolean',
             }),
             'is_need': dict({
+              'default': True,
               'description': 'Whether the need is a need.',
               'field_type': 'core',
               'type': 'boolean',
             }),
             'is_part': dict({
+              'default': False,
               'description': 'Whether the need is a part.',
               'field_type': 'core',
               'type': 'boolean',
             }),
             'jinja_content': dict({
+              'default': None,
               'description': 'Whether the content should be pre-processed by jinja.',
               'field_type': 'core',
-              'type': 'boolean',
+              'type': list([
+                'boolean',
+                'null',
+              ]),
             }),
             'layout': dict({
+              'default': None,
               'description': 'Key of the layout, which is used to render the need.',
               'field_type': 'core',
               'type': list([
@@ -374,6 +409,8 @@
               ]),
             }),
             'links': dict({
+              'default': list([
+              ]),
               'description': 'Link field',
               'field_type': 'links',
               'items': dict({
@@ -382,31 +419,38 @@
               'type': 'array',
             }),
             'max_amount': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'max_content_lines': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'modifications': dict({
+              'default': 0,
               'description': 'Number of modifications by needextend.',
               'field_type': 'core',
               'type': 'integer',
             }),
             'params': dict({
+              'default': '',
               'description': 'Added by service open-needs',
               'field_type': 'extra',
               'type': 'string',
             }),
             'parent_need': dict({
+              'default': '',
               'description': 'Simply the first parent id.',
               'field_type': 'core',
               'type': 'string',
             }),
             'parent_needs': dict({
+              'default': list([
+              ]),
               'description': 'Link field',
               'field_type': 'links',
               'items': dict({
@@ -418,16 +462,20 @@
               'additionalProperties': dict({
                 'type': 'object',
               }),
+              'default': dict({
+              }),
               'description': "Mapping of parts, a.k.a. sub-needs, IDs to data that overrides the need's data",
               'field_type': 'core',
               'type': 'object',
             }),
             'post_content': dict({
+              'default': '',
               'description': 'Post-content of the need.',
               'field_type': 'core',
               'type': 'string',
             }),
             'post_template': dict({
+              'default': None,
               'description': 'Post-template of the need.',
               'field_type': 'core',
               'type': list([
@@ -436,11 +484,13 @@
               ]),
             }),
             'pre_content': dict({
+              'default': '',
               'description': 'Pre-content of the need.',
               'field_type': 'core',
               'type': 'string',
             }),
             'pre_template': dict({
+              'default': None,
               'description': 'Pre-template of the need.',
               'field_type': 'core',
               'type': list([
@@ -449,16 +499,19 @@
               ]),
             }),
             'prefix': dict({
+              'default': '',
               'description': 'Added by service open-needs',
               'field_type': 'extra',
               'type': 'string',
             }),
             'query': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'section_name': dict({
+              'default': '',
               'description': 'Simply the first section.',
               'field_type': 'core',
               'type': list([
@@ -467,6 +520,8 @@
               ]),
             }),
             'sections': dict({
+              'default': list([
+              ]),
               'description': 'Sections of the need.',
               'field_type': 'core',
               'items': dict({
@@ -475,21 +530,25 @@
               'type': 'array',
             }),
             'service': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'signature': dict({
+              'default': '',
               'description': 'Derived from a docutils desc_name node.',
               'field_type': 'core',
               'type': 'string',
             }),
             'specific': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'status': dict({
+              'default': None,
               'description': 'Status of the need.',
               'field_type': 'core',
               'type': list([
@@ -498,6 +557,7 @@
               ]),
             }),
             'style': dict({
+              'default': None,
               'description': 'Comma-separated list of CSS classes (all appended by `needs_style_`).',
               'field_type': 'core',
               'type': list([
@@ -506,6 +566,8 @@
               ]),
             }),
             'tags': dict({
+              'default': list([
+              ]),
               'description': 'List of tags.',
               'field_type': 'core',
               'items': dict({
@@ -519,6 +581,7 @@
               'type': 'string',
             }),
             'template': dict({
+              'default': None,
               'description': 'Template of the need.',
               'field_type': 'core',
               'type': list([
@@ -532,31 +595,37 @@
               'type': 'string',
             }),
             'type': dict({
+              'default': '',
               'description': 'Type of the need.',
               'field_type': 'core',
               'type': 'string',
             }),
             'type_name': dict({
+              'default': '',
               'description': 'Name of the type.',
               'field_type': 'core',
               'type': 'string',
             }),
             'updated_at': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'url': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'url_postfix': dict({
+              'default': '',
               'description': 'Added by service open-needs',
               'field_type': 'extra',
               'type': 'string',
             }),
             'user': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
@@ -954,26 +1023,33 @@
               'additionalProperties': dict({
                 'type': 'string',
               }),
+              'default': dict({
+              }),
               'description': 'Mapping of uml key to uml content.',
               'field_type': 'core',
               'type': 'object',
             }),
             'avatar': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'closed_at': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'completion': dict({
+              'default': '',
               'description': 'Added for needgantt functionality',
               'field_type': 'extra',
               'type': 'string',
             }),
             'constraints': dict({
+              'default': list([
+              ]),
               'description': 'List of constraint names, which are defined for this need.',
               'field_type': 'core',
               'items': dict({
@@ -982,11 +1058,13 @@
               'type': 'array',
             }),
             'constraints_error': dict({
+              'default': '',
               'description': 'An error message set if any constraint failed, and `error_message` field is set in config.',
               'field_type': 'core',
               'type': 'string',
             }),
             'constraints_passed': dict({
+              'default': True,
               'description': 'True if all constraints passed, False if any failed, None if not yet checked.',
               'field_type': 'core',
               'type': list([
@@ -998,11 +1076,14 @@
               'additionalProperties': dict({
                 'type': 'object',
               }),
+              'default': dict({
+              }),
               'description': 'Mapping of constraint name, to check name, to result.',
               'field_type': 'core',
               'type': 'object',
             }),
             'content_id': dict({
+              'default': None,
               'description': 'ID of the content node.',
               'field_type': 'core',
               'type': list([
@@ -1011,16 +1092,22 @@
               ]),
             }),
             'created_at': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'delete': dict({
+              'default': None,
               'description': 'If true, the need is deleted entirely.',
               'field_type': 'core',
-              'type': 'boolean',
+              'type': list([
+                'boolean',
+                'null',
+              ]),
             }),
             'docname': dict({
+              'default': None,
               'description': 'Name of the document where the need is defined (None if external).',
               'field_type': 'core',
               'type': list([
@@ -1029,21 +1116,25 @@
               ]),
             }),
             'doctype': dict({
+              'default': '.rst',
               'description': "Type of the document where the need is defined, e.g. '.rst'.",
               'field_type': 'core',
               'type': 'string',
             }),
             'duration': dict({
+              'default': '',
               'description': 'Added for needgantt functionality',
               'field_type': 'extra',
               'type': 'string',
             }),
             'external_css': dict({
+              'default': '',
               'description': 'CSS class name, added to the external reference.',
               'field_type': 'core',
               'type': 'string',
             }),
             'external_url': dict({
+              'default': None,
               'description': 'URL of the need, if it is an external need.',
               'field_type': 'core',
               'type': list([
@@ -1052,16 +1143,19 @@
               ]),
             }),
             'full_title': dict({
+              'default': '',
               'description': 'Title of the need, of unlimited length.',
               'field_type': 'core',
               'type': 'string',
             }),
             'has_dead_links': dict({
+              'default': False,
               'description': 'True if any links reference need ids that are not found in the need list.',
               'field_type': 'core',
               'type': 'boolean',
             }),
             'has_forbidden_dead_links': dict({
+              'default': False,
               'description': 'True if any links reference need ids that are not found in the need list, and the link type does not allow dead links.',
               'field_type': 'core',
               'type': 'boolean',
@@ -1072,36 +1166,46 @@
               'type': 'string',
             }),
             'id_prefix': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'is_external': dict({
+              'default': False,
               'description': 'If true, no node is created and need is referencing external url.',
               'field_type': 'core',
               'type': 'boolean',
             }),
             'is_modified': dict({
+              'default': False,
               'description': 'Whether the need was modified by needextend.',
               'field_type': 'core',
               'type': 'boolean',
             }),
             'is_need': dict({
+              'default': True,
               'description': 'Whether the need is a need.',
               'field_type': 'core',
               'type': 'boolean',
             }),
             'is_part': dict({
+              'default': False,
               'description': 'Whether the need is a part.',
               'field_type': 'core',
               'type': 'boolean',
             }),
             'jinja_content': dict({
+              'default': None,
               'description': 'Whether the content should be pre-processed by jinja.',
               'field_type': 'core',
-              'type': 'boolean',
+              'type': list([
+                'boolean',
+                'null',
+              ]),
             }),
             'layout': dict({
+              'default': None,
               'description': 'Key of the layout, which is used to render the need.',
               'field_type': 'core',
               'type': list([
@@ -1110,6 +1214,8 @@
               ]),
             }),
             'links': dict({
+              'default': list([
+              ]),
               'description': 'Link field',
               'field_type': 'links',
               'items': dict({
@@ -1118,31 +1224,38 @@
               'type': 'array',
             }),
             'max_amount': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'max_content_lines': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'modifications': dict({
+              'default': 0,
               'description': 'Number of modifications by needextend.',
               'field_type': 'core',
               'type': 'integer',
             }),
             'params': dict({
+              'default': '',
               'description': 'Added by service open-needs',
               'field_type': 'extra',
               'type': 'string',
             }),
             'parent_need': dict({
+              'default': '',
               'description': 'Simply the first parent id.',
               'field_type': 'core',
               'type': 'string',
             }),
             'parent_needs': dict({
+              'default': list([
+              ]),
               'description': 'Link field',
               'field_type': 'links',
               'items': dict({
@@ -1154,16 +1267,20 @@
               'additionalProperties': dict({
                 'type': 'object',
               }),
+              'default': dict({
+              }),
               'description': "Mapping of parts, a.k.a. sub-needs, IDs to data that overrides the need's data",
               'field_type': 'core',
               'type': 'object',
             }),
             'post_content': dict({
+              'default': '',
               'description': 'Post-content of the need.',
               'field_type': 'core',
               'type': 'string',
             }),
             'post_template': dict({
+              'default': None,
               'description': 'Post-template of the need.',
               'field_type': 'core',
               'type': list([
@@ -1172,11 +1289,13 @@
               ]),
             }),
             'pre_content': dict({
+              'default': '',
               'description': 'Pre-content of the need.',
               'field_type': 'core',
               'type': 'string',
             }),
             'pre_template': dict({
+              'default': None,
               'description': 'Pre-template of the need.',
               'field_type': 'core',
               'type': list([
@@ -1185,16 +1304,19 @@
               ]),
             }),
             'prefix': dict({
+              'default': '',
               'description': 'Added by service open-needs',
               'field_type': 'extra',
               'type': 'string',
             }),
             'query': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'section_name': dict({
+              'default': '',
               'description': 'Simply the first section.',
               'field_type': 'core',
               'type': list([
@@ -1203,6 +1325,8 @@
               ]),
             }),
             'sections': dict({
+              'default': list([
+              ]),
               'description': 'Sections of the need.',
               'field_type': 'core',
               'items': dict({
@@ -1211,21 +1335,25 @@
               'type': 'array',
             }),
             'service': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'signature': dict({
+              'default': '',
               'description': 'Derived from a docutils desc_name node.',
               'field_type': 'core',
               'type': 'string',
             }),
             'specific': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'status': dict({
+              'default': None,
               'description': 'Status of the need.',
               'field_type': 'core',
               'type': list([
@@ -1234,6 +1362,7 @@
               ]),
             }),
             'style': dict({
+              'default': None,
               'description': 'Comma-separated list of CSS classes (all appended by `needs_style_`).',
               'field_type': 'core',
               'type': list([
@@ -1242,6 +1371,8 @@
               ]),
             }),
             'tags': dict({
+              'default': list([
+              ]),
               'description': 'List of tags.',
               'field_type': 'core',
               'items': dict({
@@ -1255,6 +1386,7 @@
               'type': 'string',
             }),
             'template': dict({
+              'default': None,
               'description': 'Template of the need.',
               'field_type': 'core',
               'type': list([
@@ -1268,31 +1400,37 @@
               'type': 'string',
             }),
             'type': dict({
+              'default': '',
               'description': 'Type of the need.',
               'field_type': 'core',
               'type': 'string',
             }),
             'type_name': dict({
+              'default': '',
               'description': 'Name of the type.',
               'field_type': 'core',
               'type': 'string',
             }),
             'updated_at': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'url': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'url_postfix': dict({
+              'default': '',
               'description': 'Added by service open-needs',
               'field_type': 'extra',
               'type': 'string',
             }),
             'user': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',

--- a/tests/__snapshots__/test_needs_builder.ambr
+++ b/tests/__snapshots__/test_needs_builder.ambr
@@ -803,6 +803,666 @@
     }),
   })
 # ---
+# name: test_doc_needs_builder_remove_defaults[test_app0]
+  dict({
+    'current_version': '1.0',
+    'versions': dict({
+      '1.0': dict({
+        'filters': dict({
+        }),
+        'filters_amount': 0,
+        'needs': dict({
+          'TC_001': dict({
+            'content_id': 'TC_001',
+            'description': '',
+            'docname': 'index',
+            'external_css': 'external_link',
+            'full_title': 'Test example',
+            'id': 'TC_001',
+            'layout': '',
+            'section_name': 'TEST DOCUMENT NEEDS Builder',
+            'sections': list([
+              'TEST DOCUMENT NEEDS Builder',
+            ]),
+            'status': 'open',
+            'target_id': 'TC_001',
+            'title': 'Test example',
+            'type': 'test',
+            'type_name': 'Test Case',
+          }),
+          'TC_NEG_001': dict({
+            'content_id': 'TC_NEG_001',
+            'description': '',
+            'docname': 'index',
+            'external_css': 'external_link',
+            'full_title': 'Negative test example',
+            'id': 'TC_NEG_001',
+            'layout': '',
+            'section_name': 'TEST DOCUMENT NEEDS Builder',
+            'sections': list([
+              'TEST DOCUMENT NEEDS Builder',
+            ]),
+            'status': 'closed',
+            'target_id': 'TC_NEG_001',
+            'title': 'Negative test example',
+            'type': 'test',
+            'type_name': 'Test Case',
+          }),
+          'US_63252': dict({
+            'content_id': 'US_63252',
+            'description': '',
+            'docname': 'index',
+            'external_css': 'external_link',
+            'full_title': 'A story',
+            'id': 'US_63252',
+            'layout': '',
+            'section_name': 'TEST DOCUMENT NEEDS Builder',
+            'sections': list([
+              'TEST DOCUMENT NEEDS Builder',
+            ]),
+            'status': 'in progress',
+            'tags': list([
+              '1',
+            ]),
+            'target_id': 'US_63252',
+            'title': 'A story',
+            'type': 'story',
+            'type_name': 'User Story',
+          }),
+        }),
+        'needs_amount': 3,
+        'needs_schema': dict({
+          '$schema': 'http://json-schema.org/draft-07/schema#',
+          'properties': dict({
+            'arch': dict({
+              'additionalProperties': dict({
+                'type': 'string',
+              }),
+              'default': dict({
+              }),
+              'description': 'Mapping of uml key to uml content.',
+              'field_type': 'core',
+              'type': 'object',
+            }),
+            'avatar': dict({
+              'default': '',
+              'description': 'Added by service github-issues',
+              'field_type': 'extra',
+              'type': 'string',
+            }),
+            'closed_at': dict({
+              'default': '',
+              'description': 'Added by service github-issues',
+              'field_type': 'extra',
+              'type': 'string',
+            }),
+            'completion': dict({
+              'default': '',
+              'description': 'Added for needgantt functionality',
+              'field_type': 'extra',
+              'type': 'string',
+            }),
+            'constraints': dict({
+              'default': list([
+              ]),
+              'description': 'List of constraint names, which are defined for this need.',
+              'field_type': 'core',
+              'items': dict({
+                'type': 'string',
+              }),
+              'type': 'array',
+            }),
+            'constraints_error': dict({
+              'default': '',
+              'description': 'An error message set if any constraint failed, and `error_message` field is set in config.',
+              'field_type': 'core',
+              'type': 'string',
+            }),
+            'constraints_passed': dict({
+              'default': True,
+              'description': 'True if all constraints passed, False if any failed, None if not yet checked.',
+              'field_type': 'core',
+              'type': list([
+                'boolean',
+                'null',
+              ]),
+            }),
+            'constraints_results': dict({
+              'additionalProperties': dict({
+                'type': 'object',
+              }),
+              'default': dict({
+              }),
+              'description': 'Mapping of constraint name, to check name, to result.',
+              'field_type': 'core',
+              'type': 'object',
+            }),
+            'content_id': dict({
+              'default': None,
+              'description': 'ID of the content node.',
+              'field_type': 'core',
+              'type': list([
+                'string',
+                'null',
+              ]),
+            }),
+            'created_at': dict({
+              'default': '',
+              'description': 'Added by service github-issues',
+              'field_type': 'extra',
+              'type': 'string',
+            }),
+            'delete': dict({
+              'default': None,
+              'description': 'If true, the need is deleted entirely.',
+              'field_type': 'core',
+              'type': list([
+                'boolean',
+                'null',
+              ]),
+            }),
+            'docname': dict({
+              'default': None,
+              'description': 'Name of the document where the need is defined (None if external).',
+              'field_type': 'core',
+              'type': list([
+                'string',
+                'null',
+              ]),
+            }),
+            'doctype': dict({
+              'default': '.rst',
+              'description': "Type of the document where the need is defined, e.g. '.rst'.",
+              'field_type': 'core',
+              'type': 'string',
+            }),
+            'duration': dict({
+              'default': '',
+              'description': 'Added for needgantt functionality',
+              'field_type': 'extra',
+              'type': 'string',
+            }),
+            'external_css': dict({
+              'default': '',
+              'description': 'CSS class name, added to the external reference.',
+              'field_type': 'core',
+              'type': 'string',
+            }),
+            'external_url': dict({
+              'default': None,
+              'description': 'URL of the need, if it is an external need.',
+              'field_type': 'core',
+              'type': list([
+                'string',
+                'null',
+              ]),
+            }),
+            'full_title': dict({
+              'default': '',
+              'description': 'Title of the need, of unlimited length.',
+              'field_type': 'core',
+              'type': 'string',
+            }),
+            'has_dead_links': dict({
+              'default': False,
+              'description': 'True if any links reference need ids that are not found in the need list.',
+              'field_type': 'core',
+              'type': 'boolean',
+            }),
+            'has_forbidden_dead_links': dict({
+              'default': False,
+              'description': 'True if any links reference need ids that are not found in the need list, and the link type does not allow dead links.',
+              'field_type': 'core',
+              'type': 'boolean',
+            }),
+            'id': dict({
+              'description': 'ID of the data.',
+              'field_type': 'core',
+              'type': 'string',
+            }),
+            'id_prefix': dict({
+              'default': '',
+              'description': 'Added by service github-issues',
+              'field_type': 'extra',
+              'type': 'string',
+            }),
+            'is_external': dict({
+              'default': False,
+              'description': 'If true, no node is created and need is referencing external url.',
+              'field_type': 'core',
+              'type': 'boolean',
+            }),
+            'is_modified': dict({
+              'default': False,
+              'description': 'Whether the need was modified by needextend.',
+              'field_type': 'core',
+              'type': 'boolean',
+            }),
+            'is_need': dict({
+              'default': True,
+              'description': 'Whether the need is a need.',
+              'field_type': 'core',
+              'type': 'boolean',
+            }),
+            'is_part': dict({
+              'default': False,
+              'description': 'Whether the need is a part.',
+              'field_type': 'core',
+              'type': 'boolean',
+            }),
+            'jinja_content': dict({
+              'default': None,
+              'description': 'Whether the content should be pre-processed by jinja.',
+              'field_type': 'core',
+              'type': list([
+                'boolean',
+                'null',
+              ]),
+            }),
+            'layout': dict({
+              'default': None,
+              'description': 'Key of the layout, which is used to render the need.',
+              'field_type': 'core',
+              'type': list([
+                'string',
+                'null',
+              ]),
+            }),
+            'links': dict({
+              'default': list([
+              ]),
+              'description': 'Link field',
+              'field_type': 'links',
+              'items': dict({
+                'type': 'string',
+              }),
+              'type': 'array',
+            }),
+            'max_amount': dict({
+              'default': '',
+              'description': 'Added by service github-issues',
+              'field_type': 'extra',
+              'type': 'string',
+            }),
+            'max_content_lines': dict({
+              'default': '',
+              'description': 'Added by service github-issues',
+              'field_type': 'extra',
+              'type': 'string',
+            }),
+            'modifications': dict({
+              'default': 0,
+              'description': 'Number of modifications by needextend.',
+              'field_type': 'core',
+              'type': 'integer',
+            }),
+            'params': dict({
+              'default': '',
+              'description': 'Added by service open-needs',
+              'field_type': 'extra',
+              'type': 'string',
+            }),
+            'parent_need': dict({
+              'default': '',
+              'description': 'Simply the first parent id.',
+              'field_type': 'core',
+              'type': 'string',
+            }),
+            'parent_needs': dict({
+              'default': list([
+              ]),
+              'description': 'Link field',
+              'field_type': 'links',
+              'items': dict({
+                'type': 'string',
+              }),
+              'type': 'array',
+            }),
+            'parts': dict({
+              'additionalProperties': dict({
+                'type': 'object',
+              }),
+              'default': dict({
+              }),
+              'description': "Mapping of parts, a.k.a. sub-needs, IDs to data that overrides the need's data",
+              'field_type': 'core',
+              'type': 'object',
+            }),
+            'post_content': dict({
+              'default': '',
+              'description': 'Post-content of the need.',
+              'field_type': 'core',
+              'type': 'string',
+            }),
+            'post_template': dict({
+              'default': None,
+              'description': 'Post-template of the need.',
+              'field_type': 'core',
+              'type': list([
+                'string',
+                'null',
+              ]),
+            }),
+            'pre_content': dict({
+              'default': '',
+              'description': 'Pre-content of the need.',
+              'field_type': 'core',
+              'type': 'string',
+            }),
+            'pre_template': dict({
+              'default': None,
+              'description': 'Pre-template of the need.',
+              'field_type': 'core',
+              'type': list([
+                'string',
+                'null',
+              ]),
+            }),
+            'prefix': dict({
+              'default': '',
+              'description': 'Added by service open-needs',
+              'field_type': 'extra',
+              'type': 'string',
+            }),
+            'query': dict({
+              'default': '',
+              'description': 'Added by service github-issues',
+              'field_type': 'extra',
+              'type': 'string',
+            }),
+            'section_name': dict({
+              'default': '',
+              'description': 'Simply the first section.',
+              'field_type': 'core',
+              'type': list([
+                'string',
+                'null',
+              ]),
+            }),
+            'sections': dict({
+              'default': list([
+              ]),
+              'description': 'Sections of the need.',
+              'field_type': 'core',
+              'items': dict({
+                'type': 'string',
+              }),
+              'type': 'array',
+            }),
+            'service': dict({
+              'default': '',
+              'description': 'Added by service github-issues',
+              'field_type': 'extra',
+              'type': 'string',
+            }),
+            'signature': dict({
+              'default': '',
+              'description': 'Derived from a docutils desc_name node.',
+              'field_type': 'core',
+              'type': 'string',
+            }),
+            'specific': dict({
+              'default': '',
+              'description': 'Added by service github-issues',
+              'field_type': 'extra',
+              'type': 'string',
+            }),
+            'status': dict({
+              'default': None,
+              'description': 'Status of the need.',
+              'field_type': 'core',
+              'type': list([
+                'string',
+                'null',
+              ]),
+            }),
+            'style': dict({
+              'default': None,
+              'description': 'Comma-separated list of CSS classes (all appended by `needs_style_`).',
+              'field_type': 'core',
+              'type': list([
+                'string',
+                'null',
+              ]),
+            }),
+            'tags': dict({
+              'default': list([
+              ]),
+              'description': 'List of tags.',
+              'field_type': 'core',
+              'items': dict({
+                'type': 'string',
+              }),
+              'type': 'array',
+            }),
+            'target_id': dict({
+              'description': 'ID of the data.',
+              'field_type': 'core',
+              'type': 'string',
+            }),
+            'template': dict({
+              'default': None,
+              'description': 'Template of the need.',
+              'field_type': 'core',
+              'type': list([
+                'string',
+                'null',
+              ]),
+            }),
+            'title': dict({
+              'description': 'Title of the need, trimmed to a maximum length.',
+              'field_type': 'core',
+              'type': 'string',
+            }),
+            'type': dict({
+              'default': '',
+              'description': 'Type of the need.',
+              'field_type': 'core',
+              'type': 'string',
+            }),
+            'type_name': dict({
+              'default': '',
+              'description': 'Name of the type.',
+              'field_type': 'core',
+              'type': 'string',
+            }),
+            'updated_at': dict({
+              'default': '',
+              'description': 'Added by service github-issues',
+              'field_type': 'extra',
+              'type': 'string',
+            }),
+            'url': dict({
+              'default': '',
+              'description': 'Added by service github-issues',
+              'field_type': 'extra',
+              'type': 'string',
+            }),
+            'url_postfix': dict({
+              'default': '',
+              'description': 'Added by service open-needs',
+              'field_type': 'extra',
+              'type': 'string',
+            }),
+            'user': dict({
+              'default': '',
+              'description': 'Added by service github-issues',
+              'field_type': 'extra',
+              'type': 'string',
+            }),
+          }),
+          'type': 'object',
+        }),
+      }),
+      '2.0': dict({
+        'filters': dict({
+        }),
+        'filters_amount': 0,
+        'needs': dict({
+          'TEST_01': dict({
+            'avatar': '',
+            'closed_at': '',
+            'completion': '',
+            'created_at': '',
+            'description': 'TEST_01',
+            'docname': 'index',
+            'duration': '',
+            'external_css': 'external_link',
+            'external_url': 'file:///home/daniel/workspace/sphinx/sphinxcontrib-needs/tests/doc_test/external_doc/__error__#TEST_01',
+            'full_title': 'TEST_01 DESCRIPTION',
+            'id': 'TEST_01',
+            'id_complete': 'TEST_01',
+            'id_parent': 'TEST_01',
+            'id_prefix': '',
+            'is_external': True,
+            'is_need': True,
+            'is_part': False,
+            'layout': None,
+            'links': list([
+              'SPEC_1',
+            ]),
+            'max_amount': '',
+            'max_content_lines': '',
+            'parent_need': None,
+            'parent_needs': list([
+            ]),
+            'parent_needs_back': list([
+            ]),
+            'parts': dict({
+            }),
+            'post_template': None,
+            'pre_template': None,
+            'query': '',
+            'section_name': '',
+            'sections': list([
+            ]),
+            'service': '',
+            'signature': '',
+            'specific': '',
+            'status': None,
+            'style': None,
+            'tags': list([
+            ]),
+            'template': None,
+            'title': 'TEST_01 DESCRIPTION',
+            'type': 'impl',
+            'type_name': 'Implementation',
+            'updated_at': '',
+            'url': '',
+            'user': '',
+          }),
+          'TEST_02': dict({
+            'avatar': '',
+            'closed_at': '',
+            'completion': '',
+            'created_at': '',
+            'description': 'TEST_02',
+            'docname': 'index',
+            'duration': '',
+            'external_css': 'external_link',
+            'external_url': 'file:///home/daniel/workspace/sphinx/sphinxcontrib-needs/tests/doc_test/external_doc/__error__#TEST_02',
+            'full_title': 'TEST_02 DESCRIPTION',
+            'id': 'TEST_02',
+            'id_complete': 'TEST_02',
+            'id_parent': 'TEST_02',
+            'id_prefix': '',
+            'is_external': True,
+            'is_need': True,
+            'is_part': False,
+            'layout': None,
+            'links': list([
+              'TEST_01',
+              'REQ_1',
+            ]),
+            'max_amount': '',
+            'max_content_lines': '',
+            'parent_need': None,
+            'parent_needs': list([
+            ]),
+            'parent_needs_back': list([
+            ]),
+            'parts': dict({
+            }),
+            'post_template': None,
+            'pre_template': None,
+            'query': '',
+            'section_name': '',
+            'sections': list([
+            ]),
+            'service': '',
+            'signature': '',
+            'specific': '',
+            'status': 'open',
+            'style': None,
+            'tags': list([
+              'test_02',
+              'test',
+            ]),
+            'template': None,
+            'title': 'TEST_02 DESCRIPTION',
+            'type': 'req',
+            'type_name': 'Requirement',
+            'updated_at': '',
+            'url': '',
+            'user': '',
+          }),
+          'TEST_03': dict({
+            'avatar': '',
+            'closed_at': '',
+            'completion': '',
+            'created_at': '',
+            'description': 'AAA',
+            'docname': 'subpage_a/subpage_b/subpage',
+            'duration': '',
+            'external_css': 'external_link',
+            'external_url': 'file:///home/daniel/workspace/sphinx/sphinxcontrib-needs/tests/doc_test/external_doc/__error__#TEST_03',
+            'full_title': 'AAA',
+            'id': 'TEST_03',
+            'id_complete': 'TEST_03',
+            'id_parent': 'TEST_03',
+            'id_prefix': '',
+            'is_external': True,
+            'is_need': True,
+            'is_part': False,
+            'layout': None,
+            'links': list([
+            ]),
+            'max_amount': '',
+            'max_content_lines': '',
+            'parent_need': None,
+            'parent_needs': list([
+            ]),
+            'parent_needs_back': list([
+            ]),
+            'parts': dict({
+            }),
+            'post_template': None,
+            'pre_template': None,
+            'query': '',
+            'section_name': '',
+            'sections': list([
+            ]),
+            'service': '',
+            'signature': '',
+            'specific': '',
+            'status': 'open',
+            'style': None,
+            'tags': list([
+            ]),
+            'template': None,
+            'title': 'AAA',
+            'type': 'req',
+            'type_name': 'Requirement',
+            'updated_at': '',
+            'url': '',
+            'user': '',
+          }),
+        }),
+        'needs_amount': 6,
+      }),
+    }),
+  })
+# ---
 # name: test_doc_needs_builder_reproducible[test_app0]
   dict({
     'current_version': '1.0',

--- a/tests/__snapshots__/test_service_github.ambr
+++ b/tests/__snapshots__/test_service_github.ambr
@@ -338,21 +338,27 @@
               'additionalProperties': dict({
                 'type': 'string',
               }),
+              'default': dict({
+              }),
               'description': 'Mapping of uml key to uml content.',
               'field_type': 'core',
               'type': 'object',
             }),
             'closed_at': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'completion': dict({
+              'default': '',
               'description': 'Added for needgantt functionality',
               'field_type': 'extra',
               'type': 'string',
             }),
             'constraints': dict({
+              'default': list([
+              ]),
               'description': 'List of constraint names, which are defined for this need.',
               'field_type': 'core',
               'items': dict({
@@ -361,11 +367,13 @@
               'type': 'array',
             }),
             'constraints_error': dict({
+              'default': '',
               'description': 'An error message set if any constraint failed, and `error_message` field is set in config.',
               'field_type': 'core',
               'type': 'string',
             }),
             'constraints_passed': dict({
+              'default': True,
               'description': 'True if all constraints passed, False if any failed, None if not yet checked.',
               'field_type': 'core',
               'type': list([
@@ -377,11 +385,14 @@
               'additionalProperties': dict({
                 'type': 'object',
               }),
+              'default': dict({
+              }),
               'description': 'Mapping of constraint name, to check name, to result.',
               'field_type': 'core',
               'type': 'object',
             }),
             'content_id': dict({
+              'default': None,
               'description': 'ID of the content node.',
               'field_type': 'core',
               'type': list([
@@ -390,16 +401,22 @@
               ]),
             }),
             'created_at': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'delete': dict({
+              'default': None,
               'description': 'If true, the need is deleted entirely.',
               'field_type': 'core',
-              'type': 'boolean',
+              'type': list([
+                'boolean',
+                'null',
+              ]),
             }),
             'docname': dict({
+              'default': None,
               'description': 'Name of the document where the need is defined (None if external).',
               'field_type': 'core',
               'type': list([
@@ -408,21 +425,25 @@
               ]),
             }),
             'doctype': dict({
+              'default': '.rst',
               'description': "Type of the document where the need is defined, e.g. '.rst'.",
               'field_type': 'core',
               'type': 'string',
             }),
             'duration': dict({
+              'default': '',
               'description': 'Added for needgantt functionality',
               'field_type': 'extra',
               'type': 'string',
             }),
             'external_css': dict({
+              'default': '',
               'description': 'CSS class name, added to the external reference.',
               'field_type': 'core',
               'type': 'string',
             }),
             'external_url': dict({
+              'default': None,
               'description': 'URL of the need, if it is an external need.',
               'field_type': 'core',
               'type': list([
@@ -431,16 +452,19 @@
               ]),
             }),
             'full_title': dict({
+              'default': '',
               'description': 'Title of the need, of unlimited length.',
               'field_type': 'core',
               'type': 'string',
             }),
             'has_dead_links': dict({
+              'default': False,
               'description': 'True if any links reference need ids that are not found in the need list.',
               'field_type': 'core',
               'type': 'boolean',
             }),
             'has_forbidden_dead_links': dict({
+              'default': False,
               'description': 'True if any links reference need ids that are not found in the need list, and the link type does not allow dead links.',
               'field_type': 'core',
               'type': 'boolean',
@@ -451,36 +475,46 @@
               'type': 'string',
             }),
             'id_prefix': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'is_external': dict({
+              'default': False,
               'description': 'If true, no node is created and need is referencing external url.',
               'field_type': 'core',
               'type': 'boolean',
             }),
             'is_modified': dict({
+              'default': False,
               'description': 'Whether the need was modified by needextend.',
               'field_type': 'core',
               'type': 'boolean',
             }),
             'is_need': dict({
+              'default': True,
               'description': 'Whether the need is a need.',
               'field_type': 'core',
               'type': 'boolean',
             }),
             'is_part': dict({
+              'default': False,
               'description': 'Whether the need is a part.',
               'field_type': 'core',
               'type': 'boolean',
             }),
             'jinja_content': dict({
+              'default': None,
               'description': 'Whether the content should be pre-processed by jinja.',
               'field_type': 'core',
-              'type': 'boolean',
+              'type': list([
+                'boolean',
+                'null',
+              ]),
             }),
             'layout': dict({
+              'default': None,
               'description': 'Key of the layout, which is used to render the need.',
               'field_type': 'core',
               'type': list([
@@ -489,6 +523,8 @@
               ]),
             }),
             'links': dict({
+              'default': list([
+              ]),
               'description': 'Link field',
               'field_type': 'links',
               'items': dict({
@@ -497,31 +533,38 @@
               'type': 'array',
             }),
             'max_amount': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'max_content_lines': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'modifications': dict({
+              'default': 0,
               'description': 'Number of modifications by needextend.',
               'field_type': 'core',
               'type': 'integer',
             }),
             'params': dict({
+              'default': '',
               'description': 'Added by service open-needs',
               'field_type': 'extra',
               'type': 'string',
             }),
             'parent_need': dict({
+              'default': '',
               'description': 'Simply the first parent id.',
               'field_type': 'core',
               'type': 'string',
             }),
             'parent_needs': dict({
+              'default': list([
+              ]),
               'description': 'Link field',
               'field_type': 'links',
               'items': dict({
@@ -533,16 +576,20 @@
               'additionalProperties': dict({
                 'type': 'object',
               }),
+              'default': dict({
+              }),
               'description': "Mapping of parts, a.k.a. sub-needs, IDs to data that overrides the need's data",
               'field_type': 'core',
               'type': 'object',
             }),
             'post_content': dict({
+              'default': '',
               'description': 'Post-content of the need.',
               'field_type': 'core',
               'type': 'string',
             }),
             'post_template': dict({
+              'default': None,
               'description': 'Post-template of the need.',
               'field_type': 'core',
               'type': list([
@@ -551,11 +598,13 @@
               ]),
             }),
             'pre_content': dict({
+              'default': '',
               'description': 'Pre-content of the need.',
               'field_type': 'core',
               'type': 'string',
             }),
             'pre_template': dict({
+              'default': None,
               'description': 'Pre-template of the need.',
               'field_type': 'core',
               'type': list([
@@ -564,16 +613,19 @@
               ]),
             }),
             'prefix': dict({
+              'default': '',
               'description': 'Added by service open-needs',
               'field_type': 'extra',
               'type': 'string',
             }),
             'query': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'section_name': dict({
+              'default': '',
               'description': 'Simply the first section.',
               'field_type': 'core',
               'type': list([
@@ -582,6 +634,8 @@
               ]),
             }),
             'sections': dict({
+              'default': list([
+              ]),
               'description': 'Sections of the need.',
               'field_type': 'core',
               'items': dict({
@@ -590,21 +644,25 @@
               'type': 'array',
             }),
             'service': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'signature': dict({
+              'default': '',
               'description': 'Derived from a docutils desc_name node.',
               'field_type': 'core',
               'type': 'string',
             }),
             'specific': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'status': dict({
+              'default': None,
               'description': 'Status of the need.',
               'field_type': 'core',
               'type': list([
@@ -613,6 +671,7 @@
               ]),
             }),
             'style': dict({
+              'default': None,
               'description': 'Comma-separated list of CSS classes (all appended by `needs_style_`).',
               'field_type': 'core',
               'type': list([
@@ -621,6 +680,8 @@
               ]),
             }),
             'tags': dict({
+              'default': list([
+              ]),
               'description': 'List of tags.',
               'field_type': 'core',
               'items': dict({
@@ -634,6 +695,7 @@
               'type': 'string',
             }),
             'template': dict({
+              'default': None,
               'description': 'Template of the need.',
               'field_type': 'core',
               'type': list([
@@ -647,31 +709,37 @@
               'type': 'string',
             }),
             'type': dict({
+              'default': '',
               'description': 'Type of the need.',
               'field_type': 'core',
               'type': 'string',
             }),
             'type_name': dict({
+              'default': '',
               'description': 'Name of the type.',
               'field_type': 'core',
               'type': 'string',
             }),
             'updated_at': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'url': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',
             }),
             'url_postfix': dict({
+              'default': '',
               'description': 'Added by service open-needs',
               'field_type': 'extra',
               'type': 'string',
             }),
             'user': dict({
+              'default': '',
               'description': 'Added by service github-issues',
               'field_type': 'extra',
               'type': 'string',

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -1,7 +1,14 @@
+from __future__ import annotations
+
 import json
+import shutil
 from pathlib import Path
+from textwrap import dedent
 
 import pytest
+from sphinx import version_info
+from sphinx.testing.util import SphinxTestApp
+from sphinx.util.console import strip_colors
 from syrupy.filters import props
 
 
@@ -10,9 +17,13 @@ from syrupy.filters import props
     [{"buildername": "html", "srcdir": "doc_test/external_doc"}],
     indirect=True,
 )
-def test_external_html(test_app):
+def test_external_html(test_app: SphinxTestApp):
     app = test_app
     app.build()
+    assert strip_colors(app._warning.getvalue()).strip() == (
+        "WARNING: Couldn't create need EXT_TEST_03. "
+        "Reason: The need-type (i.e. `ask`) is not set in the project's 'need_types' configuration in conf.py. [needs.add]"
+    )
     html = Path(app.outdir, "index.html").read_text()
     assert (
         '<a class="external_link reference external" href="http://my_company.com/docs/v1/index.html#TEST_02">'
@@ -31,7 +42,7 @@ def test_external_html(test_app):
     [{"buildername": "needs", "srcdir": "doc_test/external_doc"}],
     indirect=True,
 )
-def test_external_json(test_app, snapshot):
+def test_external_json(test_app: SphinxTestApp, snapshot):
     app = test_app
     app.build()
     json_data = Path(app.outdir, "needs.json").read_text()
@@ -39,25 +50,90 @@ def test_external_json(test_app, snapshot):
     assert needs == snapshot(exclude=props("created", "project"))
 
 
-@pytest.mark.parametrize(
-    "test_app",
-    [{"buildername": "needs", "srcdir": "doc_test/external_doc"}],
-    indirect=True,
-)
-def test_external_needs_warnings(test_app):
-    import os
-    import subprocess
+def test_export_import_round_trip(tmp_path: Path, snapshot):
+    """Test generating needs in one project and importing them in another."""
+    project_path = tmp_path / "project"
+    project_path.mkdir()
 
-    app = test_app
+    srcdir = project_path
+    builddir = project_path / "_build"
+    if version_info < (7, 2):
+        from sphinx.testing.path import path
 
-    srcdir = Path(app.srcdir)
-    out_dir = os.path.join(srcdir, "_build")
+        srcdir = path(str(srcdir))
+        builddir = path(str(builddir))
 
-    out = subprocess.run(
-        ["sphinx-build", "-b", "html", srcdir, out_dir], capture_output=True
+    # run a build that generates needs
+    project_path.joinpath("conf.py").write_text(
+        dedent("""\
+        version = "1.3"
+        extensions = ["sphinx_needs"]
+        needs_json_remove_defaults = True
+        """),
+        "utf8",
     )
-    assert (
-        "WARNING: Couldn't create need EXT_TEST_03. Reason: The need-type (i.e. `ask`) is not"
-        " set in the project's 'need_types' configuration in conf.py."
-        in out.stderr.decode("utf-8")
+    project_path.joinpath("index.rst").write_text(
+        dedent("""\
+        Title
+        =====
+               
+        .. req:: REQ_01
+           :id: REQ_01
+        """),
+        "utf8",
     )
+    app = SphinxTestApp(buildername="needs", srcdir=srcdir, builddir=builddir)
+    try:
+        app.build()
+    finally:
+        app.cleanup()
+    assert app._warning.getvalue() == ""
+
+    json_data = Path(str(app.outdir), "needs.json").read_bytes()
+
+    # remove previous project
+    app.cleanup()
+    shutil.rmtree(project_path)
+    project_path.mkdir(parents=True, exist_ok=True)
+    Path(str(app.outdir)).mkdir(parents=True, exist_ok=True)
+
+    Path(str(app.srcdir), "exported_needs.json").write_bytes(json_data)
+
+    # run a build that exports the generated needs
+    project_path.joinpath("conf.py").write_text(
+        dedent("""\
+        version = "1.3"
+        extensions = ["sphinx_needs"]
+        needs_id_regex = "^[A-Za-z0-9_]*"
+        needs_external_needs = [{
+            'json_path':  'exported_needs.json',
+            'base_url': 'http://my_company.com/docs/v1/',
+            'version': '1.3',
+            'id_prefix': 'EXT_',
+        }]
+        needs_builder_filter = ""
+        needs_json_remove_defaults = True
+        """),
+        "utf8",
+    )
+    project_path.joinpath("index.rst").write_text(
+        dedent("""\
+        Title
+        =====
+  
+        .. needimport:: exported_needs.json
+            :id_prefix: IMP_
+
+        """),
+        "utf8",
+    )
+    app = SphinxTestApp(buildername="needs", srcdir=srcdir, builddir=builddir)
+    try:
+        app.build()
+    finally:
+        app.cleanup()
+    assert app._warning.getvalue() == ""
+
+    json_data = json.loads(Path(str(app.outdir), "needs.json").read_text("utf8"))
+
+    assert json_data == snapshot(exclude=props("created", "project"))

--- a/tests/test_needs_builder.py
+++ b/tests/test_needs_builder.py
@@ -41,6 +41,25 @@ def test_doc_needs_builder_reproducible(test_app, snapshot):
 
 @pytest.mark.parametrize(
     "test_app",
+    [
+        {
+            "buildername": "needs",
+            "srcdir": "doc_test/doc_needs_builder",
+            "confoverrides": {"needs_json_remove_defaults": True},
+        }
+    ],
+    indirect=True,
+)
+def test_doc_needs_builder_remove_defaults(test_app, snapshot):
+    app = test_app
+    app.build()
+
+    needs_list = json.loads(Path(app.outdir, "needs.json").read_text())
+    assert needs_list == snapshot(exclude=props("created", "project"))
+
+
+@pytest.mark.parametrize(
+    "test_app",
     [{"buildername": "needs", "srcdir": "doc_test/doc_needs_builder_negative_tests"}],
     indirect=True,
 )


### PR DESCRIPTION
Setting `needs_json_remove_defaults=True`,
will now create a `needs.json` with all need fields that have default values removed, and the defaults are specified in the `needs_schema` (recently added in #1230)

In the external/import needs loaders, these are then restored from the `needs_schema`.

In our internal documentation (of 224 needs), this reduces the generated `needs.json`size from 19692 lines / 760kB to 5894 lines / 248kB

Note: Currently, the default is `needs_json_remove_defaults=False`, so as not to be back-breaking yet,
but I would look to eventually change this to `True` before the next "major" release.