### PR TITLE
🔧 Remove `constraints_passed`/`constraints_results` directive options

### DIFF
--- a/sphinx_needs/defaults.py
+++ b/sphinx_needs/defaults.py
@@ -269,8 +269,6 @@ NEED_DEFAULT_OPTIONS: dict[str, Any] = {
     "pre_template": directives.unchanged_required,
     "post_template": directives.unchanged_required,
     "constraints": directives.unchanged_required,
-    "constraints_passed": directives.unchanged_required,
-    "constraints_results": directives.unchanged_required,
 }
 
 NEEDS_PROFILING = [x.upper() for x in os.environ.get("NEEDS_PROFILING", "").split(",")]


### PR DESCRIPTION
These are post-processed internal fields, and so the directive options do not make sense and are in fact not used