### PR TITLE
🔧 Deprecate Python 3.9

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.10'
       - uses: pre-commit/action@v3.0.1
 
   tests-core:
@@ -23,12 +23,12 @@ jobs:
       fail-fast: false # Set on "false" to get the results of ALL builds
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.9", "3.12", "3.13"]
+        python-version: ["3.10", "3.12", "3.13"]
         sphinx-version: ["7.4", "8.2"]
         include:
           # corner cases for Windows
           - os: "windows-latest"
-            python-version: "3.9"
+            python-version: "3.10"
             sphinx-version: "7.4"
           - os: "windows-latest"
             python-version: "3.12"
@@ -39,7 +39,7 @@ jobs:
         exclude:
           # Sphinx 8.2 only supports py3.11+
           - os: "ubuntu-latest"
-            python-version: "3.9"
+            python-version: "3.10"
             sphinx-version: "8.2"
 
     steps:
@@ -81,7 +81,7 @@ jobs:
       matrix:
         include:
           - os: "ubuntu-latest"
-            python-version: "3.9"
+            python-version: "3.10"
             sphinx-version: "7.4"
           - os: "ubuntu-latest"
             python-version: "3.13"

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -85,7 +85,7 @@ Or use tox (recommended):
 
 .. code-block:: bash
 
-   tox -e py39
+   tox -e py310
 
 Note some tests use `syrupy <https://github.com/tophat/syrupy>`__ to perform snapshot testing.
 These snapshots can be updated by running:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ classifiers = [
   'Operating System :: OS Independent',
   'Programming Language :: Python',
   'Programming Language :: Python :: 3',
-  'Programming Language :: Python :: 3.9',
   'Programming Language :: Python :: 3.10',
   'Programming Language :: Python :: 3.11',
   'Programming Language :: Python :: 3.12',
@@ -26,7 +25,7 @@ classifiers = [
   'Topic :: Utilities',
   'Framework :: Sphinx :: Extension',
 ]
-requires-python = ">=3.9,<4"
+requires-python = ">=3.10,<4"
 dependencies = [
   "sphinx>=7.4,<9",
   "requests-file~=2.1",             # external links
@@ -145,19 +144,19 @@ disable_error_code = ["no-redef"]
 
 legacy_tox_ini = """
 [tox]
-envlist = py39
+envlist = py10
 
 [testenv]
 usedevelop = true
 
-[testenv:py{39,310,311,312,313}]
+[testenv:py{310,311,312,313}]
 extras =
   test
   test-parallel
 commands =
   pytest --ignore tests/benchmarks {posargs:tests}
 
-[testenv:py{39,310,311,312,313}-benchmark]
+[testenv:py{310,311,312,313}-benchmark]
 extras =
   test
   benchmark


### PR DESCRIPTION
Required as a preparation for https://github.com/useblocks/sphinx-needs/pull/1467.

The supported Sphinx versions are not touched.