### PR TITLE
fix log_warning function call with missing arguments

### DIFF
--- a/sphinx_needs/warnings.py
+++ b/sphinx_needs/warnings.py
@@ -77,7 +77,13 @@ def process_warnings(app: Sphinx, exception: Exception | None) -> None:
                     if warning_filter(need, logger):
                         result.append(need)
             else:
-                log_warning(logger, f"Unknown needs warnings filter {warning_filter}!")
+                result = []
+                log_warning(
+                    logger,
+                    f"Unknown needs warnings filter {warning_filter}!",
+                    "warnings",
+                    None,
+                )
 
             if len(result) == 0:
                 logger.info(f"{warning_name}: passed")


### PR DESCRIPTION
# Fix log_warning function call with missing arguments

Fix for #1493

## Summary
- Fixed TypeError in `sphinx_needs/warnings.py:80` where `log_warning` was called with only 2 arguments instead of the required 4 positional arguments
- This was causing crashes when processing invalid warning filters in Sphinx 8.x environments
- The fix ensures proper compatibility with the updated `log_warning` function signature

## Root Cause
The `log_warning` function signature in `sphinx_needs/logging.py` expects 4 positional arguments:
1. `logger` (SphinxLoggerAdapter)
2. `message` (str) 
3. `subtype` (WarningSubTypes)
4. `location` (str | tuple | Node | None)

However, the call on line 80 of `warnings.py` was only passing 2 arguments:
```python
log_warning(logger, f"Unknown needs warnings filter {warning_filter}!")
```

## Fix Applied
Updated the problematic call to include the missing required arguments:
```python
log_warning(logger, f"Unknown needs warnings filter {warning_filter}!", "warnings", None)
```

## Tests
- [x] All existing warning-related tests pass (`pytest tests/ -k "warning"`)