### PR TITLE
🔧 Allow pre/post template `global_options`

### DIFF
--- a/sphinx_needs/data.py
+++ b/sphinx_needs/data.py
@@ -280,11 +280,13 @@ NeedsCoreFields: Final[Mapping[str, CoreFieldParameters]] = {
         "description": "Pre-template of the need.",
         "schema": {"type": ["string", "null"], "default": None},
         "exclude_external": True,
+        "allow_default": "str",
     },
     "post_template": {
         "description": "Post-template of the need.",
         "schema": {"type": ["string", "null"], "default": None},
         "exclude_external": True,
+        "allow_default": "str",
     },
     "content": {
         "description": "Content of the need.",

--- a/tests/test_global_options.py
+++ b/tests/test_global_options.py
@@ -31,7 +31,7 @@ def test_doc_global_option_old(test_app, snapshot):
         "WARNING: needs_global_options 'link3' has a default value that is not of type 'str_list' [needs.config]",
         "WARNING: needs_global_options 'bad_value_type' has a default value that is not of type 'str' [needs.config]",
         "WARNING: needs_global_options 'too_many_params' has an unknown value format [needs.config]",
-        "WARNING: needs_global_options 'unknown' must also exist in needs_extra_options, needs_extra_links, or ['constraints', 'layout', 'status', 'style', 'tags'] [needs.config]",
+        "WARNING: needs_global_options 'unknown' must also exist in needs_extra_options, needs_extra_links, or ['constraints', 'layout', 'post_template', 'pre_template', 'status', 'style', 'tags'] [needs.config]",
         "WARNING: needs_global_options uses old, non-dict, format. please update to new format: {'layout': {'default': 'clean_l'}, 'option_1': {'default': 'test_global'}, 'option_2': {'default': \"[[copy('id')]]\"}, 'option_3': {'predicates': [('status == \"implemented\"', 'STATUS_IMPL')]}, 'option_4': {'predicates': [('status == \"closed\"', 'STATUS_CLOSED')], 'default': 'STATUS_UNKNOWN'}, 'option_5': {'predicates': [('status == \"implemented\"', 'STATUS_IMPL'), ('status == \"closed\"', 'STATUS_CLOSED')], 'default': 'final'}, 'link1': {'default': ['SPEC_1']}, 'link2': {'predicates': [('status == \"implemented\"', ['SPEC_2', \"[[copy('link1')]]\"]), ('status == \"closed\"', ['SPEC_3'])], 'default': ['SPEC_1']}, 'tags': {'predicates': [('status == \"implemented\"', ['a', 'b']), ('status == \"closed\"', ['c'])], 'default': ['d']}} [needs.deprecated]",
     ]
 

--- a/tests/test_global_options.py
+++ b/tests/test_global_options.py
@@ -65,7 +65,7 @@ def test_doc_global_option(test_app, snapshot):
         "WARNING: needs_global_options 'link3' has a default value that is not of type 'str_list' [needs.config]",
         "WARNING: needs_global_options 'bad_value_type' has a default value that is not of type 'str' [needs.config]",
         "WARNING: needs_global_options 'too_many_params', 'predicates', must be a list of (filter string, value) pairs [needs.config]",
-        "WARNING: needs_global_options 'unknown' must also exist in needs_extra_options, needs_extra_links, or ['constraints', 'layout', 'status', 'style', 'tags'] [needs.config]",
+        "WARNING: needs_global_options 'unknown' must also exist in needs_extra_options, needs_extra_links, or ['constraints', 'layout', 'post_template', 'pre_template', 'status', 'style', 'tags'] [needs.config]",
     ]
 
     needs_config = NeedsSphinxConfig(test_app.config)


### PR DESCRIPTION
Even though these template are an awful design decision in sphinx-needs (hint, you don't jinja when you have a fully expressive restructuredtext syntax), let's add them back in for now for back-compatibility

closes #1420 