### PR TITLE
♻️ Set some core need fields to nullable

### DIFF
--- a/sphinx_needs/api/need.py
+++ b/sphinx_needs/api/need.py
@@ -58,7 +58,7 @@ def generate_need(
     constraints: None | str | list[str] = None,
     parts: dict[str, NeedsPartType] | None = None,
     arch: dict[str, str] | None = None,
-    signature: str = "",
+    signature: None | str = None,
     sections: list[str] | None = None,
     jinja_content: bool | None = None,
     hide: None | bool = None,
@@ -300,7 +300,9 @@ def generate_need(
     )
     _copy_links(links, needs_config)
     # ensure parent_need is consistent with parent_needs
-    parent_need = parent_needs[0] if (parent_needs := links.get("parent_needs")) else ""
+    parent_need = (
+        parent_needs[0] if (parent_needs := links.get("parent_needs")) else None
+    )
 
     # Add the need and all needed information
     needs_data: NeedsInfoType = {
@@ -309,6 +311,8 @@ def generate_need(
         "lineno_content": lineno_content,
         "doctype": doctype,
         "content": content,
+        "pre_content": None,
+        "post_content": None,
         "type": need_type,
         "type_name": need_type_data["title"],
         "type_prefix": need_type_data["prefix"],
@@ -319,6 +323,7 @@ def generate_need(
         "constraints": constraints,
         "constraints_passed": True,
         "constraints_results": {},
+        "constraints_error": None,
         "id": need_id,
         "title": title,
         "collapse": collapse,
@@ -344,7 +349,7 @@ def generate_need(
         "has_dead_links": False,
         "has_forbidden_dead_links": False,
         "sections": sections or [],
-        "section_name": sections[0] if sections else "",
+        "section_name": sections[0] if sections else None,
         "signature": signature,
         "parent_need": parent_need,
         **extras,  # type: ignore[typeddict-item]
@@ -403,7 +408,7 @@ def add_need(
     constraints: None | str | list[str] = None,
     parts: dict[str, NeedsPartType] | None = None,
     arch: dict[str, str] | None = None,
-    signature: str = "",
+    signature: None | str = None,
     sections: list[str] | None = None,
     jinja_content: bool | None = None,
     hide: None | bool = None,

--- a/sphinx_needs/data.py
+++ b/sphinx_needs/data.py
@@ -21,10 +21,9 @@ from sphinx_needs.logging import log_warning
 from sphinx_needs.views import NeedsView
 
 if TYPE_CHECKING:
-    from docutils.nodes import Text
     from sphinx.application import Sphinx
     from sphinx.environment import BuildEnvironment
-    from typing_extensions import NotRequired, Required
+    from typing_extensions import NotRequired
 
     from sphinx_needs.need_item import NeedItem
     from sphinx_needs.nodes import Need
@@ -306,13 +305,13 @@ NeedsCoreFields: Final[Mapping[str, CoreFieldParameters]] = {
     },
     "pre_content": {
         "description": "Pre-content of the need.",
-        "schema": {"type": "string", "default": ""},
+        "schema": {"type": ["string", "null"], "default": None},
         "exclude_external": True,
         "exclude_import": True,
     },
     "post_content": {
         "description": "Post-content of the need.",
-        "schema": {"type": "string", "default": ""},
+        "schema": {"type": ["string", "null"], "default": None},
         "exclude_external": True,
         "exclude_import": True,
     },
@@ -354,7 +353,7 @@ NeedsCoreFields: Final[Mapping[str, CoreFieldParameters]] = {
     },
     "constraints_error": {
         "description": "An error message set if any constraint failed, and `error_message` field is set in config.",
-        "schema": {"type": "string", "default": ""},
+        "schema": {"type": ["string", "null"], "default": None},
         "exclude_external": True,
         "exclude_import": True,
     },
@@ -369,182 +368,132 @@ NeedsCoreFields: Final[Mapping[str, CoreFieldParameters]] = {
     },
     "section_name": {
         "description": "Simply the first section.",
-        "schema": {"type": "string", "default": ""},
+        "schema": {"type": ["string", "null"], "default": None},
         "exclude_external": True,
         "exclude_import": True,
     },
     "signature": {
         "description": "Derived from a docutils desc_name node.",
-        "schema": {"type": "string", "default": ""},
+        "schema": {"type": ["string", "null"], "default": None},
         "show_in_layout": True,
         "exclude_import": True,
     },
     "parent_need": {
         "description": "Simply the first parent id.",
-        "schema": {"type": "string", "default": ""},
+        "schema": {"type": ["string", "null"], "default": None},
         "exclude_external": True,
         "exclude_import": True,
     },
 }
 
 
-class NeedsInfoType(TypedDict, total=False):
+class NeedsInfoType(TypedDict):
     """Data for a single need."""
 
-    id: Required[str]
+    id: str
     """ID of the data."""
 
-    docname: Required[str | None]
+    docname: str | None
     """Name of the document where the need is defined (None if external)."""
-    lineno: Required[int | None]
+    lineno: int | None
     """Line number where the need is defined (None if external)."""
-    lineno_content: Required[int | None]
+    lineno_content: int | None
     """Line number on which the need content starts (None if external)."""
 
     # meta information
-    title: Required[str]
+    title: str
     """Title of the need."""
-    status: Required[None | str]
-    tags: Required[list[str]]
+    status: None | str
+    tags: list[str]
 
     # rendering information
-    collapse: Required[bool]
+    collapse: bool
     """Hide the meta-data information of the need."""
-    hide: Required[bool]
+    hide: bool
     """If true, the need is not rendered."""
-    layout: Required[None | str]
+    layout: None | str
     """Key of the layout, which is used to render the need."""
-    style: Required[None | str]
+    style: None | str
     """Comma-separated list of CSS classes (all appended by `needs_style_`)."""
 
     # TODO why is it called arch?
-    arch: Required[dict[str, str]]
+    arch: dict[str, str]
     """Mapping of uml key to uml content."""
 
-    is_import: Required[bool]
+    is_import: bool
     """If true, the need was derived from an import."""
 
     # external reference information
-    is_external: Required[bool]
+    is_external: bool
     """If true, no node is created and need is referencing external url."""
-    external_url: Required[None | str]
+    external_url: None | str
     """URL of the need, if it is an external need."""
-    external_css: Required[str]
+    external_css: str
     """CSS class name, added to the external reference."""
 
     # type information (based on needs_types config)
-    type: Required[str]
-    type_name: Required[str]
-    type_prefix: Required[str]
-    type_color: Required[str]
+    type: str
+    type_name: str
+    type_prefix: str
+    type_color: str
     """Hexadecimal color code of the type."""
-    type_style: Required[str]
+    type_style: str
 
-    is_modified: Required[bool]
+    is_modified: bool
     """Whether the need was modified by needextend."""
-    modifications: Required[int]
+    modifications: int
     """Number of modifications by needextend."""
 
     # used to distinguish a part from a need
-    is_need: Required[bool]
-    is_part: Required[bool]
+    is_need: bool
+    is_part: bool
     # Mapping of parts, a.k.a. sub-needs, IDs to data that overrides the need's data
-    parts: Required[dict[str, NeedsPartType]]
+    parts: dict[str, NeedsPartType]
     # additional information required for compatibility with parts
-    id_parent: Required[str]
+    id_parent: str
     """<parent ID>, or <self ID> if not a part."""
-    id_complete: Required[str]
+    id_complete: str
     """<parent ID>.<self ID>, or <self ID> if not a part."""
 
     # content creation information
-    jinja_content: Required[bool]
-    template: Required[None | str]
-    pre_template: Required[None | str]
-    post_template: Required[None | str]
-    content: Required[str]
-    pre_content: str
-    post_content: str
+    jinja_content: bool
+    template: None | str
+    pre_template: None | str
+    post_template: None | str
+    content: str
+    pre_content: None | str
+    post_content: None | str
 
     # these default to False and are updated in check_links post-process
-    has_dead_links: Required[bool]
+    has_dead_links: bool
     """True if any links reference need ids that are not found in the need list."""
-    has_forbidden_dead_links: Required[bool]
+    has_forbidden_dead_links: bool
     """True if any links reference need ids that are not found in the need list,
     and the link type does not allow dead links.
     """
 
     # constraints information
-    constraints: Required[list[str]]
+    constraints: list[str]
     """List of constraint names, which are defined for this need."""
     # set in process_need_nodes (-> process_constraints) transform
-    constraints_results: Required[dict[str, dict[str, bool]]]
+    constraints_results: dict[str, dict[str, bool]]
     """Mapping of constraint name, to check name, to result."""
-    constraints_passed: Required[bool]
+    constraints_passed: bool
     """True if all constraints passed, False if any failed, None if not yet checked."""
-    constraints_error: str
+    constraints_error: None | str
     """An error message set if any constraint failed, and `error_message` field is set in config."""
 
     # additional source information
-    doctype: Required[str]
+    doctype: str
     """Type of the document where the need is defined, e.g. '.rst'."""
     # set in analyse_need_locations transform
-    sections: Required[list[str]]
-    section_name: Required[str]
+    sections: list[str]
+    section_name: None | str
     """Simply the first section."""
-    signature: Required[str | Text]
+    signature: None | str
     """Derived from a docutils desc_name node."""
-    parent_need: Required[str]
+    parent_need: None | str
     """Simply the first parent id."""
-
-    # link information
-    # Note, there is more dynamically added link information;
-    # for each item in needs_extra_links config
-    # (and in prepare_env 'links' and 'parent_needs' are added if not present),
-    # you end up with a key named by the "option" field,
-    # and then another key named by the "option" field + "_back"
-    # these all have value type `list[str]`
-    # back links are all set in process_need_nodes (-> create_back_links) transform
-    links: list[str]
-    """List of need IDs, which are referenced by this need."""
-    links_back: list[str]
-    """List of need IDs, which are referencing this need."""
-    parent_needs: list[str]
-    """List of parents of the this need (by id),
-    i.e. if this need is nested in another
-    """
-    parent_needs_back: list[str]
-    """List of children of this need (by id),
-    i.e. if needs are nested within this one
-    """
-
-    # Fields added dynamically by services:
-    # options from ``BaseService.options`` get added to ``extra_options``,
-    # via `ServiceManager.register`,
-    # which in turn means they are added to every need via ``add_need``
-    # ``GithubService.options``
-    avatar: str
-    closed_at: str
-    created_at: str
-    max_amount: str
-    service: str
-    specific: str
-    ## type: str  # although this is already an internal field
-    updated_at: str
-    user: str
-    # ``OpenNeedsService.options``
-    params: str
-    prefix: str
-    url_postfix: str
-    # shared ``GithubService.options`` and ``OpenNeedsService.options``
-    max_content_lines: str
-    id_prefix: str
-    query: str
-    url: str
-
-    # Note there are also these dynamic keys:
-    # - items in ``needs_extra_options`` + ``needs_duration_option`` + ``needs_completion_option``,
-    #   which get added to ``extra_options``,
-    #   and in turn means they are added to every need via ``add_need`` (as strings)
 
 
 class NeedsBaseDataType(TypedDict):

--- a/sphinx_needs/directives/need.py
+++ b/sphinx_needs/directives/need.py
@@ -318,7 +318,7 @@ def analyse_need_locations(app: Sphinx, doctree: nodes.document) -> None:
             need_info["sections"] = []
 
         if "section_name" not in need_info:
-            need_info["section_name"] = ""
+            need_info["section_name"] = None
 
         if "signature" not in need_info:
             need_info["signature"] = ""
@@ -327,7 +327,7 @@ def analyse_need_locations(app: Sphinx, doctree: nodes.document) -> None:
             need_info["parent_needs"] = []
 
         if "parent_need" not in need_info:
-            need_info["parent_need"] = ""
+            need_info["parent_need"] = None
 
         # Fetch values from need
         # Start from the target node, which is a sibling of the current need node
@@ -341,7 +341,7 @@ def analyse_need_locations(app: Sphinx, doctree: nodes.document) -> None:
             need_info["section_name"] = sections[0]
 
         if signature:
-            need_info["signature"] = signature
+            need_info["signature"] = str(signature)
 
         if parent_needs:
             need_info["parent_needs"] = parent_needs

--- a/sphinx_needs/need_item.py
+++ b/sphinx_needs/need_item.py
@@ -20,7 +20,6 @@ class NeedItem:
 
     __slots__ = ("_data",)
 
-    _not_required = {"pre_content", "post_content", "constraints_error"}
     _immutable = {
         "id",
         "type",
@@ -33,6 +32,9 @@ class NeedItem:
         "is_part",
         "is_external",
         "is_import",
+        "template",
+        "pre_template",
+        "post_template",
     }
 
     def __init__(self, data: NeedsInfoType) -> None:
@@ -105,9 +107,6 @@ class NeedItem:
             "doctype",
             "external_url",
             "external_css",
-            "constraints_error",
-            "section_name",
-            "parent_need",
         ],
     ) -> str: ...
 
@@ -123,6 +122,9 @@ class NeedItem:
             "template",
             "post_template",
             "pre_template",
+            "constraints_error",
+            "section_name",
+            "parent_need",
         ],
     ) -> str | None: ...
 
@@ -166,7 +168,7 @@ class NeedItem:
 
     def __setitem__(self, key: str, value: Any) -> None:
         """Set an item by key."""
-        if key not in self._data and key not in self._not_required:
+        if key not in self._data:
             raise KeyError(
                 f"Cannot add new key {key!r} to NeedItem, only existing keys can be modified."
             )
@@ -179,7 +181,8 @@ class NeedItem:
         if part_id not in self._data.get("parts", {}):
             return None
         part_data = self._data["parts"][part_id]
-        full_part: NeedsInfoType = {**self._data, **part_data}
+        # TODO when creating a part, links/links_back are set to empty, but what about other link fields?
+        full_part: NeedsInfoType = {**self._data, **part_data}  # type: ignore[typeddict-unknown-key]
         full_part["id_complete"] = f"{self._data['id']}.{part_data['id']}"
         full_part["id_parent"] = self._data["id"]
         full_part["is_need"] = False
@@ -272,13 +275,8 @@ class NeedPartItem:
             "type_color",
             "type_style",
             "content",
-            "pre_content",
-            "post_content",
             "doctype",
             "external_css",
-            "constraints_error",
-            "section_name",
-            "parent_need",
         ],
     ) -> str: ...
 
@@ -294,6 +292,11 @@ class NeedPartItem:
             "template",
             "post_template",
             "pre_template",
+            "constraints_error",
+            "parent_need",
+            "pre_content",
+            "post_content",
+            "section_name",
         ],
     ) -> str | None: ...
 

--- a/tests/__snapshots__/test_basic_doc.ambr
+++ b/tests/__snapshots__/test_basic_doc.ambr
@@ -13,6 +13,7 @@
             'completion': '',
             'constraints': list([
             ]),
+            'constraints_error': None,
             'constraints_passed': True,
             'constraints_results': dict({
             }),
@@ -43,14 +44,16 @@
             'max_content_lines': '',
             'modifications': 0,
             'params': '',
-            'parent_need': '',
+            'parent_need': None,
             'parent_needs': list([
             ]),
             'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
+            'post_content': None,
             'post_template': None,
+            'pre_content': None,
             'pre_template': None,
             'prefix': '',
             'query': '',
@@ -59,7 +62,7 @@
               'TEST DOCUMENT',
             ]),
             'service': '',
-            'signature': '',
+            'signature': None,
             'specific': '',
             'status': 'open',
             'style': None,
@@ -82,6 +85,7 @@
             'completion': '',
             'constraints': list([
             ]),
+            'constraints_error': None,
             'constraints_passed': True,
             'constraints_results': dict({
             }),
@@ -112,14 +116,16 @@
             'max_content_lines': '',
             'modifications': 0,
             'params': '',
-            'parent_need': '',
+            'parent_need': None,
             'parent_needs': list([
             ]),
             'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
+            'post_content': None,
             'post_template': None,
+            'pre_content': None,
             'pre_template': None,
             'prefix': '',
             'query': '',
@@ -128,7 +134,7 @@
               'TEST DOCUMENT',
             ]),
             'service': '',
-            'signature': '',
+            'signature': None,
             'specific': '',
             'status': 'open',
             'style': None,
@@ -187,10 +193,13 @@
               'type': 'array',
             }),
             'constraints_error': dict({
-              'default': '',
+              'default': None,
               'description': 'An error message set if any constraint failed, and `error_message` field is set in config.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'constraints_passed': dict({
               'default': True,
@@ -378,10 +387,13 @@
               'type': 'string',
             }),
             'parent_need': dict({
-              'default': '',
+              'default': None,
               'description': 'Simply the first parent id.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'parent_needs': dict({
               'default': list([
@@ -414,10 +426,13 @@
               'type': 'object',
             }),
             'post_content': dict({
-              'default': '',
+              'default': None,
               'description': 'Post-content of the need.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'post_template': dict({
               'default': None,
@@ -429,10 +444,13 @@
               ]),
             }),
             'pre_content': dict({
-              'default': '',
+              'default': None,
               'description': 'Pre-content of the need.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'pre_template': dict({
               'default': None,
@@ -456,10 +474,13 @@
               'type': 'string',
             }),
             'section_name': dict({
-              'default': '',
+              'default': None,
               'description': 'Simply the first section.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'sections': dict({
               'default': list([
@@ -478,10 +499,13 @@
               'type': 'string',
             }),
             'signature': dict({
-              'default': '',
+              'default': None,
               'description': 'Derived from a docutils desc_name node.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'specific': dict({
               'default': '',

--- a/tests/__snapshots__/test_dynamic_functions.ambr
+++ b/tests/__snapshots__/test_dynamic_functions.ambr
@@ -181,10 +181,13 @@
               'type': 'array',
             }),
             'constraints_error': dict({
-              'default': '',
+              'default': None,
               'description': 'An error message set if any constraint failed, and `error_message` field is set in config.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'constraints_passed': dict({
               'default': True,
@@ -372,10 +375,13 @@
               'type': 'string',
             }),
             'parent_need': dict({
-              'default': '',
+              'default': None,
               'description': 'Simply the first parent id.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'parent_needs': dict({
               'default': list([
@@ -408,10 +414,13 @@
               'type': 'object',
             }),
             'post_content': dict({
-              'default': '',
+              'default': None,
               'description': 'Post-content of the need.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'post_template': dict({
               'default': None,
@@ -423,10 +432,13 @@
               ]),
             }),
             'pre_content': dict({
-              'default': '',
+              'default': None,
               'description': 'Pre-content of the need.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'pre_template': dict({
               'default': None,
@@ -450,10 +462,13 @@
               'type': 'string',
             }),
             'section_name': dict({
-              'default': '',
+              'default': None,
               'description': 'Simply the first section.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'sections': dict({
               'default': list([
@@ -472,10 +487,13 @@
               'type': 'string',
             }),
             'signature': dict({
-              'default': '',
+              'default': None,
               'description': 'Derived from a docutils desc_name node.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'specific': dict({
               'default': '',

--- a/tests/__snapshots__/test_external.ambr
+++ b/tests/__snapshots__/test_external.ambr
@@ -77,10 +77,13 @@
               'type': 'array',
             }),
             'constraints_error': dict({
-              'default': '',
+              'default': None,
               'description': 'An error message set if any constraint failed, and `error_message` field is set in config.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'constraints_passed': dict({
               'default': True,
@@ -268,10 +271,13 @@
               'type': 'string',
             }),
             'parent_need': dict({
-              'default': '',
+              'default': None,
               'description': 'Simply the first parent id.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'parent_needs': dict({
               'default': list([
@@ -304,10 +310,13 @@
               'type': 'object',
             }),
             'post_content': dict({
-              'default': '',
+              'default': None,
               'description': 'Post-content of the need.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'post_template': dict({
               'default': None,
@@ -319,10 +328,13 @@
               ]),
             }),
             'pre_content': dict({
-              'default': '',
+              'default': None,
               'description': 'Pre-content of the need.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'pre_template': dict({
               'default': None,
@@ -346,10 +358,13 @@
               'type': 'string',
             }),
             'section_name': dict({
-              'default': '',
+              'default': None,
               'description': 'Simply the first section.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'sections': dict({
               'default': list([
@@ -368,10 +383,13 @@
               'type': 'string',
             }),
             'signature': dict({
-              'default': '',
+              'default': None,
               'description': 'Derived from a docutils desc_name node.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'specific': dict({
               'default': '',
@@ -489,6 +507,7 @@
             'parent_needs_back': list([
               'EXT_TEST_02',
             ]),
+            'signature': '',
             'title': 'TEST_01 DESCRIPTION',
             'type': 'impl',
             'type_name': 'Implementation',
@@ -618,10 +637,13 @@
               'type': 'array',
             }),
             'constraints_error': dict({
-              'default': '',
+              'default': None,
               'description': 'An error message set if any constraint failed, and `error_message` field is set in config.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'constraints_passed': dict({
               'default': True,
@@ -821,10 +843,13 @@
               'type': 'string',
             }),
             'parent_need': dict({
-              'default': '',
+              'default': None,
               'description': 'Simply the first parent id.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'parent_needs': dict({
               'default': list([
@@ -857,10 +882,13 @@
               'type': 'object',
             }),
             'post_content': dict({
-              'default': '',
+              'default': None,
               'description': 'Post-content of the need.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'post_template': dict({
               'default': None,
@@ -872,10 +900,13 @@
               ]),
             }),
             'pre_content': dict({
-              'default': '',
+              'default': None,
               'description': 'Pre-content of the need.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'pre_template': dict({
               'default': None,
@@ -899,10 +930,13 @@
               'type': 'string',
             }),
             'section_name': dict({
-              'default': '',
+              'default': None,
               'description': 'Simply the first section.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'sections': dict({
               'default': list([
@@ -921,10 +955,13 @@
               'type': 'string',
             }),
             'signature': dict({
-              'default': '',
+              'default': None,
               'description': 'Derived from a docutils desc_name node.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'specific': dict({
               'default': '',

--- a/tests/__snapshots__/test_extra_options.ambr
+++ b/tests/__snapshots__/test_extra_options.ambr
@@ -94,10 +94,13 @@
               'type': 'array',
             }),
             'constraints_error': dict({
-              'default': '',
+              'default': None,
               'description': 'An error message set if any constraint failed, and `error_message` field is set in config.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'constraints_passed': dict({
               'default': True,
@@ -303,10 +306,13 @@
               'type': 'string',
             }),
             'parent_need': dict({
-              'default': '',
+              'default': None,
               'description': 'Simply the first parent id.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'parent_needs': dict({
               'default': list([
@@ -339,10 +345,13 @@
               'type': 'object',
             }),
             'post_content': dict({
-              'default': '',
+              'default': None,
               'description': 'Post-content of the need.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'post_template': dict({
               'default': None,
@@ -354,10 +363,13 @@
               ]),
             }),
             'pre_content': dict({
-              'default': '',
+              'default': None,
               'description': 'Pre-content of the need.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'pre_template': dict({
               'default': None,
@@ -381,10 +393,13 @@
               'type': 'string',
             }),
             'section_name': dict({
-              'default': '',
+              'default': None,
               'description': 'Simply the first section.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'sections': dict({
               'default': list([
@@ -403,10 +418,13 @@
               'type': 'string',
             }),
             'signature': dict({
-              'default': '',
+              'default': None,
               'description': 'Derived from a docutils desc_name node.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'specific': dict({
               'default': '',

--- a/tests/__snapshots__/test_list2need.ambr
+++ b/tests/__snapshots__/test_list2need.ambr
@@ -14,6 +14,7 @@
       'completion': '',
       'constraints': list([
       ]),
+      'constraints_error': None,
       'constraints_passed': True,
       'constraints_results': dict({
       }),
@@ -68,7 +69,7 @@
       'max_content_lines': '',
       'modifications': 0,
       'params': '',
-      'parent_need': '',
+      'parent_need': None,
       'parent_needs': list([
       ]),
       'parent_needs_back': list([
@@ -77,7 +78,9 @@
       ]),
       'parts': dict({
       }),
+      'post_content': None,
       'post_template': None,
+      'pre_content': None,
       'pre_template': None,
       'prefix': '',
       'query': '',
@@ -86,7 +89,7 @@
         'TEST DOCUMENT LIST2NEED',
       ]),
       'service': '',
-      'signature': '',
+      'signature': None,
       'specific': '',
       'status': None,
       'style': None,
@@ -121,6 +124,7 @@
       'completion': '',
       'constraints': list([
       ]),
+      'constraints_error': None,
       'constraints_passed': True,
       'constraints_results': dict({
       }),
@@ -163,7 +167,9 @@
       ]),
       'parts': dict({
       }),
+      'post_content': None,
       'post_template': None,
+      'pre_content': None,
       'pre_template': None,
       'prefix': '',
       'query': '',
@@ -172,7 +178,7 @@
         'TEST DOCUMENT LIST2NEED',
       ]),
       'service': '',
-      'signature': '',
+      'signature': None,
       'specific': '',
       'status': None,
       'style': None,
@@ -207,6 +213,7 @@
       'completion': '',
       'constraints': list([
       ]),
+      'constraints_error': None,
       'constraints_passed': True,
       'constraints_results': dict({
       }),
@@ -242,14 +249,16 @@
       'max_content_lines': '',
       'modifications': 0,
       'params': '',
-      'parent_need': '',
+      'parent_need': None,
       'parent_needs': list([
       ]),
       'parent_needs_back': list([
       ]),
       'parts': dict({
       }),
+      'post_content': None,
       'post_template': None,
+      'pre_content': None,
       'pre_template': None,
       'prefix': '',
       'query': '',
@@ -258,7 +267,7 @@
         'LIST2NEED OPTIONS',
       ]),
       'service': '',
-      'signature': '',
+      'signature': None,
       'specific': '',
       'status': 'open',
       'style': None,
@@ -293,6 +302,7 @@
       'completion': '',
       'constraints': list([
       ]),
+      'constraints_error': None,
       'constraints_passed': True,
       'constraints_results': dict({
       }),
@@ -328,14 +338,16 @@
       'max_content_lines': '',
       'modifications': 0,
       'params': '',
-      'parent_need': '',
+      'parent_need': None,
       'parent_needs': list([
       ]),
       'parent_needs_back': list([
       ]),
       'parts': dict({
       }),
+      'post_content': None,
       'post_template': None,
+      'pre_content': None,
       'pre_template': None,
       'prefix': '',
       'query': '',
@@ -344,7 +356,7 @@
         'LIST2NEED OPTIONS',
       ]),
       'service': '',
-      'signature': '',
+      'signature': None,
       'specific': '',
       'status': 'done',
       'style': None,
@@ -382,6 +394,7 @@
       'completion': '',
       'constraints': list([
       ]),
+      'constraints_error': None,
       'constraints_passed': True,
       'constraints_results': dict({
       }),
@@ -420,14 +433,16 @@
       'max_content_lines': '',
       'modifications': 0,
       'params': '',
-      'parent_need': '',
+      'parent_need': None,
       'parent_needs': list([
       ]),
       'parent_needs_back': list([
       ]),
       'parts': dict({
       }),
+      'post_content': None,
       'post_template': None,
+      'pre_content': None,
       'pre_template': None,
       'prefix': '',
       'query': '',
@@ -436,7 +451,7 @@
         'LIST2NEED OPTIONS',
       ]),
       'service': '',
-      'signature': '',
+      'signature': None,
       'specific': '',
       'status': None,
       'style': None,
@@ -471,6 +486,7 @@
       'completion': '',
       'constraints': list([
       ]),
+      'constraints_error': None,
       'constraints_passed': True,
       'constraints_results': dict({
       }),
@@ -506,14 +522,16 @@
       'max_content_lines': '',
       'modifications': 0,
       'params': '',
-      'parent_need': '',
+      'parent_need': None,
       'parent_needs': list([
       ]),
       'parent_needs_back': list([
       ]),
       'parts': dict({
       }),
+      'post_content': None,
       'post_template': None,
+      'pre_content': None,
       'pre_template': None,
       'prefix': '',
       'query': '',
@@ -522,7 +540,7 @@
         'LIST2NEED OPTIONS',
       ]),
       'service': '',
-      'signature': '',
+      'signature': None,
       'specific': '',
       'status': 'in progress',
       'style': None,
@@ -558,6 +576,7 @@
       'completion': '',
       'constraints': list([
       ]),
+      'constraints_error': None,
       'constraints_passed': True,
       'constraints_results': dict({
       }),
@@ -592,14 +611,16 @@
       'max_content_lines': '',
       'modifications': 0,
       'params': '',
-      'parent_need': '',
+      'parent_need': None,
       'parent_needs': list([
       ]),
       'parent_needs_back': list([
       ]),
       'parts': dict({
       }),
+      'post_content': None,
       'post_template': None,
+      'pre_content': None,
       'pre_template': None,
       'prefix': '',
       'query': '',
@@ -608,7 +629,7 @@
         'LIST2NEED LINKS_DOWN',
       ]),
       'service': '',
-      'signature': '',
+      'signature': None,
       'specific': '',
       'status': None,
       'style': None,
@@ -644,6 +665,7 @@
       'completion': '',
       'constraints': list([
       ]),
+      'constraints_error': None,
       'constraints_passed': True,
       'constraints_results': dict({
       }),
@@ -678,14 +700,16 @@
       'max_content_lines': '',
       'modifications': 0,
       'params': '',
-      'parent_need': '',
+      'parent_need': None,
       'parent_needs': list([
       ]),
       'parent_needs_back': list([
       ]),
       'parts': dict({
       }),
+      'post_content': None,
       'post_template': None,
+      'pre_content': None,
       'pre_template': None,
       'prefix': '',
       'query': '',
@@ -694,7 +718,7 @@
         'LIST2NEED LINKS_DOWN',
       ]),
       'service': '',
-      'signature': '',
+      'signature': None,
       'specific': '',
       'status': None,
       'style': None,
@@ -730,6 +754,7 @@
       'completion': '',
       'constraints': list([
       ]),
+      'constraints_error': None,
       'constraints_passed': True,
       'constraints_results': dict({
       }),
@@ -764,14 +789,16 @@
       'max_content_lines': '',
       'modifications': 0,
       'params': '',
-      'parent_need': '',
+      'parent_need': None,
       'parent_needs': list([
       ]),
       'parent_needs_back': list([
       ]),
       'parts': dict({
       }),
+      'post_content': None,
       'post_template': None,
+      'pre_content': None,
       'pre_template': None,
       'prefix': '',
       'query': '',
@@ -780,7 +807,7 @@
         'LIST2NEED LINKS_DOWN',
       ]),
       'service': '',
-      'signature': '',
+      'signature': None,
       'specific': '',
       'status': None,
       'style': None,
@@ -816,6 +843,7 @@
       'completion': '',
       'constraints': list([
       ]),
+      'constraints_error': None,
       'constraints_passed': True,
       'constraints_results': dict({
       }),
@@ -851,14 +879,16 @@
       'max_content_lines': '',
       'modifications': 0,
       'params': '',
-      'parent_need': '',
+      'parent_need': None,
       'parent_needs': list([
       ]),
       'parent_needs_back': list([
       ]),
       'parts': dict({
       }),
+      'post_content': None,
       'post_template': None,
+      'pre_content': None,
       'pre_template': None,
       'prefix': '',
       'query': '',
@@ -867,7 +897,7 @@
         'LIST2NEED GLOBAL TAGS',
       ]),
       'service': '',
-      'signature': '',
+      'signature': None,
       'specific': '',
       'status': 'open',
       'style': None,
@@ -905,6 +935,7 @@
       'completion': '',
       'constraints': list([
       ]),
+      'constraints_error': None,
       'constraints_passed': True,
       'constraints_results': dict({
       }),
@@ -939,14 +970,16 @@
       'max_content_lines': '',
       'modifications': 0,
       'params': '',
-      'parent_need': '',
+      'parent_need': None,
       'parent_needs': list([
       ]),
       'parent_needs_back': list([
       ]),
       'parts': dict({
       }),
+      'post_content': None,
       'post_template': None,
+      'pre_content': None,
       'pre_template': None,
       'prefix': '',
       'query': '',
@@ -955,7 +988,7 @@
         'LIST2NEED GLOBAL TAGS',
       ]),
       'service': '',
-      'signature': '',
+      'signature': None,
       'specific': '',
       'status': 'done',
       'style': None,
@@ -996,6 +1029,7 @@
       'completion': '',
       'constraints': list([
       ]),
+      'constraints_error': None,
       'constraints_passed': True,
       'constraints_results': dict({
       }),
@@ -1033,14 +1067,16 @@
       'max_content_lines': '',
       'modifications': 0,
       'params': '',
-      'parent_need': '',
+      'parent_need': None,
       'parent_needs': list([
       ]),
       'parent_needs_back': list([
       ]),
       'parts': dict({
       }),
+      'post_content': None,
       'post_template': None,
+      'pre_content': None,
       'pre_template': None,
       'prefix': '',
       'query': '',
@@ -1049,7 +1085,7 @@
         'LIST2NEED GLOBAL TAGS',
       ]),
       'service': '',
-      'signature': '',
+      'signature': None,
       'specific': '',
       'status': None,
       'style': None,
@@ -1087,6 +1123,7 @@
       'completion': '',
       'constraints': list([
       ]),
+      'constraints_error': None,
       'constraints_passed': True,
       'constraints_results': dict({
       }),
@@ -1122,14 +1159,16 @@
       'max_content_lines': '',
       'modifications': 0,
       'params': '',
-      'parent_need': '',
+      'parent_need': None,
       'parent_needs': list([
       ]),
       'parent_needs_back': list([
       ]),
       'parts': dict({
       }),
+      'post_content': None,
       'post_template': None,
+      'pre_content': None,
       'pre_template': None,
       'prefix': '',
       'query': '',
@@ -1138,7 +1177,7 @@
         'LIST2NEED GLOBAL TAGS',
       ]),
       'service': '',
-      'signature': '',
+      'signature': None,
       'specific': '',
       'status': 'in progress',
       'style': None,
@@ -1176,6 +1215,7 @@
       'completion': '',
       'constraints': list([
       ]),
+      'constraints_error': None,
       'constraints_passed': True,
       'constraints_results': dict({
       }),
@@ -1229,7 +1269,9 @@
       ]),
       'parts': dict({
       }),
+      'post_content': None,
       'post_template': None,
+      'pre_content': None,
       'pre_template': None,
       'prefix': '',
       'query': '',
@@ -1238,7 +1280,7 @@
         'TEST DOCUMENT LIST2NEED',
       ]),
       'service': '',
-      'signature': '',
+      'signature': None,
       'specific': '',
       'status': None,
       'style': None,
@@ -1273,6 +1315,7 @@
       'completion': '',
       'constraints': list([
       ]),
+      'constraints_error': None,
       'constraints_passed': True,
       'constraints_results': dict({
       }),
@@ -1318,7 +1361,9 @@
       ]),
       'parts': dict({
       }),
+      'post_content': None,
       'post_template': None,
+      'pre_content': None,
       'pre_template': None,
       'prefix': '',
       'query': '',
@@ -1327,7 +1372,7 @@
         'TEST DOCUMENT LIST2NEED',
       ]),
       'service': '',
-      'signature': '',
+      'signature': None,
       'specific': '',
       'status': None,
       'style': None,
@@ -1362,6 +1407,7 @@
       'completion': '',
       'constraints': list([
       ]),
+      'constraints_error': None,
       'constraints_passed': True,
       'constraints_results': dict({
       }),
@@ -1396,14 +1442,16 @@
       'max_content_lines': '',
       'modifications': 0,
       'params': '',
-      'parent_need': '',
+      'parent_need': None,
       'parent_needs': list([
       ]),
       'parent_needs_back': list([
       ]),
       'parts': dict({
       }),
+      'post_content': None,
       'post_template': None,
+      'pre_content': None,
       'pre_template': None,
       'prefix': '',
       'query': '',
@@ -1412,7 +1460,7 @@
         'TEST DOCUMENT LIST2NEED',
       ]),
       'service': '',
-      'signature': '',
+      'signature': None,
       'specific': '',
       'status': None,
       'style': None,

--- a/tests/__snapshots__/test_need_constraints.ambr
+++ b/tests/__snapshots__/test_need_constraints.ambr
@@ -13,6 +13,7 @@
             'completion': '',
             'constraints': list([
             ]),
+            'constraints_error': None,
             'constraints_passed': True,
             'constraints_results': dict({
             }),
@@ -45,14 +46,16 @@
             'max_content_lines': '',
             'modifications': 0,
             'params': '',
-            'parent_need': '',
+            'parent_need': None,
             'parent_needs': list([
             ]),
             'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
+            'post_content': None,
             'post_template': None,
+            'pre_content': None,
             'pre_template': None,
             'prefix': '',
             'query': '',
@@ -61,7 +64,7 @@
               'TEST DOCUMENT NEEDS CONSTRAINTS',
             ]),
             'service': '',
-            'signature': '',
+            'signature': None,
             'specific': '',
             'status': None,
             'style': None,
@@ -85,6 +88,7 @@
             'constraints': list([
               'critical',
             ]),
+            'constraints_error': None,
             'constraints_passed': True,
             'constraints_results': dict({
               'critical': dict({
@@ -119,14 +123,16 @@
             'max_content_lines': '',
             'modifications': 0,
             'params': '',
-            'parent_need': '',
+            'parent_need': None,
             'parent_needs': list([
             ]),
             'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
+            'post_content': None,
             'post_template': None,
+            'pre_content': None,
             'pre_template': None,
             'prefix': '',
             'query': '',
@@ -135,7 +141,7 @@
               'TEST DOCUMENT NEEDS CONSTRAINTS',
             ]),
             'service': '',
-            'signature': '',
+            'signature': None,
             'specific': '',
             'status': None,
             'style': None,
@@ -195,14 +201,16 @@
             'max_content_lines': '',
             'modifications': 0,
             'params': '',
-            'parent_need': '',
+            'parent_need': None,
             'parent_needs': list([
             ]),
             'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
+            'post_content': None,
             'post_template': None,
+            'pre_content': None,
             'pre_template': None,
             'prefix': '',
             'query': '',
@@ -211,7 +219,7 @@
               'TEST DOCUMENT NEEDS CONSTRAINTS',
             ]),
             'service': '',
-            'signature': '',
+            'signature': None,
             'specific': '',
             'status': None,
             'style': 'red_bar',
@@ -235,6 +243,7 @@
             'constraints': list([
               'team',
             ]),
+            'constraints_error': None,
             'constraints_passed': False,
             'constraints_results': dict({
               'team': dict({
@@ -268,14 +277,16 @@
             'max_content_lines': '',
             'modifications': 0,
             'params': '',
-            'parent_need': '',
+            'parent_need': None,
             'parent_needs': list([
             ]),
             'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
+            'post_content': None,
             'post_template': None,
+            'pre_content': None,
             'pre_template': None,
             'prefix': '',
             'query': '',
@@ -284,7 +295,7 @@
               'TEST DOCUMENT NEEDS CONSTRAINTS',
             ]),
             'service': '',
-            'signature': '',
+            'signature': None,
             'specific': '',
             'status': None,
             'style': 'yellow_bar,',
@@ -307,6 +318,7 @@
             'completion': '',
             'constraints': list([
             ]),
+            'constraints_error': None,
             'constraints_passed': True,
             'constraints_results': dict({
             }),
@@ -337,14 +349,16 @@
             'max_content_lines': '',
             'modifications': 0,
             'params': '',
-            'parent_need': '',
+            'parent_need': None,
             'parent_needs': list([
             ]),
             'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
+            'post_content': None,
             'post_template': None,
+            'pre_content': None,
             'pre_template': None,
             'prefix': '',
             'query': '',
@@ -353,7 +367,7 @@
               'TEST DOCUMENT NEEDS CONSTRAINTS',
             ]),
             'service': '',
-            'signature': '',
+            'signature': None,
             'specific': '',
             'status': 'implemented',
             'style': None,
@@ -413,14 +427,16 @@
             'max_content_lines': '',
             'modifications': 0,
             'params': '',
-            'parent_need': '',
+            'parent_need': None,
             'parent_needs': list([
             ]),
             'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
+            'post_content': None,
             'post_template': None,
+            'pre_content': None,
             'pre_template': None,
             'prefix': '',
             'query': '',
@@ -429,7 +445,7 @@
               'TEST DOCUMENT NEEDS CONSTRAINTS',
             ]),
             'service': '',
-            'signature': '',
+            'signature': None,
             'specific': '',
             'status': 'dev',
             'style': 'red_bar',
@@ -489,14 +505,16 @@
             'max_content_lines': '',
             'modifications': 0,
             'params': '',
-            'parent_need': '',
+            'parent_need': None,
             'parent_needs': list([
             ]),
             'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
+            'post_content': None,
             'post_template': None,
+            'pre_content': None,
             'pre_template': None,
             'prefix': '',
             'query': '',
@@ -505,7 +523,7 @@
               'TEST DOCUMENT NEEDS CONSTRAINTS',
             ]),
             'service': '',
-            'signature': '',
+            'signature': None,
             'specific': '',
             'status': None,
             'style': 'red_bar',
@@ -529,6 +547,7 @@
             'constraints': list([
               'team',
             ]),
+            'constraints_error': None,
             'constraints_passed': False,
             'constraints_results': dict({
               'team': dict({
@@ -562,14 +581,16 @@
             'max_content_lines': '',
             'modifications': 0,
             'params': '',
-            'parent_need': '',
+            'parent_need': None,
             'parent_needs': list([
             ]),
             'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
+            'post_content': None,
             'post_template': None,
+            'pre_content': None,
             'pre_template': None,
             'prefix': '',
             'query': '',
@@ -578,7 +599,7 @@
               'TEST DOCUMENT NEEDS CONSTRAINTS',
             ]),
             'service': '',
-            'signature': '',
+            'signature': None,
             'specific': '',
             'status': None,
             'style': 'blue_border, yellow_bar',
@@ -637,10 +658,13 @@
               'type': 'array',
             }),
             'constraints_error': dict({
-              'default': '',
+              'default': None,
               'description': 'An error message set if any constraint failed, and `error_message` field is set in config.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'constraints_passed': dict({
               'default': True,
@@ -828,10 +852,13 @@
               'type': 'string',
             }),
             'parent_need': dict({
-              'default': '',
+              'default': None,
               'description': 'Simply the first parent id.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'parent_needs': dict({
               'default': list([
@@ -864,10 +891,13 @@
               'type': 'object',
             }),
             'post_content': dict({
-              'default': '',
+              'default': None,
               'description': 'Post-content of the need.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'post_template': dict({
               'default': None,
@@ -879,10 +909,13 @@
               ]),
             }),
             'pre_content': dict({
-              'default': '',
+              'default': None,
               'description': 'Pre-content of the need.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'pre_template': dict({
               'default': None,
@@ -906,10 +939,13 @@
               'type': 'string',
             }),
             'section_name': dict({
-              'default': '',
+              'default': None,
               'description': 'Simply the first section.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'sections': dict({
               'default': list([
@@ -928,10 +964,13 @@
               'type': 'string',
             }),
             'signature': dict({
-              'default': '',
+              'default': None,
               'description': 'Derived from a docutils desc_name node.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'specific': dict({
               'default': '',

--- a/tests/__snapshots__/test_needextend.ambr
+++ b/tests/__snapshots__/test_needextend.ambr
@@ -13,6 +13,7 @@
             'completion': '',
             'constraints': list([
             ]),
+            'constraints_error': None,
             'constraints_passed': True,
             'constraints_results': dict({
             }),
@@ -46,14 +47,16 @@
             'max_content_lines': '',
             'modifications': 2,
             'params': '',
-            'parent_need': '',
+            'parent_need': None,
             'parent_needs': list([
             ]),
             'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
+            'post_content': None,
             'post_template': None,
+            'pre_content': None,
             'pre_template': None,
             'prefix': '',
             'query': '',
@@ -62,7 +65,7 @@
               'needextend dynamic functions',
             ]),
             'service': '',
-            'signature': '',
+            'signature': None,
             'specific': '',
             'status': None,
             'style': None,
@@ -85,6 +88,7 @@
             'completion': '',
             'constraints': list([
             ]),
+            'constraints_error': None,
             'constraints_passed': True,
             'constraints_results': dict({
             }),
@@ -116,14 +120,16 @@
             'max_content_lines': '',
             'modifications': 0,
             'params': '',
-            'parent_need': '',
+            'parent_need': None,
             'parent_needs': list([
             ]),
             'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
+            'post_content': None,
             'post_template': None,
+            'pre_content': None,
             'pre_template': None,
             'prefix': '',
             'query': '',
@@ -132,7 +138,7 @@
               'needextend dynamic functions',
             ]),
             'service': '',
-            'signature': '',
+            'signature': None,
             'specific': '',
             'status': None,
             'style': None,
@@ -155,6 +161,7 @@
             'completion': '',
             'constraints': list([
             ]),
+            'constraints_error': None,
             'constraints_passed': True,
             'constraints_results': dict({
             }),
@@ -186,14 +193,16 @@
             'max_content_lines': '',
             'modifications': 0,
             'params': '',
-            'parent_need': '',
+            'parent_need': None,
             'parent_needs': list([
             ]),
             'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
+            'post_content': None,
             'post_template': None,
+            'pre_content': None,
             'pre_template': None,
             'prefix': '',
             'query': '',
@@ -202,7 +211,7 @@
               'needextend dynamic functions',
             ]),
             'service': '',
-            'signature': '',
+            'signature': None,
             'specific': '',
             'status': None,
             'style': None,
@@ -225,6 +234,7 @@
             'completion': '',
             'constraints': list([
             ]),
+            'constraints_error': None,
             'constraints_passed': True,
             'constraints_results': dict({
             }),
@@ -255,14 +265,16 @@
             'max_content_lines': '',
             'modifications': 0,
             'params': '',
-            'parent_need': '',
+            'parent_need': None,
             'parent_needs': list([
             ]),
             'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
+            'post_content': None,
             'post_template': None,
+            'pre_content': None,
             'pre_template': None,
             'prefix': '',
             'query': '',
@@ -271,7 +283,7 @@
               'needextend dynamic functions',
             ]),
             'service': '',
-            'signature': '',
+            'signature': None,
             'specific': '',
             'status': None,
             'style': None,
@@ -294,6 +306,7 @@
             'completion': '',
             'constraints': list([
             ]),
+            'constraints_error': None,
             'constraints_passed': True,
             'constraints_results': dict({
             }),
@@ -325,14 +338,16 @@
             'max_content_lines': '',
             'modifications': 0,
             'params': '',
-            'parent_need': '',
+            'parent_need': None,
             'parent_needs': list([
             ]),
             'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
+            'post_content': None,
             'post_template': None,
+            'pre_content': None,
             'pre_template': None,
             'prefix': '',
             'query': '',
@@ -341,7 +356,7 @@
               'needextend dynamic functions',
             ]),
             'service': '',
-            'signature': '',
+            'signature': None,
             'specific': '',
             'status': None,
             'style': None,
@@ -400,10 +415,13 @@
               'type': 'array',
             }),
             'constraints_error': dict({
-              'default': '',
+              'default': None,
               'description': 'An error message set if any constraint failed, and `error_message` field is set in config.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'constraints_passed': dict({
               'default': True,
@@ -591,10 +609,13 @@
               'type': 'string',
             }),
             'parent_need': dict({
-              'default': '',
+              'default': None,
               'description': 'Simply the first parent id.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'parent_needs': dict({
               'default': list([
@@ -627,10 +648,13 @@
               'type': 'object',
             }),
             'post_content': dict({
-              'default': '',
+              'default': None,
               'description': 'Post-content of the need.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'post_template': dict({
               'default': None,
@@ -642,10 +666,13 @@
               ]),
             }),
             'pre_content': dict({
-              'default': '',
+              'default': None,
               'description': 'Pre-content of the need.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'pre_template': dict({
               'default': None,
@@ -669,10 +696,13 @@
               'type': 'string',
             }),
             'section_name': dict({
-              'default': '',
+              'default': None,
               'description': 'Simply the first section.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'sections': dict({
               'default': list([
@@ -691,10 +721,13 @@
               'type': 'string',
             }),
             'signature': dict({
-              'default': '',
+              'default': None,
               'description': 'Derived from a docutils desc_name node.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'specific': dict({
               'default': '',
@@ -801,6 +834,7 @@
             'completion': '',
             'constraints': list([
             ]),
+            'constraints_error': None,
             'constraints_passed': True,
             'constraints_results': dict({
             }),
@@ -837,14 +871,16 @@
             'max_content_lines': '',
             'modifications': 1,
             'params': '',
-            'parent_need': '',
+            'parent_need': None,
             'parent_needs': list([
             ]),
             'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
+            'post_content': None,
             'post_template': None,
+            'pre_content': None,
             'pre_template': None,
             'prefix': '',
             'query': '',
@@ -853,7 +889,7 @@
               'Need extend',
             ]),
             'service': '',
-            'signature': '',
+            'signature': None,
             'specific': '',
             'status': None,
             'style': None,
@@ -876,6 +912,7 @@
             'completion': '',
             'constraints': list([
             ]),
+            'constraints_error': None,
             'constraints_passed': True,
             'constraints_results': dict({
             }),
@@ -912,14 +949,16 @@
             'max_content_lines': '',
             'modifications': 0,
             'params': '',
-            'parent_need': '',
+            'parent_need': None,
             'parent_needs': list([
             ]),
             'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
+            'post_content': None,
             'post_template': None,
+            'pre_content': None,
             'pre_template': None,
             'prefix': '',
             'query': '',
@@ -928,7 +967,7 @@
               'Need extend',
             ]),
             'service': '',
-            'signature': '',
+            'signature': None,
             'specific': '',
             'status': None,
             'style': None,
@@ -951,6 +990,7 @@
             'completion': '',
             'constraints': list([
             ]),
+            'constraints_error': None,
             'constraints_passed': True,
             'constraints_results': dict({
             }),
@@ -985,14 +1025,16 @@
             'max_content_lines': '',
             'modifications': 1,
             'params': '',
-            'parent_need': '',
+            'parent_need': None,
             'parent_needs': list([
             ]),
             'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
+            'post_content': None,
             'post_template': None,
+            'pre_content': None,
             'pre_template': None,
             'prefix': '',
             'query': '',
@@ -1001,7 +1043,7 @@
               'Need extend',
             ]),
             'service': '',
-            'signature': '',
+            'signature': None,
             'specific': '',
             'status': None,
             'style': None,
@@ -1024,6 +1066,7 @@
             'completion': '',
             'constraints': list([
             ]),
+            'constraints_error': None,
             'constraints_passed': True,
             'constraints_results': dict({
             }),
@@ -1056,14 +1099,16 @@
             'max_content_lines': '',
             'modifications': 2,
             'params': '',
-            'parent_need': '',
+            'parent_need': None,
             'parent_needs': list([
             ]),
             'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
+            'post_content': None,
             'post_template': None,
+            'pre_content': None,
             'pre_template': None,
             'prefix': '',
             'query': '',
@@ -1072,7 +1117,7 @@
               'Need extend',
             ]),
             'service': '',
-            'signature': '',
+            'signature': None,
             'specific': '',
             'status': None,
             'style': None,
@@ -1095,6 +1140,7 @@
             'completion': '',
             'constraints': list([
             ]),
+            'constraints_error': None,
             'constraints_passed': True,
             'constraints_results': dict({
             }),
@@ -1128,14 +1174,16 @@
             'max_content_lines': '',
             'modifications': 1,
             'params': '',
-            'parent_need': '',
+            'parent_need': None,
             'parent_needs': list([
             ]),
             'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
+            'post_content': None,
             'post_template': None,
+            'pre_content': None,
             'pre_template': None,
             'prefix': '',
             'query': '',
@@ -1144,7 +1192,7 @@
               'Need extend',
             ]),
             'service': '',
-            'signature': '',
+            'signature': None,
             'specific': '',
             'status': None,
             'style': None,
@@ -1167,6 +1215,7 @@
             'completion': '',
             'constraints': list([
             ]),
+            'constraints_error': None,
             'constraints_passed': True,
             'constraints_results': dict({
             }),
@@ -1197,14 +1246,16 @@
             'max_content_lines': '',
             'modifications': 2,
             'params': '',
-            'parent_need': '',
+            'parent_need': None,
             'parent_needs': list([
             ]),
             'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
+            'post_content': None,
             'post_template': None,
+            'pre_content': None,
             'pre_template': None,
             'prefix': '',
             'query': '',
@@ -1213,7 +1264,7 @@
               'need objects',
             ]),
             'service': '',
-            'signature': '',
+            'signature': None,
             'specific': '',
             'status': 'closed',
             'style': None,
@@ -1275,10 +1326,13 @@
               'type': 'array',
             }),
             'constraints_error': dict({
-              'default': '',
+              'default': None,
               'description': 'An error message set if any constraint failed, and `error_message` field is set in config.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'constraints_passed': dict({
               'default': True,
@@ -1466,10 +1520,13 @@
               'type': 'string',
             }),
             'parent_need': dict({
-              'default': '',
+              'default': None,
               'description': 'Simply the first parent id.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'parent_needs': dict({
               'default': list([
@@ -1502,10 +1559,13 @@
               'type': 'object',
             }),
             'post_content': dict({
-              'default': '',
+              'default': None,
               'description': 'Post-content of the need.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'post_template': dict({
               'default': None,
@@ -1517,10 +1577,13 @@
               ]),
             }),
             'pre_content': dict({
-              'default': '',
+              'default': None,
               'description': 'Pre-content of the need.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'pre_template': dict({
               'default': None,
@@ -1544,10 +1607,13 @@
               'type': 'string',
             }),
             'section_name': dict({
-              'default': '',
+              'default': None,
               'description': 'Simply the first section.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'sections': dict({
               'default': list([
@@ -1566,10 +1632,13 @@
               'type': 'string',
             }),
             'signature': dict({
-              'default': '',
+              'default': None,
               'description': 'Derived from a docutils desc_name node.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'specific': dict({
               'default': '',

--- a/tests/__snapshots__/test_needimport.ambr
+++ b/tests/__snapshots__/test_needimport.ambr
@@ -1662,10 +1662,13 @@
               'type': 'array',
             }),
             'constraints_error': dict({
-              'default': '',
+              'default': None,
               'description': 'An error message set if any constraint failed, and `error_message` field is set in config.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'constraints_passed': dict({
               'default': True,
@@ -1853,10 +1856,13 @@
               'type': 'string',
             }),
             'parent_need': dict({
-              'default': '',
+              'default': None,
               'description': 'Simply the first parent id.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'parent_needs': dict({
               'default': list([
@@ -1889,10 +1895,13 @@
               'type': 'object',
             }),
             'post_content': dict({
-              'default': '',
+              'default': None,
               'description': 'Post-content of the need.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'post_template': dict({
               'default': None,
@@ -1904,10 +1913,13 @@
               ]),
             }),
             'pre_content': dict({
-              'default': '',
+              'default': None,
               'description': 'Pre-content of the need.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'pre_template': dict({
               'default': None,
@@ -1931,10 +1943,13 @@
               'type': 'string',
             }),
             'section_name': dict({
-              'default': '',
+              'default': None,
               'description': 'Simply the first section.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'sections': dict({
               'default': list([
@@ -1953,10 +1968,13 @@
               'type': 'string',
             }),
             'signature': dict({
-              'default': '',
+              'default': None,
               'description': 'Derived from a docutils desc_name node.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'specific': dict({
               'default': '',
@@ -2090,6 +2108,7 @@
       'completion': '',
       'constraints': list([
       ]),
+      'constraints_error': None,
       'constraints_passed': True,
       'constraints_results': dict({
       }),
@@ -2124,14 +2143,16 @@
       'max_content_lines': '',
       'modifications': 0,
       'params': '',
-      'parent_need': '',
+      'parent_need': None,
       'parent_needs': list([
       ]),
       'parent_needs_back': list([
       ]),
       'parts': dict({
       }),
+      'post_content': None,
       'post_template': None,
+      'pre_content': None,
       'pre_template': None,
       'prefix': '',
       'query': '',
@@ -2140,7 +2161,7 @@
         'TEST DOCUMENT NEEDIMPORT DOWNLOAD NEEDS JSON',
       ]),
       'service': '',
-      'signature': '',
+      'signature': None,
       'specific': '',
       'status': None,
       'style': None,
@@ -2168,6 +2189,7 @@
       'completion': '',
       'constraints': list([
       ]),
+      'constraints_error': None,
       'constraints_passed': True,
       'constraints_results': dict({
       }),
@@ -2202,14 +2224,16 @@
       'max_content_lines': '',
       'modifications': 0,
       'params': '',
-      'parent_need': '',
+      'parent_need': None,
       'parent_needs': list([
       ]),
       'parent_needs_back': list([
       ]),
       'parts': dict({
       }),
+      'post_content': None,
       'post_template': None,
+      'pre_content': None,
       'pre_template': None,
       'prefix': '',
       'query': '',
@@ -2218,7 +2242,7 @@
         'TEST DOCUMENT NEEDIMPORT DOWNLOAD NEEDS JSON',
       ]),
       'service': '',
-      'signature': '',
+      'signature': None,
       'specific': '',
       'status': None,
       'style': None,
@@ -2245,6 +2269,7 @@
       'completion': '',
       'constraints': list([
       ]),
+      'constraints_error': None,
       'constraints_passed': True,
       'constraints_results': dict({
       }),
@@ -2279,14 +2304,16 @@
       'max_content_lines': '',
       'modifications': 0,
       'params': '',
-      'parent_need': '',
+      'parent_need': None,
       'parent_needs': list([
       ]),
       'parent_needs_back': list([
       ]),
       'parts': dict({
       }),
+      'post_content': None,
       'post_template': None,
+      'pre_content': None,
       'pre_template': None,
       'prefix': '',
       'query': '',
@@ -2295,7 +2322,7 @@
         'TEST DOCUMENT NEEDIMPORT DOWNLOAD NEEDS JSON',
       ]),
       'service': '',
-      'signature': '',
+      'signature': None,
       'specific': '',
       'status': None,
       'style': None,

--- a/tests/__snapshots__/test_needs_builder.ambr
+++ b/tests/__snapshots__/test_needs_builder.ambr
@@ -13,6 +13,7 @@
             'completion': '',
             'constraints': list([
             ]),
+            'constraints_error': None,
             'constraints_passed': True,
             'constraints_results': dict({
             }),
@@ -43,14 +44,16 @@
             'max_content_lines': '',
             'modifications': 0,
             'params': '',
-            'parent_need': '',
+            'parent_need': None,
             'parent_needs': list([
             ]),
             'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
+            'post_content': None,
             'post_template': None,
+            'pre_content': None,
             'pre_template': None,
             'prefix': '',
             'query': '',
@@ -59,7 +62,7 @@
               'TEST DOCUMENT NEEDS Builder',
             ]),
             'service': '',
-            'signature': '',
+            'signature': None,
             'specific': '',
             'status': 'open',
             'style': None,
@@ -82,6 +85,7 @@
             'completion': '',
             'constraints': list([
             ]),
+            'constraints_error': None,
             'constraints_passed': True,
             'constraints_results': dict({
             }),
@@ -112,14 +116,16 @@
             'max_content_lines': '',
             'modifications': 0,
             'params': '',
-            'parent_need': '',
+            'parent_need': None,
             'parent_needs': list([
             ]),
             'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
+            'post_content': None,
             'post_template': None,
+            'pre_content': None,
             'pre_template': None,
             'prefix': '',
             'query': '',
@@ -128,7 +134,7 @@
               'TEST DOCUMENT NEEDS Builder',
             ]),
             'service': '',
-            'signature': '',
+            'signature': None,
             'specific': '',
             'status': 'closed',
             'style': None,
@@ -151,6 +157,7 @@
             'completion': '',
             'constraints': list([
             ]),
+            'constraints_error': None,
             'constraints_passed': True,
             'constraints_results': dict({
             }),
@@ -181,14 +188,16 @@
             'max_content_lines': '',
             'modifications': 0,
             'params': '',
-            'parent_need': '',
+            'parent_need': None,
             'parent_needs': list([
             ]),
             'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
+            'post_content': None,
             'post_template': None,
+            'pre_content': None,
             'pre_template': None,
             'prefix': '',
             'query': '',
@@ -197,7 +206,7 @@
               'TEST DOCUMENT NEEDS Builder',
             ]),
             'service': '',
-            'signature': '',
+            'signature': None,
             'specific': '',
             'status': 'in progress',
             'style': None,
@@ -257,10 +266,13 @@
               'type': 'array',
             }),
             'constraints_error': dict({
-              'default': '',
+              'default': None,
               'description': 'An error message set if any constraint failed, and `error_message` field is set in config.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'constraints_passed': dict({
               'default': True,
@@ -448,10 +460,13 @@
               'type': 'string',
             }),
             'parent_need': dict({
-              'default': '',
+              'default': None,
               'description': 'Simply the first parent id.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'parent_needs': dict({
               'default': list([
@@ -484,10 +499,13 @@
               'type': 'object',
             }),
             'post_content': dict({
-              'default': '',
+              'default': None,
               'description': 'Post-content of the need.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'post_template': dict({
               'default': None,
@@ -499,10 +517,13 @@
               ]),
             }),
             'pre_content': dict({
-              'default': '',
+              'default': None,
               'description': 'Pre-content of the need.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'pre_template': dict({
               'default': None,
@@ -526,10 +547,13 @@
               'type': 'string',
             }),
             'section_name': dict({
-              'default': '',
+              'default': None,
               'description': 'Simply the first section.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'sections': dict({
               'default': list([
@@ -548,10 +572,13 @@
               'type': 'string',
             }),
             'signature': dict({
-              'default': '',
+              'default': None,
               'description': 'Derived from a docutils desc_name node.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'specific': dict({
               'default': '',
@@ -906,10 +933,13 @@
               'type': 'array',
             }),
             'constraints_error': dict({
-              'default': '',
+              'default': None,
               'description': 'An error message set if any constraint failed, and `error_message` field is set in config.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'constraints_passed': dict({
               'default': True,
@@ -1097,10 +1127,13 @@
               'type': 'string',
             }),
             'parent_need': dict({
-              'default': '',
+              'default': None,
               'description': 'Simply the first parent id.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'parent_needs': dict({
               'default': list([
@@ -1133,10 +1166,13 @@
               'type': 'object',
             }),
             'post_content': dict({
-              'default': '',
+              'default': None,
               'description': 'Post-content of the need.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'post_template': dict({
               'default': None,
@@ -1148,10 +1184,13 @@
               ]),
             }),
             'pre_content': dict({
-              'default': '',
+              'default': None,
               'description': 'Pre-content of the need.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'pre_template': dict({
               'default': None,
@@ -1175,10 +1214,13 @@
               'type': 'string',
             }),
             'section_name': dict({
-              'default': '',
+              'default': None,
               'description': 'Simply the first section.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'sections': dict({
               'default': list([
@@ -1197,10 +1239,13 @@
               'type': 'string',
             }),
             'signature': dict({
-              'default': '',
+              'default': None,
               'description': 'Derived from a docutils desc_name node.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'specific': dict({
               'default': '',
@@ -1473,6 +1518,7 @@
             'completion': '',
             'constraints': list([
             ]),
+            'constraints_error': None,
             'constraints_passed': True,
             'constraints_results': dict({
             }),
@@ -1503,14 +1549,16 @@
             'max_content_lines': '',
             'modifications': 0,
             'params': '',
-            'parent_need': '',
+            'parent_need': None,
             'parent_needs': list([
             ]),
             'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
+            'post_content': None,
             'post_template': None,
+            'pre_content': None,
             'pre_template': None,
             'prefix': '',
             'query': '',
@@ -1519,7 +1567,7 @@
               'TEST DOCUMENT NEEDS Builder',
             ]),
             'service': '',
-            'signature': '',
+            'signature': None,
             'specific': '',
             'status': 'open',
             'style': None,
@@ -1542,6 +1590,7 @@
             'completion': '',
             'constraints': list([
             ]),
+            'constraints_error': None,
             'constraints_passed': True,
             'constraints_results': dict({
             }),
@@ -1572,14 +1621,16 @@
             'max_content_lines': '',
             'modifications': 0,
             'params': '',
-            'parent_need': '',
+            'parent_need': None,
             'parent_needs': list([
             ]),
             'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
+            'post_content': None,
             'post_template': None,
+            'pre_content': None,
             'pre_template': None,
             'prefix': '',
             'query': '',
@@ -1588,7 +1639,7 @@
               'TEST DOCUMENT NEEDS Builder',
             ]),
             'service': '',
-            'signature': '',
+            'signature': None,
             'specific': '',
             'status': 'closed',
             'style': None,
@@ -1611,6 +1662,7 @@
             'completion': '',
             'constraints': list([
             ]),
+            'constraints_error': None,
             'constraints_passed': True,
             'constraints_results': dict({
             }),
@@ -1641,14 +1693,16 @@
             'max_content_lines': '',
             'modifications': 0,
             'params': '',
-            'parent_need': '',
+            'parent_need': None,
             'parent_needs': list([
             ]),
             'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
+            'post_content': None,
             'post_template': None,
+            'pre_content': None,
             'pre_template': None,
             'prefix': '',
             'query': '',
@@ -1657,7 +1711,7 @@
               'TEST DOCUMENT NEEDS Builder',
             ]),
             'service': '',
-            'signature': '',
+            'signature': None,
             'specific': '',
             'status': 'in progress',
             'style': None,
@@ -1717,10 +1771,13 @@
               'type': 'array',
             }),
             'constraints_error': dict({
-              'default': '',
+              'default': None,
               'description': 'An error message set if any constraint failed, and `error_message` field is set in config.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'constraints_passed': dict({
               'default': True,
@@ -1908,10 +1965,13 @@
               'type': 'string',
             }),
             'parent_need': dict({
-              'default': '',
+              'default': None,
               'description': 'Simply the first parent id.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'parent_needs': dict({
               'default': list([
@@ -1944,10 +2004,13 @@
               'type': 'object',
             }),
             'post_content': dict({
-              'default': '',
+              'default': None,
               'description': 'Post-content of the need.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'post_template': dict({
               'default': None,
@@ -1959,10 +2022,13 @@
               ]),
             }),
             'pre_content': dict({
-              'default': '',
+              'default': None,
               'description': 'Pre-content of the need.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'pre_template': dict({
               'default': None,
@@ -1986,10 +2052,13 @@
               'type': 'string',
             }),
             'section_name': dict({
-              'default': '',
+              'default': None,
               'description': 'Simply the first section.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'sections': dict({
               'default': list([
@@ -2008,10 +2077,13 @@
               'type': 'string',
             }),
             'signature': dict({
-              'default': '',
+              'default': None,
               'description': 'Derived from a docutils desc_name node.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'specific': dict({
               'default': '',

--- a/tests/__snapshots__/test_needs_id_builder.ambr
+++ b/tests/__snapshots__/test_needs_id_builder.ambr
@@ -14,6 +14,7 @@
               'completion': '',
               'constraints': list([
               ]),
+              'constraints_error': None,
               'constraints_passed': True,
               'constraints_results': dict({
               }),
@@ -44,14 +45,16 @@
               'max_content_lines': '',
               'modifications': 0,
               'params': '',
-              'parent_need': '',
+              'parent_need': None,
               'parent_needs': list([
               ]),
               'parent_needs_back': list([
               ]),
               'parts': dict({
               }),
+              'post_content': None,
               'post_template': None,
+              'pre_content': None,
               'pre_template': None,
               'prefix': '',
               'query': '',
@@ -60,7 +63,7 @@
                 'TEST DOCUMENT NEEDS Builder',
               ]),
               'service': '',
-              'signature': '',
+              'signature': None,
               'specific': '',
               'status': 'open',
               'style': None,
@@ -93,6 +96,7 @@
               'completion': '',
               'constraints': list([
               ]),
+              'constraints_error': None,
               'constraints_passed': True,
               'constraints_results': dict({
               }),
@@ -123,14 +127,16 @@
               'max_content_lines': '',
               'modifications': 0,
               'params': '',
-              'parent_need': '',
+              'parent_need': None,
               'parent_needs': list([
               ]),
               'parent_needs_back': list([
               ]),
               'parts': dict({
               }),
+              'post_content': None,
               'post_template': None,
+              'pre_content': None,
               'pre_template': None,
               'prefix': '',
               'query': '',
@@ -139,7 +145,7 @@
                 'TEST DOCUMENT NEEDS Builder',
               ]),
               'service': '',
-              'signature': '',
+              'signature': None,
               'specific': '',
               'status': 'closed',
               'style': None,
@@ -172,6 +178,7 @@
               'completion': '',
               'constraints': list([
               ]),
+              'constraints_error': None,
               'constraints_passed': True,
               'constraints_results': dict({
               }),
@@ -202,14 +209,16 @@
               'max_content_lines': '',
               'modifications': 0,
               'params': '',
-              'parent_need': '',
+              'parent_need': None,
               'parent_needs': list([
               ]),
               'parent_needs_back': list([
               ]),
               'parts': dict({
               }),
+              'post_content': None,
               'post_template': None,
+              'pre_content': None,
               'pre_template': None,
               'prefix': '',
               'query': '',
@@ -218,7 +227,7 @@
                 'TEST DOCUMENT NEEDS Builder',
               ]),
               'service': '',
-              'signature': '',
+              'signature': None,
               'specific': '',
               'status': 'in progress',
               'style': None,

--- a/tests/__snapshots__/test_needuml.ambr
+++ b/tests/__snapshots__/test_needuml.ambr
@@ -10,6 +10,7 @@
       'completion': '',
       'constraints': list([
       ]),
+      'constraints_error': None,
       'constraints_passed': True,
       'constraints_results': dict({
       }),
@@ -54,14 +55,16 @@
       'max_content_lines': '',
       'modifications': 0,
       'params': '',
-      'parent_need': '',
+      'parent_need': None,
       'parent_needs': list([
       ]),
       'parent_needs_back': list([
       ]),
       'parts': dict({
       }),
+      'post_content': None,
       'post_template': None,
+      'pre_content': None,
       'pre_template': None,
       'prefix': '',
       'query': '',
@@ -70,7 +73,7 @@
         'TEST DOCUMENT NEEDUML',
       ]),
       'service': '',
-      'signature': '',
+      'signature': None,
       'specific': '',
       'status': None,
       'style': None,
@@ -97,6 +100,7 @@
       'completion': '',
       'constraints': list([
       ]),
+      'constraints_error': None,
       'constraints_passed': True,
       'constraints_results': dict({
       }),
@@ -131,14 +135,16 @@
       'max_content_lines': '',
       'modifications': 0,
       'params': '',
-      'parent_need': '',
+      'parent_need': None,
       'parent_needs': list([
       ]),
       'parent_needs_back': list([
       ]),
       'parts': dict({
       }),
+      'post_content': None,
       'post_template': None,
+      'pre_content': None,
       'pre_template': None,
       'prefix': '',
       'query': '',
@@ -147,7 +153,7 @@
         'TEST DOCUMENT NEEDUML',
       ]),
       'service': '',
-      'signature': '',
+      'signature': None,
       'specific': '',
       'status': None,
       'style': None,
@@ -186,6 +192,7 @@
       'completion': '',
       'constraints': list([
       ]),
+      'constraints_error': None,
       'constraints_passed': True,
       'constraints_results': dict({
       }),
@@ -241,14 +248,16 @@
       'max_content_lines': '',
       'modifications': 0,
       'params': '',
-      'parent_need': '',
+      'parent_need': None,
       'parent_needs': list([
       ]),
       'parent_needs_back': list([
       ]),
       'parts': dict({
       }),
+      'post_content': None,
       'post_template': None,
+      'pre_content': None,
       'pre_template': None,
       'prefix': '',
       'query': '',
@@ -257,7 +266,7 @@
         'TEST DOCUMENT NEEDUML',
       ]),
       'service': '',
-      'signature': '',
+      'signature': None,
       'specific': '',
       'status': None,
       'style': None,
@@ -298,6 +307,7 @@
       'completion': '',
       'constraints': list([
       ]),
+      'constraints_error': None,
       'constraints_passed': True,
       'constraints_results': dict({
       }),
@@ -350,14 +360,16 @@
       'max_content_lines': '',
       'modifications': 0,
       'params': '',
-      'parent_need': '',
+      'parent_need': None,
       'parent_needs': list([
       ]),
       'parent_needs_back': list([
       ]),
       'parts': dict({
       }),
+      'post_content': None,
       'post_template': None,
+      'pre_content': None,
       'pre_template': None,
       'prefix': '',
       'query': '',
@@ -366,7 +378,7 @@
         'TEST DOCUMENT NEEDUML',
       ]),
       'service': '',
-      'signature': '',
+      'signature': None,
       'specific': '',
       'status': None,
       'style': None,
@@ -411,6 +423,7 @@
       'completion': '',
       'constraints': list([
       ]),
+      'constraints_error': None,
       'constraints_passed': True,
       'constraints_results': dict({
       }),
@@ -474,14 +487,16 @@
       'max_content_lines': '',
       'modifications': 0,
       'params': '',
-      'parent_need': '',
+      'parent_need': None,
       'parent_needs': list([
       ]),
       'parent_needs_back': list([
       ]),
       'parts': dict({
       }),
+      'post_content': None,
       'post_template': None,
+      'pre_content': None,
       'pre_template': None,
       'prefix': '',
       'query': '',
@@ -490,7 +505,7 @@
         'TEST DOCUMENT NEEDUML',
       ]),
       'service': '',
-      'signature': '',
+      'signature': None,
       'specific': '',
       'status': None,
       'style': None,
@@ -517,6 +532,7 @@
       'completion': '',
       'constraints': list([
       ]),
+      'constraints_error': None,
       'constraints_passed': True,
       'constraints_results': dict({
       }),
@@ -557,14 +573,16 @@
       'max_content_lines': '',
       'modifications': 0,
       'params': '',
-      'parent_need': '',
+      'parent_need': None,
       'parent_needs': list([
       ]),
       'parent_needs_back': list([
       ]),
       'parts': dict({
       }),
+      'post_content': None,
       'post_template': None,
+      'pre_content': None,
       'pre_template': None,
       'prefix': '',
       'query': '',
@@ -573,7 +591,7 @@
         'TEST DOCUMENT NEEDUML',
       ]),
       'service': '',
-      'signature': '',
+      'signature': None,
       'specific': '',
       'status': None,
       'style': None,
@@ -600,6 +618,7 @@
       'completion': '',
       'constraints': list([
       ]),
+      'constraints_error': None,
       'constraints_passed': True,
       'constraints_results': dict({
       }),
@@ -634,14 +653,16 @@
       'max_content_lines': '',
       'modifications': 0,
       'params': '',
-      'parent_need': '',
+      'parent_need': None,
       'parent_needs': list([
       ]),
       'parent_needs_back': list([
       ]),
       'parts': dict({
       }),
+      'post_content': None,
       'post_template': None,
+      'pre_content': None,
       'pre_template': None,
       'prefix': '',
       'query': '',
@@ -650,7 +671,7 @@
         'TEST DOCUMENT NEEDUML',
       ]),
       'service': '',
-      'signature': '',
+      'signature': None,
       'specific': '',
       'status': None,
       'style': None,
@@ -677,6 +698,7 @@
       'completion': '',
       'constraints': list([
       ]),
+      'constraints_error': None,
       'constraints_passed': True,
       'constraints_results': dict({
       }),
@@ -711,14 +733,16 @@
       'max_content_lines': '',
       'modifications': 0,
       'params': '',
-      'parent_need': '',
+      'parent_need': None,
       'parent_needs': list([
       ]),
       'parent_needs_back': list([
       ]),
       'parts': dict({
       }),
+      'post_content': None,
       'post_template': None,
+      'pre_content': None,
       'pre_template': None,
       'prefix': '',
       'query': '',
@@ -727,7 +751,7 @@
         'TEST DOCUMENT NEEDUML',
       ]),
       'service': '',
-      'signature': '',
+      'signature': None,
       'specific': '',
       'status': None,
       'style': None,
@@ -754,6 +778,7 @@
       'completion': '',
       'constraints': list([
       ]),
+      'constraints_error': None,
       'constraints_passed': True,
       'constraints_results': dict({
       }),
@@ -797,14 +822,16 @@
       'max_content_lines': '',
       'modifications': 0,
       'params': '',
-      'parent_need': '',
+      'parent_need': None,
       'parent_needs': list([
       ]),
       'parent_needs_back': list([
       ]),
       'parts': dict({
       }),
+      'post_content': None,
       'post_template': None,
+      'pre_content': None,
       'pre_template': None,
       'prefix': '',
       'query': '',
@@ -813,7 +840,7 @@
         'TEST DOCUMENT NEEDUML',
       ]),
       'service': '',
-      'signature': '',
+      'signature': None,
       'specific': '',
       'status': None,
       'style': None,

--- a/tests/__snapshots__/test_service_github.ambr
+++ b/tests/__snapshots__/test_service_github.ambr
@@ -12,6 +12,7 @@
             'completion': '',
             'constraints': list([
             ]),
+            'constraints_error': None,
             'constraints_passed': True,
             'constraints_results': dict({
             }),
@@ -46,14 +47,16 @@
             'max_content_lines': '',
             'modifications': 0,
             'params': '',
-            'parent_need': '',
+            'parent_need': None,
             'parent_needs': list([
             ]),
             'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
+            'post_content': None,
             'post_template': None,
+            'pre_content': None,
             'pre_template': None,
             'prefix': '',
             'query': '',
@@ -62,7 +65,7 @@
               'Title',
             ]),
             'service': 'github-commits',
-            'signature': '',
+            'signature': None,
             'specific': 'useblocks/sphinx-needs/050bec750ff2c5acf881415fa2b5efb5fcce8414',
             'status': None,
             'style': None,
@@ -84,6 +87,7 @@
             'completion': '',
             'constraints': list([
             ]),
+            'constraints_error': None,
             'constraints_passed': True,
             'constraints_results': dict({
             }),
@@ -122,14 +126,16 @@
             'max_content_lines': '2',
             'modifications': 0,
             'params': '',
-            'parent_need': '',
+            'parent_need': None,
             'parent_needs': list([
             ]),
             'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
+            'post_content': None,
             'post_template': None,
+            'pre_content': None,
             'pre_template': None,
             'prefix': '',
             'query': 'repo:useblocks/sphinx-needs',
@@ -138,7 +144,7 @@
               'Title',
             ]),
             'service': 'github-issues',
-            'signature': '',
+            'signature': None,
             'specific': '',
             'status': 'open',
             'style': None,
@@ -161,6 +167,7 @@
             'completion': '',
             'constraints': list([
             ]),
+            'constraints_error': None,
             'constraints_passed': True,
             'constraints_results': dict({
             }),
@@ -221,14 +228,16 @@
             'max_content_lines': '',
             'modifications': 0,
             'params': '',
-            'parent_need': '',
+            'parent_need': None,
             'parent_needs': list([
             ]),
             'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
+            'post_content': None,
             'post_template': None,
+            'pre_content': None,
             'pre_template': None,
             'prefix': '',
             'query': 'repo:useblocks/sphinx-needs',
@@ -237,7 +246,7 @@
               'Title',
             ]),
             'service': 'github-prs',
-            'signature': '',
+            'signature': None,
             'specific': '',
             'status': 'open',
             'style': None,
@@ -259,6 +268,7 @@
             'completion': '',
             'constraints': list([
             ]),
+            'constraints_error': None,
             'constraints_passed': True,
             'constraints_results': dict({
             }),
@@ -304,14 +314,16 @@
             'max_content_lines': '',
             'modifications': 0,
             'params': '',
-            'parent_need': '',
+            'parent_need': None,
             'parent_needs': list([
             ]),
             'parent_needs_back': list([
             ]),
             'parts': dict({
             }),
+            'post_content': None,
             'post_template': None,
+            'pre_content': None,
             'pre_template': None,
             'prefix': '',
             'query': 'repo:useblocks/sphinx-needs error',
@@ -320,7 +332,7 @@
               'Title',
             ]),
             'service': 'github-commits',
-            'signature': '',
+            'signature': None,
             'specific': '',
             'status': None,
             'style': None,
@@ -373,10 +385,13 @@
               'type': 'array',
             }),
             'constraints_error': dict({
-              'default': '',
+              'default': None,
               'description': 'An error message set if any constraint failed, and `error_message` field is set in config.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'constraints_passed': dict({
               'default': True,
@@ -564,10 +579,13 @@
               'type': 'string',
             }),
             'parent_need': dict({
-              'default': '',
+              'default': None,
               'description': 'Simply the first parent id.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'parent_needs': dict({
               'default': list([
@@ -600,10 +618,13 @@
               'type': 'object',
             }),
             'post_content': dict({
-              'default': '',
+              'default': None,
               'description': 'Post-content of the need.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'post_template': dict({
               'default': None,
@@ -615,10 +636,13 @@
               ]),
             }),
             'pre_content': dict({
-              'default': '',
+              'default': None,
               'description': 'Pre-content of the need.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'pre_template': dict({
               'default': None,
@@ -642,10 +666,13 @@
               'type': 'string',
             }),
             'section_name': dict({
-              'default': '',
+              'default': None,
               'description': 'Simply the first section.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'sections': dict({
               'default': list([
@@ -664,10 +691,13 @@
               'type': 'string',
             }),
             'signature': dict({
-              'default': '',
+              'default': None,
               'description': 'Derived from a docutils desc_name node.',
               'field_type': 'core',
-              'type': 'string',
+              'type': list([
+                'string',
+                'null',
+              ]),
             }),
             'specific': dict({
               'default': '',


### PR DESCRIPTION
These fields were previously set as empty strings, but this makes it clearer that they are not set:
pre_content, post_content, constraints_error, section_name, section_name, signature, parent_need

