### PR TITLE
👌 Minify output of `needs.json`

### DIFF
--- a/sphinx_needs/needsfile.py
+++ b/sphinx_needs/needsfile.py
@@ -185,7 +185,7 @@ class NeedsList:
             needs_dir = self.outdir
 
         with open(os.path.join(needs_dir, needs_file), "w") as f:
-            json.dump(self.needs_list, f, indent=4, sort_keys=True)
+            json.dump(self.needs_list, f, sort_keys=True)
 
     def load_json(self, file: str) -> None:
         if not os.path.isabs(file):


### PR DESCRIPTION
Removing the indent of `json.dump` means it will now be output on a single line; reducing the size of the stored JSON.

Together with #1232, the size for the internal docs ``needs.json`` (224 needs) is reduced from ~750kB to 125kB

Most editors have built-in facilities to "format/expand" JSON, so I think this mitigates any "manual readability", without the need for any additional configuration to control this