### PR TITLE
🔧 Remove use of `extra_options` after config resolution

### DIFF
--- a/sphinx_needs/api/need.py
+++ b/sphinx_needs/api/need.py
@@ -177,9 +177,10 @@ def generate_need(
     )
 
     # validate kwargs
-    allowed_kwargs = {x["option"] for x in needs_config.extra_links} | set(
-        needs_config.extra_options
-    )
+    allowed_kwargs = {
+        *needs_schema.iter_link_field_names(),
+        *needs_schema.iter_extra_field_names(),
+    }
     unknown_kwargs = set(kwargs) - allowed_kwargs
     if unknown_kwargs:
         raise InvalidNeedException(

--- a/sphinx_needs/config.py
+++ b/sphinx_needs/config.py
@@ -353,31 +353,21 @@ class NeedsSphinxConfig:
     # such that we simply redirect all attribute access to the
     # Sphinx config object, but in a manner where type annotations will work
     # for static type analysis.
-    # Note also that we treat `extra_options`, `functions` and `warnings` as special-cases,
+    # Note also that we treat `functions` and `warnings` as special-cases,
     # since these configurations can also be added to dynamically via the API
 
     def __init__(self, config: _SphinxConfig) -> None:
         super().__setattr__("_config", config)
 
     def __getattribute__(self, name: str) -> Any:
-        if name.startswith("__") or name in (
-            "_config",
-            "extra_options",
-            "functions",
-            "warnings",
-        ):
+        if name.startswith("__") or name in ("_config", "functions", "warnings"):
             return super().__getattribute__(name)
         if name.startswith("_"):
             name = name[1:]
         return getattr(super().__getattribute__("_config"), f"needs_{name}")
 
     def __setattr__(self, name: str, value: Any) -> None:
-        if name.startswith("__") or name in (
-            "_config",
-            "extra_options",
-            "functions",
-            "warnings",
-        ):
+        if name.startswith("__") or name in ("_config", "functions", "warnings"):
             return super().__setattr__(name, value)
         if name.startswith("_"):
             name = name[1:]
@@ -601,18 +591,6 @@ class NeedsSphinxConfig:
         default_factory=list, metadata={"rebuild": "html", "types": (list,)}
     )
     """List of extra options for needs, that get added as directive options and need fields."""
-
-    @property
-    def extra_options(self) -> Mapping[str, ExtraOptionParams]:
-        """Custom need fields.
-
-        These fields can be added via sphinx configuration,
-        but also via the `add_extra_option` API function.
-
-        They are added to the each needs data item,
-        and as directive options on `NeedDirective` and `NeedserviceDirective`.
-        """
-        return _NEEDS_CONFIG.extra_options
 
     title_optional: bool = field(
         default=False, metadata={"rebuild": "html", "types": (bool,)}

--- a/sphinx_needs/directives/need.py
+++ b/sphinx_needs/directives/need.py
@@ -80,6 +80,7 @@ class NeedDirective(SphinxDirective):
             return []
 
         needs_config = NeedsSphinxConfig(self.env.config)
+        needs_schema = SphinxNeedsData(self.env).get_schema()
 
         try:
             # override global title_from_content if user set it in the directive
@@ -116,7 +117,8 @@ class NeedDirective(SphinxDirective):
         extras: dict[str, str] = {}
         links: dict[str, str] = {}
 
-        link_keys = {li["option"] for li in needs_config.extra_links}
+        link_keys = set(needs_schema.iter_link_field_names())
+        extra_keys = set(needs_schema.iter_extra_field_names())
 
         while options:
             key, value = options.popitem()
@@ -147,7 +149,7 @@ class NeedDirective(SphinxDirective):
                         post_template = value or ""
                     case "constraints":
                         constraints = value or ""
-                    case key if key in needs_config.extra_options:
+                    case key if key in extra_keys:
                         extras[key] = value or ""
                     case key if key in link_keys:
                         links[key] = value or ""

--- a/sphinx_needs/directives/needreport.py
+++ b/sphinx_needs/directives/needreport.py
@@ -10,6 +10,7 @@ from sphinx.util import logging
 from sphinx.util.docutils import SphinxDirective
 
 from sphinx_needs.config import NeedsSphinxConfig
+from sphinx_needs.data import SphinxNeedsData
 from sphinx_needs.logging import log_warning
 from sphinx_needs.utils import add_doc
 
@@ -29,6 +30,7 @@ class NeedReportDirective(SphinxDirective):
     def run(self) -> Sequence[nodes.raw]:
         env = self.env
         needs_config = NeedsSphinxConfig(env.config)
+        needs_schema = SphinxNeedsData(env).get_schema()
 
         if not set(self.options).intersection({"types", "links", "options", "usage"}):
             log_warning(
@@ -41,7 +43,7 @@ class NeedReportDirective(SphinxDirective):
 
         report_info = {
             "types": needs_config.types if "types" in self.options else [],
-            "options": list(needs_config.extra_options)
+            "options": list(needs_schema.iter_extra_field_names())
             if "options" in self.options
             else [],
             "links": needs_config.extra_links if "links" in self.options else [],

--- a/sphinx_needs/external_needs.py
+++ b/sphinx_needs/external_needs.py
@@ -35,6 +35,8 @@ def load_external_needs(
 ) -> None:
     """Load needs from configured external sources."""
     needs_config = NeedsSphinxConfig(app.config)
+    needs_schema = SphinxNeedsData(env).get_schema()
+
     for idx, source in enumerate(needs_config.external_needs):
         if "base_url" not in source:
             raise NeedsExternalException(
@@ -129,15 +131,15 @@ def load_external_needs(
         known_keys = {
             "full_title",  # legacy
             *NeedsCoreFields,
-            *(x["option"] for x in needs_config.extra_links),
-            *(x["option"] + "_back" for x in needs_config.extra_links),
-            *needs_config.extra_options,
+            *(x for x in needs_schema.iter_link_field_names()),
+            *(f"{x}_back" for x in needs_schema.iter_link_field_names()),
+            *(x for x in needs_schema.iter_extra_field_names()),
         }
         # all keys that should not be imported from external needs
         omitted_keys = {
             "full_title",  # legacy
             *(k for k, v in NeedsCoreFields.items() if v.get("exclude_external")),
-            *(x["option"] + "_back" for x in needs_config.extra_links),
+            *(f"{x}_back" for x in needs_schema.iter_link_field_names()),
         }
 
         # collect keys for warning logs, so that we only log one warning per key

--- a/sphinx_needs/needs.py
+++ b/sphinx_needs/needs.py
@@ -693,7 +693,7 @@ def check_configuration(app: Sphinx, config: Config) -> None:
     E.g. defined need-option, which is already defined internally
     """
     needs_config = NeedsSphinxConfig(config)
-    extra_options = needs_config.extra_options
+    extra_options = _NEEDS_CONFIG.extra_options
     link_types = [x["option"] for x in needs_config.extra_links]
 
     external_filter = needs_config.filter_data
@@ -808,7 +808,7 @@ def create_schema(app: Sphinx, env: BuildEnvironment, _docnames: list[str]) -> N
             schema.add_core_field(field)
         except Exception as exc:
             raise NeedsConfigException(f"Invalid core option {name!r}: {exc}") from exc
-    for name, extra in needs_config.extra_options.items():
+    for name, extra in _NEEDS_CONFIG.extra_options.items():
         try:
             _schema = (
                 deepcopy(extra.schema)  # type: ignore[arg-type]

--- a/sphinx_needs/needs_schema.py
+++ b/sphinx_needs/needs_schema.py
@@ -848,13 +848,25 @@ class FieldsSchema:
         yield from self._extra_fields.values()
         yield from self._link_fields.values()
 
+    def iter_core_field_names(self) -> Iterable[str]:
+        """Iterate over all core field names in the schema."""
+        yield from self._core_fields.keys()
+
     def iter_core_fields(self) -> Iterable[FieldSchema]:
         """Iterate over all core fields in the schema."""
         yield from self._core_fields.values()
 
+    def iter_extra_field_names(self) -> Iterable[str]:
+        """Iterate over all extra field names in the schema."""
+        yield from self._extra_fields.keys()
+
     def iter_extra_fields(self) -> Iterable[FieldSchema]:
         """Iterate over all extra fields in the schema."""
         yield from self._extra_fields.values()
+
+    def iter_link_field_names(self) -> Iterable[str]:
+        """Iterate over all link field names in the schema."""
+        yield from self._link_fields.keys()
 
     def iter_link_fields(self) -> Iterable[LinkSchema]:
         """Iterate over all link fields in the schema."""


### PR DESCRIPTION
Once the config if fully resolved, `FieldsSchema` should be the source of truth for data related to options (core/extra).

This will aide #1547