### PR TITLE
🐛 Fix name error schema_path_contains

### DIFF
--- a/sphinx_needs/schema/core.py
+++ b/sphinx_needs/schema/core.py
@@ -250,6 +250,20 @@ def recurse_validate_type_schmemas(
             """List of target need ids for contains validation that failed."""
             contains_warnings_per_target: dict[str, list[OntologyWarning]] = {}
             """Map of target need id to warnings for failed contains validation."""
+            schema_path_items = [
+                *schema_path,
+                "validate",
+                "network",
+                link_type,
+                "items",
+            ]
+            schema_path_contains = [
+                *schema_path,
+                "validate",
+                "network",
+                link_type,
+                "contains",
+            ]
             for target_need_id in need[link_type]:
                 # collect all downstream warnings for broken links, items and contains
                 # evaluation happens later
@@ -280,20 +294,6 @@ def recurse_validate_type_schmemas(
                         warnings[-1]["user_message"] = user_message
                     continue
 
-                schema_path_items = [
-                    *schema_path,
-                    "validate",
-                    "network",
-                    link_type,
-                    "items",
-                ]
-                schema_path_contains = [
-                    *schema_path,
-                    "validate",
-                    "network",
-                    link_type,
-                    "contains",
-                ]
                 need_path_link = [*need_path, link_type, target_need_id]
                 # Handle items validation - all items must pass
                 if link_schema.get("items"):

--- a/tests/schema/__snapshots__/test_schema.ambr
+++ b/tests/schema/__snapshots__/test_schema.ambr
@@ -2685,6 +2685,16 @@
   
   '''
 # ---
+# name: test_schemas[schema/fixtures/network-no_error_empty_links]
+  '''
+  WARNING: Need 'IMPL_SAFE' has validation errors:
+    Severity:       violation
+    Need path:      IMPL_SAFE > links
+    Schema path:    impl-[links]->spec[0] > validate > network > links > contains
+    Schema message: Too few valid links of type 'links' (0 < 1) [sn_schema.network_contains_too_few]
+  
+  '''
+# ---
 # name: test_schemas[schema/fixtures/network-schemas_in_conf]
   ''
 # ---

--- a/tests/schema/fixtures/network.yml
+++ b/tests/schema/fixtures/network.yml
@@ -74,6 +74,42 @@ schemas_in_conf_error:
         :id: IMPL_1
         :links: SPEC_1
 
+no_error_empty_links:
+  conf: |
+    extensions = ["sphinx_needs"]
+    needs_from_toml = "ubproject.toml"
+  ubproject: |
+    [needs]
+    schema_definitions_from_json = "schemas.json"
+  rst: |
+    .. spec:: unsafe spec
+        :id: SPEC_UNSAFE
+
+    .. impl:: safe impl
+       :id: IMPL_SAFE
+  schemas:
+    $defs:
+      type-spec:
+        properties:
+          type:
+            const: spec
+      type-impl:
+        properties:
+          type:
+            const: impl
+    schemas:
+      - id: "impl-[links]->spec"
+        message: impl links to spec
+        select:
+          $ref: "#/$defs/type-impl"
+        validate:
+          network:
+            links:
+              contains:
+                local:
+                  $ref: "#/$defs/type-spec"
+              minContains: 1
+
 min_contains:
   conf: |
     extensions = ["sphinx_needs"]


### PR DESCRIPTION
Happens when using `contains` on empty link lists.
Fixed & added a test case to prevent regressions.