### PR TITLE
🔧 Move `layout.create_need` to `needextract._build_needextract`

### DIFF
--- a/sphinx_needs/directives/needextract.py
+++ b/sphinx_needs/directives/needextract.py
@@ -1,22 +1,24 @@
 from __future__ import annotations
 
 import re
-from typing import Sequence
+from typing import Sequence, cast
 
 from docutils import nodes
 from docutils.parsers.rst import directives
 from docutils.transforms.references import Substitutions
 from sphinx.application import Sphinx
+from sphinx.environment.collectors.asset import DownloadFileCollector, ImageCollector
 
 from sphinx_needs.api.exceptions import NeedsInvalidFilter
 from sphinx_needs.config import NeedsSphinxConfig
 from sphinx_needs.data import NeedsExtractType, SphinxNeedsData
+from sphinx_needs.debug import measure_time
 from sphinx_needs.directives.utils import (
     no_needs_found_paragraph,
     used_filter_paragraph,
 )
 from sphinx_needs.filter_common import FilterBase, process_filters
-from sphinx_needs.layout import create_need
+from sphinx_needs.layout import SphinxNeedLayoutException, build_need
 from sphinx_needs.utils import add_doc, remove_node_from_tree
 
 
@@ -118,7 +120,7 @@ def process_needextract(
             # filter out need_part from found_needs, in order to generate
             # copies of filtered needs with custom layout and style
             if need_info["is_need"] and not need_info["is_part"]:
-                need_extract = create_need(
+                need_extract = _build_needextract(
                     need_info["id"],
                     app,
                     layout=current_needextract["layout"],
@@ -146,3 +148,110 @@ def process_needextract(
         # Transformers use the complete document (doctree), so we perform this action once per
         # needextract. No matter if one or multiple needs got copied
         Substitutions(doctree).apply()  # type: ignore[no-untyped-call]
+
+
+@measure_time("build_needextract")
+def _build_needextract(
+    need_id: str,
+    app: Sphinx,
+    layout: str | None = None,
+    style: str | None = None,
+    docname: str | None = None,
+) -> nodes.container:
+    """
+    Creates a new need-node for a given layout.
+
+    Need must already exist in internal dictionary.
+    This creates a new representation only.
+    :param need_id: need id
+    :param app: sphinx application
+    :param layout: layout to use, overrides layout set by need itself
+    :param style: style to use, overrides styles set by need itself
+    :param docname: Needed for calculating references
+    :return:
+    """
+    env = app.env
+    needs = SphinxNeedsData(env).get_or_create_needs()
+
+    if need_id not in needs.keys():
+        raise SphinxNeedLayoutException(f"Given need id {need_id} does not exist.")
+
+    need_data = needs[need_id]
+
+    # Resolve internal references.
+    # This is done for original need content automatically.
+    # But as we are working on  a copy, we have to trigger this on our own.
+    if docname is None:
+        # needed to calculate relative references
+        # TODO ideally we should not cast here:
+        # the docname can still be None, if the need is external, although practically these are not rendered
+        docname = cast(str, needs[need_id]["docname"])
+
+    node_container = nodes.container()
+    # node_container += needs[need_id]["need_node"].children
+
+    # We must create a standalone copy of the content_node, as it may be reused several time
+    # (multiple needextract for the same need) and the Sphinx ImageTransformator add location specific
+    # uri to some nodes, which are not valid for all locations.
+    content_node = needs[need_id]["content_node"]
+    assert content_node is not None, f"Need {need_id} has no content node."
+    node_inner = content_node.deepcopy()
+
+    # Rerun some important Sphinx collectors for need-content coming from "needsexternal".
+    # This is needed, as Sphinx needs to know images and download paths.
+    # Normally this gets done much earlier in the process, so that for the copied need-content this
+    # handling was and will not be done by Sphinx itself anymore.
+
+    # Overwrite the docname, which must be the original one from the reused need, as all used paths are relative
+    # to the original location, not to the current document.
+    env.temp_data["docname"] = need_data[
+        "docname"
+    ]  # Dirty, as in this phase normally no docname is set anymore in env
+    ImageCollector().process_doc(app, node_inner)  # type: ignore[arg-type]
+    DownloadFileCollector().process_doc(app, node_inner)  # type: ignore[arg-type]
+
+    del env.temp_data["docname"]  # Be sure our env is as it was before
+
+    node_container.append(node_inner)
+
+    # resolve_references() ignores the given docname and takes the docname from the pending_xref node.
+    # Therefore, we need to manipulate this first, before we can ask Sphinx to perform the normal
+    # reference handling for us.
+    _replace_pending_xref_refdoc(node_container, docname)
+    env.resolve_references(node_container, docname, env.app.builder)  # type: ignore[arg-type]
+
+    node_container.attributes["ids"].append(need_id)
+
+    needs_config = NeedsSphinxConfig(app.config)
+    layout = layout or need_data["layout"] or needs_config.default_layout
+    style = style or need_data["style"] or needs_config.default_style
+
+    build_need(layout, node_container, app, style, docname)
+
+    # set the layout and style for the new need
+    node_container[0].attributes = node_container.parent.children[0].attributes  # type: ignore
+    node_container[0].children[0].attributes = (  # type: ignore
+        node_container.parent.children[0].children[0].attributes  # type: ignore
+    )
+
+    node_container.attributes["ids"] = []
+
+    return node_container
+
+
+def _replace_pending_xref_refdoc(node: nodes.Element, new_refdoc: str) -> None:
+    """
+    Overwrites the refdoc attribute of all pending_xref nodes.
+    This is needed, if a doctree with references gets copied used somewhereelse in the documentation.
+    What is the normal case when using needextract.
+    :param node: doctree
+    :param new_refdoc: string, should be an existing docname
+    :return: None
+    """
+    from sphinx.addnodes import pending_xref
+
+    if isinstance(node, pending_xref):
+        node.attributes["refdoc"] = new_refdoc
+    else:
+        for child in node.children:
+            _replace_pending_xref_refdoc(child, new_refdoc)  # type: ignore[arg-type]

--- a/sphinx_needs/layout.py
+++ b/sphinx_needs/layout.py
@@ -13,7 +13,7 @@ from contextlib import suppress
 from functools import lru_cache
 from optparse import Values
 from pathlib import Path
-from typing import Callable, cast
+from typing import Callable
 from urllib.parse import urlparse
 
 import requests
@@ -24,7 +24,6 @@ from docutils.parsers.rst.states import Inliner, Struct
 from docutils.utils import new_document
 from jinja2 import Environment
 from sphinx.application import Sphinx
-from sphinx.environment.collectors.asset import DownloadFileCollector, ImageCollector
 from sphinx.util.logging import getLogger
 
 from sphinx_needs.config import NeedsSphinxConfig
@@ -34,113 +33,6 @@ from sphinx_needs.logging import log_warning
 from sphinx_needs.utils import match_string_link
 
 LOGGER = getLogger(__name__)
-
-
-@measure_time("need")
-def create_need(
-    need_id: str,
-    app: Sphinx,
-    layout: str | None = None,
-    style: str | None = None,
-    docname: str | None = None,
-) -> nodes.container:
-    """
-    Creates a new need-node for a given layout.
-
-    Need must already exist in internal dictionary.
-    This creates a new representation only.
-    :param need_id: need id
-    :param app: sphinx application
-    :param layout: layout to use, overrides layout set by need itself
-    :param style: style to use, overrides styles set by need itself
-    :param docname: Needed for calculating references
-    :return:
-    """
-    env = app.env
-    needs = SphinxNeedsData(env).get_or_create_needs()
-
-    if need_id not in needs.keys():
-        raise SphinxNeedLayoutException(f"Given need id {need_id} does not exist.")
-
-    need_data = needs[need_id]
-
-    # Resolve internal references.
-    # This is done for original need content automatically.
-    # But as we are working on  a copy, we have to trigger this on our own.
-    if docname is None:
-        # needed to calculate relative references
-        # TODO ideally we should not cast here:
-        # the docname can still be None, if the need is external, although practically these are not rendered
-        docname = cast(str, needs[need_id]["docname"])
-
-    node_container = nodes.container()
-    # node_container += needs[need_id]["need_node"].children
-
-    # We must create a standalone copy of the content_node, as it may be reused several time
-    # (multiple needextract for the same need) and the Sphinx ImageTransformator add location specific
-    # uri to some nodes, which are not valid for all locations.
-    content_node = needs[need_id]["content_node"]
-    assert content_node is not None, f"Need {need_id} has no content node."
-    node_inner = content_node.deepcopy()
-
-    # Rerun some important Sphinx collectors for need-content coming from "needsexternal".
-    # This is needed, as Sphinx needs to know images and download paths.
-    # Normally this gets done much earlier in the process, so that for the copied need-content this
-    # handling was and will not be done by Sphinx itself anymore.
-
-    # Overwrite the docname, which must be the original one from the reused need, as all used paths are relative
-    # to the original location, not to the current document.
-    env.temp_data["docname"] = need_data[
-        "docname"
-    ]  # Dirty, as in this phase normally no docname is set anymore in env
-    ImageCollector().process_doc(app, node_inner)  # type: ignore[arg-type]
-    DownloadFileCollector().process_doc(app, node_inner)  # type: ignore[arg-type]
-
-    del env.temp_data["docname"]  # Be sure our env is as it was before
-
-    node_container.append(node_inner)
-
-    # resolve_references() ignores the given docname and takes the docname from the pending_xref node.
-    # Therefore, we need to manipulate this first, before we can ask Sphinx to perform the normal
-    # reference handling for us.
-    replace_pending_xref_refdoc(node_container, docname)
-    env.resolve_references(node_container, docname, env.app.builder)  # type: ignore[arg-type]
-
-    node_container.attributes["ids"].append(need_id)
-
-    needs_config = NeedsSphinxConfig(app.config)
-    layout = layout or need_data["layout"] or needs_config.default_layout
-    style = style or need_data["style"] or needs_config.default_style
-
-    build_need(layout, node_container, app, style, docname)
-
-    # set the layout and style for the new need
-    node_container[0].attributes = node_container.parent.children[0].attributes  # type: ignore
-    node_container[0].children[0].attributes = (  # type: ignore
-        node_container.parent.children[0].children[0].attributes  # type: ignore
-    )
-
-    node_container.attributes["ids"] = []
-
-    return node_container
-
-
-def replace_pending_xref_refdoc(node: nodes.Element, new_refdoc: str) -> None:
-    """
-    Overwrites the refdoc attribute of all pending_xref nodes.
-    This is needed, if a doctree with references gets copied used somewhereelse in the documentation.
-    What is the normal case when using needextract.
-    :param node: doctree
-    :param new_refdoc: string, should be an existing docname
-    :return: None
-    """
-    from sphinx.addnodes import pending_xref
-
-    if isinstance(node, pending_xref):
-        node.attributes["refdoc"] = new_refdoc
-    else:
-        for child in node.children:
-            replace_pending_xref_refdoc(child, new_refdoc)  # type: ignore[arg-type]
 
 
 @measure_time("need")


### PR DESCRIPTION
The `create_need` function name/location was misleading, in that its only use is actually for building `needextract` representations. Therefore, we move it into the `needextract` module.

(extracted from #1198, so we can make it clearer what the changes are to the code, rather than what is just moved code)