### PR TITLE
🔧 Fix extension available check for plantuml

### DIFF
--- a/sphinx_needs/directives/needflow/_plantuml.py
+++ b/sphinx_needs/directives/needflow/_plantuml.py
@@ -240,7 +240,7 @@ def process_needflow_plantuml(
             allowed_link_types.append(link_type)
 
         try:
-            if "sphinxcontrib.plantuml" not in app.config.extensions:
+            if "sphinxcontrib.plantuml" not in app.extensions:
                 raise ImportError
             from sphinxcontrib.plantuml import generate_name, plantuml
         except ImportError:

--- a/sphinx_needs/directives/needgantt.py
+++ b/sphinx_needs/directives/needgantt.py
@@ -171,7 +171,7 @@ def process_needgantt(
 
         content = []
         try:
-            if "sphinxcontrib.plantuml" not in app.config.extensions:
+            if "sphinxcontrib.plantuml" not in app.extensions:
                 raise ImportError
             from sphinxcontrib.plantuml import generate_name, plantuml
         except ImportError:

--- a/sphinx_needs/directives/needsequence.py
+++ b/sphinx_needs/directives/needsequence.py
@@ -121,7 +121,7 @@ def process_needsequence(
 
         content = []
         try:
-            if "sphinxcontrib.plantuml" not in app.config.extensions:
+            if "sphinxcontrib.plantuml" not in app.extensions:
                 raise ImportError
             from sphinxcontrib.plantuml import generate_name, plantuml
         except ImportError:

--- a/sphinx_needs/directives/needuml.py
+++ b/sphinx_needs/directives/needuml.py
@@ -160,7 +160,7 @@ def transform_uml_to_plantuml_node(
     config: str,
 ) -> plantuml:
     try:
-        if "sphinxcontrib.plantuml" not in app.config.extensions:
+        if "sphinxcontrib.plantuml" not in app.extensions:
             raise ImportError
         from sphinxcontrib.plantuml import plantuml
     except ImportError:


### PR DESCRIPTION
It's important whether the extension is available or not, not whether it's in the config. This is relevant when extensions were added via `app.setup_extension`