### PR TITLE
♻️ Improve access to dynamic configs: extra_options, functions, warnings

### DIFF
--- a/sphinx_needs/api/configuration.py
+++ b/sphinx_needs/api/configuration.py
@@ -12,9 +12,9 @@ from sphinx.application import Sphinx
 from sphinx.util.logging import SphinxLoggerAdapter
 
 from sphinx_needs.api.exceptions import NeedsApiConfigException
-from sphinx_needs.config import NEEDS_CONFIG, NeedsSphinxConfig
+from sphinx_needs.config import _NEEDS_CONFIG, NeedsSphinxConfig
 from sphinx_needs.data import NeedsInfoType
-from sphinx_needs.functions.functions import DynamicFunction, register_func
+from sphinx_needs.functions.functions import DynamicFunction
 
 
 def get_need_types(app: Sphinx) -> list[str]:
@@ -101,7 +101,7 @@ def add_extra_option(
     :param name: Name as string of the extra option
     :return: None
     """
-    NEEDS_CONFIG.add_extra_option(name, description)
+    _NEEDS_CONFIG.add_extra_option(name, description)
 
 
 def add_dynamic_function(
@@ -130,7 +130,7 @@ def add_dynamic_function(
     :param name: Name of the dynamic function as string
     :return: None
     """
-    register_func(function, name)
+    _NEEDS_CONFIG.add_function(function, name)
 
 
 # 'Need' is untyped, so we temporarily use 'Any' here
@@ -170,7 +170,7 @@ def add_warning(
     if warning_check is None:
         raise NeedsApiConfigException("either function or filter_string must be given")
 
-    if name in NEEDS_CONFIG.warnings:
+    if name in _NEEDS_CONFIG.warnings:
         raise NeedsApiConfigException(f"Warning {name} already registered.")
 
-    NEEDS_CONFIG.warnings[name] = warning_check
+    _NEEDS_CONFIG.add_warning(name, warning_check)

--- a/sphinx_needs/api/need.py
+++ b/sphinx_needs/api/need.py
@@ -16,7 +16,7 @@ from sphinx.application import Sphinx
 from sphinx.environment import BuildEnvironment
 
 from sphinx_needs.api.exceptions import InvalidNeedException
-from sphinx_needs.config import NEEDS_CONFIG, GlobalOptionsType, NeedsSphinxConfig
+from sphinx_needs.config import GlobalOptionsType, NeedsSphinxConfig
 from sphinx_needs.data import NeedsInfoType, NeedsPartType, SphinxNeedsData
 from sphinx_needs.directives.needuml import Needuml, NeedumlException
 from sphinx_needs.filter_common import filter_single_need
@@ -118,7 +118,7 @@ def generate_need(
 
     # validate kwargs
     allowed_kwargs = {x["option"] for x in needs_config.extra_links} | set(
-        NEEDS_CONFIG.extra_options
+        needs_config.extra_options
     )
     unknown_kwargs = set(kwargs) - allowed_kwargs
     if unknown_kwargs:
@@ -235,7 +235,7 @@ def generate_need(
     }
 
     # add dynamic keys to needs_info
-    _merge_extra_options(needs_info, kwargs, NEEDS_CONFIG.extra_options)
+    _merge_extra_options(needs_info, kwargs, needs_config.extra_options)
     _merge_global_options(needs_config, needs_info, needs_config.global_options)
 
     # Merge links

--- a/sphinx_needs/data.py
+++ b/sphinx_needs/data.py
@@ -478,7 +478,7 @@ class NeedsInfoType(TypedDict, total=False):
     """
 
     # Fields added dynamically by services:
-    # options from ``BaseService.options`` get added to ``NEEDS_CONFIG.extra_options``,
+    # options from ``BaseService.options`` get added to ``extra_options``,
     # via `ServiceManager.register`,
     # which in turn means they are added to every need via ``add_need``
     # ``GithubService.options``
@@ -503,7 +503,7 @@ class NeedsInfoType(TypedDict, total=False):
 
     # Note there are also these dynamic keys:
     # - items in ``needs_extra_options`` + ``needs_duration_option`` + ``needs_completion_option``,
-    #   which get added to ``NEEDS_CONFIG.extra_options``,
+    #   which get added to ``extra_options``,
     #   and in turn means they are added to every need via ``add_need`` (as strings)
     # - keys in ``needs_global_options`` config are added to every need via ``add_need``
 

--- a/sphinx_needs/directives/need.py
+++ b/sphinx_needs/directives/need.py
@@ -10,7 +10,7 @@ from sphinx.environment import BuildEnvironment
 from sphinx.util.docutils import SphinxDirective
 
 from sphinx_needs.api import InvalidNeedException, add_need
-from sphinx_needs.config import NEEDS_CONFIG, NeedsSphinxConfig
+from sphinx_needs.config import NeedsSphinxConfig
 from sphinx_needs.data import NeedsMutable, SphinxNeedsData
 from sphinx_needs.debug import measure_time
 from sphinx_needs.defaults import NEED_DEFAULT_OPTIONS
@@ -80,7 +80,7 @@ class NeedDirective(SphinxDirective):
                 extra_link["option"], ""
             )
 
-        for extra_option in NEEDS_CONFIG.extra_options:
+        for extra_option in needs_config.extra_options:
             need_extra_options[extra_option] = self.options.get(extra_option, "")
 
         try:

--- a/sphinx_needs/directives/needimport.py
+++ b/sphinx_needs/directives/needimport.py
@@ -13,7 +13,7 @@ from requests_file import FileAdapter
 from sphinx.util.docutils import SphinxDirective
 
 from sphinx_needs.api import InvalidNeedException, add_need
-from sphinx_needs.config import NEEDS_CONFIG, NeedsSphinxConfig
+from sphinx_needs.config import NeedsSphinxConfig
 from sphinx_needs.data import NeedsCoreFields, NeedsInfoType
 from sphinx_needs.debug import measure_time
 from sphinx_needs.defaults import string_to_boolean
@@ -203,7 +203,7 @@ class NeedimportDirective(SphinxDirective):
             *NeedsCoreFields,
             *(x["option"] for x in needs_config.extra_links),
             *(x["option"] + "_back" for x in needs_config.extra_links),
-            *NEEDS_CONFIG.extra_options,
+            *needs_config.extra_options,
         }
         # all keys that should not be imported from external needs
         omitted_keys = {

--- a/sphinx_needs/directives/needreport.py
+++ b/sphinx_needs/directives/needreport.py
@@ -41,7 +41,9 @@ class NeedReportDirective(SphinxDirective):
 
         report_info = {
             "types": needs_config.types if "types" in self.options else [],
-            "options": needs_config.extra_options if "options" in self.options else [],
+            "options": list(needs_config.extra_options)
+            if "options" in self.options
+            else [],
             "links": needs_config.extra_links if "links" in self.options else [],
             # note the usage dict format here is just to keep backwards compatibility,
             # but actually this is now post-processed so we only really need the need types

--- a/sphinx_needs/external_needs.py
+++ b/sphinx_needs/external_needs.py
@@ -11,7 +11,7 @@ from sphinx.application import Sphinx
 from sphinx.environment import BuildEnvironment
 
 from sphinx_needs.api import InvalidNeedException, add_external_need, del_need
-from sphinx_needs.config import NEEDS_CONFIG, NeedsSphinxConfig
+from sphinx_needs.config import NeedsSphinxConfig
 from sphinx_needs.data import NeedsCoreFields, SphinxNeedsData
 from sphinx_needs.logging import get_logger, log_warning
 from sphinx_needs.utils import clean_log, import_prefix_link_edit
@@ -124,7 +124,7 @@ def load_external_needs(
             *NeedsCoreFields,
             *(x["option"] for x in needs_config.extra_links),
             *(x["option"] + "_back" for x in needs_config.extra_links),
-            *NEEDS_CONFIG.extra_options,
+            *needs_config.extra_options,
         }
         # all keys that should not be imported from external needs
         omitted_keys = {

--- a/sphinx_needs/functions/__init__.py
+++ b/sphinx_needs/functions/__init__.py
@@ -13,7 +13,6 @@ from sphinx_needs.functions.functions import (  # noqa: F401
     FunctionParsingException,
     execute_func,
     find_and_replace_node_content,
-    register_func,
     resolve_dynamic_values,
     resolve_variants_options,
 )

--- a/sphinx_needs/needsfile.py
+++ b/sphinx_needs/needsfile.py
@@ -17,7 +17,7 @@ from typing import Any, Iterable
 from jsonschema import Draft7Validator
 from sphinx.config import Config
 
-from sphinx_needs.config import NEEDS_CONFIG, NeedsSphinxConfig
+from sphinx_needs.config import NeedsSphinxConfig
 from sphinx_needs.data import NeedsCoreFields, NeedsInfoType
 from sphinx_needs.logging import get_logger, log_warning
 
@@ -25,7 +25,7 @@ log = get_logger(__name__)
 
 
 def generate_needs_schema(
-    config: Config, exclude_properties: Iterable[str] = ()
+    needs_config: NeedsSphinxConfig, exclude_properties: Iterable[str] = ()
 ) -> dict[str, Any]:
     """Generate a JSON schema for all fields in each need item.
 
@@ -37,7 +37,7 @@ def generate_needs_schema(
     """
     properties: dict[str, Any] = {}
 
-    for name, extra_params in NEEDS_CONFIG.extra_options.items():
+    for name, extra_params in needs_config.extra_options.items():
         properties[name] = {
             "type": "string",
             "description": extra_params.description,
@@ -53,8 +53,6 @@ def generate_needs_schema(
         properties[name] = deepcopy(core_params["schema"])
         properties[name]["description"] = f"{core_params['description']}"
         properties[name]["field_type"] = "core"
-
-    needs_config = NeedsSphinxConfig(config)
 
     for link in needs_config.extra_links:
         properties[link["option"]] = {
@@ -114,7 +112,9 @@ class NeedsList:
         self._exclude_need_keys = set(self.needs_config.json_exclude_fields)
 
         self._schema = (
-            generate_needs_schema(config, exclude_properties=self._exclude_need_keys)
+            generate_needs_schema(
+                self.needs_config, exclude_properties=self._exclude_need_keys
+            )
             if add_schema
             else None
         )

--- a/sphinx_needs/services/manager.py
+++ b/sphinx_needs/services/manager.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from sphinx.application import Sphinx
 
-from sphinx_needs.config import NEEDS_CONFIG, NeedsSphinxConfig
+from sphinx_needs.config import _NEEDS_CONFIG, NeedsSphinxConfig
 from sphinx_needs.directives.needservice import NeedserviceDirective
 from sphinx_needs.logging import get_logger
 from sphinx_needs.services.base import BaseService
@@ -28,12 +28,12 @@ class ServiceManager:
 
         # Register options from service class
         for option in klass.options:
-            if option not in NEEDS_CONFIG.extra_options:
+            if option not in _NEEDS_CONFIG.extra_options:
                 self.log.debug(f'Register option "{option}" for service "{name}"')
-                NEEDS_CONFIG.add_extra_option(option, f"Added by service {name}")
+                _NEEDS_CONFIG.add_extra_option(option, f"Added by service {name}")
                 # Register new option directly in Service directive, as its class options got already
                 # calculated
-                NeedserviceDirective.option_spec[option] = NEEDS_CONFIG.extra_options[
+                NeedserviceDirective.option_spec[option] = _NEEDS_CONFIG.extra_options[
                     option
                 ].validator
 

--- a/sphinx_needs/utils.py
+++ b/sphinx_needs/utils.py
@@ -22,26 +22,12 @@ from sphinx_needs.defaults import NEEDS_PROFILING
 from sphinx_needs.logging import get_logger, log_warning
 from sphinx_needs.views import NeedsAndPartsListView, NeedsView
 
-try:
-    from typing import TypedDict
-except ImportError:
-    from typing_extensions import TypedDict
-
 if TYPE_CHECKING:
     import matplotlib
     from matplotlib.figure import FigureBase
 
-    from sphinx_needs.functions.functions import DynamicFunction
 
 logger = get_logger(__name__)
-
-
-class NeedFunctionsType(TypedDict):
-    name: str
-    function: DynamicFunction
-
-
-NEEDS_FUNCTIONS: dict[str, NeedFunctionsType] = {}
 
 
 MONTH_NAMES = [

--- a/sphinx_needs/warnings.py
+++ b/sphinx_needs/warnings.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from sphinx.application import Sphinx
 from sphinx.util import logging
 
-from sphinx_needs.config import NEEDS_CONFIG, NeedsSphinxConfig
+from sphinx_needs.config import NeedsSphinxConfig
 from sphinx_needs.data import SphinxNeedsData
 from sphinx_needs.filter_common import filter_needs_view
 from sphinx_needs.logging import get_logger, log_warning
@@ -32,8 +32,10 @@ def process_warnings(app: Sphinx, exception: Exception | None) -> None:
     if exception:
         return
 
+    needs_config = NeedsSphinxConfig(app.config)
+
     # If no warnings were defined, we do not need to do anything
-    if not NEEDS_CONFIG.warnings:
+    if not needs_config.warnings:
         return
 
     env = app.env
@@ -59,7 +61,7 @@ def process_warnings(app: Sphinx, exception: Exception | None) -> None:
     with logging.pending_logging():
         logger.info("\nChecking sphinx-needs warnings")
         warning_raised = False
-        for warning_name, warning_filter in NEEDS_CONFIG.warnings.items():
+        for warning_name, warning_filter in needs_config.warnings.items():
             if isinstance(warning_filter, str):
                 # filter string used
                 result = filter_needs_view(


### PR DESCRIPTION
These three configurations are complicated by the fact that they can be set both in the `conf.py` configuration, but also via functions from `sphinx_needs.api`.

This has lead to confusion, when to use `NEEDS_CONFIG` and when to use `NeedsSphinxConfig`, and indeed I have already had to fix numerous bugs when `NeedsSphinxConfig` was incorrectly used

In this PR we split access to these configs into:

- `NeedsSphinxConfig._extra_options`, `NeedsSphinxConfig._functions`, `NeedsSphinxConfig._warnings`, which access the "raw" sphinx configuration
- `NeedsSphinxConfig.extra_options`, `NeedsSphinxConfig.functions`, `NeedsSphinxConfig.warnings`, which access the "combined" sphinx config + API added values

We also make `NEEDS_CONFIG` private and merge in the use of `NEEDS_FUNCTIONS`.
This makes the code less prone to mistakes in the use of the wrong variable