### PR TITLE
📚 Fix escape sequences

### DIFF
--- a/docs/filter.rst
+++ b/docs/filter.rst
@@ -225,7 +225,7 @@ The second parameter should be one of the above variables(status, id, content, .
       .. req:: Set admin e-mail to admin@mycompany.com
 
       .. needlist::
-         :filter: search("([a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)", title)
+         :filter: search(r"([a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)", title)
 
 .. _filter_string_performance:
 

--- a/docs/roles.rst
+++ b/docs/roles.rst
@@ -153,7 +153,7 @@ See :ref:`filter_string` for more information.
    | Specification needs: :need_count:`type=='spec'`
    | Open specification needs: :need_count:`type=='spec' and status=='open'`
    | Needs with tag *test*: :need_count:`'test' in tags`
-   | Needs with title longer 10 chars: :need_count:`search("[\\w\\s]{10,}", title)`
+   | Needs with title longer 10 chars: :need_count:`search(r"[\w\s]{10,}", title)`
    | All need_parts: :need_count:`is_part`
    | All needs containing need_parts: :need_count:`is_need and len(parts)>0`
 


### PR DESCRIPTION
This fixes the docs build warnings emitted by RST highlighting:
```
<unknown>:1: SyntaxWarning: invalid escape sequence '\.'
<string>:1: SyntaxWarning: invalid escape sequence '\.'
<unknown>:1: SyntaxWarning: invalid escape sequence '\w'
<string>:1: SyntaxWarning: invalid escape sequence '\w'
```

Not sure about the solution though, could also be the `need-example` directive has a bug.