### PR TITLE
♻️ Make `needextend` argument declarative

### DIFF
--- a/docs/directives/needextend.rst
+++ b/docs/directives/needextend.rst
@@ -4,7 +4,7 @@ needextend
 ==========
 .. versionadded:: 0.7.0
 
-``needextend`` allows to modify existing needs. It doesn’t provide any output, as the modifications
+``needextend`` allows to modify existing needs. It doesn't provide any output, as the modifications
 get presented at the original location of the changing need, for example:
 
 .. code-block:: rst
@@ -20,7 +20,12 @@ The following modifications are supported:
 * ``+option``: add new value to an existing value of an option.
 * ``-option``: delete a complete option.
 
-The argument of ``needextend`` must be a :ref:`filter_string` which defines the needs to modify.
+The argument of ``needextend`` will be taken as, by order of priority:
+
+- a single need ID, if it is enclosed by ``<>``,
+- a :ref:`filter_string` if it is enclosed by ``""``,
+- a single need ID, if it is a single word (no spaces),
+- a :ref:`filter_string` otherwise.
 
 ``needextend`` can modify all string-based and list-based options.
 Also, you can add links or delete tags.
@@ -40,10 +45,25 @@ Also, you can add links or delete tags.
       | And a tag was added.
       | Finally all links got removed.
 
-   .. needextend:: id == "extend_test_001"
+   .. req:: needextend Example 2
+      :id: extend_test_002
+      :tags: extend_example
+      :status: open
+
+      Contents
+
+   .. needextend:: extend_test_001
       :status: closed
       :+author: and me
+
+   .. needextend:: <extend_test_001>
       :+tags: new_tag
+
+   .. needextend:: id == "extend_test_002"
+      :status: New status
+
+   .. needextend:: ""extend_example" in tags"
+      :+tags: other
 
 Options
 -------
@@ -71,26 +91,6 @@ Default: false
 
     We have a configuration (conf.py) option called :ref:`needs_needextend_strict`
     that deactivates or activates the ``:strict:`` option behaviour for all ``needextend`` directives in a project.
-
-
-Single need modification
-------------------------
-If only one single need shall get modified, the argument of ``needextend`` can just be the need-id.
-
-.. need-example::
-
-    .. req:: needextend Example 2
-       :id: extend_test_002
-       :status: open
-
-    .. needextend:: extend_test_002
-       :status: New status
-
-.. attention::
-
-    The given argument must fully match the regular expression defined in
-    :ref:`needs_id_regex` and a need with this ID must exist!
-    Otherwise the argument is taken as normal filter string.
 
 Setting default option values
 -----------------------------

--- a/sphinx_needs/data.py
+++ b/sphinx_needs/data.py
@@ -567,7 +567,7 @@ class NeedsExtendType(NeedsBaseDataType):
     """Data to modify existing need(s)."""
 
     filter: str
-    """Filter string to select needs to extebd."""
+    """Filter string to select needs to extend."""
     filter_is_id: bool
     """Whether the filter is a single need ID."""
     modifications: dict[str, Any]

--- a/sphinx_needs/data.py
+++ b/sphinx_needs/data.py
@@ -566,9 +566,11 @@ class NeedsBarType(NeedsBaseDataType):
 class NeedsExtendType(NeedsBaseDataType):
     """Data to modify existing need(s)."""
 
-    filter: None | str
-    """Single need ID or filter string to select multiple needs."""
-    modifications: dict[str, str]
+    filter: str
+    """Filter string to select needs to extebd."""
+    filter_is_id: bool
+    """Whether the filter is a single need ID."""
+    modifications: dict[str, Any]
     """Mapping of field name to new value.
     If the field name starts with a ``+``, the new value is appended to the existing value.
     If the field name starts with a ``-``, the existing value is cleared (new value is ignored).

--- a/tests/doc_test/doc_needextend_unknown_id/index.rst
+++ b/tests/doc_test/doc_needextend_unknown_id/index.rst
@@ -21,6 +21,6 @@ needextend warnings
 
 .. needextend:: <id with space>
 .. needextend:: "bad_filter"
-.. needextend::  bad filter
+.. needextend::  bad == filter
 .. needextend:: <>
 .. needextend:: ""

--- a/tests/doc_test/doc_needextend_unknown_id/index.rst
+++ b/tests/doc_test/doc_needextend_unknown_id/index.rst
@@ -1,5 +1,5 @@
-needextend unknown id
-=====================
+needextend warnings
+===================
 
 .. story:: needextend Example 3
    :id: extend_test_003
@@ -18,3 +18,9 @@ needextend unknown id
 
 .. needextend:: unknown_id
    :status: open
+
+.. needextend:: <id with space>
+.. needextend:: "bad_filter"
+.. needextend::  bad filter
+.. needextend:: <>
+.. needextend:: ""

--- a/tests/test_needextend.py
+++ b/tests/test_needextend.py
@@ -1,4 +1,5 @@
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -54,13 +55,21 @@ def test_doc_needextend_html(test_app: Sphinx, snapshot):
     ],
     indirect=True,
 )
-def test_doc_needextend_unknown_id(test_app: Sphinx):
+def test_doc_needextend_warnings(test_app: Sphinx):
     app = test_app
     app.build()
 
-    warnings = strip_colors(app._warning.getvalue()).splitlines()
+    warnings = strip_colors(
+        app._warning.getvalue().replace(str(app.srcdir) + os.path.sep, "<srcdir>/")
+    ).splitlines()
+    print(warnings)
     assert warnings == [
-        f"{Path(str(app.srcdir)) / 'index.rst'}:19: WARNING: Provided id 'unknown_id' for needextend does not exist. [needs.needextend]"
+        "<srcdir>/index.rst:25: WARNING: Empty ID/filter argument in needextend directive. [needs.needextend]",
+        "<srcdir>/index.rst:26: WARNING: Empty ID/filter argument in needextend directive. [needs.needextend]",
+        "<srcdir>/index.rst:19: WARNING: Provided id 'unknown_id' for needextend does not exist. [needs.needextend]",
+        "<srcdir>/index.rst:22: WARNING: Provided id 'id with space' for needextend does not exist. [needs.needextend]",
+        "<srcdir>/index.rst:23: WARNING: Filter 'bad_filter' not valid. Error: name 'bad_filter' is not defined. [needs.filter]",
+        "<srcdir>/index.rst:24: WARNING: Invalid filter 'bad filter': unexpected EOF while parsing (<string>, line 1) [needs.needextend]",
     ]
 
 

--- a/tests/test_needextend.py
+++ b/tests/test_needextend.py
@@ -62,14 +62,14 @@ def test_doc_needextend_warnings(test_app: Sphinx):
     warnings = strip_colors(
         app._warning.getvalue().replace(str(app.srcdir) + os.path.sep, "<srcdir>/")
     ).splitlines()
-    print(warnings)
+    # print(warnings)
     assert warnings == [
         "<srcdir>/index.rst:25: WARNING: Empty ID/filter argument in needextend directive. [needs.needextend]",
         "<srcdir>/index.rst:26: WARNING: Empty ID/filter argument in needextend directive. [needs.needextend]",
         "<srcdir>/index.rst:19: WARNING: Provided id 'unknown_id' for needextend does not exist. [needs.needextend]",
         "<srcdir>/index.rst:22: WARNING: Provided id 'id with space' for needextend does not exist. [needs.needextend]",
         "<srcdir>/index.rst:23: WARNING: Filter 'bad_filter' not valid. Error: name 'bad_filter' is not defined. [needs.filter]",
-        "<srcdir>/index.rst:24: WARNING: Invalid filter 'bad filter': unexpected EOF while parsing (<string>, line 1) [needs.needextend]",
+        "<srcdir>/index.rst:24: WARNING: Filter 'bad == filter' not valid. Error: name 'bad' is not defined. [needs.filter]",
     ]
 
 


### PR DESCRIPTION
The argument for `needextend` can refer to either a single need ID or filter function.
Currently, the format cannot be known until all needs have been processed, and it is resolved during post-processing.
This is problematic for (a) user readability, (b) improving processing performance and issue feedback

This PR slightly modifies the argument processing to allow for two "explicit" formats:

- `<ID>`, if the argument is enclosed in `<>` it is always processed as a single ID
- `"filter string"`, if the argument is enclosed in `""` it is always processed as a filter string

If the string is not enclosed, then the logic is relatively similar to the existing:

- `ID`, if the argument is a single word (no spaces) then it is processed as a single ID
- otherwise, it is processed as a filter string

This change should not break most uses of `needextend`, but there are some corner-cases that would need to be adapted, e.g. a single `is_external` would now be processed as an ID, unless it was enclosed or expanded:

```restructuredtext
.. needextend:: "is_external"
.. needextend:: is_external is True
```