### PR TITLE
✨ Add `needimport` caching and `needs_import_cache_size` configuration

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1645,7 +1645,18 @@ keys:
             The related CSS class definition must be done by the user, e.g. by :ref:`own_css`.
             (*optional*) (*default*: ``external_link``)
 
+.. _needs_import_cache_size:
 
+needs_import_cache_size
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 3.1.0
+
+Sets the maximum number of needs cached by the :ref:`needimport` directive,
+which is used to avoid multiple reads of the same file.
+Note, setting this value too high may lead to high memory usage during the sphinx build.
+
+Default: :need_config_default:`import_cache_size`
 
 .. _needs_needextend_strict:
 

--- a/docs/directives/needimport.rst
+++ b/docs/directives/needimport.rst
@@ -30,6 +30,11 @@ The directive also supports URL as argument to download ``needs.json`` from remo
 
    .. needimport:: https://my_company.com/docs/remote-needs.json
 
+.. seealso::
+
+    :ref:`needs_import_cache_size`,
+    to control the cache size for imported needs.
+
 Options
 -------
 

--- a/sphinx_needs/config.py
+++ b/sphinx_needs/config.py
@@ -440,6 +440,10 @@ class NeedsSphinxConfig:
         default_factory=list, metadata={"rebuild": "html", "types": (list,)}
     )
     """List of external sources to load needs from."""
+    import_cache_size: int = field(
+        default=100, metadata={"rebuild": "", "types": (int,)}
+    )
+    """Maximum number of imported needs to cache."""
     builder_filter: str = field(
         default="is_external==False", metadata={"rebuild": "html", "types": (str,)}
     )

--- a/sphinx_needs/directives/needimport.py
+++ b/sphinx_needs/directives/needimport.py
@@ -288,7 +288,7 @@ class NeedimportDirective(SphinxDirective):
 class _ImportCache:
     """A simple cache for imported needs,
     mapping a (path, mtime) to a dictionary of needs.
-    that is thread safe,
+    It's thread safe,
     and has a maximum size when adding new items.
     """
 


### PR DESCRIPTION
This PR introduces "lazy and size-bounded" caching for the reading of `needs.json` in the `needimport` directive.

This reads/writes to an in-memory cache, keyed on the path and mtime,
and is bounded by the `needs_import_cache_size` (configurable by the user),
which sets the maximum number of needs allowed in the cache,
to ensure we do not have large increases in build memory usage.

---

Note, in #1148 there was discussion of "centralised, pre-caching",
however, that is problematic because:

1. It means all import sources have to be read in for every build/re-build, irrespective of whether they actually may be used
2. this can introduce a noticeable increase in memory usage and time for re-builds
3. for parallel builds, all of this data will be copied to every process, irrespective of whether that processes actually uses it, again meaning potentially large multipliers of memory usage