### PR TITLE
🔧 Deprecate use of dynamic functions in need type fields

### DIFF
--- a/docs/dynamic_functions.rst
+++ b/docs/dynamic_functions.rst
@@ -24,7 +24,7 @@ To refer to a dynamic function, you can use the following syntax:
 
       This need has id :ndf:`copy("id")` and status :ndf:`copy("status")`.
 
-Dynamic functions can be used for the directive title, and the following directive options:
+Dynamic functions can be used for the following directive options:
 
 - ``status``
 - ``tags``

--- a/docs/dynamic_functions.rst
+++ b/docs/dynamic_functions.rst
@@ -24,6 +24,16 @@ To refer to a dynamic function, you can use the following syntax:
 
       This need has id :ndf:`copy("id")` and status :ndf:`copy("status")`.
 
+Dynamic functions can be used for the directive title, and the following directive options:
+
+- ``status``
+- ``tags``
+- ``style``
+- ``constraints``
+- :ref:`needs_extra_options`
+- :ref:`needs_extra_links`
+- :ref:`needs_global_options`
+
 .. deprecated:: 3.1.0
 
    The :ref:`ndf` role replaces the use of the ``[[...]]`` syntax in need content.

--- a/sphinx_needs/data.py
+++ b/sphinx_needs/data.py
@@ -64,6 +64,8 @@ class CoreFieldParameters(TypedDict):
     """Whether field can be modified by needextend (False if not present)."""
     allow_df: NotRequired[bool]
     """Whether dynamic functions are allowed for this field (False if not present)."""
+    deprecate_df: NotRequired[bool]
+    """Whether dynamic functions are deprecated for this field (False if not present)."""
     show_in_layout: NotRequired[bool]
     """Whether to show the field in the rendered layout of the need by default (False if not present)."""
     exclude_external: NotRequired[bool]
@@ -170,14 +172,14 @@ NeedsCoreFields: Final[Mapping[str, CoreFieldParameters]] = {
     "type": {
         "description": "Type of the need.",
         "schema": {"type": "string", "default": ""},
-        "allow_df": True,
+        "deprecate_df": True,
     },
     "type_name": {
         "description": "Name of the type.",
         "schema": {"type": "string", "default": ""},
         "exclude_external": True,
         "exclude_import": True,
-        "allow_df": True,
+        "deprecate_df": True,
     },
     "type_prefix": {
         "description": "Prefix of the type.",
@@ -185,7 +187,7 @@ NeedsCoreFields: Final[Mapping[str, CoreFieldParameters]] = {
         "exclude_json": True,
         "exclude_external": True,
         "exclude_import": True,
-        "allow_df": True,
+        "deprecate_df": True,
     },
     "type_color": {
         "description": "Hexadecimal color code of the type.",
@@ -193,7 +195,7 @@ NeedsCoreFields: Final[Mapping[str, CoreFieldParameters]] = {
         "exclude_json": True,
         "exclude_external": True,
         "exclude_import": True,
-        "allow_df": True,
+        "deprecate_df": True,
     },
     "type_style": {
         "description": "Style of the type.",
@@ -201,7 +203,7 @@ NeedsCoreFields: Final[Mapping[str, CoreFieldParameters]] = {
         "exclude_json": True,
         "exclude_external": True,
         "exclude_import": True,
-        "allow_df": True,
+        "deprecate_df": True,
     },
     "is_modified": {
         "description": "Whether the need was modified by needextend.",


### PR DESCRIPTION
It is unintended and unlikely the dynamic functions would have been used in there fields, but just in case we issue a warning of the deprecation, so that we can remove them in the future

fields affected: `type`, `type_name`, `type_prefix`, `type_color`, `type_style`.

this follows on from #1387 and the fields now allowed are:

- ``title``
- ``status``
- ``tags``
- ``style``
- ``constraints``
- all `needs_extra_options`
- all `needs_extra_links`
- all `needs_global_options`

---

Note, there are still maybe some outstanding questions about where dynamic functions should be processed:
- should they be processed for the need title?
- should they be processed at all for needs coming from external and/or needimport `needs.json`?