### PR TITLE
♻️ Change `needs_global_options` format

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -341,6 +341,7 @@ This can be provided in a few ways:
    needs_global_options = {
       # if field1 is unset and status is "done", set field1 to "a"
       'field1': ('a', 'status == "done"')
+   }
 
 .. code-block:: python
 
@@ -350,6 +351,7 @@ This can be provided in a few ways:
       #     if status is "done", set to "a",
       #     else, set to "b"
       'field1': ('a', 'status == "done"', 'b')
+   }
 
 .. code-block:: python
 
@@ -365,6 +367,7 @@ This can be provided in a few ways:
             ('b', 'status == "ongoing"'),
             ('c', 'status == "other"', 'd')
         ]
+   }
 
 .. warning::
 

--- a/sphinx_needs/api/need.py
+++ b/sphinx_needs/api/need.py
@@ -811,7 +811,7 @@ def _set_field_defaults(needs_info: NeedsInfoType, config: NeedsSphinxConfig) ->
     for key, defaults in config.field_defaults.items():
         if key not in needs_info or needs_info[key]:
             continue
-        for predicate, v in defaults.get("predicate_defaults", []):
+        for predicate, v in defaults.get("predicates", []):
             # use the first predicate that is satisfied
             if filter_single_need(needs_info, config, predicate):
                 needs_info[key] = v

--- a/sphinx_needs/config.py
+++ b/sphinx_needs/config.py
@@ -36,7 +36,7 @@ class ExtraOptionParams:
 class FieldDefault(TypedDict):
     """Defines a default value for a field."""
 
-    predicate_defaults: NotRequired[list[tuple[str, Any]]]
+    predicates: NotRequired[list[tuple[str, Any]]]
     """List of (need filter, value) pairs for default predicate values.
 
     Used if the field has not been specifically set.

--- a/tests/__snapshots__/test_global_options.ambr
+++ b/tests/__snapshots__/test_global_options.ambr
@@ -13,7 +13,7 @@
       'default': list([
         'SPEC_1',
       ]),
-      'predicate_defaults': list([
+      'predicates': list([
         tuple(
           'status == "implemented"',
           list([
@@ -36,7 +36,7 @@
       'default': "[[copy('id')]]",
     }),
     'option_3': dict({
-      'predicate_defaults': list([
+      'predicates': list([
         tuple(
           'status == "implemented"',
           'STATUS_IMPL',
@@ -45,7 +45,7 @@
     }),
     'option_4': dict({
       'default': 'STATUS_UNKNOWN',
-      'predicate_defaults': list([
+      'predicates': list([
         tuple(
           'status == "closed"',
           'STATUS_CLOSED',
@@ -54,7 +54,7 @@
     }),
     'option_5': dict({
       'default': 'final',
-      'predicate_defaults': list([
+      'predicates': list([
         tuple(
           'status == "implemented"',
           'STATUS_IMPL',
@@ -69,7 +69,7 @@
       'default': list([
         'd',
       ]),
-      'predicate_defaults': list([
+      'predicates': list([
         tuple(
           'status == "implemented"',
           list([
@@ -88,6 +88,209 @@
   })
 # ---
 # name: test_doc_global_option[test_app0].1
+  dict({
+    'current_version': '',
+    'versions': dict({
+      '': dict({
+        'needs': dict({
+          'SPEC_1': dict({
+            'docname': 'index',
+            'external_css': 'external_link',
+            'id': 'SPEC_1',
+            'layout': 'clean_l',
+            'lineno': 4,
+            'link1': list([
+              'SPEC_1',
+            ]),
+            'link1_back': list([
+              'SPEC_1',
+              'SPEC_2',
+              'SPEC_3',
+            ]),
+            'link2': list([
+              'SPEC_2',
+              'SPEC_1',
+            ]),
+            'link2_back': list([
+              'SPEC_1',
+              'SPEC_3',
+            ]),
+            'option_1': 'other',
+            'option_2': 'SPEC_1',
+            'option_3': 'STATUS_IMPL',
+            'option_4': 'STATUS_UNKNOWN',
+            'option_5': 'STATUS_IMPL',
+            'section_name': 'GLOBAL OPTIONS',
+            'sections': list([
+              'GLOBAL OPTIONS',
+            ]),
+            'status': 'implemented',
+            'tags': list([
+              'a',
+              'b',
+            ]),
+            'title': 'Specification 1',
+            'type': 'spec',
+            'type_name': 'Specification',
+          }),
+          'SPEC_2': dict({
+            'docname': 'index',
+            'external_css': 'external_link',
+            'id': 'SPEC_2',
+            'layout': 'clean_l',
+            'lineno': 9,
+            'link1': list([
+              'SPEC_1',
+            ]),
+            'link2': list([
+              'SPEC_3',
+            ]),
+            'link2_back': list([
+              'SPEC_1',
+            ]),
+            'option_1': 'test_global',
+            'option_2': 'SPEC_2',
+            'option_4': 'STATUS_CLOSED',
+            'option_5': 'STATUS_CLOSED',
+            'section_name': 'GLOBAL OPTIONS',
+            'sections': list([
+              'GLOBAL OPTIONS',
+            ]),
+            'status': 'closed',
+            'tags': list([
+              'c',
+            ]),
+            'title': 'Specification 2',
+            'type': 'spec',
+            'type_name': 'Specification',
+          }),
+          'SPEC_3': dict({
+            'docname': 'index',
+            'external_css': 'external_link',
+            'id': 'SPEC_3',
+            'layout': 'clean_l',
+            'lineno': 13,
+            'link1': list([
+              'SPEC_1',
+            ]),
+            'link2': list([
+              'SPEC_1',
+            ]),
+            'link2_back': list([
+              'SPEC_2',
+            ]),
+            'option_1': 'test_global',
+            'option_2': 'SPEC_3',
+            'option_4': 'STATUS_UNKNOWN',
+            'option_5': 'final',
+            'section_name': 'GLOBAL OPTIONS',
+            'sections': list([
+              'GLOBAL OPTIONS',
+            ]),
+            'status': 'other',
+            'tags': list([
+              'd',
+            ]),
+            'title': 'Specification 3',
+            'type': 'spec',
+            'type_name': 'Specification',
+          }),
+        }),
+        'needs_amount': 3,
+        'needs_defaults_removed': True,
+      }),
+    }),
+  })
+# ---
+# name: test_doc_global_option_old[test_app0]
+  dict({
+    'layout': dict({
+      'default': 'clean_l',
+    }),
+    'link1': dict({
+      'default': list([
+        'SPEC_1',
+      ]),
+    }),
+    'link2': dict({
+      'default': list([
+        'SPEC_1',
+      ]),
+      'predicates': list([
+        tuple(
+          'status == "implemented"',
+          list([
+            'SPEC_2',
+            "[[copy('link1')]]",
+          ]),
+        ),
+        tuple(
+          'status == "closed"',
+          list([
+            'SPEC_3',
+          ]),
+        ),
+      ]),
+    }),
+    'option_1': dict({
+      'default': 'test_global',
+    }),
+    'option_2': dict({
+      'default': "[[copy('id')]]",
+    }),
+    'option_3': dict({
+      'predicates': list([
+        tuple(
+          'status == "implemented"',
+          'STATUS_IMPL',
+        ),
+      ]),
+    }),
+    'option_4': dict({
+      'default': 'STATUS_UNKNOWN',
+      'predicates': list([
+        tuple(
+          'status == "closed"',
+          'STATUS_CLOSED',
+        ),
+      ]),
+    }),
+    'option_5': dict({
+      'default': 'final',
+      'predicates': list([
+        tuple(
+          'status == "implemented"',
+          'STATUS_IMPL',
+        ),
+        tuple(
+          'status == "closed"',
+          'STATUS_CLOSED',
+        ),
+      ]),
+    }),
+    'tags': dict({
+      'default': list([
+        'd',
+      ]),
+      'predicates': list([
+        tuple(
+          'status == "implemented"',
+          list([
+            'a',
+            'b',
+          ]),
+        ),
+        tuple(
+          'status == "closed"',
+          list([
+            'c',
+          ]),
+        ),
+      ]),
+    }),
+  })
+# ---
+# name: test_doc_global_option_old[test_app0].1
   dict({
     'current_version': '',
     'versions': dict({

--- a/tests/doc_test/doc_global_options/conf.py
+++ b/tests/doc_test/doc_global_options/conf.py
@@ -37,28 +37,40 @@ needs_extra_options = [
 ]
 
 needs_global_options = {
-    "layout": "clean_l",
-    "option_1": "test_global",
-    "option_2": "[[copy('id')]]",
-    "option_3": ("STATUS_IMPL", 'status == "implemented"'),
-    "option_4": ("STATUS_CLOSED", 'status == "closed"', "STATUS_UNKNOWN"),
-    "option_5": [
-        ("STATUS_IMPL", 'status == "implemented"', "bad"),
-        ("STATUS_CLOSED", 'status == "closed"', "final"),
-    ],
-    "link1": "SPEC_1",
-    "link2": [
-        ("SPEC_2,[[copy('link1')", 'status == "implemented"'),
-        ("SPEC_3", 'status == "closed"', ["SPEC_1"]),
-    ],
-    "link3": 1,
-    "tags": [
-        ("a,b", 'status == "implemented"'),
-        ("c", 'status == "closed"', ["d"]),
-    ],
-    "bad_value_type": 1.27,
-    "too_many_params": ("a", "b", "c", "d"),
-    "unknown": "unknown",
+    "layout": {"default": "clean_l"},
+    "option_1": {"default": "test_global"},
+    "option_2": {"default": "[[copy('id')]]"},
+    "option_3": {"predicates": [('status == "implemented"', "STATUS_IMPL")]},
+    "option_4": {
+        "default": "STATUS_UNKNOWN",
+        "predicates": [('status == "closed"', "STATUS_CLOSED")],
+    },
+    "option_5": {
+        "predicates": [
+            ('status == "implemented"', "STATUS_IMPL"),
+            ('status == "closed"', "STATUS_CLOSED"),
+        ],
+        "default": "final",
+    },
+    "link1": {"default": ["SPEC_1"]},
+    "link2": {
+        "predicates": [
+            ('status == "implemented"', ["SPEC_2", "[[copy('link1')]]"]),
+            ('status == "closed"', ["SPEC_3"]),
+        ],
+        "default": ["SPEC_1"],
+    },
+    "tags": {
+        "predicates": [
+            ('status == "implemented"', ["a", "b"]),
+            ('status == "closed"', ["c"]),
+        ],
+        "default": ["d"],
+    },
+    "link3": {"default": 1},
+    "bad_value_type": {"default": 1.27},
+    "too_many_params": {"predicates": [("a", "b", "c", "d")]},
+    "unknown": {"default": "unknown"},
 }
 
 needs_build_json = True

--- a/tests/doc_test/doc_global_options_old/conf.py
+++ b/tests/doc_test/doc_global_options_old/conf.py
@@ -1,0 +1,65 @@
+extensions = ["sphinx_needs"]
+
+needs_types = [
+    {
+        "directive": "spec",
+        "title": "Specification",
+        "prefix": "SP_",
+    }
+]
+
+needs_extra_links = [
+    {
+        "option": "link1",
+        "incoming": "is linked by",
+        "outgoing": "links to",
+    },
+    {
+        "option": "link2",
+        "incoming": "is linked by",
+        "outgoing": "links to",
+    },
+    {
+        "option": "link3",
+        "incoming": "is linked by",
+        "outgoing": "links to",
+    },
+]
+
+needs_extra_options = [
+    "option_1",
+    "option_2",
+    "option_3",
+    "option_4",
+    "option_5",
+    "bad_value_type",
+    "too_many_params",
+]
+
+needs_global_options = {
+    "layout": "clean_l",
+    "option_1": "test_global",
+    "option_2": "[[copy('id')]]",
+    "option_3": ("STATUS_IMPL", 'status == "implemented"'),
+    "option_4": ("STATUS_CLOSED", 'status == "closed"', "STATUS_UNKNOWN"),
+    "option_5": [
+        ("STATUS_IMPL", 'status == "implemented"', "bad"),
+        ("STATUS_CLOSED", 'status == "closed"', "final"),
+    ],
+    "link1": "SPEC_1",
+    "link2": [
+        ("SPEC_2,[[copy('link1')", 'status == "implemented"'),
+        ("SPEC_3", 'status == "closed"', ["SPEC_1"]),
+    ],
+    "link3": 1,
+    "tags": [
+        ("a,b", 'status == "implemented"'),
+        ("c", 'status == "closed"', ["d"]),
+    ],
+    "bad_value_type": 1.27,
+    "too_many_params": ("a", "b", "c", "d"),
+    "unknown": "unknown",
+}
+
+needs_build_json = True
+needs_json_remove_defaults = True

--- a/tests/doc_test/doc_global_options_old/index.rst
+++ b/tests/doc_test/doc_global_options_old/index.rst
@@ -1,0 +1,15 @@
+GLOBAL OPTIONS
+==============
+
+.. spec:: Specification 1
+    :id: SPEC_1
+    :status: implemented
+    :option_1: other
+
+.. spec:: Specification 2
+    :id: SPEC_2
+    :status: closed
+
+.. spec:: Specification 3
+    :id: SPEC_3
+    :status: other

--- a/tests/test_global_options.py
+++ b/tests/test_global_options.py
@@ -14,6 +14,42 @@ from sphinx_needs.config import NeedsSphinxConfig
     [
         {
             "buildername": "html",
+            "srcdir": "doc_test/doc_global_options_old",
+            "no_plantuml": True,
+        }
+    ],
+    indirect=True,
+)
+def test_doc_global_option_old(test_app, snapshot):
+    test_app.build()
+    warnings = strip_colors(
+        test_app._warning.getvalue().replace(str(test_app.srcdir) + os.sep, "srcdir/")
+    ).splitlines()
+    assert warnings == [
+        "WARNING: needs_global_options 'option_5', item 0, has default value but is not the last item [needs.config]",
+        "WARNING: Dynamic function not closed correctly:  (in needs_global_options) [needs.dynamic_function]",
+        "WARNING: needs_global_options 'link3' has a default value that is not of type 'str_list' [needs.config]",
+        "WARNING: needs_global_options 'bad_value_type' has a default value that is not of type 'str' [needs.config]",
+        "WARNING: needs_global_options 'too_many_params' has an unknown value format [needs.config]",
+        "WARNING: needs_global_options 'unknown' must also exist in needs_extra_options, needs_extra_links, or ['constraints', 'layout', 'status', 'style', 'tags'] [needs.config]",
+        "WARNING: needs_global_options uses old, non-dict, format. please update to new format: {'layout': {'default': 'clean_l'}, 'option_1': {'default': 'test_global'}, 'option_2': {'default': \"[[copy('id')]]\"}, 'option_3': {'predicates': [('status == \"implemented\"', 'STATUS_IMPL')]}, 'option_4': {'predicates': [('status == \"closed\"', 'STATUS_CLOSED')], 'default': 'STATUS_UNKNOWN'}, 'option_5': {'predicates': [('status == \"implemented\"', 'STATUS_IMPL'), ('status == \"closed\"', 'STATUS_CLOSED')], 'default': 'final'}, 'link1': {'default': ['SPEC_1']}, 'link2': {'predicates': [('status == \"implemented\"', ['SPEC_2', \"[[copy('link1')]]\"]), ('status == \"closed\"', ['SPEC_3'])], 'default': ['SPEC_1']}, 'tags': {'predicates': [('status == \"implemented\"', ['a', 'b']), ('status == \"closed\"', ['c'])], 'default': ['d']}} [needs.deprecated]",
+    ]
+
+    needs_config = NeedsSphinxConfig(test_app.config)
+    assert needs_config.field_defaults == snapshot
+
+    json_data = Path(test_app.outdir, "needs.json").read_text()
+    needs = json.loads(json_data)
+    assert needs == snapshot(
+        exclude=props("created", "project", "creator", "needs_schema")
+    )
+
+
+@pytest.mark.parametrize(
+    "test_app",
+    [
+        {
+            "buildername": "html",
             "srcdir": "doc_test/doc_global_options",
             "no_plantuml": True,
         }
@@ -25,14 +61,11 @@ def test_doc_global_option(test_app, snapshot):
     warnings = strip_colors(
         test_app._warning.getvalue().replace(str(test_app.srcdir) + os.sep, "srcdir/")
     ).splitlines()
-    print(warnings)
     assert warnings == [
-        "WARNING: needs_global_options key 'option_5', item 0 has default value but is not the last item [needs.config]",
-        "WARNING: Dynamic function not closed correctly:  (in needs_global_options) [needs.dynamic_function]",
-        "WARNING: needs_global_options key 'link3' has a default value that is not of type 'str_list' [needs.config]",
-        "WARNING: needs_global_options key 'bad_value_type' has a default value that is not of type 'str' [needs.config]",
-        "WARNING: needs_global_options key 'too_many_params' has an unknown format [needs.config]",
-        "WARNING: needs_global_options key 'unknown' must also exist in needs_extra_options, needs_extra_links, or ['constraints', 'layout', 'status', 'style', 'tags'] [needs.config]",
+        "WARNING: needs_global_options 'link3' has a default value that is not of type 'str_list' [needs.config]",
+        "WARNING: needs_global_options 'bad_value_type' has a default value that is not of type 'str' [needs.config]",
+        "WARNING: needs_global_options 'too_many_params', 'predicates', must be a list of (filter string, value) pairs [needs.config]",
+        "WARNING: needs_global_options 'unknown' must also exist in needs_extra_options, needs_extra_links, or ['constraints', 'layout', 'status', 'style', 'tags'] [needs.config]",
     ]
 
     needs_config = NeedsSphinxConfig(test_app.config)


### PR DESCRIPTION
In the current format each value can be in multiple different formats, which makes it difficult to understand, parse, and provide a JSON schema for in `ubproject.toml`

In this PR we deprecate the old format (it can still be used for now but will emit a warning), and replace it with a slightly more verbose, but consistent format:

old:

```python
needs_global_options = {
    "field1": "a",
    "field2": ("a", 'status == "done"'),
    "field3": ("a", 'status == "done"', "b"),
    "field4": [
        ("a", 'status == "done"'),
        ("b", 'status == "ongoing"'),
        ("c", 'status == "other"', "d"),
    ],
}
```

new:

```python
needs_global_options = {
    "field1": {"default": "a"},
    "field2": {"predicates": [('status == "done"', "a")]},
    "field3": {
        "predicates": [('status == "done"', "a")],
        "default": "b",
    },
    "field4": {
        "predicates": [
            ('status == "done"', "a"),
            ('status == "ongoing"', "b"),
            ('status == "other"', "c"),
        ],
        "default": "d",
    },
}
```

new in `ubproject.toml` format:

```toml
[needs.global_options]
field1.default = "a"
field2.predicates = [['status == "done"', "a"]]
field3.predicates = [['status == "done"', "a"]]
field3.default = "b"
field4.predicates = [
    ['status == "done"', "a"],
    ['status == "ongoing"', "b"],
    ['status == "other"', "c"]
]
field4.default = "d"
```

TODO update documentation