### PR TITLE
♻️ Store needs as `NeedItem` / `NeedPartItem`, rather than standard `dict`

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -37,6 +37,9 @@ Exceptions
 Data
 ----
 
+.. automodule:: sphinx_needs.need_item
+   :members: NeedItem, NeedPartItem
+
 .. automodule:: sphinx_needs.data
    :members: NeedsInfoType, NeedsMutable, NeedsPartType
 

--- a/sphinx_needs/api/configuration.py
+++ b/sphinx_needs/api/configuration.py
@@ -12,9 +12,9 @@ from sphinx.application import Sphinx
 from sphinx.util.logging import SphinxLoggerAdapter
 
 from sphinx_needs.config import _NEEDS_CONFIG, NeedsSphinxConfig
-from sphinx_needs.data import NeedsInfoType
 from sphinx_needs.exceptions import NeedsApiConfigException
 from sphinx_needs.functions.functions import DynamicFunction
+from sphinx_needs.need_item import NeedItem
 
 
 def get_need_types(app: Sphinx) -> list[str]:
@@ -134,7 +134,7 @@ def add_dynamic_function(
 
 
 # 'Need' is untyped, so we temporarily use 'Any' here
-WarningCheck = Callable[[NeedsInfoType, SphinxLoggerAdapter], bool]
+WarningCheck = Callable[[NeedItem, SphinxLoggerAdapter], bool]
 
 
 def add_warning(

--- a/sphinx_needs/config.py
+++ b/sphinx_needs/config.py
@@ -27,8 +27,8 @@ if TYPE_CHECKING:
     from sphinx.util.logging import SphinxLoggerAdapter
     from typing_extensions import NotRequired, Required
 
-    from sphinx_needs.data import NeedsInfoType
     from sphinx_needs.functions.functions import DynamicFunction
+    from sphinx_needs.need_item import NeedItem
 
 
 LOGGER = get_logger(__name__)
@@ -85,7 +85,7 @@ class _Config:
         self._field_defaults: dict[str, FieldDefault] = {}
         self._functions: dict[str, NeedFunctionsType] = {}
         self._warnings: dict[
-            str, str | Callable[[NeedsInfoType, SphinxLoggerAdapter], bool]
+            str, str | Callable[[NeedItem, SphinxLoggerAdapter], bool]
         ] = {}
 
     def clear(self) -> None:
@@ -180,7 +180,7 @@ class _Config:
     @property
     def warnings(
         self,
-    ) -> Mapping[str, str | Callable[[NeedsInfoType, SphinxLoggerAdapter], bool]]:
+    ) -> Mapping[str, str | Callable[[NeedItem, SphinxLoggerAdapter], bool]]:
         """Warning handlers that are added by the user,
         then called at the end of the build.
         """
@@ -189,7 +189,7 @@ class _Config:
     def add_warning(
         self,
         name: str,
-        filter: str | Callable[[NeedsInfoType, SphinxLoggerAdapter], bool],
+        filter: str | Callable[[NeedItem, SphinxLoggerAdapter], bool],
     ) -> None:
         """Adds a warning handler to the configuration."""
         self._warnings[name] = filter
@@ -690,7 +690,7 @@ class NeedsSphinxConfig:
     @property
     def warnings(
         self,
-    ) -> Mapping[str, str | Callable[[NeedsInfoType, SphinxLoggerAdapter], bool]]:
+    ) -> Mapping[str, str | Callable[[NeedItem, SphinxLoggerAdapter], bool]]:
         """Defines warnings to be checked at the end of the build (name -> string filter / filter function).
 
         These handlers can be added via sphinx configuration,

--- a/sphinx_needs/data.py
+++ b/sphinx_needs/data.py
@@ -26,13 +26,14 @@ if TYPE_CHECKING:
     from sphinx.environment import BuildEnvironment
     from typing_extensions import NotRequired, Required
 
+    from sphinx_needs.need_item import NeedItem
     from sphinx_needs.nodes import Need
     from sphinx_needs.services.manager import ServiceManager
 
 
 LOGGER = getLogger(__name__)
 
-ENV_DATA_VERSION: Final = 2
+ENV_DATA_VERSION: Final = 3
 """Version of the data stored in the environment.
 
 See https://www.sphinx-doc.org/en/master/extdev/index.html#extension-metadata
@@ -767,7 +768,7 @@ class NeedsUmlType(NeedsBaseDataType):
     """Time taken to process the diagram."""
 
 
-NeedsMutable = NewType("NeedsMutable", dict[str, NeedsInfoType])
+NeedsMutable = NewType("NeedsMutable", dict[str, "NeedItem"])
 """A mutable view of the needs, before resolution
 """
 
@@ -779,7 +780,7 @@ class SphinxNeedsData:
         self.env = env
 
     @property
-    def _env_needs(self) -> dict[str, NeedsInfoType]:
+    def _env_needs(self) -> dict[str, NeedItem]:
         try:
             return self.env._needs_all_needs
         except AttributeError:
@@ -790,7 +791,7 @@ class SphinxNeedsData:
         """Check if a need with the given ID exists."""
         return need_id in self._env_needs
 
-    def add_need(self, need: NeedsInfoType) -> None:
+    def add_need(self, need: NeedItem) -> None:
         """Add an unprocessed need to the cache.
 
         This will overwrite any existing need with the same ID.

--- a/sphinx_needs/diagrams_common.py
+++ b/sphinx_needs/diagrams_common.py
@@ -17,9 +17,10 @@ from sphinx.application import Sphinx
 from sphinx.util.docutils import SphinxDirective
 
 from sphinx_needs.config import NeedsSphinxConfig, NeedType
-from sphinx_needs.data import NeedsFilteredBaseType, NeedsInfoType
+from sphinx_needs.data import NeedsFilteredBaseType
 from sphinx_needs.errors import NoUri
 from sphinx_needs.logging import get_logger
+from sphinx_needs.need_item import NeedItem, NeedPartItem
 from sphinx_needs.utils import get_scale, split_link_types
 
 logger = get_logger(__name__)
@@ -170,7 +171,7 @@ def get_debug_container(puml_node: nodes.Element) -> nodes.container:
 
 def calculate_link(
     app: Sphinx,
-    need_info: NeedsInfoType,
+    need_info: NeedItem | NeedPartItem,
     _fromdocname: None | str,
     relative: str = "..",
 ) -> str:

--- a/sphinx_needs/directives/needextract.py
+++ b/sphinx_needs/directives/needextract.py
@@ -11,7 +11,7 @@ from sphinx.environment.collectors.asset import DownloadFileCollector, ImageColl
 from sphinx.util.logging import getLogger
 
 from sphinx_needs.config import NeedsSphinxConfig
-from sphinx_needs.data import NeedsExtractType, NeedsInfoType, SphinxNeedsData
+from sphinx_needs.data import NeedsExtractType, SphinxNeedsData
 from sphinx_needs.debug import measure_time
 from sphinx_needs.directives.utils import (
     no_needs_found_paragraph,
@@ -21,6 +21,7 @@ from sphinx_needs.filter_common import FilterBase, process_filters
 from sphinx_needs.functions.functions import find_and_replace_node_content
 from sphinx_needs.layout import build_need_repr
 from sphinx_needs.logging import log_warning
+from sphinx_needs.need_item import NeedItem
 from sphinx_needs.utils import add_doc, remove_node_from_tree
 
 LOGGER = getLogger(__name__)
@@ -138,6 +139,7 @@ def process_needextract(
             if (
                 need_info["is_need"]
                 and not need_info["is_part"]
+                and isinstance(need_info, NeedItem)
                 and (
                     need_extract := _build_needextract(
                         app, node, need_info, current_needextract
@@ -167,7 +169,7 @@ def process_needextract(
 def _build_needextract(
     app: Sphinx,
     extract_node: Needextract,
-    need_data: NeedsInfoType,
+    need_data: NeedItem,
     extract_data: NeedsExtractType,
 ) -> nodes.container | None:
     """Creates a new need representation."""

--- a/sphinx_needs/directives/needflow/_plantuml.py
+++ b/sphinx_needs/directives/needflow/_plantuml.py
@@ -9,13 +9,14 @@ from jinja2 import Template
 from sphinx.application import Sphinx
 
 from sphinx_needs.config import LinkOptionsType, NeedsSphinxConfig
-from sphinx_needs.data import NeedsFlowType, NeedsInfoType, SphinxNeedsData
+from sphinx_needs.data import NeedsFlowType, SphinxNeedsData
 from sphinx_needs.debug import measure_time
 from sphinx_needs.diagrams_common import calculate_link, create_legend
 from sphinx_needs.directives.needflow._directive import NeedflowPlantuml
 from sphinx_needs.directives.utils import no_needs_found_paragraph
 from sphinx_needs.filter_common import filter_single_need, process_filters
 from sphinx_needs.logging import get_logger, log_warning
+from sphinx_needs.need_item import NeedItem, NeedPartItem
 from sphinx_needs.utils import (
     match_variants,
     remove_node_from_tree,
@@ -40,7 +41,7 @@ def get_need_node_rep_for_plantuml(
     fromdocname: str,
     current_needflow: NeedsFlowType,
     needs_view: NeedsView,
-    need_info: NeedsInfoType,
+    need_info: NeedItem | NeedPartItem,
 ) -> str:
     """Calculate need node representation for plantuml."""
     needs_config = NeedsSphinxConfig(app.config)
@@ -89,8 +90,8 @@ def walk_curr_need_tree(
     fromdocname: str,
     current_needflow: NeedsFlowType,
     needs_view: NeedsView,
-    found_needs: list[NeedsInfoType],
-    need: NeedsInfoType,
+    found_needs: list[NeedItem | NeedPartItem],
+    need: NeedItem | NeedPartItem,
 ) -> str:
     """
     Walk through each need to find all its child needs and need parts recursively and wrap them together in nested structure.
@@ -157,7 +158,7 @@ def cal_needs_node(
     fromdocname: str,
     current_needflow: NeedsFlowType,
     needs_view: NeedsView,
-    found_needs: list[NeedsInfoType],
+    found_needs: list[NeedItem | NeedPartItem],
 ) -> str:
     """Calculate and get needs node representaion for plantuml including all child needs and need parts."""
     top_needs = get_root_needs(found_needs)
@@ -386,7 +387,7 @@ def process_needflow_plantuml(
 
 
 def render_connections(
-    found_needs: list[NeedsInfoType],
+    found_needs: list[NeedItem | NeedPartItem],
     allowed_link_types: list[LinkOptionsType],
     show_links: bool,
 ) -> str:
@@ -396,7 +397,7 @@ def render_connections(
     puml_connections = ""
     for need_info in found_needs:
         for link_type in allowed_link_types:
-            for link in need_info[link_type["option"]]:  # type: ignore[literal-required]
+            for link in need_info[link_type["option"]]:
                 # Do not create an links, if the link target is not part of the search result.
                 if link not in [
                     x["id"] for x in found_needs if x["is_need"]

--- a/sphinx_needs/directives/needflow/_shared.py
+++ b/sphinx_needs/directives/needflow/_shared.py
@@ -5,8 +5,9 @@ from typing import Literal
 from docutils import nodes
 
 from sphinx_needs.config import LinkOptionsType
-from sphinx_needs.data import NeedsFlowType, NeedsInfoType
+from sphinx_needs.data import NeedsFlowType
 from sphinx_needs.logging import get_logger
+from sphinx_needs.need_item import NeedItem, NeedPartItem
 from sphinx_needs.views import NeedsView
 
 logger = get_logger(__name__)
@@ -47,7 +48,7 @@ def filter_by_tree(
             roots.update(
                 {
                     i: (root_depth + 1, needs_view[i])
-                    for i in root.get(link_type_name, [])  # type: ignore[attr-defined]
+                    for i in root.get(link_type_name, [])
                     if i in needs_view
                 }
             )
@@ -55,10 +56,10 @@ def filter_by_tree(
     return needs_view.filter_ids(need_ids)
 
 
-def get_root_needs(found_needs: list[NeedsInfoType]) -> list[NeedsInfoType]:
+def get_root_needs(found_needs: list[NeedItem | NeedPartItem]) -> list[NeedItem]:
     return_list = []
     for current_need in found_needs:
-        if current_need["is_need"]:
+        if current_need["is_need"] and isinstance(current_need, NeedItem):
             if "parent_need" not in current_need or current_need["parent_need"] == "":
                 # need has no parent, we have to add the need to the root needs
                 return_list.append(current_need)

--- a/sphinx_needs/directives/needgantt.py
+++ b/sphinx_needs/directives/needgantt.py
@@ -243,9 +243,9 @@ def process_needgantt(
                 )
             else:  # Normal gantt element handling
                 duration_option = current_needgantt["duration_option"]
-                duration = need[duration_option]  # type: ignore[literal-required]
+                duration = need[duration_option]
                 complete_option = current_needgantt["completion_option"]
-                complete = need[complete_option]  # type: ignore[literal-required]
+                complete = need[complete_option]
                 if not (duration and duration.isdigit()):
                     need_location = (
                         f" (located: {need['docname']}:{need['lineno']})"
@@ -318,7 +318,7 @@ def process_needgantt(
                     start_end_sync = "start"
 
                 for link_type in current_needgantt[con_type]:
-                    start_with_links = need[link_type]  # type: ignore[literal-required]
+                    start_with_links = need[link_type]
                     for start_with_link in start_with_links:
                         start_need = all_needs_dict[start_with_link]
                         gantt_constraint = "[{}] {} at [{}]'s {}\n".format(

--- a/sphinx_needs/directives/needsequence.py
+++ b/sphinx_needs/directives/needsequence.py
@@ -10,7 +10,7 @@ from docutils.parsers.rst import directives
 from sphinx.application import Sphinx
 
 from sphinx_needs.config import NeedsSphinxConfig
-from sphinx_needs.data import NeedsInfoType, NeedsSequenceType, SphinxNeedsData
+from sphinx_needs.data import NeedsSequenceType, SphinxNeedsData
 from sphinx_needs.diagrams_common import (
     DiagramBase,
     add_config,
@@ -22,6 +22,7 @@ from sphinx_needs.diagrams_common import (
 from sphinx_needs.directives.utils import no_needs_found_paragraph
 from sphinx_needs.filter_common import FilterBase
 from sphinx_needs.logging import get_logger, log_warning
+from sphinx_needs.need_item import NeedItem
 from sphinx_needs.utils import add_doc, remove_node_from_tree
 from sphinx_needs.views import NeedsView
 
@@ -248,7 +249,7 @@ def process_needsequence(
 
 def get_message_needs(
     app: Sphinx,
-    sender: NeedsInfoType,
+    sender: NeedItem,
     link_types: list[str],
     all_needs_dict: NeedsView,
     tracked_receivers: list[str] | None = None,

--- a/sphinx_needs/functions/common.py
+++ b/sphinx_needs/functions/common.py
@@ -13,20 +13,21 @@ from typing import Any
 from sphinx.application import Sphinx
 
 from sphinx_needs.config import NeedsSphinxConfig
-from sphinx_needs.data import NeedsInfoType, NeedsMutable
+from sphinx_needs.data import NeedsMutable
 from sphinx_needs.exceptions import NeedsInvalidFilter
 from sphinx_needs.filter_common import (
-    filter_needs,
+    filter_needs_and_parts,
     filter_single_need,
 )
 from sphinx_needs.logging import log_warning
+from sphinx_needs.need_item import NeedItem, NeedPartItem
 from sphinx_needs.utils import logger
 from sphinx_needs.views import NeedsView
 
 
 def test(
     app: Sphinx,
-    need: NeedsInfoType | None,
+    need: NeedItem | NeedPartItem | None,
     needs: NeedsMutable | NeedsView,
     *args: Any,
     **kwargs: Any,
@@ -50,7 +51,7 @@ def test(
 
 def echo(
     app: Sphinx,
-    need: NeedsInfoType | None,
+    need: NeedItem | NeedPartItem | None,
     needs: NeedsMutable | NeedsView,
     text: str,
     *args: Any,
@@ -72,7 +73,7 @@ def echo(
 
 def copy(
     app: Sphinx,
-    need: NeedsInfoType | None,
+    need: NeedItem | NeedPartItem | None,
     needs: NeedsMutable | NeedsView,
     option: str,
     need_id: str | None = None,
@@ -142,7 +143,7 @@ def copy(
         location = (
             (need["docname"], need["lineno"]) if need and need["docname"] else None
         )
-        result = filter_needs(
+        result = filter_needs_and_parts(
             needs.values(),
             NeedsSphinxConfig(app.config),
             filter,
@@ -158,7 +159,7 @@ def copy(
     if option not in need:
         raise ValueError(f"Option {option} not found in need {need['id']}")
 
-    value = need[option]  # type: ignore[literal-required]
+    value = need[option]
 
     if lower:
         return str(value).lower()
@@ -170,7 +171,7 @@ def copy(
 
 def check_linked_values(
     app: Sphinx,
-    need: NeedsInfoType | None,
+    need: NeedItem | NeedPartItem | None,
     needs: NeedsMutable | NeedsView,
     result: Any,
     search_option: str,
@@ -288,7 +289,7 @@ def check_linked_values(
                     None,
                 )
 
-        need_value = need[search_option]  # type: ignore[literal-required]
+        need_value = need[search_option]
         if not one_hit and need_value not in search_value:
             return None
         elif one_hit and need_value in search_value:
@@ -299,7 +300,7 @@ def check_linked_values(
 
 def calc_sum(
     app: Sphinx,
-    need: NeedsInfoType | None,
+    need: NeedItem | NeedPartItem | None,
     needs: NeedsMutable | NeedsView,
     option: str,
     filter: str | None = None,
@@ -396,14 +397,14 @@ def calc_sum(
                 )
 
         with contextlib.suppress(ValueError):
-            calculated_sum += float(check_need[option])  # type: ignore[literal-required]
+            calculated_sum += float(check_need[option])
 
     return calculated_sum
 
 
 def links_from_content(
     app: Sphinx,
-    need: NeedsInfoType | None,
+    need: NeedItem | NeedPartItem | None,
     needs: NeedsMutable | NeedsView,
     need_id: str | None = None,
     filter: str | None = None,

--- a/sphinx_needs/layout.py
+++ b/sphinx_needs/layout.py
@@ -27,9 +27,10 @@ from sphinx.application import Sphinx
 from sphinx.util.logging import getLogger
 
 from sphinx_needs.config import NeedsSphinxConfig
-from sphinx_needs.data import NeedsCoreFields, NeedsInfoType
+from sphinx_needs.data import NeedsCoreFields
 from sphinx_needs.debug import measure_time
 from sphinx_needs.logging import log_warning
+from sphinx_needs.need_item import NeedItem
 from sphinx_needs.nodes import Need
 from sphinx_needs.utils import match_string_link
 
@@ -39,7 +40,7 @@ LOGGER = getLogger(__name__)
 @measure_time("build_need_repr")
 def build_need_repr(
     node: Need,
-    data: NeedsInfoType,
+    data: NeedItem,
     app: Sphinx,
     *,
     layout: str | None = None,
@@ -94,7 +95,7 @@ class LayoutHandler:
     def __init__(
         self,
         app: Sphinx,
-        need: NeedsInfoType,
+        need: NeedItem,
         node: Need,
         *,
         layout: str | None = None,
@@ -462,7 +463,7 @@ class LayoutHandler:
             # To escape { we need to use 2 of them.
             # So {{ becomes {{{{
             replace_string = f"{{{{{item}}}}}"
-            data = data.replace(replace_string, self.need[item])  # type: ignore[literal-required]
+            data = data.replace(replace_string, self.need[item])
         return data
 
     def meta(
@@ -490,7 +491,7 @@ class LayoutHandler:
             label_node += prefix_node
             data_container.append(label_node)
         try:
-            data = self.need[name]  # type: ignore[literal-required]
+            data = self.need[name]
         except KeyError:
             data = ""
 
@@ -702,7 +703,7 @@ class LayoutHandler:
         data_container = []
         for link_type in self.needs_config.extra_links:
             type_key = link_type["option"]
-            if self.need[type_key] and type_key not in exclude:  # type: ignore[literal-required]
+            if self.need[type_key] and type_key not in exclude:
                 outgoing_line = nodes.line()
                 outgoing_label = (
                     prefix + "{}:".format(link_type["outgoing"]) + postfix + " "
@@ -712,7 +713,7 @@ class LayoutHandler:
                 data_container.append(outgoing_line)
 
             type_key = link_type["option"] + "_back"
-            if self.need[type_key] and type_key not in exclude:  # type: ignore[literal-required]
+            if self.need[type_key] and type_key not in exclude:
                 incoming_line = nodes.line()
                 incoming_label = (
                     prefix + "{}:".format(link_type["incoming"]) + postfix + " "
@@ -821,7 +822,7 @@ class LayoutHandler:
         elif url.startswith("field:"):
             field = url.split(":")[1]
             try:
-                value = self.need[field]  # type: ignore[literal-required]
+                value = self.need[field]
             except KeyError:
                 value = ""
 
@@ -910,7 +911,7 @@ class LayoutHandler:
 
         if is_dynamic:
             try:
-                url = self.need[url]  # type: ignore[literal-required]
+                url = self.need[url]
             except KeyError:
                 url = ""
 

--- a/sphinx_needs/need_item.py
+++ b/sphinx_needs/need_item.py
@@ -1,0 +1,333 @@
+# To maintain back-compatibility,
+# we need to implement MutableMapping semantics, these are the methods that need to be implemented:
+# - implement immutable: __getitem__, __iter__, __len__
+# - implement mutable: __setitem__, __delitem__
+# - inherit immutable: __contains__, keys, items, values, get, __eq__, and __ne__
+# - inherit mutable: pop, popitem, clear, update, and setdefault
+#
+# For NeedPartItem, we should not allow any mutability, as it is a view into a need.
+# For NeedItem, we allow mutability, but only for values, i.e. it should not allow adding or removing keys.
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator, Mapping, Sequence
+from typing import Any, Literal, overload
+
+from sphinx_needs.data import NeedsInfoType, NeedsPartType
+
+
+class NeedItem:
+    """A class representing a single need item."""
+
+    __slots__ = ("_data",)
+
+    _not_required = {"pre_content", "post_content", "constraints_error"}
+    _immutable = {
+        "id",
+        "type",
+        "docname",
+        "lineno",
+        "lineno_content",
+        "id_complete",
+        "id_parent",
+        "is_need",
+        "is_part",
+        "is_external",
+        "is_import",
+    }
+
+    def __init__(self, data: NeedsInfoType) -> None:
+        """Initialize the NeedItem instance."""
+        self._data = data
+
+    def __repr__(self) -> str:
+        """Return a string representation of the NeedItem."""
+        return f"NeedItem({self._data!r})"
+
+    def __str__(self) -> str:
+        """Return a string representation of the NeedItem."""
+        return f"NeedItem({self._data!s})"
+
+    def copy(self) -> NeedItem:
+        """Return a copy of the NeedItem."""
+        return NeedItem(self._data.copy())
+
+    def __eq__(self, other: object) -> bool:
+        """Check if two NeedItems are equal."""
+        if not isinstance(other, NeedItem):
+            return False
+        return self._data == other._data
+
+    def __ne__(self, other: object) -> bool:
+        """Check if two NeedItems are not equal."""
+        return not self.__eq__(other)
+
+    def __contains__(self, key: str) -> bool:
+        """Check if the need item contains a key."""
+        return key in self._data
+
+    def __iter__(self) -> Iterator[str]:
+        """Return an iterator over the keys of the need item."""
+        return self._data.__iter__()
+
+    @overload
+    def __getitem__(
+        self,
+        key: Literal[
+            "collapse",
+            "hide",
+            "is_import",
+            "is_external",
+            "is_modified",
+            "is_need",
+            "is_part",
+            "jinja_content",
+            "has_dead_links",
+            "has_forbidden_dead_links",
+            "constraints_passed",
+        ],
+    ) -> bool: ...
+
+    @overload
+    def __getitem__(
+        self,
+        key: Literal[
+            "id",
+            "id_parent",
+            "id_complete",
+            "type",
+            "type_name",
+            "type_prefix",
+            "type_color",
+            "type_style",
+            "content",
+            "pre_content",
+            "post_content",
+            "doctype",
+            "external_url",
+            "external_css",
+            "constraints_error",
+            "section_name",
+            "parent_need",
+        ],
+    ) -> str: ...
+
+    @overload
+    def __getitem__(
+        self,
+        key: Literal[
+            "status",
+            "docname",
+            "external_url",
+            "layout",
+            "style",
+            "template",
+            "post_template",
+            "pre_template",
+        ],
+    ) -> str | None: ...
+
+    @overload
+    def __getitem__(self, key: Literal["modifications"]) -> int: ...
+
+    @overload
+    def __getitem__(self, key: Literal["lineno", "lineno_content"]) -> int | None: ...
+
+    @overload
+    def __getitem__(self, key: Literal["tags"]) -> Sequence[str]: ...
+
+    @overload
+    def __getitem__(self, key: Literal["arch"]) -> dict[str, str]: ...
+
+    @overload
+    def __getitem__(self, key: Literal["parts"]) -> dict[str, NeedsPartType]: ...
+
+    @overload
+    def __getitem__(self, key: str) -> Any: ...
+
+    def __getitem__(self, key: str) -> Any:
+        """Get an item by key."""
+        return self._data[key]  # type: ignore[literal-required]
+
+    def get(self, key: str, default: Any = None) -> Any:
+        """Get an item by key with a default value."""
+        return self._data.get(key, default)
+
+    def keys(self) -> Iterable[str]:
+        """Return the keys of the need item."""
+        return self._data.keys()
+
+    def values(self) -> Iterable[Any]:
+        """Return the values of the need item."""
+        return self._data.values()
+
+    def items(self) -> Iterable[tuple[str, Any]]:
+        """Return the items of the need item."""
+        return self._data.items()
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        """Set an item by key."""
+        if key not in self._data and key not in self._not_required:
+            raise KeyError(
+                f"Cannot add new key {key!r} to NeedItem, only existing keys can be modified."
+            )
+        if key in self._immutable:
+            raise KeyError(f"Cannot modify immutable key {key!r} in NeedItem.")
+        self._data[key] = value  # type: ignore[literal-required]
+
+    def get_part(self, part_id: str) -> NeedPartItem | None:
+        """Get a part by its ID."""
+        if part_id not in self._data.get("parts", {}):
+            return None
+        part_data = self._data["parts"][part_id]
+        full_part: NeedsInfoType = {**self._data, **part_data}
+        full_part["id_complete"] = f"{self._data['id']}.{part_data['id']}"
+        full_part["id_parent"] = self._data["id"]
+        full_part["is_need"] = False
+        full_part["is_part"] = True
+        return NeedPartItem(full_part)
+
+    def iter_parts(self) -> Iterable[NeedPartItem]:
+        """Yield all parts, a.k.a sub-needs, from a need."""
+        for part_id in self._data.get("parts", {}):
+            if (part := self.get_part(part_id)) is not None:
+                yield part
+
+
+class NeedPartItem:
+    """A class representing a part of a need, which is a sub-need."""
+
+    __slots__ = ("_data",)
+
+    def __init__(self, data: NeedsInfoType) -> None:
+        """Initialize the NeedPartItem instance."""
+        self._data = data
+
+    def __repr__(self) -> str:
+        """Return a string representation of the NeedPartItem."""
+        return f"NeedPartItem({self._data!r})"
+
+    def __str__(self) -> str:
+        """Return a string representation of the NeedPartItem."""
+        return f"NeedPartItem({self._data!s})"
+
+    def copy(self) -> NeedPartItem:
+        """Return a copy of the NeedPartItem."""
+        return NeedPartItem(self._data.copy())
+
+    def copy_for_needtable(self) -> NeedPartItem:
+        """Return a copy of the NeedPartItem with specific fields for needtable."""
+        # TODO this is a hack for current logic in the needtable processing
+        # but we don't want to start exposing mutability on the part just for this
+        part_data = self._data.copy()
+        part_data["id"] = part_data["id_complete"]
+        part_data["title"] = part_data["content"]
+        return NeedPartItem(part_data)
+
+    def __eq__(self, other: object) -> bool:
+        """Check if two NeedItems are equal."""
+        if not isinstance(other, NeedPartItem):
+            return False
+        return self._data == other._data
+
+    def __ne__(self, other: object) -> bool:
+        """Check if two NeedItems are not equal."""
+        return not self.__eq__(other)
+
+    def __contains__(self, key: str) -> bool:
+        """Check if the need item contains a key."""
+        return key in self._data
+
+    def __iter__(self) -> Iterator[str]:
+        """Return an iterator over the keys of the need item."""
+        return self._data.__iter__()
+
+    @overload
+    def __getitem__(
+        self,
+        key: Literal[
+            "collapse",
+            "hide",
+            "is_import",
+            "is_external",
+            "is_modified",
+            "is_need",
+            "is_part",
+            "jinja_content",
+            "has_dead_links",
+            "has_forbidden_dead_links",
+            "constraints_passed",
+        ],
+    ) -> bool: ...
+
+    @overload
+    def __getitem__(
+        self,
+        key: Literal[
+            "id",
+            "id_parent",
+            "id_complete",
+            "type",
+            "type_name",
+            "type_prefix",
+            "type_color",
+            "type_style",
+            "content",
+            "pre_content",
+            "post_content",
+            "doctype",
+            "external_css",
+            "constraints_error",
+            "section_name",
+            "parent_need",
+        ],
+    ) -> str: ...
+
+    @overload
+    def __getitem__(
+        self,
+        key: Literal[
+            "status",
+            "docname",
+            "external_url",
+            "layout",
+            "style",
+            "template",
+            "post_template",
+            "pre_template",
+        ],
+    ) -> str | None: ...
+
+    @overload
+    def __getitem__(self, key: Literal["modifications"]) -> int: ...
+
+    @overload
+    def __getitem__(self, key: Literal["lineno", "lineno_content"]) -> int | None: ...
+
+    @overload
+    def __getitem__(self, key: Literal["tags"]) -> Sequence[str]: ...
+
+    @overload
+    def __getitem__(self, key: Literal["arch"]) -> Mapping[str, str]: ...
+
+    @overload
+    def __getitem__(self, key: str) -> Any: ...
+
+    def __getitem__(self, key: str) -> Any:
+        """Get an item by key."""
+        return self._data[key]  # type: ignore[literal-required]
+
+    def get(self, key: str, default: Any = None) -> Any:
+        """Get an item by key with a default value."""
+        return self._data.get(key, default)
+
+    def keys(self) -> Iterable[str]:
+        """Return the keys of the need item."""
+        return self._data.keys()
+
+    def values(self) -> Iterable[Any]:
+        """Return the values of the need item."""
+        return self._data.values()
+
+    def items(self) -> Iterable[tuple[str, Any]]:
+        """Return the items of the need item."""
+        return self._data.items()

--- a/sphinx_needs/needsfile.py
+++ b/sphinx_needs/needsfile.py
@@ -19,8 +19,9 @@ from jsonschema import Draft7Validator
 from sphinx.config import Config
 
 from sphinx_needs.config import NeedsSphinxConfig
-from sphinx_needs.data import NeedsCoreFields, NeedsInfoType
+from sphinx_needs.data import NeedsCoreFields
 from sphinx_needs.logging import get_logger, log_warning
+from sphinx_needs.need_item import NeedItem
 
 log = get_logger(__name__)
 
@@ -149,7 +150,7 @@ class NeedsList:
         if not self.needs_config.reproducible_json:
             self.needs_list["versions"][version]["created"] = datetime.now().isoformat()
 
-    def add_need(self, version: str, need_info: NeedsInfoType) -> None:
+    def add_need(self, version: str, need_info: NeedItem) -> None:
         self.update_or_add_version(version)
         writable_needs = {
             key: value

--- a/sphinx_needs/roles/need_func.py
+++ b/sphinx_needs/roles/need_func.py
@@ -9,8 +9,9 @@ from sphinx.application import Sphinx
 from sphinx.environment import BuildEnvironment
 from sphinx.util.docutils import SphinxRole
 
-from sphinx_needs.data import NeedsInfoType, SphinxNeedsData
+from sphinx_needs.data import SphinxNeedsData
 from sphinx_needs.logging import get_logger, log_warning
+from sphinx_needs.need_item import NeedItem
 from sphinx_needs.utils import add_doc
 
 LOGGER = get_logger(__name__)
@@ -55,7 +56,7 @@ class NeedFunc(nodes.Inline, nodes.Element):
         """Return the function with brackets."""
         return self.get("with_brackets", False)  # type: ignore[no-any-return]
 
-    def get_text(self, env: BuildEnvironment, need: NeedsInfoType | None) -> nodes.Text:
+    def get_text(self, env: BuildEnvironment, need: NeedItem | None) -> nodes.Text:
         """Execute function and return result."""
         from sphinx_needs.functions.functions import check_and_get_content, execute_func
 

--- a/sphinx_needs/roles/need_incoming.py
+++ b/sphinx_needs/roles/need_incoming.py
@@ -33,7 +33,7 @@ def process_need_incoming(
 
         # Let's check if NeedIncoming shall follow a specific link type
         if "link_type" in node_need_backref.attributes:
-            links_back = ref_need[node_need_backref.attributes["link_type"]]  # type: ignore[literal-required]
+            links_back = ref_need[node_need_backref.attributes["link_type"]]
         # if not, follow back to default links
         else:
             links_back = ref_need["links_back"]

--- a/sphinx_needs/roles/need_outgoing.py
+++ b/sphinx_needs/roles/need_outgoing.py
@@ -36,7 +36,7 @@ def process_need_outgoing(
 
         # Let's check if NeedIncoming shall follow a specific link type
         if "link_type" in node_need_ref.attributes:
-            links = ref_need[node_need_ref.attributes["link_type"]]  # type: ignore[literal-required]
+            links = ref_need[node_need_ref.attributes["link_type"]]
             link_type = node_need_ref.attributes["link_type"]
         # if not, follow back to default links
         else:

--- a/sphinx_needs/roles/need_part.py
+++ b/sphinx_needs/roles/need_part.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import hashlib
 import re
-from collections.abc import Iterable
 
 from docutils import nodes
 from sphinx.application import Sphinx
@@ -17,8 +16,8 @@ from sphinx.environment import BuildEnvironment
 from sphinx.util.docutils import SphinxRole
 from sphinx.util.nodes import make_refnode
 
-from sphinx_needs.data import NeedsInfoType, NeedsPartType
 from sphinx_needs.logging import get_logger, log_warning
+from sphinx_needs.need_item import NeedItem
 from sphinx_needs.nodes import Need
 
 LOGGER = get_logger(__name__)
@@ -89,28 +88,8 @@ def process_need_part(
             )
 
 
-def create_need_from_part(need: NeedsInfoType, part: NeedsPartType) -> NeedsInfoType:
-    """Create a full need from a part and its parent need."""
-    full_part: NeedsInfoType = {**need, **part}
-    full_part["id_complete"] = f"{need['id']}.{part['id']}"
-    full_part["id_parent"] = need["id"]
-    full_part["is_need"] = False
-    full_part["is_part"] = True
-    return full_part
-
-
-def iter_need_parts(need: NeedsInfoType) -> Iterable[NeedsInfoType]:
-    """Yield all parts, a.k.a sub-needs, from a need.
-
-    A sub-need is a child of a need, which has its own ID,
-    and overrides the content of the parent need.
-    """
-    for part in need["parts"].values():
-        yield create_need_from_part(need, part)
-
-
 def update_need_with_parts(
-    env: BuildEnvironment, need: NeedsInfoType, part_nodes: list[NeedPart]
+    env: BuildEnvironment, need: NeedItem, part_nodes: list[NeedPart]
 ) -> None:
     app = env.app
     for part_node in part_nodes:

--- a/sphinx_needs/roles/need_ref.py
+++ b/sphinx_needs/roles/need_ref.py
@@ -9,9 +9,10 @@ from sphinx.application import Sphinx
 from sphinx.util.nodes import make_refnode
 
 from sphinx_needs.config import NeedsSphinxConfig
-from sphinx_needs.data import NeedsInfoType, SphinxNeedsData
+from sphinx_needs.data import SphinxNeedsData
 from sphinx_needs.errors import NoUri
 from sphinx_needs.logging import get_logger, log_warning
+from sphinx_needs.need_item import NeedItem
 from sphinx_needs.utils import check_and_calc_base_url_rel_path, split_need_id
 
 log = get_logger(__name__)
@@ -21,7 +22,7 @@ class NeedRef(nodes.Inline, nodes.Element):
     pass
 
 
-def transform_need_to_dict(need: NeedsInfoType) -> dict[str, str]:
+def transform_need_to_dict(need: NeedItem) -> dict[str, str]:
     """
     The function will transform a need in a dictionary of strings. Used to
     be given e.g. to a python format string.
@@ -158,7 +159,7 @@ def process_need_ref(
             node_need_ref[0].children[0] = nodes.Text(link_text)  # type: ignore[index]
 
             with contextlib.suppress(NoUri):
-                if not target_need.get("is_external", False) and (
+                if not target_need["is_external"] and (
                     _docname := target_need["docname"]
                 ):
                     new_node_ref = make_refnode(

--- a/sphinx_needs/schema/core.py
+++ b/sphinx_needs/schema/core.py
@@ -7,7 +7,7 @@ from typing import Any, cast
 from jsonschema import Draft202012Validator, FormatChecker, ValidationError
 
 from sphinx_needs.config import NeedsSphinxConfig
-from sphinx_needs.data import NeedsInfoType
+from sphinx_needs.need_item import NeedItem
 from sphinx_needs.schema.config import (
     MAP_RULE_DEFAULT_SEVERITY,
     MAX_NESTED_NETWORK_VALIDATION_LEVELS,
@@ -89,7 +89,7 @@ def merge_static_schemas(config: NeedsSphinxConfig) -> bool:
 
 def validate_need(
     config: NeedsSphinxConfig,
-    need: NeedsInfoType,
+    need: NeedItem,
     needs: NeedsView,
     type_schemas: list[SchemasRootType],
 ) -> list[OntologyWarning]:
@@ -174,7 +174,7 @@ def validate_need(
 
 def recurse_validate_type_schmemas(
     config: NeedsSphinxConfig,
-    need: NeedsInfoType,
+    need: NeedItem,
     needs: NeedsView,
     user_message: str | None,
     schema: ValidateSchemaType,
@@ -250,7 +250,7 @@ def recurse_validate_type_schmemas(
             """List of target need ids for contains validation that failed."""
             contains_warnings_per_target: dict[str, list[OntologyWarning]] = {}
             """Map of target need id to warnings for failed contains validation."""
-            for target_need_id in need[link_type]:  # type: ignore[literal-required]
+            for target_need_id in need[link_type]:
                 # collect all downstream warnings for broken links, items and contains
                 # evaluation happens later
                 try:
@@ -442,7 +442,7 @@ def recurse_validate_type_schmemas(
 
 def validate_local_need(
     config: NeedsSphinxConfig,
-    need: NeedsInfoType,
+    need: NeedItem,
     schema: NeedFieldsSchemaType,
 ) -> ValidateNeedType:
     """
@@ -486,7 +486,7 @@ def validate_local_need(
 
 def reduce_need(
     config: NeedsSphinxConfig,
-    need: NeedsInfoType,
+    need: NeedItem,
     json_schema: NeedFieldsSchemaWithVersionType,
 ) -> dict[str, Any]:
     """
@@ -624,7 +624,7 @@ def any_not_of_rule(warnings: list[OntologyWarning], rule: MessageRuleEnum) -> b
 
 def get_ontology_warnings(
     config: NeedsSphinxConfig,
-    need: NeedsInfoType,
+    need: NeedItem,
     schema: NeedFieldsSchemaType,
     fail_rule: MessageRuleEnum,
     success_rule: MessageRuleEnum,

--- a/sphinx_needs/schema/reporting.py
+++ b/sphinx_needs/schema/reporting.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, TypedDict
 
 from sphinx_needs.config import NeedsSphinxConfig
-from sphinx_needs.data import NeedsInfoType
+from sphinx_needs.need_item import NeedItem
 from sphinx_needs.schema.config import (
     MAP_RULE_DEFAULT_SEVERITY,
     MessageRuleEnum,
@@ -29,7 +29,7 @@ class OntologyWarning(TypedDict):
     severity: SeverityEnum
     user_message: NotRequired[str]
     validation_message: NotRequired[str]
-    need: NeedsInfoType
+    need: NeedItem
     reduced_need: NotRequired[dict[str, Any]]
     final_schema: NotRequired[NeedFieldsSchemaWithVersionType]
     schema_path: NotRequired[list[str]]

--- a/sphinx_needs/utils.py
+++ b/sphinx_needs/utils.py
@@ -17,10 +17,11 @@ from sphinx.application import Sphinx
 from sphinx.environment import BuildEnvironment
 
 from sphinx_needs.config import LinkOptionsType, NeedsSphinxConfig
-from sphinx_needs.data import NeedsInfoType, SphinxNeedsData
+from sphinx_needs.data import SphinxNeedsData
 from sphinx_needs.defaults import NEEDS_PROFILING
 from sphinx_needs.exceptions import NeedsInvalidFilter
 from sphinx_needs.logging import get_logger, log_warning
+from sphinx_needs.need_item import NeedItem, NeedPartItem
 from sphinx_needs.views import NeedsAndPartsListView, NeedsView
 
 if TYPE_CHECKING:
@@ -95,7 +96,7 @@ def row_col_maker(
     app: Sphinx,
     fromdocname: str,
     all_needs: NeedsView,
-    need_info: NeedsInfoType,
+    need_info: NeedItem | NeedPartItem,
     need_key: str,
     make_ref: bool = False,
     ref_lookup: bool = False,
@@ -125,8 +126,8 @@ def row_col_maker(
     for v in needs_config.string_links.values():
         needs_string_links_option.extend(v["options"])
 
-    if need_key in need_info and need_info[need_key] is not None:  # type: ignore[literal-required]
-        value = need_info[need_key]  # type: ignore[literal-required]
+    if need_key in need_info and need_info[need_key] is not None:
+        value = need_info[need_key]
         if isinstance(value, list | set):
             data = value
         elif isinstance(value, str) and need_key in needs_string_links_option:

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -6,6 +6,7 @@ import pytest
 from sphinx.util.console import strip_colors
 
 from sphinx_needs.filter_common import filter_needs_parts, filter_needs_view
+from sphinx_needs.need_item import NeedItem
 from sphinx_needs.views import NeedsView
 
 
@@ -172,7 +173,9 @@ def create_needs_view():
         },
     ]
 
-    return NeedsView._from_needs({n["id"]: n for n in needs})
+    need_items = [NeedItem(n) for n in needs]
+
+    return NeedsView._from_needs({n["id"]: n for n in need_items})
 
 
 std_test_params = (

--- a/tests/test_list2need.py
+++ b/tests/test_list2need.py
@@ -16,7 +16,7 @@ def test_doc_list2need_html(test_app, snapshot):
     assert app._warning.getvalue() == ""
 
     view = get_needs_view(app)
-    assert dict(view) == snapshot
+    assert {k: {**v} for k, v in view.items()} == snapshot
 
     index_html = Path(app.outdir, "index.html").read_text()
     assert "NEED-002" in index_html

--- a/tests/test_needimport.py
+++ b/tests/test_needimport.py
@@ -353,7 +353,9 @@ def test_needimport_needs_json_download(test_app, snapshot):
         m.get("http://my_company.com/docs/v1/remote-needs.json", json=remote_json)
         app.build()
 
-    needs_all_needs = dict(SphinxNeedsData(app.env).get_needs_view())
+    needs_all_needs = {
+        k: {**v} for k, v in SphinxNeedsData(app.env).get_needs_view().items()
+    }
     assert needs_all_needs == snapshot()
 
 

--- a/tests/test_needuml.py
+++ b/tests/test_needuml.py
@@ -20,7 +20,7 @@ def test_doc_build_html(test_app, snapshot):
 
     data = SphinxNeedsData(app.env)
 
-    all_needs = dict(data.get_needs_view())
+    all_needs = {k: {**v} for k, v in data.get_needs_view().items()}
     assert all_needs == snapshot()
 
     all_needumls = data.get_or_create_umls()


### PR DESCRIPTION
Currently, need data items are stored as standard Python dicts, which is also exposed to the user in various APIs and as the `needs.json`.
This is problematic as it does not allow for

1. any internal checks to ensure data is stored/updated consistently (e.g. fields like `id` should never be changed), 
2. any data to be "hid" from the user, or presented in a different way to its internal structure.
    - because the dict is a flat key/val store, it does not allow for distinction between internal / user set extra/link fields
    - we would like to improve how values that are dynamic/variant functions are stored (prior to evaluation)
    - we would also like to store source mapping data from distinct sources (directives, external, imports) in a more coherent way.
4. deprecations of any fields in a non-breaking manner

In this PR, we instead add a specific `NeedItem` class, which closely mimics a`dict`, but also allows for additional constraints and functionality.

We also introduce a `NeedPartItem` which is distinctly different from a `NeedItem`, e.g. it should not be mutated.

To ensure that no existing user code is accidentally breaking this, e.g. by directly add dictionaries to the list of needs,
we perform a check, at the end of the post-processing stage, to make sure all need items are instances of `NeedItem`
(and point them towards the "correct" `add_need` API)

---

‼️ Breaking

This would be breaking for any users doing "non-API" modifications / additions to the needs data, i.e. directly adding dict items.
It should not change interactions with standard APIs like `add_need` or filter strings, etc