### PR TITLE
♻️ Restrict `needs_global_options` keys

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -279,13 +279,29 @@ And use it like:
 needs_global_options
 ~~~~~~~~~~~~~~~~~~~~
 .. versionadded:: 0.3.0
+.. versionchanged:: 5.1.0
 
-Global options are set on global level for all needs, so that all needs get the same value for the configured option.
+    Unknown keys are no longer accepted,
+    these should also be set in the :ref:`needs_extra_options` list.
+
+This configuration allows for global defaults to be set for all needs,
+for any of the following fields:
+
+- any ``needs_extra_options`` item
+- any ``needs_extra_links`` item
+- ``collapse``
+- ``constraints``
+- ``hide``
+- ``layout``
+- ``status``
+- ``style``
+- ``tags``
 
 .. code-block:: python
 
+   needs_extra_options = ["option1"]
    needs_global_options = {
-      'global_option': 'Fix value'
+      'option1': 'Fix value'
    }
 
 Default value: ``{}``
@@ -294,8 +310,9 @@ You can combine global options with :ref:`dynamic_functions` to automate data ha
 
 .. code-block:: python
 
+   needs_extra_options = ["option1"]
    needs_global_options = {
-         'global_option': '[[copy("id")]]'
+        'option1': '[[copy("id")]]'
    }
 
 .. _global_option_filters:
@@ -316,6 +333,7 @@ To use filters for global_options, the given value must be a tuple containing th
 
 .. code-block:: python
 
+   needs_extra_options = ["author", "req_id"]
    needs_global_options = {
       # Without default value
       'status': ('closed', 'status.lower() in ["done", "resolved", "closed"]')

--- a/sphinx_needs/data.py
+++ b/sphinx_needs/data.py
@@ -60,6 +60,8 @@ class CoreFieldParameters(TypedDict):
     """Description of the field."""
     schema: dict[str, Any]
     """JSON schema for the field."""
+    allow_default: NotRequired[bool]
+    """Whether the field allows custom default values to be set, via needs_global_options (False if not present)."""
     allow_extend: NotRequired[bool]
     """Whether field can be modified by needextend (False if not present)."""
     allow_df: NotRequired[bool]
@@ -106,6 +108,7 @@ NeedsCoreFields: Final[Mapping[str, CoreFieldParameters]] = {
         "description": "Status of the need.",
         "schema": {"type": ["string", "null"], "default": None},
         "show_in_layout": True,
+        "allow_default": True,
         "allow_df": True,
         "allow_extend": True,
     },
@@ -113,6 +116,7 @@ NeedsCoreFields: Final[Mapping[str, CoreFieldParameters]] = {
         "description": "List of tags.",
         "schema": {"type": "array", "items": {"type": "string"}, "default": []},
         "show_in_layout": True,
+        "allow_default": True,
         "allow_df": True,
         "allow_extend": True,
     },
@@ -121,6 +125,7 @@ NeedsCoreFields: Final[Mapping[str, CoreFieldParameters]] = {
         "schema": {"type": "boolean", "default": False},
         "exclude_json": True,
         "exclude_external": True,
+        "allow_default": True,
         "allow_extend": True,
     },
     "hide": {
@@ -128,12 +133,14 @@ NeedsCoreFields: Final[Mapping[str, CoreFieldParameters]] = {
         "schema": {"type": "boolean", "default": False},
         "exclude_json": True,
         "exclude_external": True,
+        "allow_default": True,
         "allow_extend": True,
     },
     "layout": {
         "description": "Key of the layout, which is used to render the need.",
         "schema": {"type": ["string", "null"], "default": None},
         "show_in_layout": True,
+        "allow_default": True,
         "exclude_external": True,
     },
     "style": {
@@ -141,6 +148,7 @@ NeedsCoreFields: Final[Mapping[str, CoreFieldParameters]] = {
         "schema": {"type": ["string", "null"], "default": None},
         "show_in_layout": True,
         "exclude_external": True,
+        "allow_default": True,
         "allow_df": True,
         "allow_extend": True,
     },
@@ -302,6 +310,7 @@ NeedsCoreFields: Final[Mapping[str, CoreFieldParameters]] = {
     "constraints": {
         "description": "List of constraint names, which are defined for this need.",
         "schema": {"type": "array", "items": {"type": "string"}, "default": []},
+        "allow_default": True,
         "allow_df": True,
         "allow_extend": True,
     },

--- a/sphinx_needs/needs.py
+++ b/sphinx_needs/needs.py
@@ -726,6 +726,23 @@ def check_configuration(app: Sphinx, config: Config) -> None:
                 "This is not allowed."
             )
 
+    # check all global option keys are valid
+    allowed_internal_defaults = {
+        k for k, v in NeedsCoreFields.items() if v.get("allow_default") is True
+    }
+    for key in needs_config.global_options:
+        if not (
+            key in extra_options
+            or key in link_types
+            or key in allowed_internal_defaults
+        ):
+            log_warning(
+                LOGGER,
+                f"needs_global_options key {key!r} must also exist in needs_extra_options, needs_extra_links, or {sorted(allowed_internal_defaults)}",
+                "deprecated",
+                None,
+            )
+
 
 class NeedsConfigException(SphinxError):
     pass

--- a/tests/__snapshots__/test_global_options.ambr
+++ b/tests/__snapshots__/test_global_options.ambr
@@ -1,0 +1,38 @@
+# serializer version: 1
+# name: test_doc_global_option[test_app0]
+  dict({
+    'current_version': '',
+    'versions': dict({
+      '': dict({
+        'needs': dict({
+          'GLOBAL_ID_1': dict({
+            'docname': 'index',
+            'external_css': 'external_link',
+            'global_1': 'other',
+            'global_2': 1.27,
+            'global_3': 'Test output of dynamic function; need: GLOBAL_ID_1; args: (); kwargs: {}',
+            'global_4': 'STATUS_IMPL',
+            'global_5': 'STATUS_UNKNOWN',
+            'id': 'GLOBAL_ID_1',
+            'layout': '',
+            'lineno': 4,
+            'section_name': 'GLOBAL OPTIONS',
+            'sections': list([
+              'GLOBAL OPTIONS',
+            ]),
+            'status': 'implemented',
+            'tags': list([
+              'test',
+              'test2',
+            ]),
+            'title': 'Command line interface',
+            'type': 'spec',
+            'type_name': 'Specification',
+          }),
+        }),
+        'needs_amount': 1,
+        'needs_defaults_removed': True,
+      }),
+    }),
+  })
+# ---

--- a/tests/doc_test/doc_global_options/conf.py
+++ b/tests/doc_test/doc_global_options/conf.py
@@ -31,6 +31,8 @@ needs_types = [
     },
 ]
 
+needs_extra_options = ["global_1", "global_2", "global_3", "global_4"]
+
 needs_global_options = {
     "global_1": "test_global",
     "global_2": 1.27,
@@ -38,3 +40,6 @@ needs_global_options = {
     "global_4": ("STATUS_IMPL", 'status == "implemented"'),
     "global_5": ("STATUS_CLOSED", 'status == "closed"', "STATUS_UNKNOWN"),
 }
+
+needs_build_json = True
+needs_json_remove_defaults = True

--- a/tests/doc_test/doc_global_options/index.rst
+++ b/tests/doc_test/doc_global_options/index.rst
@@ -2,6 +2,7 @@ GLOBAL OPTIONS
 ==============
 
 .. spec:: Command line interface
-    :id: GLOBAL_ID
+    :id: GLOBAL_ID_1
     :status: implemented
     :tags: test;test2
+    :global_1: other

--- a/tests/test_global_options.py
+++ b/tests/test_global_options.py
@@ -1,28 +1,35 @@
+import json
+import os
 from pathlib import Path
 
 import pytest
+from sphinx.util.console import strip_colors
+from syrupy.filters import props
 
 
 @pytest.mark.parametrize(
     "test_app",
-    [{"buildername": "html", "srcdir": "doc_test/doc_global_options"}],
+    [
+        {
+            "buildername": "html",
+            "srcdir": "doc_test/doc_global_options",
+            "no_plantuml": True,
+        }
+    ],
     indirect=True,
 )
-def test_doc_global_option(test_app):
-    app = test_app
-    app.build()
-    html = Path(app.outdir, "index.html").read_text()
+def test_doc_global_option(test_app, snapshot):
+    test_app.build()
+    warnings = strip_colors(
+        test_app._warning.getvalue().replace(str(test_app.srcdir) + os.sep, "srcdir/")
+    ).splitlines()
+    print(warnings)
+    assert warnings == [
+        "WARNING: needs_global_options key 'global_5' must also exist in needs_extra_options, needs_extra_links, or ['collapse', 'constraints', 'hide', 'layout', 'status', 'style', 'tags'] [needs.deprecated]"
+    ]
 
-    assert "global_1" in html
-    assert "global_2" in html
-    assert "global_3" in html
-    assert "global_4" in html
-    assert "global_5" in html
-
-    assert "test_global" in html
-    assert "1.27" in html
-    assert "Test output of dynamic function; need: GLOBAL_ID" in html
-
-    assert "STATUS_IMPL" in html
-    assert "STATUS_UNKNOWN" in html
-    assert "STATUS_CLOSED" not in html
+    json_data = Path(test_app.outdir, "needs.json").read_text()
+    needs = json.loads(json_data)
+    assert needs == snapshot(
+        exclude=props("created", "project", "creator", "needs_schema")
+    )


### PR DESCRIPTION
As discussed in #1409,
`needs_global_options` has overlapping functionality with `needs_extra_options`.
It makes more sense that `needs_global_options` is only used to define defaults for fields,
whereas `needs_extra_options` is for specifying new fields.

This PR restricts the keys allowed to:

- any ``needs_extra_options`` item
- any ``needs_extra_links`` item
- ``collapse``
- ``constraints``
- ``hide``
- ``layout``
- ``status``
- ``style``
- ``tags``

Currently, just a deprecation warning is emitted, and no actual functionality is changed;
this will be left for change in a later version