### PR TITLE
Allow setting parent_needs manually

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,17 @@
 Changelog
 =========
 
+.. _`release:6.3.0+1`:
+
+6.3.0+1
+-------
+
+- 👌 Allow setting ``parent_needs`` manually
+
+  Use ``:parent_needs: PARENT_ID`` to assign a parent
+  without actually nesting the needs in the source file.
+
+
 .. _`release:6.3.0`:
 
 6.3.0

--- a/docs/directives/need.rst
+++ b/docs/directives/need.rst
@@ -164,6 +164,34 @@ By using :ref:`needs_extra_links <needs_extra_links>`, you can use the configure
 
       Perform some tests
 
+.. _need_parent_needs:
+
+parent_needs
+~~~~~~~~~~~~
+
+The ``parent_needs`` option is set automatically when one need is nested within another.
+But if desired, you can set it like a normal option.
+
+.. need-example::
+
+   .. req:: Example 1 Parent
+      :id: REQ_P1
+
+      .. req:: Example 1 Child
+         :id: REQ_C1
+
+has the same parent/child relationship as
+
+.. need-example::
+
+   .. req:: Example 2 Parent
+      :id: REQ_P2
+
+   .. req:: Example 2 Child
+      :id: REQ_C2
+      :parent_needs: REQ_P2
+
+
 .. _need_delete:
 
 delete

--- a/sphinx_needs/__init__.py
+++ b/sphinx_needs/__init__.py
@@ -1,6 +1,6 @@
 """Sphinx needs extension for managing needs/requirements and specifications"""
 
-__version__ = "6.3.0"
+__version__ = "6.3.0+1"
 
 
 def setup(app):  # type: ignore[no-untyped-def]

--- a/sphinx_needs/directives/need.py
+++ b/sphinx_needs/directives/need.py
@@ -319,7 +319,7 @@ def analyse_need_locations(app: Sphinx, doctree: nodes.document) -> None:
         # append / set values from need
         need_info["sections"] = tuple(sections)
         need_info["signature"] = str(signature) if signature is not None else None
-        need_info["parent_needs"] = parent_needs
+        need_info["parent_needs"] += parent_needs
 
         if need_node.get("hidden"):
             hidden_needs.append(need_node)

--- a/tests/doc_test/filter_doc/nested_needs.rst
+++ b/tests/doc_test/filter_doc/nested_needs.rst
@@ -11,3 +11,6 @@ Nested Needs
       .. story:: child 2 story
          :id: CHILD_2_STORY
 
+.. story:: child 3 story
+   :id: CHILD_3_STORY
+   :parent_needs: CHILD_2_STORY

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -85,6 +85,16 @@ def test_filter_build_html(test_app):
         'href="#CHILD_1_STORY" title="CHILD_2_STORY">CHILD_1_STORY</a></span></span></div>'
         in html_5
     )
+    assert (
+        '<div class="line">child needs: <span class="parent_needs"><span><a class="reference internal" '
+        'href="#CHILD_3_STORY" title="CHILD_2_STORY">CHILD_3_STORY</a></span></span></div>'
+        in html_5
+    )
+    assert (
+        '<div class="line">parent needs: <span class="parent_needs"><span><a class="reference internal" '
+        'href="#CHILD_2_STORY" title="CHILD_3_STORY">CHILD_2_STORY</a></span></span></div>'
+        in html_5
+    )
 
     html_6 = Path(app.outdir, "filter_no_needs.html").read_text()
     assert html_6.count("No needs passed the filters") == 6


### PR DESCRIPTION
Instead of overwriting it with the parents_needs derived from nesting, append it.

Related discussion: https://github.com/useblocks/sphinx-needs/discussions/1608