### PR TITLE
🔧 benchmark group non win32

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,10 @@ test = [
   "pytest-xprocess~=1.0",
 ]
 test-parallel = ["pytest-xdist"]
-benchmark = ["pytest-benchmark~=5.0", "memray>=1.3.1,<2.0.0"]
+benchmark = [
+  "pytest-benchmark~=5.0; sys_platform != 'win32'",
+  "memray>=1.3.1,<2.0.0; sys_platform != 'win32'",
+]
 docs = [
   "matplotlib>=3.3.0",
   "sphinxcontrib-plantuml~=0.0",

--- a/tests/benchmarks/test_official.py
+++ b/tests/benchmarks/test_official.py
@@ -1,10 +1,11 @@
+import contextlib
 import json
 import re
+import sys
 import uuid
 from pathlib import Path
 from random import randrange
 
-import memray
 import pytest
 import responses
 
@@ -14,6 +15,10 @@ from tests.data.service_github import (
     GITHUB_SPECIFIC_COMMIT_ANSWER,
     GITHUB_SPECIFIC_ISSUE_ANSWER,
 )
+
+with contextlib.suppress(ImportError):
+    # not available for Windows
+    import memray
 
 
 def random_data_callback(request):
@@ -69,6 +74,9 @@ def test_official_time(test_app, benchmark):
     "test_app",
     [{"buildername": "html", "srcdir": "../docs", "parallel": 1}],
     indirect=True,
+)
+@pytest.mark.skipif(
+    sys.platform.startswith("win"), reason="memray not available on Windows"
 )
 def test_official_memory(test_app):
     responses.add_callback(


### PR DESCRIPTION
The memray dependency is only available for linux and macos.