### PR TITLE
Allow filter-func in need-pie to have multiple dots in the import path. 

### DIFF
--- a/sphinx_needs/utils.py
+++ b/sphinx_needs/utils.py
@@ -326,7 +326,7 @@ def check_and_get_external_filter_func(
         return None
 
     try:
-        filter_module, filter_function = filter_func_ref.rsplit(".")
+        filter_module, filter_function = filter_func_ref.rsplit(".",1)
     except ValueError:
         raise NeedsInvalidFilter("does not contain a dot")
 

--- a/sphinx_needs/utils.py
+++ b/sphinx_needs/utils.py
@@ -326,7 +326,7 @@ def check_and_get_external_filter_func(
         return None
 
     try:
-        filter_module, filter_function = filter_func_ref.rsplit(".",1)
+        filter_module, filter_function = filter_func_ref.rsplit(".", 1)
     except ValueError:
         raise NeedsInvalidFilter("does not contain a dot")
 

--- a/tests/doc_test/doc_needs_filter_data/filter_code.rst
+++ b/tests/doc_test/doc_needs_filter_data/filter_code.rst
@@ -22,6 +22,14 @@ Filter code test cases
     :labels: project_x, project_y
     :filter-func: filter_code_func.my_pie_filter_code
 
+.. needtable:: Filter code func table with multiple dots filter function path 
+   :style: table
+   :filter-func: module.filter_code_func.own_filter_code
+
+
+.. needpie:: Filter code func pie with multiple dots filter function path 
+    :labels: project_x, project_y
+    :filter-func: module.filter_code_func.my_pie_filter_code
 
 .. needtable:: Malformed filter func table
    :style: table
@@ -31,3 +39,12 @@ Filter code test cases
 .. needpie:: Malformed filter func pie
     :labels: project_x, project_y
     :filter-func: filter_code_func.my_pie_filter_code(
+
+.. needtable:: Malformed filter func table with multiple dots filter function path 
+   :style: table
+   :filter-func: module.filter_code_func.own_filter_code(
+
+
+.. needpie:: Malformed filter func pie with multiple dots filter function path 
+    :labels: project_x, project_y
+    :filter-func: module.filter_code_func.my_pie_filter_code(

--- a/tests/doc_test/doc_needs_filter_data/module/filter_code_func.py
+++ b/tests/doc_test/doc_needs_filter_data/module/filter_code_func.py
@@ -1,0 +1,34 @@
+def own_filter_code(needs, results):
+    for need in needs:
+        if need["type"] == "test":
+            results.append(need)
+
+
+def own_filter_code_args(needs, results, **kwargs):
+    for need in needs:
+        if need["status"] == kwargs["arg1"]:
+            results.append(need)
+
+
+def my_pie_filter_code(needs, results):
+    cnt_x = 0
+    cnt_y = 0
+    for need in needs:
+        if need["variant"] == "project_x":
+            cnt_x += 1
+        if need["variant"] == "project_y":
+            cnt_y += 1
+    results.append(cnt_x)
+    results.append(cnt_y)
+
+
+def my_pie_filter_code_args(needs, results, **kwargs):
+    cnt_x = 0
+    cnt_y = 0
+    for need in needs:
+        if need["status"] == kwargs["arg1"]:
+            cnt_x += 1
+        if need["status"] == kwargs["arg2"]:
+            cnt_y += 1
+    results.append(cnt_x)
+    results.append(cnt_y)

--- a/tests/test_needs_filter_data.py
+++ b/tests/test_needs_filter_data.py
@@ -48,7 +48,10 @@ def test_doc_needs_filter_data_html(test_app):
         '<td class="needs_tags"><p>my_tag<em>; </em>current_variant</p></td>'
         in index_html
     )
-    assert '<span class="caption-text">Filter code func table with multiple dots filter function path</span>' in filter_code
+    assert (
+        '<span class="caption-text">Filter code func table with multiple dots filter function path</span>'
+        in filter_code
+    )
 
     # check needflow works
     if int(doc_ver.split(".")[1]) >= 18:
@@ -62,8 +65,14 @@ def test_doc_needs_filter_data_html(test_app):
 
     # check needpie works
     assert '<img alt="_images/need_pie_dba00.svg" id="needpie-index-0"' in index_html
-    assert '<img alt="_images/need_pie_446e9.svg" id="needpie-filter_code-0"' in filter_code
-    assert '<img alt="_images/need_pie_fac86.svg" id="needpie-filter_code-1"' in filter_code
+    assert (
+        '<img alt="_images/need_pie_446e9.svg" id="needpie-filter_code-0"'
+        in filter_code
+    )
+    assert (
+        '<img alt="_images/need_pie_fac86.svg" id="needpie-filter_code-1"'
+        in filter_code
+    )
     # check needextend works
     assert (
         '<span class="needs_tags"><span class="needs_label">tags: </span>'
@@ -71,7 +80,7 @@ def test_doc_needs_filter_data_html(test_app):
         '<span class="needs_spacer">, </span><span class="needs_data">current_variant</span></span>'
         in index_html
     )
-    
+
 
 @pytest.mark.parametrize(
     "test_app",

--- a/tests/test_needs_filter_data.py
+++ b/tests/test_needs_filter_data.py
@@ -20,14 +20,17 @@ def test_doc_needs_filter_data_html(test_app):
     ).splitlines()
     print(warnings)
     assert warnings == [
-        "srcdir/filter_code.rst:26: WARNING: malformed function signature: 'own_filter_code(' [needs.filter_func]",
-        "srcdir/filter_code.rst:31: WARNING: malformed function signature: 'my_pie_filter_code(' [needs.filter_func]",
+        "srcdir/filter_code.rst:34: WARNING: malformed function signature: 'own_filter_code(' [needs.filter_func]",
+        "srcdir/filter_code.rst:43: WARNING: malformed function signature: 'own_filter_code(' [needs.filter_func]",
+        "srcdir/filter_code.rst:39: WARNING: malformed function signature: 'my_pie_filter_code(' [needs.filter_func]",
+        "srcdir/filter_code.rst:48: WARNING: malformed function signature: 'my_pie_filter_code(' [needs.filter_func]",
         "WARNING: variant_not_equal_current_variant: failed",
         "\t\tfailed needs: 1 (extern_filter_story_002)",
         "\t\tused filter: variant != current_variant [needs.warnings]",
     ]
 
     index_html = Path(app.outdir, "index.html").read_text()
+    filter_code = Path(app.outdir, "filter_code.html").read_text()
 
     # Check need_count works
     assert "The amount of needs that belong to current variants: 6" in index_html
@@ -45,6 +48,7 @@ def test_doc_needs_filter_data_html(test_app):
         '<td class="needs_tags"><p>my_tag<em>; </em>current_variant</p></td>'
         in index_html
     )
+    assert '<span class="caption-text">Filter code func table with multiple dots filter function path</span>' in filter_code
 
     # check needflow works
     if int(doc_ver.split(".")[1]) >= 18:
@@ -58,7 +62,8 @@ def test_doc_needs_filter_data_html(test_app):
 
     # check needpie works
     assert '<img alt="_images/need_pie_dba00.svg" id="needpie-index-0"' in index_html
-
+    assert '<img alt="_images/need_pie_446e9.svg" id="needpie-filter_code-0"' in filter_code
+    assert '<img alt="_images/need_pie_fac86.svg" id="needpie-filter_code-1"' in filter_code
     # check needextend works
     assert (
         '<span class="needs_tags"><span class="needs_label">tags: </span>'
@@ -66,7 +71,7 @@ def test_doc_needs_filter_data_html(test_app):
         '<span class="needs_spacer">, </span><span class="needs_data">current_variant</span></span>'
         in index_html
     )
-
+    
 
 @pytest.mark.parametrize(
     "test_app",


### PR DESCRIPTION
I just changed the split of the path of filter-func to split on the first dot starting from the right.
This means anything to the right will be the function name and anything to the left will be the module import path 
This Fix will close the issue #1372 