### PR TITLE
✨ Capture filter processing times

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -288,7 +288,7 @@ plantuml_output_format = "svg_img"
 
 # -- Options for Needs extension ---------------------------------------
 
-needs_debug_measurement = False
+needs_debug_measurement = "READTHEDOCS" in os.environ  # run on CI
 
 needs_types = [
     # Architecture types

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,6 +201,7 @@ extras =
 passenv =
     BUILDER
     CLEAN
+    READTHEDOCS
     TERM
 setenv =
     alabaster: DOCS_THEME=alabaster

--- a/sphinx_needs/data.py
+++ b/sphinx_needs/data.py
@@ -28,10 +28,15 @@ class NeedsFilterType(TypedDict):
     status: list[str]
     tags: list[str]
     types: list[str]
-    result: list[str]
     amount: int
     export_id: str
     """If set, the filter is exported with this ID in the needs.json file."""
+    origin: str
+    """Origin of the request (e.g. needlist, needtable, needflow)."""
+    location: str
+    """Location of the request (e.g. "docname:lineno")"""
+    runtime: float
+    """Time take to run filter (seconds)."""
 
 
 class NeedsPartType(TypedDict):
@@ -792,13 +797,19 @@ def merge_data(
 
     Needs to update env manually for all data Sphinx-Needs collect during read phase
     """
+    this_data = SphinxNeedsData(env)
+    other_data = SphinxNeedsData(other)
 
-    if SphinxNeedsData(other).has_export_filters:
-        SphinxNeedsData(env).has_export_filters = True
+    # update filters
+    if other_data.has_export_filters:
+        this_data.has_export_filters = True
+    # merge these just to be safe,
+    # although actually all should be added in the write phase
+    this_data.get_or_create_filters().update(other_data.get_or_create_filters())
 
     # Update needs
-    needs = SphinxNeedsData(env).get_or_create_needs()
-    other_needs = SphinxNeedsData(other).get_or_create_needs()
+    needs = this_data.get_or_create_needs()
+    other_needs = other_data.get_or_create_needs()
     for other_id, other_need in other_needs.items():
         if other_id in needs:
             # we only want to warn if the need comes from one of the docs parsed in this worker

--- a/sphinx_needs/debug.py
+++ b/sphinx_needs/debug.py
@@ -180,6 +180,16 @@ def _store_timing_results_json(app: Sphinx, build_data: dict[str, Any]) -> None:
     print(f"Timing measurement results (JSON) stored under {json_result_path}")
 
 
+def _store_filter_results_json(app: Sphinx) -> None:
+    json_result_path = os.path.join(str(app.outdir), "debug_filters.json")
+
+    data = SphinxNeedsData(app.env).get_or_create_filters()
+
+    with open(json_result_path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=4)
+    print(f"Filter results (JSON) stored under {json_result_path}")
+
+
 def _store_timing_results_html(app: Sphinx, build_data: dict[str, Any]) -> None:
     jinja_env = Environment(
         loader=PackageLoader("sphinx_needs"), autoescape=select_autoescape()
@@ -203,4 +213,5 @@ def process_timing(app: Sphinx, _exception: Exception | None) -> None:
 
         _print_timing_results(app)
         _store_timing_results_json(app, build_data)
+        _store_filter_results_json(app)
         _store_timing_results_html(app, build_data)

--- a/sphinx_needs/directives/needextract.py
+++ b/sphinx_needs/directives/needextract.py
@@ -106,7 +106,13 @@ def process_needextract(
                 )
             current_needextract["filter"] = need_filter_arg
 
-        found_needs = process_filters(app, all_needs.values(), current_needextract)
+        found_needs = process_filters(
+            app,
+            all_needs.values(),
+            current_needextract,
+            origin="needextract",
+            location=f"{node.source}:{node.line}",
+        )
 
         for need_info in found_needs:
             # filter out need_part from found_needs, in order to generate

--- a/sphinx_needs/directives/needfilter.py
+++ b/sphinx_needs/directives/needfilter.py
@@ -158,7 +158,13 @@ def process_needfilters(
             tgroup += tbody
             content += tgroup
 
-        found_needs = process_filters(app, all_needs.values(), current_needfilter)
+        found_needs = process_filters(
+            app,
+            all_needs.values(),
+            current_needfilter,
+            origin="needfilter",
+            location=f"{node.source}:{node.line}",
+        )
 
         line_block = nodes.line_block()
         for need_info in found_needs:

--- a/sphinx_needs/directives/needflow/_graphviz.py
+++ b/sphinx_needs/directives/needflow/_graphviz.py
@@ -120,7 +120,13 @@ def process_needflow_graphviz(
             if (root_id := attributes["root_id"])
             else all_needs.values()
         )
-        filtered_needs = process_filters(app, init_filtered_needs, node.attributes)
+        filtered_needs = process_filters(
+            app,
+            init_filtered_needs,
+            node.attributes,
+            origin="needflow",
+            location=f"{node.source}:{node.line}",
+        )
 
         if not filtered_needs:
             node.replace_self(

--- a/sphinx_needs/directives/needflow/_plantuml.py
+++ b/sphinx_needs/directives/needflow/_plantuml.py
@@ -275,7 +275,13 @@ def process_needflow_plantuml(
             else all_needs.values()
         )
 
-        found_needs = process_filters(app, need_values, current_needflow)
+        found_needs = process_filters(
+            app,
+            need_values,
+            current_needflow,
+            origin="needflow",
+            location=f"{node.source}:{node.line}",
+        )
 
         if found_needs:
             plantuml_block_text = ".. plantuml::\n" "\n" "   @startuml" "   @enduml"

--- a/sphinx_needs/directives/needgantt.py
+++ b/sphinx_needs/directives/needgantt.py
@@ -195,7 +195,13 @@ def process_needgantt(
         puml_node["uml"] += add_config(config)
 
         all_needs = list(all_needs_dict.values())
-        found_needs = process_filters(app, all_needs, current_needgantt)
+        found_needs = process_filters(
+            app,
+            all_needs,
+            current_needgantt,
+            origin="needgantt",
+            location=f"{node.source}:{node.line}",
+        )
 
         # Scale/timeline handling
         if current_needgantt["timeline"]:

--- a/sphinx_needs/directives/needlist.py
+++ b/sphinx_needs/directives/needlist.py
@@ -86,7 +86,13 @@ def process_needlist(
         current_needfilter: NeedsListType = node.attributes
         content: list[nodes.Node] = []
         all_needs = list(SphinxNeedsData(env).get_or_create_needs().values())
-        found_needs = process_filters(app, all_needs, current_needfilter)
+        found_needs = process_filters(
+            app,
+            all_needs,
+            current_needfilter,
+            origin="needlist",
+            location=f"{node.source}:{node.line}",
+        )
 
         if len(found_needs) > 0:
             line_block = nodes.line_block()

--- a/sphinx_needs/directives/needtable.py
+++ b/sphinx_needs/directives/needtable.py
@@ -210,12 +210,13 @@ def process_needtables(
         table_node.line = current_needtable["lineno"]
 
         # Perform filtering of needs
-        try:
-            filtered_needs = process_filters(
-                app, list(all_needs.values()), current_needtable
-            )
-        except Exception as e:
-            raise e
+        filtered_needs = process_filters(
+            app,
+            list(all_needs.values()),
+            current_needtable,
+            origin="needtable",
+            location=f"{node.source}:{node.line}",
+        )
 
         def get_sorter(key: str) -> Callable[[NeedsInfoType], Any]:
             """

--- a/tests/__snapshots__/test_export_id.ambr
+++ b/tests/__snapshots__/test_export_id.ambr
@@ -8,18 +8,7 @@
             'amount': 10,
             'export_id': 'FLOW_1',
             'filter': '',
-            'result': list([
-              'REQ_001',
-              'REQ_002',
-              'REQ_003',
-              'REQ_004',
-              'REQ_005',
-              'TEST_001',
-              'TEST_002',
-              'TEST_003',
-              'REQ_005.1',
-              'REQ_005.cool',
-            ]),
+            'origin': 'needflow',
             'status': list([
             ]),
             'tags': list([
@@ -31,13 +20,7 @@
             'amount': 5,
             'export_id': 'FLOW_2',
             'filter': 'is_need is False or type != "story"',
-            'result': list([
-              'TEST_001',
-              'TEST_002',
-              'TEST_003',
-              'REQ_005.1',
-              'REQ_005.cool',
-            ]),
+            'origin': 'needflow',
             'status': list([
             ]),
             'tags': list([
@@ -49,18 +32,7 @@
             'amount': 10,
             'export_id': 'LIST_1',
             'filter': '',
-            'result': list([
-              'REQ_001',
-              'REQ_002',
-              'REQ_003',
-              'REQ_004',
-              'REQ_005',
-              'TEST_001',
-              'TEST_002',
-              'TEST_003',
-              'REQ_005.1',
-              'REQ_005.cool',
-            ]),
+            'origin': 'needlist',
             'status': list([
             ]),
             'tags': list([
@@ -72,18 +44,7 @@
             'amount': 10,
             'export_id': 'TABLE_1',
             'filter': '',
-            'result': list([
-              'REQ_001',
-              'REQ_002',
-              'REQ_003',
-              'REQ_004',
-              'REQ_005',
-              'TEST_001',
-              'TEST_002',
-              'TEST_003',
-              'REQ_005.1',
-              'REQ_005.cool',
-            ]),
+            'origin': 'needtable',
             'status': list([
             ]),
             'tags': list([
@@ -95,11 +56,7 @@
             'amount': 3,
             'export_id': 'TABLE_2',
             'filter': '"test" in type',
-            'result': list([
-              'TEST_001',
-              'TEST_002',
-              'TEST_003',
-            ]),
+            'origin': 'needtable',
             'status': list([
             ]),
             'tags': list([

--- a/tests/test_export_id.py
+++ b/tests/test_export_id.py
@@ -15,7 +15,9 @@ def test_export_id(test_app, snapshot):
     app = test_app
     app.build()
     needs_data = json.loads(Path(app.outdir, "needs.json").read_text())
-    assert needs_data == snapshot(exclude=props("created", "project"))
+    assert needs_data == snapshot(
+        exclude=props("created", "project", "location", "runtime")
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR adds capturing of origin location and runtimes of each call to `process_filters`.

For `needs_debug_measurement=True` it also outputs this data to `<outdir>/debug_filters.json`, and
prints the 10 longest running filters to stdout, e.g. for the internal docs build:


```
Slowest need filters:
/Users/chrisjsewell/GitHub/sphinx-needs/docs/filter.rst:282: 0.003848s (needlist)
/Users/chrisjsewell/GitHub/sphinx-needs/docs/services/github.rst:276: 0.001176s (needtable)
/Users/chrisjsewell/GitHub/sphinx-needs/docs/directives/needtable.rst:156: 0.000704s (needtable)
/Users/chrisjsewell/GitHub/sphinx-needs/docs/directives/needextract.rst:20: 0.000687s (needextract)
/Users/chrisjsewell/GitHub/sphinx-needs/docs/directives/needflow.rst:14: 0.000639s (needflow)
/Users/chrisjsewell/GitHub/sphinx-needs/docs/configuration.rst:195: 0.000608s (needfilter)
/Users/chrisjsewell/GitHub/sphinx-needs/docs/filter.rst:255: 0.000602s (needfilter)
/Users/chrisjsewell/GitHub/sphinx-needs/docs/roles.rst:133: 0.000579s (needtable)
/Users/chrisjsewell/GitHub/sphinx-needs/docs/directives/needlist.rst:12: 0.000539s (needlist)
/Users/chrisjsewell/GitHub/sphinx-needs/docs/directives/needextend.rst:178: 0.000532s (needtable)
```