### PR TITLE
Allow for multiple regex matches

### DIFF
--- a/sphinx_needs/utils.py
+++ b/sphinx_needs/utils.py
@@ -457,25 +457,24 @@ def match_string_link(
     try:
         link_name = None
         link_url = None
-        link_conf = matching_link_confs[
-            0
-        ]  # We only handle the first matching string_link
-        match = link_conf["regex_compiled"].search(data)
-        if match:
-            render_content = match.groupdict()
-            link_url = link_conf["url_template"].render(
-                **render_content, **render_context
-            )
-            link_name = link_conf["name_template"].render(
-                **render_content, **render_context
-            )
+        link_conf = matching_link_confs
+        for lc in link_conf:
+            match = lc["regex_compiled"].search(data)
+            if match:
+                render_content = match.groupdict()
+                link_url = lc["url_template"].render(
+                    **render_content, **render_context
+                )
+                link_name = lc["name_template"].render(
+                    **render_content, **render_context
+                )
 
-        # if no string_link match was made, we handle it as normal string value
-        ref_item = (
-            nodes.reference(link_name, link_name, refuri=link_url)
-            if link_name
-            else nodes.Text(text_item)
-        )
+            # if no string_link match was made, we handle it as normal string value
+            ref_item = (
+                nodes.reference(link_name, link_name, refuri=link_url)
+                if link_name
+                else nodes.Text(text_item)
+            )
 
     except Exception as e:
         log_warning(

--- a/sphinx_needs/utils.py
+++ b/sphinx_needs/utils.py
@@ -462,9 +462,7 @@ def match_string_link(
             match = lc["regex_compiled"].search(data)
             if match:
                 render_content = match.groupdict()
-                link_url = lc["url_template"].render(
-                    **render_content, **render_context
-                )
+                link_url = lc["url_template"].render(**render_content, **render_context)
                 link_name = lc["name_template"].render(
                     **render_content, **render_context
                 )


### PR DESCRIPTION
This is a suggested change to close #1351. 
All it does is basically just iterating over each found match instead of just taking the first one.

I have tested it locally, and it works fine. 

Unsure however if there is other things that need to be changed that are effected by this. 

