### PR TITLE
🐛 Coerce dynamic function return to str (when replacing content)

### DIFF
--- a/sphinx_needs/functions/functions.py
+++ b/sphinx_needs/functions/functions.py
@@ -155,7 +155,10 @@ def find_and_replace_node_content(
             if isinstance(func_return, list):
                 func_return = ", ".join([str(v) for v in func_return])
 
-            new_text = new_text.replace(f"[[{func_string_org}]]", str(func_return))
+            new_text = new_text.replace(
+                f"[[{func_string_org}]]",
+                "" if func_return is None else str(func_return),
+            )
 
         if isinstance(node, nodes.reference):
             node.attributes["refuri"] = new_text
@@ -347,7 +350,9 @@ def check_and_get_content(
     )  # Execute function call and get return value
 
     # Replace the function_call with the calculated value
-    content = content.replace(f"[[{func_call}]]", str(func_return))
+    content = content.replace(
+        f"[[{func_call}]]", "" if func_return is None else str(func_return)
+    )
     return content
 
 

--- a/sphinx_needs/functions/functions.py
+++ b/sphinx_needs/functions/functions.py
@@ -153,9 +153,9 @@ def find_and_replace_node_content(
 
             # This should never happen, but we can not be sure.
             if isinstance(func_return, list):
-                func_return = ", ".join(func_return)
+                func_return = ", ".join([str(v) for v in func_return])
 
-            new_text = new_text.replace(f"[[{func_string_org}]]", func_return)
+            new_text = new_text.replace(f"[[{func_string_org}]]", str(func_return))
 
         if isinstance(node, nodes.reference):
             node.attributes["refuri"] = new_text
@@ -347,7 +347,7 @@ def check_and_get_content(
     )  # Execute function call and get return value
 
     # Replace the function_call with the calculated value
-    content = content.replace(f"[[{func_call}]]", func_return)
+    content = content.replace(f"[[{func_call}]]", str(func_return))
     return content
 
 


### PR DESCRIPTION
As found by @ubmarco, the return type of a dynamic function may not be a string, as so we need to make sure it is coerced to one, otherwise `str.replace` will except

I guess for your exception @ubmarco perhaps a field value was changed from an empty string to `None` (going from v2.1.0 to v3.0.0) 🤔