### PR TITLE
🐛 Fix schema network type injection

### DIFF
--- a/sphinx_needs/schema/config_utils.py
+++ b/sphinx_needs/schema/config_utils.py
@@ -451,6 +451,11 @@ def populate_field_type(
                         f"Item has keys {found_keys_object}, but type is '{curr_item['type']}', "
                         f"expected 'object'."
                     )
+        # Skip array type injection if we're directly inside a 'network' context,
+        # because in that case keys like 'contains', 'items' are link field names,
+        # not JSON schema array keywords
+        is_inside_network = path.endswith(".network") or path == "validate.network"
+
         keys_indicating_array = {
             "items",
             "contains",
@@ -460,7 +465,10 @@ def populate_field_type(
             "maxContains",
         }
         found_keys_array = [key for key in keys_indicating_array if key in curr_item]
-        if any(key in curr_item for key in keys_indicating_array):
+        if (
+            any(key in curr_item for key in keys_indicating_array)
+            and not is_inside_network
+        ):
             if "type" not in curr_item:
                 curr_item["type"] = "array"
             else:

--- a/tests/schema/__snapshots__/test_schema.ambr
+++ b/tests/schema/__snapshots__/test_schema.ambr
@@ -3431,6 +3431,16 @@
     }),
   })
 # ---
+# name: test_schemas[schema/fixtures/network-link_name_contains]
+  ''
+# ---
+# name: test_schemas[schema/fixtures/network-link_name_contains].1
+  dict({
+    'validated_needs_count': 2,
+    'validation_warnings': dict({
+    }),
+  })
+# ---
 # name: test_schemas[schema/fixtures/network-local_max_items]
   ''
 # ---

--- a/tests/schema/fixtures/network.yml
+++ b/tests/schema/fixtures/network.yml
@@ -629,3 +629,47 @@ max_network_levels:
                                                 properties:
                                                   type:
                                                     const: spec
+
+link_name_contains:
+  conf: |
+    extensions = ["sphinx_needs"]
+    needs_from_toml = "ubproject.toml"
+    needs_schema_definitions_from_json = "schemas.json"
+  ubproject: |
+    [[needs.extra_links]]
+    option = "contains"
+    outgoing = "contains"
+    incoming = "contained by"
+    [[needs.extra_links]]
+    option = "items"
+    outgoing = "items"
+    incoming = "item of"
+  rst: |
+    .. spec:: title
+        :id: SPEC_1
+
+    .. impl:: title
+        :id: IMPL_1
+        :contains: SPEC_1
+        :items: SPEC_1
+  schemas:
+    $defs: []
+    schemas:
+      - select:
+          properties:
+            type:
+              const: "impl"
+        validate:
+          network:
+            contains:
+              "contains":
+                "local":
+                  "properties":
+                    "type":
+                      "const": "spec"
+            items:
+              "contains":
+                "local":
+                  "properties":
+                    "type":
+                      "const": "spec"


### PR DESCRIPTION
The type injection mechanism fails for link types called 'contains' or 'items' as those indicate arrays.
Fix is to constrain the injection for certain schema path structure locations.
Added a test for this.