### PR TITLE
PR - Add 'hide' support and a new meta-data option to List2need directive

### DIFF
--- a/docs/directives/list2need.rst
+++ b/docs/directives/list2need.rst
@@ -169,6 +169,62 @@ tags
 The tags ``A`` and ``B`` are attached to all ``NEED-A``, ``NEED-B``, ``NEED-C`` and ``NEED-D``.
 
 
+
+hide
+~~~~
+
+``hide`` sets the hide-option globally to all items in the list.
+
+.. code-block:: rst
+
+   .. list2need::
+      :types: req
+      :tags: A
+      :hide: True
+
+      * (NEED-A) Login user
+      * (NEED-B) Provide login screen
+      * (NEED-C) Create password hash
+      * (NEED-D) Recalculate hash and compare
+
+All ``NEED-A``, ``NEED-B``, ``NEED-C`` and ``NEED-D`` requirements will be marked as hidden. This allows to easily create a list of requirements and presenting them as a table in the final output.
+
+.. code-block:: rst
+
+   .. list2need::
+      :types: req
+      :tags: A
+      :hide: True
+
+      * (NEED-A) Login user
+      * (NEED-B) Provide login screen
+      * (NEED-C) Create password hash
+      * (NEED-D) Recalculate hash and compare
+  
+   .. needtable::
+      :types: req
+      :tags: A
+      :style: table
+      :columns: id, title, content, links
+
+
+meta-data
+~~~~~~~~~
+
+Meta-data can be set directly in the related line via, for example: ``((status="open"))``. This meta-data option allows to define meta-data that will be affected to all needs in the list, including extra custom options.
+
+.. code-block:: rst
+
+   .. list2need::
+      :types: req
+      :tags: A
+      :meta-data: validation="Test, Review of Design", status="open"
+
+      * (NEED-A) Login user
+      * (NEED-B) Provide login screen
+      * (NEED-C) Create password hash
+      * (NEED-D) Recalculate hash and compare
+
 List examples
 -------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "sphinx-needs"
 
 # !! Don't miss updates in sphinx_needs.__version__, changelog.rst, and .github/workflows/docker !!!
-version = "4.1.0"
+version = "4.2.0"
 
 description = "Sphinx needs extension for managing needs/requirements and specifications"
 authors = ["team useblocks <info@useblocks.com>"]

--- a/sphinx_needs/directives/list2need.py
+++ b/sphinx_needs/directives/list2need.py
@@ -59,7 +59,7 @@ class List2NeedDirective(SphinxDirective):
         "links-down": directives.unchanged,
         "tags": directives.unchanged,
         "hide": directives.unchanged,
-        "meta-data": directives.unchanged,
+        "list_global_options": directives.unchanged,
     }
 
     def run(self) -> Sequence[nodes.Node]:
@@ -113,7 +113,7 @@ class List2NeedDirective(SphinxDirective):
         # Retrieve tags defined at list level
         tags = self.options.get("tags", "")
         hide = self.options.get("hide", "")
-        metadata = self.options.get("meta-data", "")
+        global_options = self.options.get("list_global_options", "")
 
         list_needs = []
         # Storing the data in a sorted list
@@ -212,15 +212,14 @@ class List2NeedDirective(SphinxDirective):
             if hide:
                 if "options" not in list_need:
                     list_need["options"] = {}
-                hide_option = list_need["options"].get("hide", "")
-                list_need["options"]["hide"] = hide_option
+                list_need["options"]["hide"] = hide
 
-            if metadata:
+            if global_options:
                 if "options" not in list_need:
                     list_need["options"] = {}
-                metadata_items = re.findall(r'([^=,]+)=["\']([^"\']+)["\']', metadata)
+                global_options_items = re.findall(r'([^=,]+)=["\']([^"\']+)["\']', global_options)
 
-                for key, value in metadata_items:
+                for key, value in global_options_items:
                     current_options = list_need["options"].get(key.strip(), "")
 
                     if current_options:

--- a/sphinx_needs/directives/list2need.py
+++ b/sphinx_needs/directives/list2need.py
@@ -17,8 +17,9 @@ NEED_TEMPLATE = """.. {{type}}:: {{title}}
    {% if need_id is not none %}:id: {{need_id}}{%endif%}
    {% if set_links_down %}:{{links_down_type}}: {{ links_down|join(', ') }}{%endif%}
    {%- for name, value in options.items() %}:{{name}}: {{value}}
-   {% endfor %}
-
+   {% endfor %}{% if need_hide %}:hide:{%endif%}
+   
+   
    {{content}}
 
 """
@@ -63,6 +64,13 @@ class List2NeedDirective(SphinxDirective):
     }
 
     def run(self) -> Sequence[nodes.Node]:
+        """_Implementation details_
+
+        The directive is used to create a list of needs (list_needs). Each list entry is used to create a single need using
+        a jinja2 template (Template). The template is defined in the NEED_TEMPLATE variable. The template is rendered for each list entry
+        
+        """
+        
         env = self.env
         needs_config = NeedsSphinxConfig(env.config)
 
@@ -112,7 +120,12 @@ class List2NeedDirective(SphinxDirective):
 
         # Retrieve tags defined at list level
         tags = self.options.get("tags", "")
-        hide = self.options.get("hide", "")
+        
+        if "hide" in self.options:
+            hide = True
+        else:
+            hide = False
+            
         global_options = self.options.get("list_global_options", "")
 
         list_needs = []
@@ -209,11 +222,8 @@ class List2NeedDirective(SphinxDirective):
                 else:
                     list_need["options"]["tags"] = tags
 
-            if hide:
-                if "options" not in list_need:
-                    list_need["options"] = {}
-                list_need["options"]["hide"] = hide
-
+            list_need["need_hide"] = hide
+                
             if global_options:
                 if "options" not in list_need:
                     list_need["options"] = {}

--- a/sphinx_needs/directives/list2need.py
+++ b/sphinx_needs/directives/list2need.py
@@ -217,7 +217,9 @@ class List2NeedDirective(SphinxDirective):
             if global_options:
                 if "options" not in list_need:
                     list_need["options"] = {}
-                global_options_items = re.findall(r'([^=,]+)=["\']([^"\']+)["\']', global_options)
+                global_options_items = re.findall(
+                    r'([^=,]+)=["\']([^"\']+)["\']', global_options
+                )
 
                 for key, value in global_options_items:
                     current_options = list_need["options"].get(key.strip(), "")

--- a/sphinx_needs/directives/list2need.py
+++ b/sphinx_needs/directives/list2need.py
@@ -13,12 +13,6 @@ from sphinx.util.docutils import SphinxDirective
 
 from sphinx_needs.config import NeedsSphinxConfig
 
-
-from sphinx_needs.logging import get_logger, log_warning
-
-logger = get_logger(__name__)
-
-
 NEED_TEMPLATE = """.. {{type}}:: {{title}}
    {% if need_id is not none %}:id: {{need_id}}{%endif%}
    {% if set_links_down %}:{{links_down_type}}: {{ links_down|join(', ') }}{%endif%}
@@ -120,15 +114,6 @@ class List2NeedDirective(SphinxDirective):
         tags = self.options.get("tags", "")
         hide = self.options.get("hide", "")
         metadata = self.options.get("meta-data", "")
-
-        if metadata:
-             log_warning(
-                    logger,
-                    metadata,
-                    "needsequence",
-                    location=None,
-                    
-                )
 
         list_needs = []
         # Storing the data in a sorted list

--- a/sphinx_needs/directives/list2need.py
+++ b/sphinx_needs/directives/list2need.py
@@ -59,7 +59,7 @@ class List2NeedDirective(SphinxDirective):
         "links-down": directives.unchanged,
         "tags": directives.unchanged,
         "hide": directives.unchanged,
-        "meta-data": directives.unchanged
+        "meta-data": directives.unchanged,
     }
 
     def run(self) -> Sequence[nodes.Node]:
@@ -215,23 +215,20 @@ class List2NeedDirective(SphinxDirective):
                 hide_option = list_need["options"].get("hide", "")
                 list_need["options"]["hide"] = hide_option
 
-
             if metadata:
                 if "options" not in list_need:
                     list_need["options"] = {}
                 metadata_items = re.findall(r'([^=,]+)=["\']([^"\']+)["\']', metadata)
-                                                           
+
                 for key, value in metadata_items:
                     current_options = list_need["options"].get(key.strip(), "")
 
-
-
                     if current_options:
-                        list_need["options"][key.strip()] = current_options + "," + value
+                        list_need["options"][key.strip()] = (
+                            current_options + "," + value
+                        )
                     else:
                         list_need["options"][key.strip()] = value
-                
-
 
             template = Template(NEED_TEMPLATE, autoescape=True)
 

--- a/tests/doc_test/doc_list2need_hide/conf.py
+++ b/tests/doc_test/doc_list2need_hide/conf.py
@@ -1,0 +1,43 @@
+extensions = ["sphinx_needs"]
+project = "test for list2need hide"
+author = 'Christophe SEYLER'
+
+needs_table_style = "TABLE"
+
+needs_id_regex = "^[A-Za-z0-9_]"
+
+needs_types = [
+    {
+        "directive": "story",
+        "title": "User Story",
+        "prefix": "US_",
+        "color": "#BFD8D2",
+        "style": "node",
+    },
+    {
+        "directive": "spec",
+        "title": "Specification",
+        "prefix": "SP_",
+        "color": "#FEDCD2",
+        "style": "node",
+    },
+    {
+        "directive": "impl",
+        "title": "Implementation",
+        "prefix": "IM_",
+        "color": "#DF744A",
+        "style": "node",
+    },
+    {
+        "directive": "test",
+        "title": "Test Case",
+        "prefix": "TC_",
+        "color": "#DCB239",
+        "style": "node",
+    },
+]
+
+needs_extra_links = [
+    {"option": "checks", "incoming": "is checked by", "outgoing": "checks"},
+    {"option": "triggers", "incoming": "is triggered by", "outgoing": "triggers"},
+]

--- a/tests/doc_test/doc_list2need_hide/index.rst
+++ b/tests/doc_test/doc_list2need_hide/index.rst
@@ -1,0 +1,28 @@
+TEST DOCUMENT LIST2NEED
+=======================
+
+
+.. list2need::
+   :types: spec, spec
+   :tags: tag1
+   :hide: 
+
+   * (NEED-A) Need example on level 1. fsdfsdf. ((status="closed",tags="tag2"))
+   * (NEED-B) Link example  ((status="closed",tags="tag2"))
+     * (NEED-B-1) Need example on level 2
+   * (NEED-C) New line example.  ((status="closed",tags="tag2"))
+     With some content in the next line.
+
+
+
+List
+====
+
+.. needtable:: Example table
+   :tags: tag1
+   :style: table
+   :columns: id
+   :show_filters: 
+
+
+.. _test:

--- a/tests/doc_test/doc_list2need_list_global_options/conf.py
+++ b/tests/doc_test/doc_list2need_list_global_options/conf.py
@@ -1,0 +1,46 @@
+extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
+project = "test for list2need list_global_options"
+author = 'Christophe SEYLER'
+
+needs_table_style = "TABLE"
+
+needs_id_regex = "^[A-Za-z0-9_]"
+
+needs_types = [
+    {
+        "directive": "story",
+        "title": "User Story",
+        "prefix": "US_",
+        "color": "#BFD8D2",
+        "style": "node",
+    },
+    {
+        "directive": "spec",
+        "title": "Specification",
+        "prefix": "SP_",
+        "color": "#FEDCD2",
+        "style": "node",
+    },
+    {
+        "directive": "impl",
+        "title": "Implementation",
+        "prefix": "IM_",
+        "color": "#DF744A",
+        "style": "node",
+    },
+    {
+        "directive": "test",
+        "title": "Test Case",
+        "prefix": "TC_",
+        "color": "#DCB239",
+        "style": "node",
+    },
+]
+
+needs_extra_links = [
+    {"option": "checks", "incoming": "is checked by", "outgoing": "checks"},
+    {"option": "triggers", "incoming": "is triggered by", "outgoing": "triggers"},
+]
+needs_extra_options = [
+    "aggregateoption"
+]

--- a/tests/doc_test/doc_list2need_list_global_options/index.rst
+++ b/tests/doc_test/doc_list2need_list_global_options/index.rst
@@ -1,0 +1,16 @@
+TEST DOCUMENT LIST2NEED
+=======================
+
+
+.. list2need::
+   :types: spec, spec
+   :list_global_options: status="open", aggregateoption="SomeValue"
+   
+   * (NEED-A) Need example on level 1 
+   * (NEED-B) Need example on level 1
+   * (NEED-C) Link example 
+     * (NEED-C-1) Need example on level 2
+   * (NEED-D) New line example. ((aggregateoption="OtherValue"))
+     With some content in the next line.
+
+.. _test:

--- a/tests/test_list2need.py
+++ b/tests/test_list2need.py
@@ -2,7 +2,10 @@ from pathlib import Path
 
 import pytest
 
+
 from sphinx_needs.api import get_needs_view
+
+
 
 
 @pytest.mark.parametrize(
@@ -68,3 +71,4 @@ def test_doc_list2need_html(test_app, snapshot):
         'href="#NEED-B" title="NEED-C">NEED-B</a></span></span></div>'
         in links_down_html
     )
+

--- a/tests/test_list2need_hide.py
+++ b/tests/test_list2need_hide.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+import pytest
+import json
+
+from sphinx_needs.api import get_needs_view
+
+
+
+
+@pytest.mark.parametrize(
+    "test_app",
+     [{"buildername": "html", "srcdir": "doc_test/doc_list2need_hide"}],
+    indirect=True,
+)
+def test_doc_list2need_hide(test_app, snapshot):
+    app = test_app
+    app.build()
+
+    index_html = Path(app.outdir, "index.html").read_text()
+    assert '<tr class="need row-even"><td class="needs_id"><p><a class="reference internal" href="#NEED-A">NEED-A</a></p></td>' in index_html
+    assert '<tr class="need row-odd"><td class="needs_id"><p><a class="reference internal" href="#NEED-B">NEED-B</a></p></td>' in index_html
+    assert '<tr class="need row-even"><td class="needs_id"><p><a class="reference internal" href="#NEED-C">NEED-C</a></p></td>' in index_html
+    
+    
+    assert 'class="need_container docutils container"' not in index_html
+    
+        
+    
+    
+    
+    

--- a/tests/test_list2need_hide.py
+++ b/tests/test_list2need_hide.py
@@ -14,8 +14,16 @@ from sphinx_needs.api import get_needs_view
     indirect=True,
 )
 def test_doc_list2need_hide(test_app, snapshot):
+    """
+    The test validates the list2need directive with the hide option.
+    The needs must be valid, but the rendered output must not contain the need content.
+    
+    To validate that the needs are valid, the needs are rendered using a needtable directive.
+    """
     app = test_app
     app.build()
+
+
 
     index_html = Path(app.outdir, "index.html").read_text()
     assert '<tr class="need row-even"><td class="needs_id"><p><a class="reference internal" href="#NEED-A">NEED-A</a></p></td>' in index_html

--- a/tests/test_list2need_list_global_options.py
+++ b/tests/test_list2need_list_global_options.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+import pytest
+import json
+
+from sphinx_needs.api import get_needs_view
+
+
+
+
+@pytest.mark.parametrize(
+    "test_app",
+    [
+        {
+            "buildername": "needs",
+            "srcdir": "doc_test/doc_list2need_list_global_options",
+            "confoverrides": {"needs_reproducible_json": True},
+        }
+    ],
+    indirect=True,
+)
+def test_doc_list2need_list_global_options(test_app, snapshot):
+    app = test_app
+    app.build()
+
+    needs_list = json.loads(Path(app.outdir, "needs.json").read_text())
+    
+    needs = needs_list["versions"][""]["needs"]
+ 
+    # Check that all entries have a status item equal to "open"
+    for need_id, need in needs.items():
+        assert need.get("status") == "open", f"Need {need_id} does not have status 'open'"
+        assert "SomeValue" in need.get("aggregateoption", ""), f"Need {need_id} does not have 'SomeValue' in aggregateoption"
+
+    # Check that NEED-D has "OtherValue" in its aggregateoption
+    need_d = needs.get("NEED-D")
+    assert need_d is not None, "NEED-D is missing"
+    assert "OtherValue" in need_d.get("aggregateoption", ""), "NEED-D does not have 'OtherValue' in aggregateoption"
+    
+    
+    
+    
+    


### PR DESCRIPTION
Added the support for "hide" option to affect the hidden status to all requirements in the list. This allows to easily create a list of requirements that could be only presented as a table in the final output.
```rst
.. list2need::
      :types: req
      :tags: A
      :hide: True
      * (NEED-A) Login user
      * (NEED-B) Provide login screen
      * (NEED-C) Create password hash
      * (NEED-D) Recalculate hash and compare
  
   .. needtable::
      :types: req
      :tags: A
      :style: table
      :columns: id, title, content, links
```
this example is added in the documentation


The PR also add a new meta-data option to give the ability to set meta-data (including extra defined custom option to all elements in the list)
```rst
.. list2need::
      :types: req
      :tags: A
      :meta-data: validation="Test, Review of Design", status="open"
      * (NEED-A) Login user
      * (NEED-B) Provide login screen
      * (NEED-C) Create password hash
      * (NEED-D) Recalculate hash and compare
```