### PR TITLE
👌 Ensure `extra_links` `schema` contains item type

### DIFF
--- a/sphinx_needs/schema/config_utils.py
+++ b/sphinx_needs/schema/config_utils.py
@@ -225,14 +225,28 @@ def inject_type_extra_link_schemas(needs_config: NeedsSphinxConfig) -> None:
             continue
         if "type" not in extra_link["schema"]:
             extra_link["schema"]["type"] = "array"
-        type_inject_fields = ["contains", "items"]
+        elif extra_link["schema"]["type"] != "array":
+            raise NeedsConfigException(
+                f"Schema for extra link '{extra_link['option']}' has invalid type: "
+                f"{extra_link['schema']['type']}, expected 'array'."
+            )
+        if "items" not in extra_link["schema"]:
+            extra_link["schema"]["items"] = {"type": "string"}
+        elif not isinstance(extra_link["schema"]["items"], dict):
+            raise NeedsConfigException(
+                f"Schema for extra link '{extra_link['option']}' has invalid 'items' value: "
+                f"{extra_link['schema']['items']}, expected a dict."
+            )
+        type_inject_fields: list[Literal["contains", "items"]] = ["contains", "items"]
         for field in type_inject_fields:
-            if (
-                field in extra_link["schema"]
-                and "type" not in extra_link["schema"][field]  # type: ignore[literal-required]
-            ):
-                # set string as default
-                extra_link["schema"][field]["type"] = "string"  # type: ignore[literal-required]
+            if field in extra_link["schema"]:
+                if "type" not in extra_link["schema"][field]:
+                    extra_link["schema"][field]["type"] = "string"
+                elif extra_link["schema"][field]["type"] != "string":
+                    raise NeedsConfigException(
+                        f"Schema for extra link '{extra_link['option']}' has invalid '{field}.type' value: "
+                        f"{extra_link['schema'][field]['type']}, expected 'string'."
+                    )
 
 
 def validate_extra_link_schemas(needs_config: NeedsSphinxConfig) -> None:

--- a/tests/schema/__snapshots__/test_schema.ambr
+++ b/tests/schema/__snapshots__/test_schema.ambr
@@ -487,11 +487,11 @@
 # name: test_schema_config[both_definitions_and_json_given]
   "You cannot use both 'needs_schema_definitions' and 'needs_schema_definitions_from_json' at the same time."
 # ---
+# name: test_schema_config[extra_link_array_wrong_item_type]
+  "Schema for extra link 'links' has invalid 'items.type' value: other, expected 'string'."
+# ---
 # name: test_schema_config[extra_link_array_wrong_type]
-  '''
-  Schema for extra link 'links' is not valid:
-  value of key 'type' of dict is not any of ('array')
-  '''
+  "Schema for extra link 'links' has invalid type: object, expected 'array'."
 # ---
 # name: test_schema_config[extra_link_pattern_unsafe_error]
   "Unsafe pattern '^IMPL_(?!SAFE)' at 'extra_links.links.schema.items': contains lookahead/lookbehind assertions"

--- a/tests/schema/fixtures/config.yml
+++ b/tests/schema/fixtures/config.yml
@@ -8,14 +8,20 @@ extra_link_array_wrong_type:
     outgoing = "links"
     incoming = "linked by"
     schema.type = "object"
-    schema.minItems = 2
-  rst: |
-    .. spec:: title
-        :id: SPEC_1
+  rst: ""
 
-    .. impl:: title
-        :id: IMPL_1
-        :links: SPEC_1
+extra_link_array_wrong_item_type:
+  conf: |
+    extensions = ["sphinx_needs"]
+    needs_from_toml = "ubproject.toml"
+  ubproject: |
+    [[needs.extra_links]]
+    option = "links"
+    outgoing = "links"
+    incoming = "linked by"
+    schema.type = "array"
+    schema.items = { type = "other" }
+  rst: ""
 
 extra_option_empty_schema:
   conf: |


### PR DESCRIPTION
This PR enhances validation for extra link schemas in the sphinx_needs configuration, ensuring that the `items` field is properly validated and initialized with the correct type,
i.e and empty schema `{}` will be converted to `{"type": "array", "items": {"type": "string"}}`, rather than currently just `{"type": "array"}`