### PR TITLE
🔧 Improve storage of content generation on `NeedItem`

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -38,7 +38,7 @@ Data
 ----
 
 .. automodule:: sphinx_needs.need_item
-   :members: NeedItem, NeedPartItem, NeedItemSourceProtocol, NeedModification, NeedConstraintResults
+   :members: NeedItem, NeedPartItem, NeedItemSourceProtocol, NeedsContent, NeedModification, NeedConstraintResults
 
 .. automodule:: sphinx_needs.data
    :members: NeedsInfoType, NeedsInfoComputedType, NeedsSourceInfoType, NeedsMutable, NeedsPartType

--- a/sphinx_needs/api/need.py
+++ b/sphinx_needs/api/need.py
@@ -477,7 +477,7 @@ def add_need(
     Otherwise, the following parameters are used:
 
     :param is_external: Is true, no node is created and need is referencing external url
-    :param external_uneeds_inforl: URL as string, which is used as target if ``is_external`` is ``True``
+    :param external_url: URL as string, which is used as target if ``is_external`` is ``True``
     :param external_css: CSS class name as string, which is set for the <a> tag.
 
     Additional parameters:

--- a/sphinx_needs/data.py
+++ b/sphinx_needs/data.py
@@ -280,40 +280,40 @@ NeedsCoreFields: Final[Mapping[str, CoreFieldParameters]] = {
         "exclude_import": True,
     },
     "jinja_content": {
-        "description": "Whether the content should be pre-processed by jinja.",
+        "description": "Whether the content was pre-processed by jinja.",
         "schema": {"type": "boolean", "default": False},
         "exclude_external": True,
     },
     "template": {
-        "description": "Template of the need.",
+        "description": "Whether the content was created from a jinja template.",
         "schema": {"type": ["string", "null"], "default": None},
         "exclude_external": True,
         "allow_default": "str",
     },
     "pre_template": {
-        "description": "Pre-template of the need.",
+        "description": "Whether the pre_content was created from a jinja template.",
         "schema": {"type": ["string", "null"], "default": None},
         "exclude_external": True,
         "allow_default": "str",
     },
     "post_template": {
-        "description": "Post-template of the need.",
+        "description": "Whether the post_content was created from a jinja template.",
         "schema": {"type": ["string", "null"], "default": None},
         "exclude_external": True,
         "allow_default": "str",
     },
     "content": {
-        "description": "Content of the need.",
+        "description": "The main content of the need.",
         "schema": {"type": "string", "default": ""},
     },
     "pre_content": {
-        "description": "Pre-content of the need.",
+        "description": "Additional content before the need.",
         "schema": {"type": ["string", "null"], "default": None},
         "exclude_external": True,
         "exclude_import": True,
     },
     "post_content": {
-        "description": "Post-content of the need.",
+        "description": "Additional content after the need.",
         "schema": {"type": ["string", "null"], "default": None},
         "exclude_external": True,
         "exclude_import": True,
@@ -338,7 +338,7 @@ NeedsCoreFields: Final[Mapping[str, CoreFieldParameters]] = {
         "allow_extend": True,
     },
     "constraints_results": {
-        "description": "Mapping of constraint name, to check name, to result.",
+        "description": "Mapping of constraint name, to check name, to result, None if not yet checked.",
         "schema": {
             "type": ["object", "null"],
             "additionalProperties": {"type": "object"},
@@ -360,7 +360,7 @@ NeedsCoreFields: Final[Mapping[str, CoreFieldParameters]] = {
         "exclude_import": True,
     },
     "doctype": {
-        "description": "Type of the document where the need is defined, e.g. '.rst'.",
+        "description": "The markup type of the content, denoted by the suffix of the source file, e.g. '.rst'.",
         "schema": {"type": "string", "default": ".rst"},
     },
     "sections": {
@@ -406,6 +406,27 @@ class NeedsSourceInfoType(TypedDict):
     """If true, no node is created and need is referencing external url."""
 
 
+class NeedsContentInfoType(TypedDict):
+    """Data for the content of a single need."""
+
+    jinja_content: bool
+    """Whether the content was pre-processed by jinja."""
+    template: None | str
+    """Whether the content was created from a jinja template."""
+    pre_template: None | str
+    """Whether the pre_content was created from a jinja template."""
+    post_template: None | str
+    """Whether the post_content was created from a jinja template."""
+    doctype: str
+    """The markup type of the content, denoted by the suffix of the source file, e.g. '.rst'."""
+    content: str
+    """The main content of the need."""
+    pre_content: None | str
+    """Additional content before the need."""
+    post_content: None | str
+    """Additional content after the need."""
+
+
 class NeedsInfoType(TypedDict):
     """Data for a single need."""
 
@@ -441,17 +462,6 @@ class NeedsInfoType(TypedDict):
 
     # Mapping of parts, a.k.a. sub-needs, IDs to data that overrides the need's data
     parts: Mapping[str, NeedsPartType]
-
-    # content creation information
-    jinja_content: bool
-    template: None | str
-    pre_template: None | str
-    post_template: None | str
-    content: str
-    pre_content: None | str
-    post_content: None | str
-    doctype: str
-    """Type of the document where the need is defined, e.g. '.rst'."""
 
     # these default to False and are updated in check_links post-process
     has_dead_links: bool

--- a/sphinx_needs/data.py
+++ b/sphinx_needs/data.py
@@ -285,19 +285,19 @@ NeedsCoreFields: Final[Mapping[str, CoreFieldParameters]] = {
         "exclude_external": True,
     },
     "template": {
-        "description": "Whether the content was created from a jinja template.",
+        "description": "The template key, if the content was created from a jinja template.",
         "schema": {"type": ["string", "null"], "default": None},
         "exclude_external": True,
         "allow_default": "str",
     },
     "pre_template": {
-        "description": "Whether the pre_content was created from a jinja template.",
+        "description": "The template key, if the pre_content was created from a jinja template.",
         "schema": {"type": ["string", "null"], "default": None},
         "exclude_external": True,
         "allow_default": "str",
     },
     "post_template": {
-        "description": "Whether the post_content was created from a jinja template.",
+        "description": "The template key, if the post_content was created from a jinja template.",
         "schema": {"type": ["string", "null"], "default": None},
         "exclude_external": True,
         "allow_default": "str",
@@ -412,11 +412,11 @@ class NeedsContentInfoType(TypedDict):
     jinja_content: bool
     """Whether the content was pre-processed by jinja."""
     template: None | str
-    """Whether the content was created from a jinja template."""
+    """The template key, if the content was created from a jinja template."""
     pre_template: None | str
-    """Whether the pre_content was created from a jinja template."""
+    """The template key, if the pre_content was created from a jinja template."""
     post_template: None | str
-    """Whether the post_content was created from a jinja template."""
+    """The template key, if the post_content was created from a jinja template."""
     doctype: str
     """The markup type of the content, denoted by the suffix of the source file, e.g. '.rst'."""
     content: str

--- a/tests/__snapshots__/test_basic_doc.ambr
+++ b/tests/__snapshots__/test_basic_doc.ambr
@@ -212,7 +212,7 @@
               }),
               'default': dict({
               }),
-              'description': 'Mapping of constraint name, to check name, to result.',
+              'description': 'Mapping of constraint name, to check name, to result, None if not yet checked.',
               'field_type': 'core',
               'type': list([
                 'object',
@@ -221,7 +221,7 @@
             }),
             'content': dict({
               'default': '',
-              'description': 'Content of the need.',
+              'description': 'The main content of the need.',
               'field_type': 'core',
               'type': 'string',
             }),
@@ -242,7 +242,7 @@
             }),
             'doctype': dict({
               'default': '.rst',
-              'description': "Type of the document where the need is defined, e.g. '.rst'.",
+              'description': "The markup type of the content, denoted by the suffix of the source file, e.g. '.rst'.",
               'field_type': 'core',
               'type': 'string',
             }),
@@ -310,7 +310,7 @@
             }),
             'jinja_content': dict({
               'default': False,
-              'description': 'Whether the content should be pre-processed by jinja.',
+              'description': 'Whether the content was pre-processed by jinja.',
               'field_type': 'core',
               'type': 'boolean',
             }),
@@ -417,7 +417,7 @@
             }),
             'post_content': dict({
               'default': None,
-              'description': 'Post-content of the need.',
+              'description': 'Additional content after the need.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -426,7 +426,7 @@
             }),
             'post_template': dict({
               'default': None,
-              'description': 'Post-template of the need.',
+              'description': 'Whether the post_content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -435,7 +435,7 @@
             }),
             'pre_content': dict({
               'default': None,
-              'description': 'Pre-content of the need.',
+              'description': 'Additional content before the need.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -444,7 +444,7 @@
             }),
             'pre_template': dict({
               'default': None,
-              'description': 'Pre-template of the need.',
+              'description': 'Whether the pre_content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -533,7 +533,7 @@
             }),
             'template': dict({
               'default': None,
-              'description': 'Template of the need.',
+              'description': 'Whether the content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',

--- a/tests/__snapshots__/test_basic_doc.ambr
+++ b/tests/__snapshots__/test_basic_doc.ambr
@@ -426,7 +426,7 @@
             }),
             'post_template': dict({
               'default': None,
-              'description': 'Whether the post_content was created from a jinja template.',
+              'description': 'The template key, if the post_content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -444,7 +444,7 @@
             }),
             'pre_template': dict({
               'default': None,
-              'description': 'Whether the pre_content was created from a jinja template.',
+              'description': 'The template key, if the pre_content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -533,7 +533,7 @@
             }),
             'template': dict({
               'default': None,
-              'description': 'Whether the content was created from a jinja template.',
+              'description': 'The template key, if the content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',

--- a/tests/__snapshots__/test_dynamic_functions.ambr
+++ b/tests/__snapshots__/test_dynamic_functions.ambr
@@ -204,7 +204,7 @@
               }),
               'default': dict({
               }),
-              'description': 'Mapping of constraint name, to check name, to result.',
+              'description': 'Mapping of constraint name, to check name, to result, None if not yet checked.',
               'field_type': 'core',
               'type': list([
                 'object',
@@ -213,7 +213,7 @@
             }),
             'content': dict({
               'default': '',
-              'description': 'Content of the need.',
+              'description': 'The main content of the need.',
               'field_type': 'core',
               'type': 'string',
             }),
@@ -234,7 +234,7 @@
             }),
             'doctype': dict({
               'default': '.rst',
-              'description': "Type of the document where the need is defined, e.g. '.rst'.",
+              'description': "The markup type of the content, denoted by the suffix of the source file, e.g. '.rst'.",
               'field_type': 'core',
               'type': 'string',
             }),
@@ -302,7 +302,7 @@
             }),
             'jinja_content': dict({
               'default': False,
-              'description': 'Whether the content should be pre-processed by jinja.',
+              'description': 'Whether the content was pre-processed by jinja.',
               'field_type': 'core',
               'type': 'boolean',
             }),
@@ -409,7 +409,7 @@
             }),
             'post_content': dict({
               'default': None,
-              'description': 'Post-content of the need.',
+              'description': 'Additional content after the need.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -418,7 +418,7 @@
             }),
             'post_template': dict({
               'default': None,
-              'description': 'Post-template of the need.',
+              'description': 'Whether the post_content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -427,7 +427,7 @@
             }),
             'pre_content': dict({
               'default': None,
-              'description': 'Pre-content of the need.',
+              'description': 'Additional content before the need.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -436,7 +436,7 @@
             }),
             'pre_template': dict({
               'default': None,
-              'description': 'Pre-template of the need.',
+              'description': 'Whether the pre_content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -525,7 +525,7 @@
             }),
             'template': dict({
               'default': None,
-              'description': 'Template of the need.',
+              'description': 'Whether the content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',

--- a/tests/__snapshots__/test_dynamic_functions.ambr
+++ b/tests/__snapshots__/test_dynamic_functions.ambr
@@ -418,7 +418,7 @@
             }),
             'post_template': dict({
               'default': None,
-              'description': 'Whether the post_content was created from a jinja template.',
+              'description': 'The template key, if the post_content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -436,7 +436,7 @@
             }),
             'pre_template': dict({
               'default': None,
-              'description': 'Whether the pre_content was created from a jinja template.',
+              'description': 'The template key, if the pre_content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -525,7 +525,7 @@
             }),
             'template': dict({
               'default': None,
-              'description': 'Whether the content was created from a jinja template.',
+              'description': 'The template key, if the content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',

--- a/tests/__snapshots__/test_external.ambr
+++ b/tests/__snapshots__/test_external.ambr
@@ -314,7 +314,7 @@
             }),
             'post_template': dict({
               'default': None,
-              'description': 'Whether the post_content was created from a jinja template.',
+              'description': 'The template key, if the post_content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -332,7 +332,7 @@
             }),
             'pre_template': dict({
               'default': None,
-              'description': 'Whether the pre_content was created from a jinja template.',
+              'description': 'The template key, if the pre_content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -421,7 +421,7 @@
             }),
             'template': dict({
               'default': None,
-              'description': 'Whether the content was created from a jinja template.',
+              'description': 'The template key, if the content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -880,7 +880,7 @@
             }),
             'post_template': dict({
               'default': None,
-              'description': 'Whether the post_content was created from a jinja template.',
+              'description': 'The template key, if the post_content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -898,7 +898,7 @@
             }),
             'pre_template': dict({
               'default': None,
-              'description': 'Whether the pre_content was created from a jinja template.',
+              'description': 'The template key, if the pre_content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -987,7 +987,7 @@
             }),
             'template': dict({
               'default': None,
-              'description': 'Whether the content was created from a jinja template.',
+              'description': 'The template key, if the content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',

--- a/tests/__snapshots__/test_external.ambr
+++ b/tests/__snapshots__/test_external.ambr
@@ -100,7 +100,7 @@
               }),
               'default': dict({
               }),
-              'description': 'Mapping of constraint name, to check name, to result.',
+              'description': 'Mapping of constraint name, to check name, to result, None if not yet checked.',
               'field_type': 'core',
               'type': list([
                 'object',
@@ -109,7 +109,7 @@
             }),
             'content': dict({
               'default': '',
-              'description': 'Content of the need.',
+              'description': 'The main content of the need.',
               'field_type': 'core',
               'type': 'string',
             }),
@@ -130,7 +130,7 @@
             }),
             'doctype': dict({
               'default': '.rst',
-              'description': "Type of the document where the need is defined, e.g. '.rst'.",
+              'description': "The markup type of the content, denoted by the suffix of the source file, e.g. '.rst'.",
               'field_type': 'core',
               'type': 'string',
             }),
@@ -198,7 +198,7 @@
             }),
             'jinja_content': dict({
               'default': False,
-              'description': 'Whether the content should be pre-processed by jinja.',
+              'description': 'Whether the content was pre-processed by jinja.',
               'field_type': 'core',
               'type': 'boolean',
             }),
@@ -305,7 +305,7 @@
             }),
             'post_content': dict({
               'default': None,
-              'description': 'Post-content of the need.',
+              'description': 'Additional content after the need.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -314,7 +314,7 @@
             }),
             'post_template': dict({
               'default': None,
-              'description': 'Post-template of the need.',
+              'description': 'Whether the post_content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -323,7 +323,7 @@
             }),
             'pre_content': dict({
               'default': None,
-              'description': 'Pre-content of the need.',
+              'description': 'Additional content before the need.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -332,7 +332,7 @@
             }),
             'pre_template': dict({
               'default': None,
-              'description': 'Pre-template of the need.',
+              'description': 'Whether the pre_content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -421,7 +421,7 @@
             }),
             'template': dict({
               'default': None,
-              'description': 'Template of the need.',
+              'description': 'Whether the content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -654,7 +654,7 @@
               }),
               'default': dict({
               }),
-              'description': 'Mapping of constraint name, to check name, to result.',
+              'description': 'Mapping of constraint name, to check name, to result, None if not yet checked.',
               'field_type': 'core',
               'type': list([
                 'object',
@@ -663,7 +663,7 @@
             }),
             'content': dict({
               'default': '',
-              'description': 'Content of the need.',
+              'description': 'The main content of the need.',
               'field_type': 'core',
               'type': 'string',
             }),
@@ -684,7 +684,7 @@
             }),
             'doctype': dict({
               'default': '.rst',
-              'description': "Type of the document where the need is defined, e.g. '.rst'.",
+              'description': "The markup type of the content, denoted by the suffix of the source file, e.g. '.rst'.",
               'field_type': 'core',
               'type': 'string',
             }),
@@ -764,7 +764,7 @@
             }),
             'jinja_content': dict({
               'default': False,
-              'description': 'Whether the content should be pre-processed by jinja.',
+              'description': 'Whether the content was pre-processed by jinja.',
               'field_type': 'core',
               'type': 'boolean',
             }),
@@ -871,7 +871,7 @@
             }),
             'post_content': dict({
               'default': None,
-              'description': 'Post-content of the need.',
+              'description': 'Additional content after the need.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -880,7 +880,7 @@
             }),
             'post_template': dict({
               'default': None,
-              'description': 'Post-template of the need.',
+              'description': 'Whether the post_content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -889,7 +889,7 @@
             }),
             'pre_content': dict({
               'default': None,
-              'description': 'Pre-content of the need.',
+              'description': 'Additional content before the need.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -898,7 +898,7 @@
             }),
             'pre_template': dict({
               'default': None,
-              'description': 'Pre-template of the need.',
+              'description': 'Whether the pre_content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -987,7 +987,7 @@
             }),
             'template': dict({
               'default': None,
-              'description': 'Template of the need.',
+              'description': 'Whether the content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',

--- a/tests/__snapshots__/test_extra_options.ambr
+++ b/tests/__snapshots__/test_extra_options.ambr
@@ -349,7 +349,7 @@
             }),
             'post_template': dict({
               'default': None,
-              'description': 'Whether the post_content was created from a jinja template.',
+              'description': 'The template key, if the post_content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -367,7 +367,7 @@
             }),
             'pre_template': dict({
               'default': None,
-              'description': 'Whether the pre_content was created from a jinja template.',
+              'description': 'The template key, if the pre_content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -456,7 +456,7 @@
             }),
             'template': dict({
               'default': None,
-              'description': 'Whether the content was created from a jinja template.',
+              'description': 'The template key, if the content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',

--- a/tests/__snapshots__/test_extra_options.ambr
+++ b/tests/__snapshots__/test_extra_options.ambr
@@ -117,7 +117,7 @@
               }),
               'default': dict({
               }),
-              'description': 'Mapping of constraint name, to check name, to result.',
+              'description': 'Mapping of constraint name, to check name, to result, None if not yet checked.',
               'field_type': 'core',
               'type': list([
                 'object',
@@ -126,7 +126,7 @@
             }),
             'content': dict({
               'default': '',
-              'description': 'Content of the need.',
+              'description': 'The main content of the need.',
               'field_type': 'core',
               'type': 'string',
             }),
@@ -147,7 +147,7 @@
             }),
             'doctype': dict({
               'default': '.rst',
-              'description': "Type of the document where the need is defined, e.g. '.rst'.",
+              'description': "The markup type of the content, denoted by the suffix of the source file, e.g. '.rst'.",
               'field_type': 'core',
               'type': 'string',
             }),
@@ -227,7 +227,7 @@
             }),
             'jinja_content': dict({
               'default': False,
-              'description': 'Whether the content should be pre-processed by jinja.',
+              'description': 'Whether the content was pre-processed by jinja.',
               'field_type': 'core',
               'type': 'boolean',
             }),
@@ -340,7 +340,7 @@
             }),
             'post_content': dict({
               'default': None,
-              'description': 'Post-content of the need.',
+              'description': 'Additional content after the need.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -349,7 +349,7 @@
             }),
             'post_template': dict({
               'default': None,
-              'description': 'Post-template of the need.',
+              'description': 'Whether the post_content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -358,7 +358,7 @@
             }),
             'pre_content': dict({
               'default': None,
-              'description': 'Pre-content of the need.',
+              'description': 'Additional content before the need.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -367,7 +367,7 @@
             }),
             'pre_template': dict({
               'default': None,
-              'description': 'Pre-template of the need.',
+              'description': 'Whether the pre_content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -456,7 +456,7 @@
             }),
             'template': dict({
               'default': None,
-              'description': 'Template of the need.',
+              'description': 'Whether the content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',

--- a/tests/__snapshots__/test_need_constraints.ambr
+++ b/tests/__snapshots__/test_need_constraints.ambr
@@ -665,7 +665,7 @@
               }),
               'default': dict({
               }),
-              'description': 'Mapping of constraint name, to check name, to result.',
+              'description': 'Mapping of constraint name, to check name, to result, None if not yet checked.',
               'field_type': 'core',
               'type': list([
                 'object',
@@ -674,7 +674,7 @@
             }),
             'content': dict({
               'default': '',
-              'description': 'Content of the need.',
+              'description': 'The main content of the need.',
               'field_type': 'core',
               'type': 'string',
             }),
@@ -695,7 +695,7 @@
             }),
             'doctype': dict({
               'default': '.rst',
-              'description': "Type of the document where the need is defined, e.g. '.rst'.",
+              'description': "The markup type of the content, denoted by the suffix of the source file, e.g. '.rst'.",
               'field_type': 'core',
               'type': 'string',
             }),
@@ -763,7 +763,7 @@
             }),
             'jinja_content': dict({
               'default': False,
-              'description': 'Whether the content should be pre-processed by jinja.',
+              'description': 'Whether the content was pre-processed by jinja.',
               'field_type': 'core',
               'type': 'boolean',
             }),
@@ -870,7 +870,7 @@
             }),
             'post_content': dict({
               'default': None,
-              'description': 'Post-content of the need.',
+              'description': 'Additional content after the need.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -879,7 +879,7 @@
             }),
             'post_template': dict({
               'default': None,
-              'description': 'Post-template of the need.',
+              'description': 'Whether the post_content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -888,7 +888,7 @@
             }),
             'pre_content': dict({
               'default': None,
-              'description': 'Pre-content of the need.',
+              'description': 'Additional content before the need.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -897,7 +897,7 @@
             }),
             'pre_template': dict({
               'default': None,
-              'description': 'Pre-template of the need.',
+              'description': 'Whether the pre_content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -986,7 +986,7 @@
             }),
             'template': dict({
               'default': None,
-              'description': 'Template of the need.',
+              'description': 'Whether the content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',

--- a/tests/__snapshots__/test_need_constraints.ambr
+++ b/tests/__snapshots__/test_need_constraints.ambr
@@ -879,7 +879,7 @@
             }),
             'post_template': dict({
               'default': None,
-              'description': 'Whether the post_content was created from a jinja template.',
+              'description': 'The template key, if the post_content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -897,7 +897,7 @@
             }),
             'pre_template': dict({
               'default': None,
-              'description': 'Whether the pre_content was created from a jinja template.',
+              'description': 'The template key, if the pre_content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -986,7 +986,7 @@
             }),
             'template': dict({
               'default': None,
-              'description': 'Whether the content was created from a jinja template.',
+              'description': 'The template key, if the content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',

--- a/tests/__snapshots__/test_needextend.ambr
+++ b/tests/__snapshots__/test_needextend.ambr
@@ -428,7 +428,7 @@
               }),
               'default': dict({
               }),
-              'description': 'Mapping of constraint name, to check name, to result.',
+              'description': 'Mapping of constraint name, to check name, to result, None if not yet checked.',
               'field_type': 'core',
               'type': list([
                 'object',
@@ -437,7 +437,7 @@
             }),
             'content': dict({
               'default': '',
-              'description': 'Content of the need.',
+              'description': 'The main content of the need.',
               'field_type': 'core',
               'type': 'string',
             }),
@@ -458,7 +458,7 @@
             }),
             'doctype': dict({
               'default': '.rst',
-              'description': "Type of the document where the need is defined, e.g. '.rst'.",
+              'description': "The markup type of the content, denoted by the suffix of the source file, e.g. '.rst'.",
               'field_type': 'core',
               'type': 'string',
             }),
@@ -526,7 +526,7 @@
             }),
             'jinja_content': dict({
               'default': False,
-              'description': 'Whether the content should be pre-processed by jinja.',
+              'description': 'Whether the content was pre-processed by jinja.',
               'field_type': 'core',
               'type': 'boolean',
             }),
@@ -633,7 +633,7 @@
             }),
             'post_content': dict({
               'default': None,
-              'description': 'Post-content of the need.',
+              'description': 'Additional content after the need.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -642,7 +642,7 @@
             }),
             'post_template': dict({
               'default': None,
-              'description': 'Post-template of the need.',
+              'description': 'Whether the post_content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -651,7 +651,7 @@
             }),
             'pre_content': dict({
               'default': None,
-              'description': 'Pre-content of the need.',
+              'description': 'Additional content before the need.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -660,7 +660,7 @@
             }),
             'pre_template': dict({
               'default': None,
-              'description': 'Pre-template of the need.',
+              'description': 'Whether the pre_content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -749,7 +749,7 @@
             }),
             'template': dict({
               'default': None,
-              'description': 'Template of the need.',
+              'description': 'Whether the content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -1321,7 +1321,7 @@
               }),
               'default': dict({
               }),
-              'description': 'Mapping of constraint name, to check name, to result.',
+              'description': 'Mapping of constraint name, to check name, to result, None if not yet checked.',
               'field_type': 'core',
               'type': list([
                 'object',
@@ -1330,7 +1330,7 @@
             }),
             'content': dict({
               'default': '',
-              'description': 'Content of the need.',
+              'description': 'The main content of the need.',
               'field_type': 'core',
               'type': 'string',
             }),
@@ -1351,7 +1351,7 @@
             }),
             'doctype': dict({
               'default': '.rst',
-              'description': "Type of the document where the need is defined, e.g. '.rst'.",
+              'description': "The markup type of the content, denoted by the suffix of the source file, e.g. '.rst'.",
               'field_type': 'core',
               'type': 'string',
             }),
@@ -1419,7 +1419,7 @@
             }),
             'jinja_content': dict({
               'default': False,
-              'description': 'Whether the content should be pre-processed by jinja.',
+              'description': 'Whether the content was pre-processed by jinja.',
               'field_type': 'core',
               'type': 'boolean',
             }),
@@ -1526,7 +1526,7 @@
             }),
             'post_content': dict({
               'default': None,
-              'description': 'Post-content of the need.',
+              'description': 'Additional content after the need.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -1535,7 +1535,7 @@
             }),
             'post_template': dict({
               'default': None,
-              'description': 'Post-template of the need.',
+              'description': 'Whether the post_content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -1544,7 +1544,7 @@
             }),
             'pre_content': dict({
               'default': None,
-              'description': 'Pre-content of the need.',
+              'description': 'Additional content before the need.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -1553,7 +1553,7 @@
             }),
             'pre_template': dict({
               'default': None,
-              'description': 'Pre-template of the need.',
+              'description': 'Whether the pre_content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -1642,7 +1642,7 @@
             }),
             'template': dict({
               'default': None,
-              'description': 'Template of the need.',
+              'description': 'Whether the content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',

--- a/tests/__snapshots__/test_needextend.ambr
+++ b/tests/__snapshots__/test_needextend.ambr
@@ -642,7 +642,7 @@
             }),
             'post_template': dict({
               'default': None,
-              'description': 'Whether the post_content was created from a jinja template.',
+              'description': 'The template key, if the post_content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -660,7 +660,7 @@
             }),
             'pre_template': dict({
               'default': None,
-              'description': 'Whether the pre_content was created from a jinja template.',
+              'description': 'The template key, if the pre_content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -749,7 +749,7 @@
             }),
             'template': dict({
               'default': None,
-              'description': 'Whether the content was created from a jinja template.',
+              'description': 'The template key, if the content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -1535,7 +1535,7 @@
             }),
             'post_template': dict({
               'default': None,
-              'description': 'Whether the post_content was created from a jinja template.',
+              'description': 'The template key, if the post_content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -1553,7 +1553,7 @@
             }),
             'pre_template': dict({
               'default': None,
-              'description': 'Whether the pre_content was created from a jinja template.',
+              'description': 'The template key, if the pre_content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -1642,7 +1642,7 @@
             }),
             'template': dict({
               'default': None,
-              'description': 'Whether the content was created from a jinja template.',
+              'description': 'The template key, if the content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',

--- a/tests/__snapshots__/test_needimport.ambr
+++ b/tests/__snapshots__/test_needimport.ambr
@@ -1685,7 +1685,7 @@
               }),
               'default': dict({
               }),
-              'description': 'Mapping of constraint name, to check name, to result.',
+              'description': 'Mapping of constraint name, to check name, to result, None if not yet checked.',
               'field_type': 'core',
               'type': list([
                 'object',
@@ -1694,7 +1694,7 @@
             }),
             'content': dict({
               'default': '',
-              'description': 'Content of the need.',
+              'description': 'The main content of the need.',
               'field_type': 'core',
               'type': 'string',
             }),
@@ -1715,7 +1715,7 @@
             }),
             'doctype': dict({
               'default': '.rst',
-              'description': "Type of the document where the need is defined, e.g. '.rst'.",
+              'description': "The markup type of the content, denoted by the suffix of the source file, e.g. '.rst'.",
               'field_type': 'core',
               'type': 'string',
             }),
@@ -1783,7 +1783,7 @@
             }),
             'jinja_content': dict({
               'default': False,
-              'description': 'Whether the content should be pre-processed by jinja.',
+              'description': 'Whether the content was pre-processed by jinja.',
               'field_type': 'core',
               'type': 'boolean',
             }),
@@ -1890,7 +1890,7 @@
             }),
             'post_content': dict({
               'default': None,
-              'description': 'Post-content of the need.',
+              'description': 'Additional content after the need.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -1899,7 +1899,7 @@
             }),
             'post_template': dict({
               'default': None,
-              'description': 'Post-template of the need.',
+              'description': 'Whether the post_content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -1908,7 +1908,7 @@
             }),
             'pre_content': dict({
               'default': None,
-              'description': 'Pre-content of the need.',
+              'description': 'Additional content before the need.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -1917,7 +1917,7 @@
             }),
             'pre_template': dict({
               'default': None,
-              'description': 'Pre-template of the need.',
+              'description': 'Whether the pre_content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -2006,7 +2006,7 @@
             }),
             'template': dict({
               'default': None,
-              'description': 'Template of the need.',
+              'description': 'Whether the content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',

--- a/tests/__snapshots__/test_needimport.ambr
+++ b/tests/__snapshots__/test_needimport.ambr
@@ -1899,7 +1899,7 @@
             }),
             'post_template': dict({
               'default': None,
-              'description': 'Whether the post_content was created from a jinja template.',
+              'description': 'The template key, if the post_content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -1917,7 +1917,7 @@
             }),
             'pre_template': dict({
               'default': None,
-              'description': 'Whether the pre_content was created from a jinja template.',
+              'description': 'The template key, if the pre_content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -2006,7 +2006,7 @@
             }),
             'template': dict({
               'default': None,
-              'description': 'Whether the content was created from a jinja template.',
+              'description': 'The template key, if the content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',

--- a/tests/__snapshots__/test_needs_builder.ambr
+++ b/tests/__snapshots__/test_needs_builder.ambr
@@ -497,7 +497,7 @@
             }),
             'post_template': dict({
               'default': None,
-              'description': 'Whether the post_content was created from a jinja template.',
+              'description': 'The template key, if the post_content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -515,7 +515,7 @@
             }),
             'pre_template': dict({
               'default': None,
-              'description': 'Whether the pre_content was created from a jinja template.',
+              'description': 'The template key, if the pre_content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -604,7 +604,7 @@
             }),
             'template': dict({
               'default': None,
-              'description': 'Whether the content was created from a jinja template.',
+              'description': 'The template key, if the content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -1158,7 +1158,7 @@
             }),
             'post_template': dict({
               'default': None,
-              'description': 'Whether the post_content was created from a jinja template.',
+              'description': 'The template key, if the post_content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -1176,7 +1176,7 @@
             }),
             'pre_template': dict({
               'default': None,
-              'description': 'Whether the pre_content was created from a jinja template.',
+              'description': 'The template key, if the pre_content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -1265,7 +1265,7 @@
             }),
             'template': dict({
               'default': None,
-              'description': 'Whether the content was created from a jinja template.',
+              'description': 'The template key, if the content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -1984,7 +1984,7 @@
             }),
             'post_template': dict({
               'default': None,
-              'description': 'Whether the post_content was created from a jinja template.',
+              'description': 'The template key, if the post_content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -2002,7 +2002,7 @@
             }),
             'pre_template': dict({
               'default': None,
-              'description': 'Whether the pre_content was created from a jinja template.',
+              'description': 'The template key, if the pre_content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -2091,7 +2091,7 @@
             }),
             'template': dict({
               'default': None,
-              'description': 'Whether the content was created from a jinja template.',
+              'description': 'The template key, if the content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',

--- a/tests/__snapshots__/test_needs_builder.ambr
+++ b/tests/__snapshots__/test_needs_builder.ambr
@@ -283,7 +283,7 @@
               }),
               'default': dict({
               }),
-              'description': 'Mapping of constraint name, to check name, to result.',
+              'description': 'Mapping of constraint name, to check name, to result, None if not yet checked.',
               'field_type': 'core',
               'type': list([
                 'object',
@@ -292,7 +292,7 @@
             }),
             'content': dict({
               'default': '',
-              'description': 'Content of the need.',
+              'description': 'The main content of the need.',
               'field_type': 'core',
               'type': 'string',
             }),
@@ -313,7 +313,7 @@
             }),
             'doctype': dict({
               'default': '.rst',
-              'description': "Type of the document where the need is defined, e.g. '.rst'.",
+              'description': "The markup type of the content, denoted by the suffix of the source file, e.g. '.rst'.",
               'field_type': 'core',
               'type': 'string',
             }),
@@ -381,7 +381,7 @@
             }),
             'jinja_content': dict({
               'default': False,
-              'description': 'Whether the content should be pre-processed by jinja.',
+              'description': 'Whether the content was pre-processed by jinja.',
               'field_type': 'core',
               'type': 'boolean',
             }),
@@ -488,7 +488,7 @@
             }),
             'post_content': dict({
               'default': None,
-              'description': 'Post-content of the need.',
+              'description': 'Additional content after the need.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -497,7 +497,7 @@
             }),
             'post_template': dict({
               'default': None,
-              'description': 'Post-template of the need.',
+              'description': 'Whether the post_content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -506,7 +506,7 @@
             }),
             'pre_content': dict({
               'default': None,
-              'description': 'Pre-content of the need.',
+              'description': 'Additional content before the need.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -515,7 +515,7 @@
             }),
             'pre_template': dict({
               'default': None,
-              'description': 'Pre-template of the need.',
+              'description': 'Whether the pre_content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -604,7 +604,7 @@
             }),
             'template': dict({
               'default': None,
-              'description': 'Template of the need.',
+              'description': 'Whether the content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -944,7 +944,7 @@
               }),
               'default': dict({
               }),
-              'description': 'Mapping of constraint name, to check name, to result.',
+              'description': 'Mapping of constraint name, to check name, to result, None if not yet checked.',
               'field_type': 'core',
               'type': list([
                 'object',
@@ -953,7 +953,7 @@
             }),
             'content': dict({
               'default': '',
-              'description': 'Content of the need.',
+              'description': 'The main content of the need.',
               'field_type': 'core',
               'type': 'string',
             }),
@@ -974,7 +974,7 @@
             }),
             'doctype': dict({
               'default': '.rst',
-              'description': "Type of the document where the need is defined, e.g. '.rst'.",
+              'description': "The markup type of the content, denoted by the suffix of the source file, e.g. '.rst'.",
               'field_type': 'core',
               'type': 'string',
             }),
@@ -1042,7 +1042,7 @@
             }),
             'jinja_content': dict({
               'default': False,
-              'description': 'Whether the content should be pre-processed by jinja.',
+              'description': 'Whether the content was pre-processed by jinja.',
               'field_type': 'core',
               'type': 'boolean',
             }),
@@ -1149,7 +1149,7 @@
             }),
             'post_content': dict({
               'default': None,
-              'description': 'Post-content of the need.',
+              'description': 'Additional content after the need.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -1158,7 +1158,7 @@
             }),
             'post_template': dict({
               'default': None,
-              'description': 'Post-template of the need.',
+              'description': 'Whether the post_content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -1167,7 +1167,7 @@
             }),
             'pre_content': dict({
               'default': None,
-              'description': 'Pre-content of the need.',
+              'description': 'Additional content before the need.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -1176,7 +1176,7 @@
             }),
             'pre_template': dict({
               'default': None,
-              'description': 'Pre-template of the need.',
+              'description': 'Whether the pre_content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -1265,7 +1265,7 @@
             }),
             'template': dict({
               'default': None,
-              'description': 'Template of the need.',
+              'description': 'Whether the content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -1770,7 +1770,7 @@
               }),
               'default': dict({
               }),
-              'description': 'Mapping of constraint name, to check name, to result.',
+              'description': 'Mapping of constraint name, to check name, to result, None if not yet checked.',
               'field_type': 'core',
               'type': list([
                 'object',
@@ -1779,7 +1779,7 @@
             }),
             'content': dict({
               'default': '',
-              'description': 'Content of the need.',
+              'description': 'The main content of the need.',
               'field_type': 'core',
               'type': 'string',
             }),
@@ -1800,7 +1800,7 @@
             }),
             'doctype': dict({
               'default': '.rst',
-              'description': "Type of the document where the need is defined, e.g. '.rst'.",
+              'description': "The markup type of the content, denoted by the suffix of the source file, e.g. '.rst'.",
               'field_type': 'core',
               'type': 'string',
             }),
@@ -1868,7 +1868,7 @@
             }),
             'jinja_content': dict({
               'default': False,
-              'description': 'Whether the content should be pre-processed by jinja.',
+              'description': 'Whether the content was pre-processed by jinja.',
               'field_type': 'core',
               'type': 'boolean',
             }),
@@ -1975,7 +1975,7 @@
             }),
             'post_content': dict({
               'default': None,
-              'description': 'Post-content of the need.',
+              'description': 'Additional content after the need.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -1984,7 +1984,7 @@
             }),
             'post_template': dict({
               'default': None,
-              'description': 'Post-template of the need.',
+              'description': 'Whether the post_content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -1993,7 +1993,7 @@
             }),
             'pre_content': dict({
               'default': None,
-              'description': 'Pre-content of the need.',
+              'description': 'Additional content before the need.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -2002,7 +2002,7 @@
             }),
             'pre_template': dict({
               'default': None,
-              'description': 'Pre-template of the need.',
+              'description': 'Whether the pre_content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -2091,7 +2091,7 @@
             }),
             'template': dict({
               'default': None,
-              'description': 'Template of the need.',
+              'description': 'Whether the content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',

--- a/tests/__snapshots__/test_service_github.ambr
+++ b/tests/__snapshots__/test_service_github.ambr
@@ -614,7 +614,7 @@
             }),
             'post_template': dict({
               'default': None,
-              'description': 'Whether the post_content was created from a jinja template.',
+              'description': 'The template key, if the post_content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -632,7 +632,7 @@
             }),
             'pre_template': dict({
               'default': None,
-              'description': 'Whether the pre_content was created from a jinja template.',
+              'description': 'The template key, if the pre_content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -721,7 +721,7 @@
             }),
             'template': dict({
               'default': None,
-              'description': 'Whether the content was created from a jinja template.',
+              'description': 'The template key, if the content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',

--- a/tests/__snapshots__/test_service_github.ambr
+++ b/tests/__snapshots__/test_service_github.ambr
@@ -400,7 +400,7 @@
               }),
               'default': dict({
               }),
-              'description': 'Mapping of constraint name, to check name, to result.',
+              'description': 'Mapping of constraint name, to check name, to result, None if not yet checked.',
               'field_type': 'core',
               'type': list([
                 'object',
@@ -409,7 +409,7 @@
             }),
             'content': dict({
               'default': '',
-              'description': 'Content of the need.',
+              'description': 'The main content of the need.',
               'field_type': 'core',
               'type': 'string',
             }),
@@ -430,7 +430,7 @@
             }),
             'doctype': dict({
               'default': '.rst',
-              'description': "Type of the document where the need is defined, e.g. '.rst'.",
+              'description': "The markup type of the content, denoted by the suffix of the source file, e.g. '.rst'.",
               'field_type': 'core',
               'type': 'string',
             }),
@@ -498,7 +498,7 @@
             }),
             'jinja_content': dict({
               'default': False,
-              'description': 'Whether the content should be pre-processed by jinja.',
+              'description': 'Whether the content was pre-processed by jinja.',
               'field_type': 'core',
               'type': 'boolean',
             }),
@@ -605,7 +605,7 @@
             }),
             'post_content': dict({
               'default': None,
-              'description': 'Post-content of the need.',
+              'description': 'Additional content after the need.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -614,7 +614,7 @@
             }),
             'post_template': dict({
               'default': None,
-              'description': 'Post-template of the need.',
+              'description': 'Whether the post_content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -623,7 +623,7 @@
             }),
             'pre_content': dict({
               'default': None,
-              'description': 'Pre-content of the need.',
+              'description': 'Additional content before the need.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -632,7 +632,7 @@
             }),
             'pre_template': dict({
               'default': None,
-              'description': 'Pre-template of the need.',
+              'description': 'Whether the pre_content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',
@@ -721,7 +721,7 @@
             }),
             'template': dict({
               'default': None,
-              'description': 'Template of the need.',
+              'description': 'Whether the content was created from a jinja template.',
               'field_type': 'core',
               'type': list([
                 'string',

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -6,7 +6,7 @@ import pytest
 from sphinx.util.console import strip_colors
 
 from sphinx_needs.filter_common import filter_needs_parts, filter_needs_view
-from sphinx_needs.need_item import NeedItem, NeedItemSourceExternal
+from sphinx_needs.need_item import NeedItem, NeedItemSourceExternal, NeedsContent
 from sphinx_needs.views import NeedsView
 
 
@@ -187,10 +187,6 @@ def create_needs_view():
 
     core_base = {
         "id": "abc",
-        "doctype": ".rst",
-        "content": "content",
-        "pre_content": None,
-        "post_content": None,
         "type": "type",
         "type_name": "type title",
         "type_prefix": "type prefix",
@@ -204,11 +200,7 @@ def create_needs_view():
         "arch": {},
         "style": None,
         "layout": None,
-        "template": None,
-        "pre_template": None,
-        "post_template": None,
         "hide": False,
-        "jinja_content": False,
         "parts": {},
         "external_css": "external_link",
         "has_dead_links": False,
@@ -217,12 +209,18 @@ def create_needs_view():
         "signature": None,
     }
 
+    content = NeedsContent(
+        content="content",
+        doctype=".rst",
+    )
+
     need_items = [
         NeedItem(
             core=core_base | core,
             extras={},
             links={},
             source=source,
+            content=content,
         )
         for core, source in needs_core
     ]


### PR DESCRIPTION
Add `NeedsContent` construct, to store all data to do with content generation: `doctype`, `content`, `pre_content`, `post_content`, `jinja_content`, `template`, `pre_template`, `post_template`

These are all immutable, after the content has been initially set

note, this is part of the rationalisation of internal need fields:

<img width="976" height="757" alt="image" src="https://github.com/user-attachments/assets/ee45a64a-328a-4ee8-8527-9592dfabddfa" />
