### PR TITLE
‼️ Improve needs default field application (via needs_global_options)

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -349,7 +349,22 @@ Defaults will be used if the field is not set specifically by the user and thus 
    }
 
 To set a default based on a one or more predicates, use the ``predicates`` key.
-These predicates are a list of (:ref:`filter string <filter_string>`, value), evaluated in order, with the first match set as the default value.
+These predicates are a list of ``(match expression, value)``, evaluated in order, with the first match set as the default value.
+
+A match expression is a string, using Python syntax, that will be evaluated against data from each need (before the resolution of defaults or dynamic functions etc):
+
+- `id` (`str`)
+- `type` (`str`)
+- `title` (`str`)
+- `tags` (`tuple[str, ...]`)
+- `status` (`str | None`)
+- `docname` (`str | None`)
+- `is_external` (`bool`)
+- `is_import` (`bool`)
+- :ref:`needs_extra_options` (`str`)
+- :ref:`needs_extra_links` (`tuple[str, ...]`)
+- :ref:`needs_filter_data`
+
 If no predicates match, the ``default`` value is used (if present).
 
 .. code-block:: python
@@ -379,17 +394,6 @@ If no predicates match, the ``default`` value is used (if present).
       needs_global_options = {
               "option1": {"default": '[[copy("id")]]'}
       }
-
-.. warning::
-
-   The filter string gets executed against the current need only and has no access to other needs.
-   So avoid any references to other needs in the filter string.
-
-   If you need access to other needs for complex filtering, you can maybe provide your own :ref:`dynamic_functions`
-   and perform the filtering there.
-
-   Default replacements are done, for each field, in the order they are defined in the configuration,
-   so a filter string should not depend on the value of a field below it in the configuration.
 
 .. _`needs_report_dead_links`:
 

--- a/sphinx_needs/directives/need.py
+++ b/sphinx_needs/directives/need.py
@@ -69,27 +69,17 @@ class NeedDirective(SphinxDirective):
         collapse = self.options.get("collapse")
         jinja_content = self.options.get("jinja_content")
         hide = self.options.get("hide")
-
         id = self.options.get("id")
         status = self.options.get("status")
-        tags = self.options.get("tags", "")
+        tags = self.options.get("tags")
         style = self.options.get("style")
-        layout = self.options.get("layout", "")
+        layout = self.options.get("layout")
         template = self.options.get("template")
         pre_template = self.options.get("pre_template")
         post_template = self.options.get("post_template")
-        constraints = self.options.get("constraints", [])
+        constraints = self.options.get("constraints")
 
         title, full_title = self._get_title(needs_config)
-
-        need_extra_options = {}
-        for extra_link in needs_config.extra_links:
-            need_extra_options[extra_link["option"]] = self.options.get(
-                extra_link["option"], ""
-            )
-
-        for extra_option in needs_config.extra_options:
-            need_extra_options[extra_option] = self.options.get(extra_option, "")
 
         try:
             need_nodes = add_need(
@@ -114,7 +104,16 @@ class NeedDirective(SphinxDirective):
                 layout=layout,
                 jinja_content=jinja_content,
                 constraints=constraints,
-                **need_extra_options,
+                **{
+                    n: self.options[n]
+                    for n in needs_config.extra_options
+                    if n in self.options
+                },
+                **{
+                    n["option"]: self.options[n["option"]]
+                    for n in needs_config.extra_links
+                    if n["option"] in self.options
+                },
             )
         except InvalidNeedException as err:
             log_warning(

--- a/tests/__snapshots__/test_add_sections_sigs.ambr
+++ b/tests/__snapshots__/test_add_sections_sigs.ambr
@@ -8,7 +8,6 @@
       'id': 'R_12345',
       'impacts': 'component_a',
       'introduced': '1.0.0',
-      'layout': '',
       'lineno': 9,
       'section_name': '1.1 First Section',
       'sections': list([
@@ -31,7 +30,6 @@
       'id': 'R_12346',
       'impacts': 'component_b',
       'introduced': '1.1.1',
-      'layout': '',
       'lineno': 20,
       'section_name': '1.2 Second Section',
       'sections': list([
@@ -51,7 +49,6 @@
       'docname': 'index',
       'external_css': 'external_link',
       'id': 'T_001',
-      'layout': '',
       'lineno': 40,
       'section_name': '1.3 need in API',
       'sections': list([

--- a/tests/__snapshots__/test_basic_doc.ambr
+++ b/tests/__snapshots__/test_basic_doc.ambr
@@ -33,7 +33,7 @@
             'is_need': True,
             'is_part': False,
             'jinja_content': False,
-            'layout': '',
+            'layout': None,
             'lineno': 4,
             'links': list([
             ]),
@@ -102,7 +102,7 @@
             'is_need': True,
             'is_part': False,
             'jinja_content': False,
-            'layout': '',
+            'layout': None,
             'lineno': 8,
             'links': list([
             ]),

--- a/tests/__snapshots__/test_dynamic_functions.ambr
+++ b/tests/__snapshots__/test_dynamic_functions.ambr
@@ -16,7 +16,6 @@
             'docname': 'index',
             'external_css': 'external_link',
             'id': 'SP_TOO_001',
-            'layout': '',
             'lineno': 4,
             'section_name': 'DYNAMIC FUNCTIONS',
             'sections': list([
@@ -35,7 +34,6 @@
             'docname': 'index',
             'external_css': 'external_link',
             'id': 'TEST_2',
-            'layout': '',
             'lineno': 15,
             'section_name': 'DYNAMIC FUNCTIONS',
             'sections': list([
@@ -54,7 +52,6 @@
             'docname': 'index',
             'external_css': 'external_link',
             'id': 'TEST_3',
-            'layout': '',
             'lineno': 19,
             'section_name': 'DYNAMIC FUNCTIONS',
             'sections': list([
@@ -70,7 +67,6 @@
             'docname': 'index',
             'external_css': 'external_link',
             'id': 'TEST_4',
-            'layout': '',
             'lineno': 23,
             'section_name': 'DYNAMIC FUNCTIONS',
             'sections': list([
@@ -101,7 +97,6 @@
             'docname': 'index',
             'external_css': 'external_link',
             'id': 'TEST_5',
-            'layout': '',
             'lineno': 29,
             'parent_needs_back': list([
               'TEST_6',
@@ -128,7 +123,6 @@
             'docname': 'index',
             'external_css': 'external_link',
             'id': 'TEST_6',
-            'layout': '',
             'lineno': 35,
             'parent_need': 'TEST_5',
             'parent_needs': list([

--- a/tests/__snapshots__/test_external.ambr
+++ b/tests/__snapshots__/test_external.ambr
@@ -23,7 +23,6 @@
             'external_css': 'external_link',
             'id': 'IMP_REQ_01',
             'is_import': True,
-            'layout': '',
             'lineno': 4,
             'section_name': 'Title',
             'sections': list([
@@ -528,7 +527,6 @@
             'docname': 'index',
             'external_css': 'external_link',
             'id': 'REQ_1',
-            'layout': '',
             'lineno': 9,
             'links_back': list([
               'EXT_TEST_02',
@@ -546,7 +544,6 @@
             'docname': 'index',
             'external_css': 'external_link',
             'id': 'SPEC_1',
-            'layout': '',
             'lineno': 12,
             'links': list([
               'REQ_1',
@@ -567,7 +564,6 @@
             'docname': 'subfolder_a/subfolder_b/subpage',
             'external_css': 'external_link',
             'id': 'SUB_002',
-            'layout': '',
             'lineno': 4,
             'section_name': 'Subpage',
             'sections': list([

--- a/tests/__snapshots__/test_extra_options.ambr
+++ b/tests/__snapshots__/test_extra_options.ambr
@@ -12,7 +12,6 @@
             'id': 'R_12345',
             'impacts': 'component_a',
             'introduced': '1.0.0',
-            'layout': '',
             'lineno': 7,
             'section_name': 'Section 1',
             'sections': list([
@@ -35,7 +34,6 @@
             'id': 'R_12346',
             'impacts': 'component_b',
             'introduced': '1.1.1',
-            'layout': '',
             'lineno': 16,
             'section_name': 'Section 1',
             'sections': list([

--- a/tests/__snapshots__/test_list2need.ambr
+++ b/tests/__snapshots__/test_list2need.ambr
@@ -57,7 +57,7 @@
       'is_need': True,
       'is_part': False,
       'jinja_content': False,
-      'layout': '',
+      'layout': None,
       'lineno': 26,
       'lineno_content': 32,
       'links': list([
@@ -144,7 +144,7 @@
       'is_need': True,
       'is_part': False,
       'jinja_content': False,
-      'layout': '',
+      'layout': None,
       'lineno': 32,
       'lineno_content': 35,
       'links': list([
@@ -230,7 +230,7 @@
       'is_need': True,
       'is_part': False,
       'jinja_content': False,
-      'layout': '',
+      'layout': None,
       'lineno': 20,
       'lineno_content': 24,
       'links': list([
@@ -316,7 +316,7 @@
       'is_need': True,
       'is_part': False,
       'jinja_content': False,
-      'layout': '',
+      'layout': None,
       'lineno': 27,
       'lineno_content': 32,
       'links': list([
@@ -405,7 +405,7 @@
       'is_need': True,
       'is_part': False,
       'jinja_content': False,
-      'layout': '',
+      'layout': None,
       'lineno': 35,
       'lineno_content': 39,
       'links': list([
@@ -494,7 +494,7 @@
       'is_need': True,
       'is_part': False,
       'jinja_content': False,
-      'layout': '',
+      'layout': None,
       'lineno': 42,
       'lineno_content': 49,
       'links': list([
@@ -581,7 +581,7 @@
       'is_need': True,
       'is_part': False,
       'jinja_content': False,
-      'layout': '',
+      'layout': None,
       'lineno': 19,
       'lineno_content': 23,
       'links': list([
@@ -667,7 +667,7 @@
       'is_need': True,
       'is_part': False,
       'jinja_content': False,
-      'layout': '',
+      'layout': None,
       'lineno': 25,
       'lineno_content': 29,
       'links': list([
@@ -753,7 +753,7 @@
       'is_need': True,
       'is_part': False,
       'jinja_content': False,
-      'layout': '',
+      'layout': None,
       'lineno': 31,
       'lineno_content': 34,
       'links': list([
@@ -839,7 +839,7 @@
       'is_need': True,
       'is_part': False,
       'jinja_content': False,
-      'layout': '',
+      'layout': None,
       'lineno': 21,
       'lineno_content': 26,
       'links': list([
@@ -928,7 +928,7 @@
       'is_need': True,
       'is_part': False,
       'jinja_content': False,
-      'layout': '',
+      'layout': None,
       'lineno': 29,
       'lineno_content': 34,
       'links': list([
@@ -1019,7 +1019,7 @@
       'is_need': True,
       'is_part': False,
       'jinja_content': False,
-      'layout': '',
+      'layout': None,
       'lineno': 37,
       'lineno_content': 42,
       'links': list([
@@ -1110,7 +1110,7 @@
       'is_need': True,
       'is_part': False,
       'jinja_content': False,
-      'layout': '',
+      'layout': None,
       'lineno': 45,
       'lineno_content': 53,
       'links': list([
@@ -1209,7 +1209,7 @@
       'is_need': True,
       'is_part': False,
       'jinja_content': False,
-      'layout': '',
+      'layout': None,
       'lineno': 38,
       'lineno_content': 42,
       'links': list([
@@ -1299,7 +1299,7 @@
       'is_need': True,
       'is_part': False,
       'jinja_content': False,
-      'layout': '',
+      'layout': None,
       'lineno': 45,
       'lineno_content': 49,
       'links': list([
@@ -1385,7 +1385,7 @@
       'is_need': True,
       'is_part': False,
       'jinja_content': False,
-      'layout': '',
+      'layout': None,
       'lineno': 20,
       'lineno_content': 23,
       'links': list([

--- a/tests/__snapshots__/test_need_constraints.ambr
+++ b/tests/__snapshots__/test_need_constraints.ambr
@@ -33,7 +33,7 @@
             'is_need': True,
             'is_part': False,
             'jinja_content': False,
-            'layout': '',
+            'layout': None,
             'lineno': 20,
             'links': list([
             ]),
@@ -108,7 +108,7 @@
             'is_need': True,
             'is_part': False,
             'jinja_content': False,
-            'layout': '',
+            'layout': None,
             'lineno': 25,
             'links': list([
               'SECURITY_REQ',
@@ -258,7 +258,7 @@
             'is_need': True,
             'is_part': False,
             'jinja_content': False,
-            'layout': '',
+            'layout': None,
             'lineno': 39,
             'links': list([
             ]),
@@ -327,7 +327,7 @@
             'is_need': True,
             'is_part': False,
             'jinja_content': False,
-            'layout': '',
+            'layout': None,
             'lineno': 4,
             'links': list([
             ]),
@@ -403,7 +403,7 @@
             'is_need': True,
             'is_part': False,
             'jinja_content': False,
-            'layout': '',
+            'layout': None,
             'lineno': 11,
             'links': list([
             ]),
@@ -479,7 +479,7 @@
             'is_need': True,
             'is_part': False,
             'jinja_content': False,
-            'layout': '',
+            'layout': None,
             'lineno': 4,
             'links': list([
             ]),
@@ -552,7 +552,7 @@
             'is_need': True,
             'is_part': False,
             'jinja_content': False,
-            'layout': '',
+            'layout': None,
             'lineno': 11,
             'links': list([
             ]),

--- a/tests/__snapshots__/test_need_parts.ambr
+++ b/tests/__snapshots__/test_need_parts.ambr
@@ -23,7 +23,6 @@
       'docname': 'index',
       'external_css': 'external_link',
       'id': 'SP_TOO_001',
-      'layout': '',
       'lineno': 4,
       'parent_needs_back': list([
         'TEST_2',
@@ -99,7 +98,6 @@
       'docname': 'index',
       'external_css': 'external_link',
       'id': 'TEST_2',
-      'layout': '',
       'lineno': 21,
       'parent_need': 'SP_TOO_001',
       'parent_needs': list([

--- a/tests/__snapshots__/test_needextend.ambr
+++ b/tests/__snapshots__/test_needextend.ambr
@@ -33,7 +33,7 @@
             'is_need': True,
             'is_part': False,
             'jinja_content': False,
-            'layout': '',
+            'layout': None,
             'lineno': 4,
             'links': list([
               'REQ_A_1',
@@ -105,7 +105,7 @@
             'is_need': True,
             'is_part': False,
             'jinja_content': False,
-            'layout': '',
+            'layout': None,
             'lineno': 7,
             'links': list([
             ]),
@@ -175,7 +175,7 @@
             'is_need': True,
             'is_part': False,
             'jinja_content': False,
-            'layout': '',
+            'layout': None,
             'lineno': 10,
             'links': list([
             ]),
@@ -245,7 +245,7 @@
             'is_need': True,
             'is_part': False,
             'jinja_content': False,
-            'layout': '',
+            'layout': None,
             'lineno': 13,
             'links': list([
             ]),
@@ -314,7 +314,7 @@
             'is_need': True,
             'is_part': False,
             'jinja_content': False,
-            'layout': '',
+            'layout': None,
             'lineno': 16,
             'links': list([
             ]),
@@ -824,7 +824,7 @@
             'is_need': True,
             'is_part': False,
             'jinja_content': False,
-            'layout': '',
+            'layout': None,
             'lineno': 9,
             'links': list([
               'extend_test_004',
@@ -899,7 +899,7 @@
             'is_need': True,
             'is_part': False,
             'jinja_content': False,
-            'layout': '',
+            'layout': None,
             'lineno': 15,
             'links': list([
             ]),
@@ -974,7 +974,7 @@
             'is_need': True,
             'is_part': False,
             'jinja_content': False,
-            'layout': '',
+            'layout': None,
             'lineno': 21,
             'links': list([
             ]),
@@ -1044,7 +1044,7 @@
             'is_need': True,
             'is_part': False,
             'jinja_content': False,
-            'layout': '',
+            'layout': None,
             'lineno': 28,
             'links': list([
               'extend_test_003',
@@ -1115,7 +1115,7 @@
             'is_need': True,
             'is_part': False,
             'jinja_content': False,
-            'layout': '',
+            'layout': None,
             'lineno': 34,
             'links': list([
               'extend_test_003',
@@ -1187,7 +1187,7 @@
             'is_need': True,
             'is_part': False,
             'jinja_content': False,
-            'layout': '',
+            'layout': None,
             'lineno': 5,
             'links': list([
             ]),

--- a/tests/__snapshots__/test_needimport.ambr
+++ b/tests/__snapshots__/test_needimport.ambr
@@ -77,7 +77,6 @@
             'docname': 'index',
             'external_css': 'external_link',
             'id': 'REQ_1',
-            'layout': '',
             'lineno': 47,
             'section_name': 'FILTERED',
             'sections': list([
@@ -192,7 +191,6 @@
             'docname': 'index',
             'external_css': 'external_link',
             'id': 'SPEC_1',
-            'layout': '',
             'lineno': 50,
             'section_name': 'FILTERED',
             'sections': list([
@@ -2193,7 +2191,7 @@
       'is_need': True,
       'is_part': False,
       'jinja_content': False,
-      'layout': '',
+      'layout': None,
       'lineno': 9,
       'lineno_content': 12,
       'links': list([
@@ -2270,7 +2268,7 @@
       'is_need': True,
       'is_part': False,
       'jinja_content': False,
-      'layout': '',
+      'layout': None,
       'lineno': 4,
       'lineno_content': 7,
       'links': list([

--- a/tests/__snapshots__/test_needs_builder.ambr
+++ b/tests/__snapshots__/test_needs_builder.ambr
@@ -33,7 +33,7 @@
             'is_need': True,
             'is_part': False,
             'jinja_content': False,
-            'layout': '',
+            'layout': None,
             'lineno': 8,
             'links': list([
             ]),
@@ -102,7 +102,7 @@
             'is_need': True,
             'is_part': False,
             'jinja_content': False,
-            'layout': '',
+            'layout': None,
             'lineno': 12,
             'links': list([
             ]),
@@ -171,7 +171,7 @@
             'is_need': True,
             'is_part': False,
             'jinja_content': False,
-            'layout': '',
+            'layout': None,
             'lineno': 4,
             'links': list([
             ]),
@@ -820,7 +820,6 @@
             'docname': 'index',
             'external_css': 'external_link',
             'id': 'TC_001',
-            'layout': '',
             'lineno': 8,
             'section_name': 'TEST DOCUMENT NEEDS Builder',
             'sections': list([
@@ -835,7 +834,6 @@
             'docname': 'index',
             'external_css': 'external_link',
             'id': 'TC_NEG_001',
-            'layout': '',
             'lineno': 12,
             'section_name': 'TEST DOCUMENT NEEDS Builder',
             'sections': list([
@@ -850,7 +848,6 @@
             'docname': 'index',
             'external_css': 'external_link',
             'id': 'US_63252',
-            'layout': '',
             'lineno': 4,
             'section_name': 'TEST DOCUMENT NEEDS Builder',
             'sections': list([
@@ -1496,7 +1493,7 @@
             'is_need': True,
             'is_part': False,
             'jinja_content': False,
-            'layout': '',
+            'layout': None,
             'lineno': 8,
             'links': list([
             ]),
@@ -1565,7 +1562,7 @@
             'is_need': True,
             'is_part': False,
             'jinja_content': False,
-            'layout': '',
+            'layout': None,
             'lineno': 12,
             'links': list([
             ]),
@@ -1634,7 +1631,7 @@
             'is_need': True,
             'is_part': False,
             'jinja_content': False,
-            'layout': '',
+            'layout': None,
             'lineno': 4,
             'links': list([
             ]),

--- a/tests/__snapshots__/test_needs_from_toml.ambr
+++ b/tests/__snapshots__/test_needs_from_toml.ambr
@@ -10,7 +10,6 @@
             'docname': 'index',
             'external_css': 'external_link',
             'id': 'O_001',
-            'layout': '',
             'lineno': 4,
             'section_name': 'TEST DOCUMENT',
             'sections': list([

--- a/tests/__snapshots__/test_needs_id_builder.ambr
+++ b/tests/__snapshots__/test_needs_id_builder.ambr
@@ -34,7 +34,7 @@
               'is_need': True,
               'is_part': False,
               'jinja_content': False,
-              'layout': '',
+              'layout': None,
               'lineno': 8,
               'links': list([
               ]),
@@ -113,7 +113,7 @@
               'is_need': True,
               'is_part': False,
               'jinja_content': False,
-              'layout': '',
+              'layout': None,
               'lineno': 12,
               'links': list([
               ]),
@@ -192,7 +192,7 @@
               'is_need': True,
               'is_part': False,
               'jinja_content': False,
-              'layout': '',
+              'layout': None,
               'lineno': 4,
               'links': list([
               ]),

--- a/tests/__snapshots__/test_needuml.ambr
+++ b/tests/__snapshots__/test_needuml.ambr
@@ -43,7 +43,7 @@
       'is_need': True,
       'is_part': False,
       'jinja_content': False,
-      'layout': '',
+      'layout': None,
       'lineno': 19,
       'lineno_content': 22,
       'links': list([
@@ -120,7 +120,7 @@
       'is_need': True,
       'is_part': False,
       'jinja_content': False,
-      'layout': '',
+      'layout': None,
       'lineno': 14,
       'lineno_content': 17,
       'links': list([
@@ -230,7 +230,7 @@
       'is_need': True,
       'is_part': False,
       'jinja_content': False,
-      'layout': '',
+      'layout': None,
       'lineno': 70,
       'lineno_content': 73,
       'links': list([
@@ -339,7 +339,7 @@
       'is_need': True,
       'is_part': False,
       'jinja_content': False,
-      'layout': '',
+      'layout': None,
       'lineno': 95,
       'lineno_content': 98,
       'links': list([
@@ -463,7 +463,7 @@
       'is_need': True,
       'is_part': False,
       'jinja_content': False,
-      'layout': '',
+      'layout': None,
       'lineno': 117,
       'lineno_content': 120,
       'links': list([
@@ -546,7 +546,7 @@
       'is_need': True,
       'is_part': False,
       'jinja_content': False,
-      'layout': '',
+      'layout': None,
       'lineno': 46,
       'lineno_content': 49,
       'links': list([
@@ -623,7 +623,7 @@
       'is_need': True,
       'is_part': False,
       'jinja_content': False,
-      'layout': '',
+      'layout': None,
       'lineno': 4,
       'lineno_content': 7,
       'links': list([
@@ -700,7 +700,7 @@
       'is_need': True,
       'is_part': False,
       'jinja_content': False,
-      'layout': '',
+      'layout': None,
       'lineno': 9,
       'lineno_content': 12,
       'links': list([
@@ -786,7 +786,7 @@
       'is_need': True,
       'is_part': False,
       'jinja_content': False,
-      'layout': '',
+      'layout': None,
       'lineno': 33,
       'lineno_content': 36,
       'links': list([


### PR DESCRIPTION
Previously defaults would be applied to any fields of a need with a "falsy" value, e.g. `None`, `False`, `0` , `""`, `[]`. ...

This is an issue, if the user wants to specifically set fields to these values, without them being overridden by defaults. Therefore, now defaults are only applied to fields with a missing or `None` value.

In the need directive context, this means that defaults will only be set for fields not specifically set in the directive options.

In the external/import need context, defaults will only be applied to missing keys in the `needs.json`, or fields with the value set to `null`.

For predicate defaults, the context passed to the expression has been restricted to a subset of fields, and these values are no longer mutated by previous defaults, i.e. each predicate gets the same immutable context data.
This makes these predicates more isolated / understandable, and allows for them potentially later being co-located with the type information.

----

‼️ Breaking

This PR may be breaking:

1. For users expecting defaults to be applied to external/import `needs.json`, although I would suggest this was never the intention for these defaults and that `needs.json` should, at least by default, be seen as static ingest data which has already had defaults etc applied.

2. For users with "exotic" predicate expressions, that potentially rely on the application of previous defaults.