### PR TITLE
🔧 Fix release job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,44 +3,24 @@ on:
   push:
     tags:
       - '[0-9].[0-9]+.[0-9]+'
-jobs:
-  build:
-    name: Build packages
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.9
-      - name: install Poetry
-        run: python -m pip install poetry
-      - name: poetry build
-        run: poetry build
-      - uses: actions/upload-artifact@v4
-        with:
-          name: poetry_build
-          path: dist/
 
-  publish_oficial:
-    name: Publish on PyPi
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python 3.9
+jobs:
+    publish:
+
+      name: Publish to PyPi
+      # needs: check
+      # if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+      runs-on: ubuntu-latest
+      steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+      - name: Set up Python 3.10
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
-      - uses: actions/download-artifact@v4
-        with:
-          name:  poetry_build
-          path: dist/
-      - name: Display structure of downloaded files
-        run: ls -R
-      # PyPi Release
+          python-version: "3.10"
       - name: install Poetry
         run: python -m pip install poetry
       - name: poetry configure PyPI Token
         run: poetry config pypi-token.pypi ${{ secrets.PYPI }}
-      - name: poetry publish PyPi
-        run: poetry publish
+      - name: poetry build and publish PyPi
+        run: poetry --build publish


### PR DESCRIPTION
build and publish in one go, rather than having to use upload/download between two jobs