### PR TITLE
🧪 Add tests for unused schema fields

### DIFF
--- a/tests/schema/__snapshots__/test_schema.ambr
+++ b/tests/schema/__snapshots__/test_schema.ambr
@@ -2807,6 +2807,16 @@
     }),
   })
 # ---
+# name: test_schemas[schema/fixtures/extra_options-given_schema_with_null_field]
+  ''
+# ---
+# name: test_schemas[schema/fixtures/extra_options-given_schema_with_null_field].1
+  dict({
+    'validated_needs_count': 1,
+    'validation_warnings': dict({
+    }),
+  })
+# ---
 # name: test_schemas[schema/fixtures/extra_options-integer_multiple_of]
   ''
 # ---

--- a/tests/schema/__snapshots__/test_schema.ambr
+++ b/tests/schema/__snapshots__/test_schema.ambr
@@ -2807,16 +2807,6 @@
     }),
   })
 # ---
-# name: test_schemas[schema/fixtures/extra_options-given_schema_with_null_field]
-  ''
-# ---
-# name: test_schemas[schema/fixtures/extra_options-given_schema_with_null_field].1
-  dict({
-    'validated_needs_count': 1,
-    'validation_warnings': dict({
-    }),
-  })
-# ---
 # name: test_schemas[schema/fixtures/extra_options-integer_multiple_of]
   ''
 # ---
@@ -2865,6 +2855,16 @@
   ''
 # ---
 # name: test_schemas[schema/fixtures/extra_options-no_schema].1
+  dict({
+    'validated_needs_count': 1,
+    'validation_warnings': dict({
+    }),
+  })
+# ---
+# name: test_schemas[schema/fixtures/extra_options-no_schema_with_empty_string_field]
+  ''
+# ---
+# name: test_schemas[schema/fixtures/extra_options-no_schema_with_empty_string_field].1
   dict({
     'validated_needs_count': 1,
     'validation_warnings': dict({
@@ -3008,6 +3008,16 @@
           'type': 'sn_schema_violation',
         }),
       ]),
+    }),
+  })
+# ---
+# name: test_schemas[schema/fixtures/extra_options-schema_with_null_field]
+  ''
+# ---
+# name: test_schemas[schema/fixtures/extra_options-schema_with_null_field].1
+  dict({
+    'validated_needs_count': 1,
+    'validation_warnings': dict({
     }),
   })
 # ---

--- a/tests/schema/fixtures/extra_options.yml
+++ b/tests/schema/fixtures/extra_options.yml
@@ -203,7 +203,7 @@ auto_inject_type_wrong_const:
               asil:
                 const: QM
 
-given_schema_with_null_field:
+schema_with_null_field:
   conf: |
     extensions = ["sphinx_needs"]
     needs_from_toml = "ubproject.toml"
@@ -213,6 +213,27 @@ given_schema_with_null_field:
     [[needs.extra_options]]
     name = "asil"
     schema.type = "string"
+  rst: |
+    .. impl:: title
+        :id: IMPL_1
+  schemas:
+    $defs: []
+    schemas:
+      - validate:
+          local:
+            properties:
+              asil:
+                const: QM
+
+no_schema_with_empty_string_field:
+  conf: |
+    extensions = ["sphinx_needs"]
+    needs_from_toml = "ubproject.toml"
+  ubproject: |
+    [needs]
+    schema_definitions_from_json = "schemas.json"
+    [[needs.extra_options]]
+    name = "asil"
   rst: |
     .. impl:: title
         :id: IMPL_1

--- a/tests/schema/fixtures/extra_options.yml
+++ b/tests/schema/fixtures/extra_options.yml
@@ -207,8 +207,9 @@ given_schema_with_null_field:
   conf: |
     extensions = ["sphinx_needs"]
     needs_from_toml = "ubproject.toml"
-    needs_schema_definitions_from_json = "schemas.json"
   ubproject: |
+    [needs]
+    schema_definitions_from_json = "schemas.json"
     [[needs.extra_options]]
     name = "asil"
     schema.type = "string"

--- a/tests/schema/fixtures/extra_options.yml
+++ b/tests/schema/fixtures/extra_options.yml
@@ -203,6 +203,27 @@ auto_inject_type_wrong_const:
               asil:
                 const: QM
 
+given_schema_with_null_field:
+  conf: |
+    extensions = ["sphinx_needs"]
+    needs_from_toml = "ubproject.toml"
+    needs_schema_definitions_from_json = "schemas.json"
+  ubproject: |
+    [[needs.extra_options]]
+    name = "asil"
+    schema.type = "string"
+  rst: |
+    .. impl:: title
+        :id: IMPL_1
+  schemas:
+    $defs: []
+    schemas:
+      - validate:
+          local:
+            properties:
+              asil:
+                const: QM
+
 required_based_on_select_field_missing:
   conf: |
     extensions = ["sphinx_needs"]


### PR DESCRIPTION
Currently, if there is no schema defined for an extra option, the field is not nullable as this resembles the behavior of SN<6.
If the field is unset, the value will be an empty string.

If there is a schema defined, the field is nullable because, if the field is given, it must coerce to the given type and, if it is not given, it is stored as `None` in Python and `null` in JSON.

Adding tests for these 2 cases.