### PR TITLE
♻️ Move `needs_statuses` and `need_tags` checking to schema validation

### DIFF
--- a/sphinx_needs/api/need.py
+++ b/sphinx_needs/api/need.py
@@ -248,32 +248,6 @@ def generate_need(
     )
 
     if (
-        needs_config.statuses
-        and isinstance(status_converted, FieldLiteralValue)
-        and status_converted.value
-        not in [stat["name"] for stat in needs_config.statuses]
-    ):
-        # TODO this check should be later in processing, once we have resolved any dynamic functions
-        raise InvalidNeedException(
-            "invalid_status",
-            f"Status {status_converted.value!r} not in 'needs_statuses'.",
-        )
-
-    if (
-        needs_config.tags
-        and isinstance(tags_converted, FieldLiteralValue)
-        and isinstance(tags_converted.value, Iterable)
-        and (
-            unknown_tags := set(tags_converted.value)
-            - {t["name"] for t in needs_config.tags}
-        )
-    ):
-        # TODO this check should be later in processing, once we have resolved any dynamic functions
-        raise InvalidNeedException(
-            "invalid_tags", f"Tags {unknown_tags!r} not in 'needs_tags'."
-        )
-
-    if (
         isinstance(constraints_converted, FieldLiteralValue)
         and isinstance(constraints_converted.value, Iterable)
         and (

--- a/sphinx_needs/needs.py
+++ b/sphinx_needs/needs.py
@@ -778,6 +778,17 @@ def create_schema(app: Sphinx, env: BuildEnvironment, _docnames: list[str]) -> N
         _schema = {"type": type_}
         if type_ == "array":
             _schema["items"] = data["schema"].get("items", {"type": "string"})
+
+        # merge in additional schema from needs_statuses and needs_tags config
+        # TODO eventually deprecate these two configs in favor of schema config
+        if name == "status" and needs_config.statuses:
+            _schema["enum"] = [status["name"] for status in needs_config.statuses]
+        if name == "tags" and needs_config.tags:
+            _schema["items"] = {
+                "type": "string",
+                "enum": [tag["name"] for tag in needs_config.tags],
+            }
+
         default = data["schema"].get("default", None)
         field = FieldSchema(
             name=name,

--- a/sphinx_needs/schema/config.py
+++ b/sphinx_needs/schema/config.py
@@ -386,9 +386,9 @@ class MessageRuleEnum(str, Enum):
 
     cfg_schema_error = "cfg_schema_error"
     """The user provided schema is invalid."""
-    extra_option_success = "extra_option_success"
+    option_success = "option_success"
     """Global extra option validation was successful."""
-    extra_option_fail = "extra_option_fail"
+    option_fail = "option_fail"
     """Global extra option validation failed."""
     extra_link_success = "extra_link_success"
     """Global extra link validation was successful."""
@@ -480,8 +480,8 @@ Severity levels that can be set in the user provided schemas and for the schema_
 
 MAP_RULE_DEFAULT_SEVERITY: Final[dict[MessageRuleEnum, SeverityEnum]] = {
     MessageRuleEnum.cfg_schema_error: SeverityEnum.config_error,
-    MessageRuleEnum.extra_option_success: SeverityEnum.none,
-    MessageRuleEnum.extra_option_fail: SeverityEnum.violation,  # cannot be changed by user
+    MessageRuleEnum.option_success: SeverityEnum.none,
+    MessageRuleEnum.option_fail: SeverityEnum.violation,  # cannot be changed by user
     MessageRuleEnum.extra_link_success: SeverityEnum.none,
     MessageRuleEnum.extra_link_fail: SeverityEnum.violation,  # cannot be changed by user
     MessageRuleEnum.select_success: SeverityEnum.none,

--- a/sphinx_needs/schema/core.py
+++ b/sphinx_needs/schema/core.py
@@ -42,7 +42,7 @@ The implementation requires at least draft 2019-09 as unevaluatedProperties was 
 """
 
 
-def validate_extra_options(
+def validate_option_fields(
     config: NeedsSphinxConfig,
     schema: NeedFieldsSchemaType,
     field_properties: Mapping[str, NeedFieldProperties],
@@ -56,9 +56,9 @@ def validate_extra_options(
             need,
             field_properties,
             validator,
-            fail_rule=MessageRuleEnum.extra_option_fail,
-            success_rule=MessageRuleEnum.extra_option_success,
-            schema_path=["extra_options", "schema"],
+            fail_rule=MessageRuleEnum.option_fail,
+            success_rule=MessageRuleEnum.option_success,
+            schema_path=["options", "schema"],
             need_path=[need["id"]],
         )
         save_debug_files(config, schema_warnings)

--- a/tests/schema/__snapshots__/test_schema.ambr
+++ b/tests/schema/__snapshots__/test_schema.ambr
@@ -3345,8 +3345,8 @@
     Severity:       violation
     Field:          efforts
     Need path:      IMPL_1
-    Schema path:    extra_options > schema > properties > efforts > multipleOf
-    Schema message: 8 is not a multiple of 3 [sn_schema_violation.extra_option_fail]
+    Schema path:    options > schema > properties > efforts > multipleOf
+    Schema message: 8 is not a multiple of 3 [sn_schema_violation.option_fail]
   
   '''
 # ---
@@ -3361,12 +3361,12 @@
           'details': dict({
             'field': 'efforts',
             'need_path': 'IMPL_1',
-            'schema_path': 'extra_options > schema > properties > efforts > multipleOf',
+            'schema_path': 'options > schema > properties > efforts > multipleOf',
             'severity': 'violation',
             'validation_msg': '8 is not a multiple of 3',
           }),
           'log_lvl': 'error',
-          'subtype': 'extra_option_fail',
+          'subtype': 'option_fail',
           'type': 'sn_schema_violation',
         }),
       ]),
@@ -3399,8 +3399,8 @@
     Severity:       violation
     Field:          efforts
     Need path:      IMPL_1
-    Schema path:    extra_options > schema > properties > efforts > multipleOf
-    Schema message: 5.0 is not a multiple of 3.3 [sn_schema_violation.extra_option_fail]
+    Schema path:    options > schema > properties > efforts > multipleOf
+    Schema message: 5.0 is not a multiple of 3.3 [sn_schema_violation.option_fail]
   
   '''
 # ---
@@ -3415,12 +3415,12 @@
           'details': dict({
             'field': 'efforts',
             'need_path': 'IMPL_1',
-            'schema_path': 'extra_options > schema > properties > efforts > multipleOf',
+            'schema_path': 'options > schema > properties > efforts > multipleOf',
             'severity': 'violation',
             'validation_msg': '5.0 is not a multiple of 3.3',
           }),
           'log_lvl': 'error',
-          'subtype': 'extra_option_fail',
+          'subtype': 'option_fail',
           'type': 'sn_schema_violation',
         }),
       ]),
@@ -3549,8 +3549,8 @@
     Severity:       violation
     Field:          start_date
     Need path:      IMPL_1
-    Schema path:    extra_options > schema > properties > start_date > format
-    Schema message: "not-a-date" is not a "date" [sn_schema_violation.extra_option_fail]
+    Schema path:    options > schema > properties > start_date > format
+    Schema message: "not-a-date" is not a "date" [sn_schema_violation.option_fail]
   
   '''
 # ---
@@ -3565,12 +3565,12 @@
           'details': dict({
             'field': 'start_date',
             'need_path': 'IMPL_1',
-            'schema_path': 'extra_options > schema > properties > start_date > format',
+            'schema_path': 'options > schema > properties > start_date > format',
             'severity': 'violation',
             'validation_msg': '"not-a-date" is not a "date"',
           }),
           'log_lvl': 'error',
-          'subtype': 'extra_option_fail',
+          'subtype': 'option_fail',
           'type': 'sn_schema_violation',
         }),
       ]),
@@ -3593,8 +3593,8 @@
     Severity:       violation
     Field:          start_date
     Need path:      IMPL_1
-    Schema path:    extra_options > schema > properties > start_date > format
-    Schema message: "2025-07-1099:99:99Z" is not a "date-time" [sn_schema_violation.extra_option_fail]
+    Schema path:    options > schema > properties > start_date > format
+    Schema message: "2025-07-1099:99:99Z" is not a "date-time" [sn_schema_violation.option_fail]
   
   '''
 # ---
@@ -3609,12 +3609,12 @@
           'details': dict({
             'field': 'start_date',
             'need_path': 'IMPL_1',
-            'schema_path': 'extra_options > schema > properties > start_date > format',
+            'schema_path': 'options > schema > properties > start_date > format',
             'severity': 'violation',
             'validation_msg': '"2025-07-1099:99:99Z" is not a "date-time"',
           }),
           'log_lvl': 'error',
-          'subtype': 'extra_option_fail',
+          'subtype': 'option_fail',
           'type': 'sn_schema_violation',
         }),
       ]),
@@ -3637,8 +3637,8 @@
     Severity:       violation
     Field:          _duration
     Need path:      IMPL_1
-    Schema path:    extra_options > schema > properties > _duration > format
-    Schema message: "P1Q2Q10DT2H30M" is not a "duration" [sn_schema_violation.extra_option_fail]
+    Schema path:    options > schema > properties > _duration > format
+    Schema message: "P1Q2Q10DT2H30M" is not a "duration" [sn_schema_violation.option_fail]
   
   '''
 # ---
@@ -3653,12 +3653,12 @@
           'details': dict({
             'field': '_duration',
             'need_path': 'IMPL_1',
-            'schema_path': 'extra_options > schema > properties > _duration > format',
+            'schema_path': 'options > schema > properties > _duration > format',
             'severity': 'violation',
             'validation_msg': '"P1Q2Q10DT2H30M" is not a "duration"',
           }),
           'log_lvl': 'error',
-          'subtype': 'extra_option_fail',
+          'subtype': 'option_fail',
           'type': 'sn_schema_violation',
         }),
       ]),
@@ -3681,8 +3681,8 @@
     Severity:       violation
     Field:          email
     Need path:      IMPL_1
-    Schema path:    extra_options > schema > properties > email > format
-    Schema message: "not-a-mail" is not a "email" [sn_schema_violation.extra_option_fail]
+    Schema path:    options > schema > properties > email > format
+    Schema message: "not-a-mail" is not a "email" [sn_schema_violation.option_fail]
   
   '''
 # ---
@@ -3697,12 +3697,12 @@
           'details': dict({
             'field': 'email',
             'need_path': 'IMPL_1',
-            'schema_path': 'extra_options > schema > properties > email > format',
+            'schema_path': 'options > schema > properties > email > format',
             'severity': 'violation',
             'validation_msg': '"not-a-mail" is not a "email"',
           }),
           'log_lvl': 'error',
-          'subtype': 'extra_option_fail',
+          'subtype': 'option_fail',
           'type': 'sn_schema_violation',
         }),
       ]),
@@ -3725,8 +3725,8 @@
     Severity:       violation
     Field:          time
     Need path:      IMPL_1
-    Schema path:    extra_options > schema > properties > time > format
-    Schema message: "26:12:13+00:00" is not a "time" [sn_schema_violation.extra_option_fail]
+    Schema path:    options > schema > properties > time > format
+    Schema message: "26:12:13+00:00" is not a "time" [sn_schema_violation.option_fail]
   
   '''
 # ---
@@ -3741,12 +3741,12 @@
           'details': dict({
             'field': 'time',
             'need_path': 'IMPL_1',
-            'schema_path': 'extra_options > schema > properties > time > format',
+            'schema_path': 'options > schema > properties > time > format',
             'severity': 'violation',
             'validation_msg': '"26:12:13+00:00" is not a "time"',
           }),
           'log_lvl': 'error',
-          'subtype': 'extra_option_fail',
+          'subtype': 'option_fail',
           'type': 'sn_schema_violation',
         }),
       ]),
@@ -3769,8 +3769,8 @@
     Severity:       violation
     Field:          uri
     Need path:      IMPL_1
-    Schema path:    extra_options > schema > properties > uri > format
-    Schema message: "examplecom" is not a "uri" [sn_schema_violation.extra_option_fail]
+    Schema path:    options > schema > properties > uri > format
+    Schema message: "examplecom" is not a "uri" [sn_schema_violation.option_fail]
   
   '''
 # ---
@@ -3785,12 +3785,12 @@
           'details': dict({
             'field': 'uri',
             'need_path': 'IMPL_1',
-            'schema_path': 'extra_options > schema > properties > uri > format',
+            'schema_path': 'options > schema > properties > uri > format',
             'severity': 'violation',
             'validation_msg': '"examplecom" is not a "uri"',
           }),
           'log_lvl': 'error',
-          'subtype': 'extra_option_fail',
+          'subtype': 'option_fail',
           'type': 'sn_schema_violation',
         }),
       ]),
@@ -3813,8 +3813,8 @@
     Severity:       violation
     Field:          uuid
     Need path:      IMPL_1
-    Schema path:    extra_options > schema > properties > uuid > format
-    Schema message: "deadbeef-deadbeef-deadbeef-deadbeef" is not a "uuid" [sn_schema_violation.extra_option_fail]
+    Schema path:    options > schema > properties > uuid > format
+    Schema message: "deadbeef-deadbeef-deadbeef-deadbeef" is not a "uuid" [sn_schema_violation.option_fail]
   
   '''
 # ---
@@ -3829,12 +3829,12 @@
           'details': dict({
             'field': 'uuid',
             'need_path': 'IMPL_1',
-            'schema_path': 'extra_options > schema > properties > uuid > format',
+            'schema_path': 'options > schema > properties > uuid > format',
             'severity': 'violation',
             'validation_msg': '"deadbeef-deadbeef-deadbeef-deadbeef" is not a "uuid"',
           }),
           'log_lvl': 'error',
-          'subtype': 'extra_option_fail',
+          'subtype': 'option_fail',
           'type': 'sn_schema_violation',
         }),
       ]),

--- a/tests/test_broken_docs.py
+++ b/tests/test_broken_docs.py
@@ -77,7 +77,12 @@ def test_broken_links(test_app: SphinxTestApp):
 def test_broken_statuses(test_app: SphinxTestApp):
     test_app.build()
     assert get_warnings(test_app) == [
-        "<srcdir>/index.rst:11: WARNING: Need could not be created: Status 'NOT_ALLOWED' not in 'needs_statuses'. [needs.create_need]"
+        "ERROR: Need 'SP_TOO_002' has schema violations:",
+        "  Severity:       violation",
+        "  Field:          status",
+        "  Need path:      SP_TOO_002",
+        "  Schema path:    options > schema > properties > status > enum",
+        '  Schema message: "NOT_ALLOWED" is not one of "open" or "implemented" [sn_schema_violation.option_fail]',
     ]
 
 
@@ -113,5 +118,10 @@ def test_broken_syntax(test_app: SphinxTestApp):
 def test_broken_tags(test_app: SphinxTestApp):
     test_app.build()
     assert get_warnings(test_app) == [
-        "<srcdir>/index.rst:17: WARNING: Need could not be created: Tags {'BROKEN'} not in 'needs_tags'. [needs.create_need]"
+        "ERROR: Need 'SP_TOO_003' has schema violations:",
+        "  Severity:       violation",
+        "  Field:          tags.2",
+        "  Need path:      SP_TOO_003",
+        "  Schema path:    options > schema > properties > tags > items > enum",
+        '  Schema message: "BROKEN" is not one of "new" or "security" [sn_schema_violation.option_fail]',
     ]


### PR DESCRIPTION
This PR refactors `needs_statuses` and `needs_tags` checking, from explicit validation logic (at need creation time) to the new generic schema-based validation system. 
The changes rename `extra_option` schema validation to `option` validation (covering both core and extra options) and automatically generate schema constraints from the `needs_statuses` and `needs_tags` configuration, for example:

- `needs_statuses = ["a", "b"]` to `{"status": {"type": "string", "enum": ["a", "b"]}}` and 
- `needs_tags = ["a", "b"]` to `{"tags":  {"type": array", "items": {"type": "string", "enum": ["a", "b"]}}}` 

This fixes issues with these being evaluated too early and not accounting for dynamic functions, needextend, etc ...
and will also facilitate #1547