### PR TITLE
🐛 Handle malformed `filter-func` option value

### DIFF
--- a/tests/doc_test/doc_needs_filter_data/filter_code.rst
+++ b/tests/doc_test/doc_needs_filter_data/filter_code.rst
@@ -21,3 +21,13 @@ Filter code test cases
 .. needpie:: Filter code func pie
     :labels: project_x, project_y
     :filter-func: filter_code_func.my_pie_filter_code
+
+
+.. needtable:: Malformed filter func table
+   :style: table
+   :filter-func: filter_code_func.own_filter_code(
+
+
+.. needpie:: Malformed filter func pie
+    :labels: project_x, project_y
+    :filter-func: filter_code_func.my_pie_filter_code(

--- a/tests/doc_test/doc_needs_filter_data/index.rst
+++ b/tests/doc_test/doc_needs_filter_data/index.rst
@@ -61,3 +61,9 @@ Needflow example
 
 .. needflow:: My needflow
    :filter: variant == current_variant
+
+
+.. toctree::
+
+   filter_code
+   filter_code_args

--- a/tests/test_needs_filter_data.py
+++ b/tests/test_needs_filter_data.py
@@ -1,7 +1,9 @@
+import os
 from pathlib import Path
 
 import pytest
 from docutils import __version__ as doc_ver
+from sphinx.util.console import strip_colors
 
 
 @pytest.mark.parametrize(
@@ -12,6 +14,19 @@ from docutils import __version__ as doc_ver
 def test_doc_needs_filter_data_html(test_app):
     app = test_app
     app.build()
+
+    warnings = strip_colors(
+        app._warning.getvalue().replace(str(app.srcdir) + os.sep, "srcdir/")
+    ).splitlines()
+    print(warnings)
+    assert warnings == [
+        "srcdir/filter_code.rst:26: WARNING: malformed function signature: 'own_filter_code(' [needs.filter_func]",
+        "srcdir/filter_code.rst:31: WARNING: malformed function signature: 'my_pie_filter_code(' [needs.filter_func]",
+        "WARNING: variant_not_equal_current_variant: failed",
+        "\t\tfailed needs: 1 (extern_filter_story_002)",
+        "\t\tused filter: variant != current_variant [needs.warnings]",
+    ]
+
     index_html = Path(app.outdir, "index.html").read_text()
 
     # Check need_count works
@@ -51,15 +66,6 @@ def test_doc_needs_filter_data_html(test_app):
         '<span class="needs_spacer">, </span><span class="needs_data">current_variant</span></span>'
         in index_html
     )
-
-    # check needs_warnings works
-    warning = app._warning
-    warnings = warning.getvalue()
-
-    # check warnings contents
-    assert "WARNING: variant_not_equal_current_variant: failed" in warnings
-    assert "failed needs: 1 (extern_filter_story_002)" in warnings
-    assert "used filter: variant != current_variant" in warnings
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Currently malformed filter function strings would simply be ignored, and thus the results would not be filtered,
which is especially bad if you have a large amount of needs.

This PR provides a warning for all malformed `filter-func` values, and also returns the result as an empty list of needs,
so we do not wasted time processing them.

A test is also added