### PR TITLE
🐛 Fix removal of `Needextend` nodes

### DIFF
--- a/sphinx_needs/directives/need.py
+++ b/sphinx_needs/directives/need.py
@@ -406,7 +406,7 @@ def process_need_nodes(app: Sphinx, doctree: nodes.document, fromdocname: str) -
 
     post_process_needs_data(app)
 
-    for extend_node in doctree.findall(Needextend):
+    for extend_node in list(doctree.findall(Needextend)):
         remove_node_from_tree(extend_node)
 
     format_need_nodes(app, doctree, fromdocname, list(doctree.findall(Need)))


### PR DESCRIPTION
We need to exhaust the entire `findall` iterator, before performing mutations on the doctree, otherwise this can lead to unexpected results (as has been found in the PACE project)