### PR TITLE
👌 Add `needs_uml_process_max_time` configuration

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -542,6 +542,15 @@ needs_filter_max_time
 
 If set, warn if any :ref:`filter processing <filter>` call takes longer than the given time in seconds.
 
+.. _needs_uml_process_max_time:
+
+needs_uml_process_max_time
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 4.0.0
+
+If set, warn if any :ref:`needuml` or :ref:`needarch` jinja content rendering takes longer than the given time in seconds.
+
 .. _needs_flow_engine:
 
 needs_flow_engine

--- a/docs/filter.rst
+++ b/docs/filter.rst
@@ -213,6 +213,7 @@ Also filters containing ``and`` will be split into multiple filters and evaluate
 For example, ``type == 'spec' and other == 'value'`` will first be filtered performantly by ``type == 'spec'`` and then the remaining needs will be filtered by ``other == 'value'``.
 
 To guard against long running filters, the :ref:`needs_filter_max_time` configuration option can be used to set a maximum time limit for filter evaluation.
+Also see :ref:`needs_uml_process_max_time`, to guard against long running ``needuml`` / ``needarch`` processes containing :ref:`filters <needuml_jinja_filter>`.
 
 To debug which filters are being used across your project and their run times, you can enable the :ref:`needs_debug_filters` configuration option.
 

--- a/sphinx_needs/config.py
+++ b/sphinx_needs/config.py
@@ -387,7 +387,11 @@ class NeedsSphinxConfig:
     filter_max_time: int | float | None = field(
         default=None, metadata={"rebuild": "html", "types": (type(None), int, float)}
     )
-    """Warn if a filter runs for longer than this time (in seconds)."""
+    """Warn if process_filter runs for longer than this time (in seconds)."""
+    uml_process_max_time: int | float | None = field(
+        default=None, metadata={"rebuild": "html", "types": (type(None), int, float)}
+    )
+    """Warn if process_needuml runs for longer than this time (in seconds)."""
     flow_engine: Literal["plantuml", "graphviz"] = field(
         default="plantuml", metadata={"rebuild": "env", "types": (str,)}
     )

--- a/sphinx_needs/data.py
+++ b/sphinx_needs/data.py
@@ -660,6 +660,8 @@ class NeedsUmlType(NeedsBaseDataType):
     is_arch: bool
     # set in process_needuml
     content_calculated: str
+    process_time: float
+    """Time taken to process the diagram."""
 
 
 NeedsMutable = NewType("NeedsMutable", Dict[str, NeedsInfoType])

--- a/tests/test_needarch.py
+++ b/tests/test_needarch.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+from syrupy.filters import props
 
 
 @pytest.mark.parametrize(
@@ -52,7 +53,7 @@ def test_doc_needarch_jinja_import(test_app, snapshot):
 
     # check needarch
     all_needumls = app.env._needs_all_needumls
-    assert all_needumls == snapshot
+    assert all_needumls == snapshot(exclude=props("process_time"))
 
 
 @pytest.mark.parametrize(
@@ -65,7 +66,7 @@ def test_needarch_jinja_func_need(test_app, snapshot):
     app.build()
 
     all_needumls = app.env._needs_all_needumls
-    assert all_needumls == snapshot
+    assert all_needumls == snapshot(exclude=props("process_time"))
 
     html = Path(app.outdir, "index.html").read_text(encoding="utf8")
     assert "as INT_001 [[../index.html#INT_001]]" in html

--- a/tests/test_needuml.py
+++ b/tests/test_needuml.py
@@ -2,6 +2,7 @@ import subprocess
 from pathlib import Path
 
 import pytest
+from syrupy.filters import props
 
 from sphinx_needs.data import SphinxNeedsData
 
@@ -17,11 +18,13 @@ def test_doc_build_html(test_app, snapshot):
 
     assert Path(app.outdir, "index.html").read_text(encoding="utf8")
 
-    all_needs = dict(SphinxNeedsData(app.env).get_needs_view())
+    data = SphinxNeedsData(app.env)
+
+    all_needs = dict(data.get_needs_view())
     assert all_needs == snapshot()
 
-    all_needumls = app.env._needs_all_needumls
-    assert all_needumls == snapshot
+    all_needumls = data.get_or_create_umls()
+    assert all_needumls == snapshot(exclude=props("process_time"))
 
 
 @pytest.mark.parametrize(
@@ -170,7 +173,7 @@ def test_needuml_filter(test_app, snapshot):
     app.build()
 
     all_needumls = app.env._needs_all_needumls
-    assert all_needumls == snapshot
+    assert all_needumls == snapshot(exclude=props("process_time"))
 
     html = Path(app.outdir, "index.html").read_text(encoding="utf8")
     assert "as ST_002 [[../index.html#ST_002]]" in html
@@ -194,7 +197,7 @@ def test_needuml_jinja_func_flow(test_app, snapshot):
     app.build()
 
     all_needumls = app.env._needs_all_needumls
-    assert all_needumls == snapshot
+    assert all_needumls == snapshot(exclude=props("process_time"))
 
     html = Path(app.outdir, "index.html").read_text(encoding="utf8")
     assert "as ST_001 [[../index.html#ST_001]]" in html
@@ -268,7 +271,7 @@ def test_needuml_jinja_func_ref(test_app, snapshot):
     app.build()
 
     all_needumls = app.env._needs_all_needumls
-    assert all_needumls == snapshot
+    assert all_needumls == snapshot(exclude=props("process_time"))
 
     html = Path(app.outdir, "index.html").read_text(encoding="utf8")
     assert "Marvel: [[../index.html#ST_001 Test story]]" in html


### PR DESCRIPTION
To guard against long-running `needuml` / `needarch` processing times. In particular, these can occur if the jinja template contains many calls to the filter function.