### PR TITLE
🐛 Fix: make external paths relative to `confdir`, not `srcdir`

### DIFF
--- a/sphinx_needs/external_needs.py
+++ b/sphinx_needs/external_needs.py
@@ -77,7 +77,7 @@ def load_external_needs(
             if os.path.isabs(source["json_path"]):
                 json_path = source["json_path"]
             else:
-                json_path = os.path.join(app.srcdir, source["json_path"])
+                json_path = os.path.join(app.confdir, source["json_path"])
 
             if not os.path.exists(json_path):
                 raise NeedsExternalException(


### PR DESCRIPTION
Paths set in the `conf.py` should be relative to it, not to the `srcdir`.
Note, often `confdir` and `srcdir` are equivalent, but this is not always the case.