### PR TITLE
🐛 Fix schema rule severity

### DIFF
--- a/sphinx_needs/schema/core.py
+++ b/sphinx_needs/schema/core.py
@@ -156,7 +156,7 @@ def validate_need(
             local_network_schema["local"] = type_schema["validate"]["local"]
         if "network" in type_schema["validate"]:
             local_network_schema["network"] = type_schema["validate"]["network"]
-        _, new_warnings_recurse = recurse_validate_type_schmemas(
+        _, new_warnings_recurse = recurse_validate_schemas(
             config,
             need,
             needs,
@@ -172,7 +172,7 @@ def validate_need(
     return all_warnings
 
 
-def recurse_validate_type_schmemas(
+def recurse_validate_schemas(
     config: NeedsSphinxConfig,
     need: NeedItem,
     needs: NeedsView,
@@ -228,6 +228,7 @@ def recurse_validate_type_schmemas(
             schema_path=[*schema_path, "local"],
             need_path=need_path,
             user_message=user_message if recurse_level == 0 else None,
+            user_severity=severity if recurse_level == 0 else None,
         )
         save_debug_files(config, warnings_local)
         warnings_local_filtered = filter_warnings_severity(
@@ -297,7 +298,7 @@ def recurse_validate_type_schmemas(
                 need_path_link = [*need_path, link_type, target_need_id]
                 # Handle items validation - all items must pass
                 if link_schema.get("items"):
-                    new_success, new_warnings = recurse_validate_type_schmemas(
+                    new_success, new_warnings = recurse_validate_schemas(
                         config=config,
                         need=target_need,
                         needs=needs,
@@ -318,7 +319,7 @@ def recurse_validate_type_schmemas(
 
                 # Handle contains validation - at least some items must pass
                 if link_schema.get("contains"):
-                    new_success, new_warnings = recurse_validate_type_schmemas(
+                    new_success, new_warnings = recurse_validate_schemas(
                         config=config,
                         need=target_need,
                         needs=needs,
@@ -594,6 +595,7 @@ def get_ontology_warnings(
     schema_path: list[str],
     need_path: list[str],
     user_message: str | None = None,
+    user_severity: SeverityEnum | None = None,
 ) -> list[OntologyWarning]:
     warnings: list[OntologyWarning] = []
     warning: OntologyWarning
@@ -620,7 +622,7 @@ def get_ontology_warnings(
         for msg in validation_report["messages"]:
             warning = {
                 "rule": fail_rule,
-                "severity": get_severity(fail_rule),
+                "severity": get_severity(fail_rule, user_severity),
                 "validation_message": msg["message"],
                 "need": need,
                 "reduced_need": validation_report["reduced_need"],

--- a/tests/schema/__snapshots__/test_schema.ambr
+++ b/tests/schema/__snapshots__/test_schema.ambr
@@ -170,7 +170,7 @@
 # name: test_schema_e2e[test_app0]
   '''
   WARNING: Need 'FEAt' has validation errors:
-    Severity:       violation
+    Severity:       warning
     Field:          id
     Need path:      FEAt
     Schema path:    [0] > local > properties > id > pattern
@@ -2711,6 +2711,67 @@
       Need path:      IMPL_1 > links > SPEC_1
       Schema path:    [0] > validate > network > links > contains > local > properties > type > const
       Schema message: 'req' was expected [sn_schema.network_contains_too_few]
+  
+  '''
+# ---
+# name: test_schemas[schema/fixtures/reporting-severity_rule_info_min_unset_is_reported]
+  '''
+  WARNING: Need 'IMPL_1' has validation errors:
+    Severity:       info
+    Field:          asil
+    Need path:      IMPL_1
+    Schema path:    [0] > local > properties > asil > const
+    Schema message: 'A' was expected [sn_schema.local_fail]
+  
+  '''
+# ---
+# name: test_schemas[schema/fixtures/reporting-severity_rule_info_min_warning_not_reported]
+  ''
+# ---
+# name: test_schemas[schema/fixtures/reporting-severity_rule_unset_min_unset_is_reported]
+  '''
+  WARNING: Need 'IMPL_1' has validation errors:
+    Severity:       violation
+    Field:          asil
+    Need path:      IMPL_1
+    Schema path:    [0] > local > properties > asil > const
+    Schema message: 'A' was expected [sn_schema.local_fail]
+  
+  '''
+# ---
+# name: test_schemas[schema/fixtures/reporting-severity_rule_violation_min_unset_is_reported]
+  '''
+  WARNING: Need 'IMPL_1' has validation errors:
+    Severity:       violation
+    Field:          asil
+    Need path:      IMPL_1
+    Schema path:    [0] > local > properties > asil > const
+    Schema message: 'A' was expected [sn_schema.local_fail]
+  
+  '''
+# ---
+# name: test_schemas[schema/fixtures/reporting-severity_rule_warning_min_unset_is_reported]
+  '''
+  WARNING: Need 'IMPL_1' has validation errors:
+    Severity:       warning
+    Field:          asil
+    Need path:      IMPL_1
+    Schema path:    [0] > local > properties > asil > const
+    Schema message: 'A' was expected [sn_schema.local_fail]
+  
+  '''
+# ---
+# name: test_schemas[schema/fixtures/reporting-severity_rule_warning_min_violation_not_reported]
+  ''
+# ---
+# name: test_schemas[schema/fixtures/reporting-severity_rule_warning_min_warning_is_reported]
+  '''
+  WARNING: Need 'IMPL_1' has validation errors:
+    Severity:       warning
+    Field:          asil
+    Need path:      IMPL_1
+    Schema path:    [0] > local > properties > asil > const
+    Schema message: 'A' was expected [sn_schema.local_fail]
   
   '''
 # ---

--- a/tests/schema/fixtures/reporting.yml
+++ b/tests/schema/fixtures/reporting.yml
@@ -1,0 +1,161 @@
+severity_rule_unset_min_unset_is_reported:
+  conf: |
+    extensions = ["sphinx_needs"]
+    needs_from_toml = "ubproject.toml"
+    needs_schema_definitions_from_json = "schemas.json"
+  ubproject: |
+    [[needs.extra_options]]
+    name = "asil"
+  rst: |
+    .. impl:: title
+        :id: IMPL_1
+        :asil: QM
+  schemas:
+    $defs: []
+    schemas:
+      - validate:
+          local:
+            properties:
+              asil:
+                const: A
+
+severity_rule_info_min_unset_is_reported:
+  conf: |
+    extensions = ["sphinx_needs"]
+    needs_from_toml = "ubproject.toml"
+    needs_schema_definitions_from_json = "schemas.json"
+  ubproject: |
+    [[needs.extra_options]]
+    name = "asil"
+  rst: |
+    .. impl:: title
+        :id: IMPL_1
+        :asil: QM
+  schemas:
+    $defs: []
+    schemas:
+      - severity: "info"
+        validate:
+          local:
+            properties:
+              asil:
+                const: A
+
+severity_rule_warning_min_unset_is_reported:
+  conf: |
+    extensions = ["sphinx_needs"]
+    needs_from_toml = "ubproject.toml"
+    needs_schema_definitions_from_json = "schemas.json"
+  ubproject: |
+    [[needs.extra_options]]
+    name = "asil"
+  rst: |
+    .. impl:: title
+        :id: IMPL_1
+        :asil: QM
+  schemas:
+    $defs: []
+    schemas:
+      - severity: "warning"
+        validate:
+          local:
+            properties:
+              asil:
+                const: A
+
+severity_rule_violation_min_unset_is_reported:
+  conf: |
+    extensions = ["sphinx_needs"]
+    needs_from_toml = "ubproject.toml"
+    needs_schema_definitions_from_json = "schemas.json"
+  ubproject: |
+    [[needs.extra_options]]
+    name = "asil"
+  rst: |
+    .. impl:: title
+        :id: IMPL_1
+        :asil: QM
+  schemas:
+    $defs: []
+    schemas:
+      - severity: "violation"
+        validate:
+          local:
+            properties:
+              asil:
+                const: A
+
+severity_rule_info_min_warning_not_reported:
+  conf: |
+    extensions = ["sphinx_needs"]
+    needs_from_toml = "ubproject.toml"
+    needs_schema_definitions_from_json = "schemas.json"
+  ubproject: |
+    [needs]
+    schema_severity = "warning"
+
+    [[needs.extra_options]]
+    name = "asil"
+  rst: |
+    .. impl:: title
+        :id: IMPL_1
+        :asil: QM
+  schemas:
+    $defs: []
+    schemas:
+      - severity: "info"
+        validate:
+          local:
+            properties:
+              asil:
+                const: A
+
+severity_rule_warning_min_warning_is_reported:
+  conf: |
+    extensions = ["sphinx_needs"]
+    needs_from_toml = "ubproject.toml"
+    needs_schema_definitions_from_json = "schemas.json"
+  ubproject: |
+    [needs]
+    schema_severity = "warning"
+
+    [[needs.extra_options]]
+    name = "asil"
+  rst: |
+    .. impl:: title
+        :id: IMPL_1
+        :asil: QM
+  schemas:
+    $defs: []
+    schemas:
+      - severity: "warning"
+        validate:
+          local:
+            properties:
+              asil:
+                const: A
+
+severity_rule_warning_min_violation_not_reported:
+  conf: |
+    extensions = ["sphinx_needs"]
+    needs_from_toml = "ubproject.toml"
+    needs_schema_definitions_from_json = "schemas.json"
+  ubproject: |
+    [needs]
+    schema_severity = "violation"
+
+    [[needs.extra_options]]
+    name = "asil"
+  rst: |
+    .. impl:: title
+        :id: IMPL_1
+        :asil: QM
+  schemas:
+    $defs: []
+    schemas:
+      - severity: "warning"
+        validate:
+          local:
+            properties:
+              asil:
+                const: A

--- a/tests/schema/test_schema.py
+++ b/tests/schema/test_schema.py
@@ -43,6 +43,7 @@ def test_schema_config(
     "schema/fixtures/extra_links.yml",
     "schema/fixtures/extra_options.yml",
     "schema/fixtures/network.yml",
+    "schema/fixtures/reporting.yml",
     "schema/fixtures/unevaluated.yml",
 )
 def test_schemas(


### PR DESCRIPTION
This fixes the reported rule severity set in [schema rule definitions](https://sphinx-needs.readthedocs.io/en/latest/schema/index.html#severity-levels).

The filtering for severity based on rule severity and the [needs_schema_severity](https://sphinx-needs.readthedocs.io/en/latest/configuration.html#needs-schema-severity) (minimum report severity) actually did work, but the reported severity was not set correctly.