### PR TITLE
📚 Fix markup for dynamic functions

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1136,7 +1136,7 @@ custom css definitions you need to update them.
 0.1.33
 ------
 * New feature: Directive :ref:`needimport` implemented
-* Improvement: needs-builder stores needs.json for all cases in the build directory (like _build/needs/needs.json) (See `issue comment <https://github.com/useblocks/sphinx-needs/issues/9#issuecomment-325010790>`_)
+* Improvement: needs-builder stores needs.json for all cases in the build directory (like _build/needs/needs.json) (See `issue <https://github.com/useblocks/sphinx-needs/issues/9>`_)
 * Bugfix: Wrong version in needs.json, if an existing needs.json got imported
 * Bugfix: Wrong need amount in initial needs.json fixed
 

--- a/docs/dynamic_functions.rst
+++ b/docs/dynamic_functions.rst
@@ -13,7 +13,7 @@ Or if you will request specific data from an external server like JIRA.
 To refer to a dynamic function, you can use the following syntax:
 
 - In a need directive option, wrap the function call in double square brackets: ``function_name(arg)``
-- In a need content, use the :ref:`ndf` role: ``:ndf:\`function_name(arg)\```
+- In a need content, use the :ref:`ndf` role: ``:ndf:`function_name(arg)```
 
 .. need-example:: Dynamic function example
 


### PR DESCRIPTION
Fix RST syntax in https://sphinx-needs.readthedocs.io/en/latest/dynamic_functions.html

![image](https://github.com/user-attachments/assets/0444f18d-d106-43fa-a848-e3d7bc8a16ea)

The linkcheck builder fails with a certain anchor. I removed it and just referred to the issue.