### PR TITLE
👌 pass parent need to `need_func`

### DIFF
--- a/sphinx_needs/functions/common.py
+++ b/sphinx_needs/functions/common.py
@@ -140,7 +140,7 @@ def copy(
         .. test:: test of current_need value
            :id: copy_4
 
-           The es the title of the first need found under the same highest
+           The following copy command copies the title of the first need found under the same  highest
            section (headline):
 
            [[copy('title', filter='current_need["sections"][-1]==sections[-1]')]]
@@ -151,7 +151,7 @@ def copy(
        The following copy command copies the title of the first need found under the same  highest
        section (headline):
 
-            [[copy('title', filter='current_need["sections"][-1]==sections[-1]')]]
+       [[copy('title', filter='current_need["sections"][-1]==sections[-1]')]]
 
     This filter possibilities get really powerful in combination with :ref:`needs_global_options`.
 

--- a/sphinx_needs/needs.py
+++ b/sphinx_needs/needs.py
@@ -100,7 +100,7 @@ from sphinx_needs.functions import NEEDS_COMMON_FUNCTIONS, register_func
 from sphinx_needs.logging import get_logger, log_warning
 from sphinx_needs.roles import NeedsXRefRole
 from sphinx_needs.roles.need_count import NeedCount, process_need_count
-from sphinx_needs.roles.need_func import NeedFunc, process_need_func
+from sphinx_needs.roles.need_func import NeedFunc, NeedFuncRole, process_need_func
 from sphinx_needs.roles.need_incoming import NeedIncoming, process_need_incoming
 from sphinx_needs.roles.need_outgoing import NeedOutgoing, process_need_outgoing
 from sphinx_needs.roles.need_part import NeedPart, process_need_part
@@ -253,12 +253,7 @@ def setup(app: Sphinx) -> dict[str, Any]:
         ),
     )
 
-    app.add_role(
-        "need_func",
-        NeedsXRefRole(
-            nodeclass=NeedFunc, innernodeclass=nodes.inline, warn_dangling=True
-        ),
-    )
+    app.add_role("need_func", NeedFuncRole())
 
     ########################################################################
     # EVENTS

--- a/sphinx_needs/roles/need_func.py
+++ b/sphinx_needs/roles/need_func.py
@@ -6,16 +6,35 @@ from __future__ import annotations
 
 from docutils import nodes
 from sphinx.application import Sphinx
+from sphinx.environment import BuildEnvironment
+from sphinx.util.docutils import SphinxRole
 
 from sphinx_needs.data import NeedsInfoType
-from sphinx_needs.functions.functions import check_and_get_content
 from sphinx_needs.logging import get_logger
+from sphinx_needs.utils import add_doc
 
 log = get_logger(__name__)
 
 
+class NeedFuncRole(SphinxRole):
+    """Role for creating ``NeedFunc`` node."""
+
+    def run(self) -> tuple[list[nodes.Node], list[nodes.system_message]]:
+        add_doc(self.env, self.env.docname)
+        node = NeedFunc(
+            self.rawtext, nodes.literal(self.rawtext, self.text), **self.options
+        )
+        self.set_source_info(node)
+        return [node], []
+
+
 class NeedFunc(nodes.Inline, nodes.Element):
-    pass
+    def get_text(self, env: BuildEnvironment, need: NeedsInfoType | None) -> nodes.Text:
+        """Execute function and return result."""
+        from sphinx_needs.functions.functions import check_and_get_content
+
+        result = check_and_get_content(self.astext(), need, env, self)
+        return nodes.Text(str(result))
 
 
 def process_need_func(
@@ -24,12 +43,7 @@ def process_need_func(
     _fromdocname: str,
     found_nodes: list[nodes.Element],
 ) -> None:
-    env = app.env
-    # for node_need_func in doctree.findall(NeedFunc):
-    dummy_need: NeedsInfoType = {"id": "need_func_dummy"}  # type: ignore[typeddict-item]
-    for node_need_func in found_nodes:
-        result = check_and_get_content(
-            node_need_func.attributes["reftarget"], dummy_need, env, node_need_func
-        )
-        new_node_func = nodes.Text(str(result))
+    node_need_func: NeedFunc
+    for node_need_func in found_nodes:  # type: ignore[assignment]
+        new_node_func = node_need_func.get_text(app.env, None)
         node_need_func.replace_self(new_node_func)

--- a/tests/doc_test/doc_dynamic_functions/index.rst
+++ b/tests/doc_test/doc_dynamic_functions/index.rst
@@ -8,6 +8,8 @@ DYNAMIC FUNCTIONS
 
     This is id [[copy("id")]]
 
+    This is also id :need_func:`[[copy("id")]]`
+
 .. spec:: TEST_2
    :id: TEST_2
    :tags: my_tag; [[copy("tags", "SP_TOO_001")]]
@@ -30,3 +32,7 @@ DYNAMIC FUNCTIONS
         :id: TEST_6
 
         nested id [[copy('id')]]
+
+        nested id also :need_func:`[[copy("id")]]`
+
+This should warn since it has no associated need: :need_func:`[[copy("id")]]`

--- a/tests/doc_test/doc_dynamic_functions/index.rst
+++ b/tests/doc_test/doc_dynamic_functions/index.rst
@@ -22,6 +22,8 @@ DYNAMIC FUNCTIONS
     :id: TEST_4
     :tags: test_4a;test_4b;[[copy('title')]]
 
+    Test dynamic func in tags: [[copy("tags")]]
+
 .. spec:: TEST_5
     :id: TEST_5
     :tags: [[copy('id')]]

--- a/tests/test_dynamic_functions.py
+++ b/tests/test_dynamic_functions.py
@@ -25,10 +25,14 @@ def test_doc_dynamic_functions(test_app):
     warnings = strip_colors(
         app._warning.getvalue().replace(str(app.srcdir) + os.sep, "srcdir/")
     ).splitlines()
-    assert warnings == []
+    # print(warnings)
+    assert warnings == [
+        "srcdir/index.rst:38: WARNING: Error while executing function 'copy': Need not found [needs.dynamic_function]"
+    ]
 
     html = Path(app.outdir, "index.html").read_text()
     assert "This is id SP_TOO_001" in html
+    assert "This is also id SP_TOO_001" in html
 
     assert (
         sum(1 for _ in re.finditer('<span class="needs_data">test2</span>', html)) == 2
@@ -56,11 +60,12 @@ def test_doc_dynamic_functions(test_app):
         sum(1 for _ in re.finditer('<span class="needs_data">TEST_5</span>', html)) == 2
     )
 
-    assert "Test output of need TEST_3. args:" in html
+    assert "Test output of need_func; need: TEST_3" in html
 
     assert '<a class="reference external" href="http://www.TEST_5">link</a>' in html
 
     assert "nested id TEST_6" in html
+    assert "nested id also TEST_6" in html
 
 
 @pytest.mark.parametrize(

--- a/tests/test_dynamic_functions.py
+++ b/tests/test_dynamic_functions.py
@@ -25,9 +25,8 @@ def test_doc_dynamic_functions(test_app):
     warnings = strip_colors(
         app._warning.getvalue().replace(str(app.srcdir) + os.sep, "srcdir/")
     ).splitlines()
-    # print(warnings)
     assert warnings == [
-        "srcdir/index.rst:38: WARNING: Error while executing function 'copy': Need not found [needs.dynamic_function]"
+        "srcdir/index.rst:40: WARNING: Error while executing function 'copy': Need not found [needs.dynamic_function]"
     ]
 
     html = Path(app.outdir, "index.html").read_text()
@@ -61,6 +60,8 @@ def test_doc_dynamic_functions(test_app):
     )
 
     assert "Test output of need_func; need: TEST_3" in html
+
+    assert "Test dynamic func in tags: test_4a, test_4b, TEST_4" in html
 
     assert '<a class="reference external" href="http://www.TEST_5">link</a>' in html
 

--- a/tests/test_global_options.py
+++ b/tests/test_global_options.py
@@ -21,7 +21,7 @@ def test_doc_global_option(test_app):
 
     assert "test_global" in html
     assert "1.27" in html
-    assert "Test output of need GLOBAL_ID" in html
+    assert "Test output of need_func; need: GLOBAL_ID" in html
 
     assert "STATUS_IMPL" in html
     assert "STATUS_UNKNOWN" in html


### PR DESCRIPTION
Currently, the `need_func` role passes a "dummy need" to dynamic functions, which would except for most dynamic functions. So:

1. we replace the dummy need with `None` and ensure dynamic functions account for this input.
2. when a `need_func` is used within a need directive, it uses that need as input for the dynamic function, rather than `None`