### PR TITLE
🔧 Fix `check_needs_data` not checking remote files in `needimport`

### DIFF
--- a/sphinx_needs/directives/needimport.py
+++ b/sphinx_needs/directives/needimport.py
@@ -113,14 +113,14 @@ class NeedimportDirective(SphinxDirective):
             except (OSError, json.JSONDecodeError) as e:
                 # TODO: Add exception handling
                 raise SphinxNeedsFileException(correct_need_import_path) from e
-
-            errors = check_needs_data(needs_import_list)
-            if errors.schema:
-                logger.info(
-                    f"Schema validation errors detected in file {correct_need_import_path}:"
-                )
-                for error in errors.schema:
-                    logger.info(f"  {error.message} -> {'.'.join(error.path)}")
+            
+        errors = check_needs_data(needs_import_list)
+        if errors.schema:
+            logger.info(
+                f"Schema validation errors detected in file {correct_need_import_path}:"
+            )
+            for error in errors.schema:
+                logger.info(f"  {error.message} -> {'.'.join(error.path)}")
 
         if version is None:
             try:

--- a/sphinx_needs/directives/needimport.py
+++ b/sphinx_needs/directives/needimport.py
@@ -113,7 +113,6 @@ class NeedimportDirective(SphinxDirective):
             except (OSError, json.JSONDecodeError) as e:
                 # TODO: Add exception handling
                 raise SphinxNeedsFileException(correct_need_import_path) from e
-            
         errors = check_needs_data(needs_import_list)
         if errors.schema:
             logger.info(


### PR DESCRIPTION
After discussing with @chrisjsewell this PR was created to use `check_needs_data` to also validate remote jsons
(was previously indented and was only happening for the else case)