### PR TITLE
✨ Add `ndf` role, deprecate `need_func` & `[[...]]` in need content

### DIFF
--- a/docs/directives/needextend.rst
+++ b/docs/directives/needextend.rst
@@ -35,8 +35,8 @@ Also, you can add links or delete tags.
 
       This requirement got modified.
 
-      | Status was **open**, now it is **[[copy('status')]]**.
-      | Also author got changed from **Foo** to **[[copy('author')]]**.
+      | Status was **open**, now it is :ndf:`copy('status')`.
+      | Also author got changed from **Foo** to :ndf:`copy('author')`.
       | And a tag was added.
       | Finally all links got removed.
 

--- a/docs/dynamic_functions.rst
+++ b/docs/dynamic_functions.rst
@@ -3,32 +3,35 @@
 Dynamic functions
 =================
 
-**Sphinx-Needs** provides a mechanism to set dynamic data for need-options during generation.
-We do this by giving an author the possibility to set a function call to a predefined function, which calculates
-the final result/value for the option.
+Dynamic functions provide a mechanism to specify need fields or content that are calculated at build time, based on other fields or needs.
+
+We do this by giving an author the possibility to set a function call to a predefined function, which calculates the final value **after all needs have been collected**.
 
 For instance, you can use the feature if the status of a requirement depends on linked test cases and their status.
 Or if you will request specific data from an external server like JIRA.
 
-**needtable**
+To refer to a dynamic function, you can use the following syntax:
 
-The options :ref:`needtable_style_row` of :ref:`needtable` also support
-dynamic function execution. In this case, the function gets executed with the found need for each row.
-
-This allows you to set row and column specific styles such as, set a row background to red, if a need-status is *failed*.
-
+- In a need directive option, wrap the function call in double square brackets: ``function_name(arg)``
+- In a need content, use the :ref:`ndf` role: ``:ndf:\`function_name(arg)\```
 
 .. need-example:: Dynamic function example
 
    .. req:: my test requirement
       :id: df_1
       :status: open
+      :tags: test;[[copy("status")]]
 
-      This need has id **[[copy("id")]]** and status **[[copy("status")]]**.
+      This need has id :ndf:`copy("id")` and status :ndf:`copy("status")`.
+
+.. deprecated:: 3.1.0
+
+   The :ref:`ndf` role replaces the use of the ``[[...]]`` syntax in need content.
 
 Built-in functions
 -------------------
-The following functions are available in all **Sphinx-Needs** installations.
+
+The following functions are available by default.
 
 .. note::
 

--- a/docs/needs_templates/spec_template.need
+++ b/docs/needs_templates/spec_template.need
@@ -19,5 +19,5 @@ Tags:
 {# by using dynamic_functions #}
 Links:
 {% for link in links %}
-| **{{link}}**: [[copy('title', '{{link}}')]] ([[copy('type_name', '{{link}}')]])
+| **{{link}}**: :ndf:`copy('title', '{{link}}')` (:ndf:`copy('type_name', '{{link}}')`)
 {%- endfor %}

--- a/docs/roles.rst
+++ b/docs/roles.rst
@@ -188,10 +188,18 @@ To calculate the ratio of one filter to another filter, you can define two filte
 
 need_func
 ---------
-.. versionadded:: 0.6.3
+.. deprecated:: 3.1.0
 
-Executes :ref:`dynamic_functions` and uses the return values as content.
+   Use :ref:`ndf` instead.
+
+.. _ndf:
+
+ndf
+---
+.. versionadded:: 3.1.0
+
+Executes a :ref:`need dynamic function <dynamic_functions>` and uses the return values as content.
 
 .. need-example::
 
-    A nice :need_func:`[[echo("first")]] test` for need_func.
+    A nice :ndf:`echo("first test")` for dynamic functions.

--- a/sphinx_needs/directives/needextend.py
+++ b/sphinx_needs/directives/needextend.py
@@ -71,7 +71,10 @@ class NeedextendDirective(SphinxDirective):
 
         add_doc(env, env.docname)
 
-        return [targetnode, Needextend("")]
+        node = Needextend("")
+        self.set_source_info(node)
+
+        return [targetnode, node]
 
 
 RE_ID_FUNC = re.compile(r"\s*((?P<function>\[\[[^\]]*\]\])|(?P<id>[^;,]+))\s*([;,]|$)")

--- a/sphinx_needs/directives/needextract.py
+++ b/sphinx_needs/directives/needextract.py
@@ -196,6 +196,8 @@ def _build_needextract(
 
     dummy_need.extend(need_node.children)
 
+    find_and_replace_node_content(dummy_need, env, need_data)
+
     # resolve_references() ignores the given docname and takes the docname from the pending_xref node.
     # Therefore, we need to manipulate this first, before we can ask Sphinx to perform the normal
     # reference handling for us.
@@ -203,7 +205,6 @@ def _build_needextract(
     env.resolve_references(dummy_need, extract_data["docname"], app.builder)  # type: ignore[arg-type]
 
     dummy_need.attributes["ids"].append(need_data["id"])
-    find_and_replace_node_content(dummy_need, env, need_data)
     rendered_node = build_need_repr(
         dummy_need,  # type: ignore[arg-type]
         need_data,

--- a/sphinx_needs/functions/common.py
+++ b/sphinx_needs/functions/common.py
@@ -39,16 +39,16 @@ def test(
 
         .. req:: test requirement
 
-            [[test('arg_1', [1,2,3], my_keyword='awesome')]]
+            :ndf:`test('arg_1', [1,2,3], my_keyword='awesome')`
 
     .. req:: test requirement
 
-        [[test('arg_1', [1,2,3], my_keyword='awesome')]]
+        :ndf:`test('arg_1', [1,2,3], my_keyword='awesome')`
 
     :return: single test string
     """
     need_id = "none" if need is None else need["id"]
-    return f"Test output of need_func; need: {need_id}; args: {args}; kwargs: {kwargs}"
+    return f"Test output of dynamic function; need: {need_id}; args: {args}; kwargs: {kwargs}"
 
 
 def echo(
@@ -67,9 +67,9 @@ def echo(
 
     .. code-block:: jinja
 
-       A nice :need_func:`[[echo("first")]] test` for need_func.
+       A nice :ndf:`echo("first test")` for a dynamic function.
 
-    **Result**: A nice :need_func:`[[echo("first")]] test` for need_func.
+    **Result**: A nice :ndf:`echo("first test")` for a dynamic function.
 
     """
     return text
@@ -146,7 +146,7 @@ def copy(
            The following copy command copies the title of the first need found under the same  highest
            section (headline):
 
-           [[copy('title', filter='current_need["sections"][-1]==sections[-1]')]]
+           :ndf:`copy('title', filter='current_need["sections"][-1]==sections[-1]')`
 
     .. test:: test of current_need value
        :id: copy_4
@@ -154,7 +154,7 @@ def copy(
        The following copy command copies the title of the first need found under the same  highest
        section (headline):
 
-       [[copy('title', filter='current_need["sections"][-1]==sections[-1]')]]
+       :ndf:`copy('title', filter='current_need["sections"][-1]==sections[-1]')`
 
     This filter possibilities get really powerful in combination with :ref:`needs_global_options`.
 

--- a/sphinx_needs/needs.py
+++ b/sphinx_needs/needs.py
@@ -254,8 +254,8 @@ def setup(app: Sphinx) -> dict[str, Any]:
         ),
     )
 
-    app.add_role("need_func", NeedFuncRole())
-    app.add_role("ndf", NeedFuncRole(no_braces=True))
+    app.add_role("need_func", NeedFuncRole(with_brackets=True))  # deprecrated
+    app.add_role("ndf", NeedFuncRole(with_brackets=False))
 
     ########################################################################
     # EVENTS

--- a/sphinx_needs/needs.py
+++ b/sphinx_needs/needs.py
@@ -255,6 +255,7 @@ def setup(app: Sphinx) -> dict[str, Any]:
     )
 
     app.add_role("need_func", NeedFuncRole())
+    app.add_role("ndf", NeedFuncRole(no_braces=True))
 
     ########################################################################
     # EVENTS

--- a/tests/doc_test/doc_dynamic_functions/index.rst
+++ b/tests/doc_test/doc_dynamic_functions/index.rst
@@ -10,6 +10,8 @@ DYNAMIC FUNCTIONS
 
     This is also id :need_func:`[[copy("id")]]`
 
+    This is the best id :ndf:`copy("id")`
+
 .. spec:: TEST_2
    :id: TEST_2
    :tags: my_tag; [[copy("tags", "SP_TOO_001")]]
@@ -37,4 +39,6 @@ DYNAMIC FUNCTIONS
 
         nested id also :need_func:`[[copy("id")]]`
 
-This should warn since it has no associated need: :need_func:`[[copy("id")]]`
+        nested id best :ndf:`copy("id")`
+
+These should warn since they have no associated need: :need_func:`[[copy("id")]]`, :ndf:`copy("id")`

--- a/tests/doc_test/needextract_with_nested_needs/index.rst
+++ b/tests/doc_test/needextract_with_nested_needs/index.rst
@@ -10,7 +10,7 @@ Test
 
    Another, child spec
 
-   This is id [[copy("id")]]
+   This is id [[copy("id")]] :ndf:`copy("id")`
 
    .. spec:: Child spec
      :id: SPEC_1_1
@@ -30,6 +30,6 @@ Test
    
          awesome grandchild spec number 2.
 
-         This is grandchild id [[copy("id")]]
+         This is grandchild id [[copy("id")]] :ndf:`copy("id")`
    
    Some parent text

--- a/tests/test_dynamic_functions.py
+++ b/tests/test_dynamic_functions.py
@@ -26,12 +26,14 @@ def test_doc_dynamic_functions(test_app):
         app._warning.getvalue().replace(str(app.srcdir) + os.sep, "srcdir/")
     ).splitlines()
     assert warnings == [
-        "srcdir/index.rst:40: WARNING: Error while executing function 'copy': Need not found [needs.dynamic_function]"
+        "srcdir/index.rst:44: WARNING: Error while executing function 'copy': Need not found [needs.dynamic_function]",
+        "srcdir/index.rst:44: WARNING: Error while executing function 'copy': Need not found [needs.dynamic_function]",
     ]
 
     html = Path(app.outdir, "index.html").read_text()
     assert "This is id SP_TOO_001" in html
     assert "This is also id SP_TOO_001" in html
+    assert "This is the best id SP_TOO_001" in html
 
     assert (
         sum(1 for _ in re.finditer('<span class="needs_data">test2</span>', html)) == 2
@@ -67,6 +69,7 @@ def test_doc_dynamic_functions(test_app):
 
     assert "nested id TEST_6" in html
     assert "nested id also TEST_6" in html
+    assert "nested id best TEST_6" in html
 
 
 @pytest.mark.parametrize(

--- a/tests/test_dynamic_functions.py
+++ b/tests/test_dynamic_functions.py
@@ -26,6 +26,13 @@ def test_doc_dynamic_functions(test_app):
         app._warning.getvalue().replace(str(app.srcdir) + os.sep, "srcdir/")
     ).splitlines()
     assert warnings == [
+        'srcdir/index.rst:11: WARNING: The `need_func` role is deprecated. Replace with :ndf:`copy("id")` instead. [needs.deprecation]',
+        'srcdir/index.rst:40: WARNING: The `need_func` role is deprecated. Replace with :ndf:`copy("id")` instead. [needs.deprecation]',
+        'srcdir/index.rst:44: WARNING: The `need_func` role is deprecated. Replace with :ndf:`copy("id")` instead. [needs.deprecation]',
+        'srcdir/index.rst:9: WARNING: The [[copy("id")]] syntax in need content is deprecated. Replace with :ndf:`copy("id")` instead. [needs.deprecation]',
+        'srcdir/index.rst:27: WARNING: The [[copy("tags")]] syntax in need content is deprecated. Replace with :ndf:`copy("tags")` instead. [needs.deprecation]',
+        "srcdir/index.rst:33: WARNING: The [[copy('id')]] syntax in need content is deprecated. Replace with :ndf:`copy('id')` instead. [needs.deprecation]",
+        "srcdir/index.rst:38: WARNING: The [[copy('id')]] syntax in need content is deprecated. Replace with :ndf:`copy('id')` instead. [needs.deprecation]",
         "srcdir/index.rst:44: WARNING: Error while executing function 'copy': Need not found [needs.dynamic_function]",
         "srcdir/index.rst:44: WARNING: Error while executing function 'copy': Need not found [needs.dynamic_function]",
     ]
@@ -61,7 +68,7 @@ def test_doc_dynamic_functions(test_app):
         sum(1 for _ in re.finditer('<span class="needs_data">TEST_5</span>', html)) == 2
     )
 
-    assert "Test output of need_func; need: TEST_3" in html
+    assert "Test output of dynamic function; need: TEST_3" in html
 
     assert "Test dynamic func in tags: test_4a, test_4b, TEST_4" in html
 
@@ -121,8 +128,12 @@ def test_doc_df_user_functions(test_app):
     # print(warnings)
     expected = [
         "srcdir/index.rst:10: WARNING: Return value of function 'bad_function' is of type <class 'object'>. Allowed are str, int, float, list [needs.dynamic_function]",
+        "srcdir/index.rst:8: WARNING: The [[my_own_function()]] syntax in need content is deprecated. Replace with :ndf:`my_own_function()` instead. [needs.deprecation]",
+        "srcdir/index.rst:14: WARNING: The [[bad_function()]] syntax in need content is deprecated. Replace with :ndf:`bad_function()` instead. [needs.deprecation]",
         "srcdir/index.rst:14: WARNING: Return value of function 'bad_function' is of type <class 'object'>. Allowed are str, int, float, list [needs.dynamic_function]",
+        "srcdir/index.rst:16: WARNING: The [[invalid]] syntax in need content is deprecated. Replace with :ndf:`invalid` instead. [needs.deprecation]",
         "srcdir/index.rst:16: WARNING: Function string 'invalid' could not be parsed: Given dynamic function string is not a valid python call. Got: invalid [needs.dynamic_function]",
+        "srcdir/index.rst:18: WARNING: The [[unknown()]] syntax in need content is deprecated. Replace with :ndf:`unknown()` instead. [needs.deprecation]",
         "srcdir/index.rst:18: WARNING: Unknown function 'unknown' [needs.dynamic_function]",
     ]
     if version_info >= (7, 3):

--- a/tests/test_global_options.py
+++ b/tests/test_global_options.py
@@ -21,7 +21,7 @@ def test_doc_global_option(test_app):
 
     assert "test_global" in html
     assert "1.27" in html
-    assert "Test output of need_func; need: GLOBAL_ID" in html
+    assert "Test output of dynamic function; need: GLOBAL_ID" in html
 
     assert "STATUS_IMPL" in html
     assert "STATUS_UNKNOWN" in html


### PR DESCRIPTION
There are currently two ways to use dynamic functions within need directive's content:

1. ``[[copy("id")]]``; is problematic, because it does not adhere to the rst/myst syntax specification, and has already show to cause issues and be surprising to users (#1263)

2. `` :need_func:`[[copy("id")]]` ``; is better but overly verbose

In this PR, I introduce a new role, which I believe should supersede both: `` :ndf:`copy("id")` `` (open to other suggestions for the name)
Here we take the entire content to be the function, as so do not require the `[[]]`, reducing verbosity and processing

Note, one thing that the role approach cannot do, is to allow placeholders in URLs, e.g. `` `link <http://www.[[copy('id')]]>`_ ``
However, if this is truly required, then I believe we should introduce a new role specifically for that.

---

if this is accepted, I would then move to emit warnings if users already use `[[...]]`, explaining how to replace them,
then eventually remove `[[...]]` after some deprecation period

---

things to clarify:

- [x] do we agree this role should be added
- [x] do we agree on its name
- [x] do we agree this should deprecate `[[...]]` in content
  - [ ] do we need an additional role for URL links with placeholders
- [x] do we agree this should deprecate `need_func`