### PR TITLE
♻️ Early resolution of schema_debug_path

### DIFF
--- a/sphinx_needs/needs.py
+++ b/sphinx_needs/needs.py
@@ -755,7 +755,7 @@ def check_configuration(app: Sphinx, config: Config) -> None:
                 "This is not allowed."
             )
 
-    validate_schemas_config(needs_config)
+    validate_schemas_config(app, needs_config)
 
 
 def create_schema(app: Sphinx, env: BuildEnvironment, _docnames: list[str]) -> None:

--- a/sphinx_needs/schema/config_utils.py
+++ b/sphinx_needs/schema/config_utils.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from pathlib import Path
 from typing import Any, Literal, cast
 
 from sphinx.application import Sphinx
@@ -52,8 +53,15 @@ def has_any_global_extra_schema_defined(needs_config: NeedsSphinxConfig) -> bool
     return False
 
 
-def validate_schemas_config(needs_config: NeedsSphinxConfig) -> None:
+def validate_schemas_config(app: Sphinx, needs_config: NeedsSphinxConfig) -> None:
     """Check basics in extra option and extra link schemas."""
+
+    orig_debug_path = Path(needs_config.schema_debug_path)
+    if not orig_debug_path.is_absolute():
+        # make it relative to confdir
+        needs_config.schema_debug_path = str(
+            (Path(app.confdir) / orig_debug_path).resolve()
+        )
 
     validate_extra_option_schemas(needs_config)
 

--- a/sphinx_needs/schema/process.py
+++ b/sphinx_needs/schema/process.py
@@ -1,5 +1,4 @@
 import time
-from pathlib import Path
 
 from sphinx.application import Sphinx
 from sphinx.builders import Builder
@@ -53,11 +52,6 @@ def process_schemas(app: Sphinx, builder: Builder) -> None:
     schema = SphinxNeedsData(app.env).get_schema()
     needs_schema = generate_needs_schema(schema)["properties"]
     _needs_schema.update(needs_schema)
-
-    orig_debug_path = Path(config.schema_debug_path)
-    if not orig_debug_path.is_absolute():
-        # make it relative to confdir
-        config.schema_debug_path = str((Path(app.confdir) / orig_debug_path).resolve())
 
     if config.schema_debug_active:
         clear_debug_dir(config)


### PR DESCRIPTION
The configuration should ideally be final after `config-inited` and latest with `env-before-read-docs`.
The PR moved the resolution of `schema_debug_path` from `write-started` to `config-inited`.