### PR TITLE
✨ Add `nullable` key to `needs_fields` items

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -212,6 +212,8 @@ For new fields the following can be defined:
     This uses the same format as :ref:`needs_schema_definitions` and :ref:`needs_schema_definitions_from_json`.
     If specified, the field value will be validated against this schema when needs are parsed, see :ref:`schema_validation` for more details.
     By default the field schema will be ``{"type": "string"}``.
+- ``nullable``: If set to ``True``, the field can be set to ``None`` (optional), e.g. if no value is specifically given and no default applies,
+    If ``False``, the field must have a value (either explicitly set or via default/predicates), otherwise the need is invalid and will not be created.
 - ``predicates``: A list of ``(match expression, value)`` tuples (optional).
     If specified, these will be evaluated in order for any need that does not explicitly set the field, with the first match setting the field value.
 - ``default``: A default value for the field (optional).
@@ -228,6 +230,7 @@ For example:
                "type": "string",
                "format": "date",
            },
+           "nullable": False,
        },
        "cost": {
              "description": "Approximated cost in Euros",
@@ -264,14 +267,7 @@ Core field specialization
 
 The following core fields can be specialized:
 
-- ``title`` (string)
-- ``status`` (nullable string)
-- ``tags`` (array of strings)
-- ``collapse`` (boolean)
-- ``hide`` (boolean)
-- ``layout`` (nullable string)
-- ``style`` (nullable string)
-
+.. need-core-fields::
 
 Specialization allows you to redefine the description and tighten the schema of these fields:
 Schemas will inherit any constraints defined in the core schema that are not redefined, and redefinitions must be not weaken the constraints of the original schema (this is intended to obey the `Liskov substitution principle <https://en.wikipedia.org/wiki/Liskov_substitution_principle>`__).
@@ -286,6 +282,9 @@ For example, you could redefine the ``status`` and ``tags`` fields to only allow
                # adds tighter constraint on allowed values
                "enum": ["open", "in progress", "done", "closed"],
            },
+           # adds tighter constraint on nullability,
+           # i.e. the status must always be set
+           "nullable": False,
        },
          "tags": {
             "schema": {

--- a/sphinx_needs/api/configuration.py
+++ b/sphinx_needs/api/configuration.py
@@ -92,6 +92,7 @@ def add_extra_option(
     *,
     description: str = "Added by add_extra_option API",
     schema: ExtraOptionSchemaTypes | None = None,
+    nullable: bool | None = None,
 ) -> None:
     """
     Adds an extra option to the configuration. This option can then later be used inside needs or ``add_need``.
@@ -108,9 +109,10 @@ def add_extra_option(
     :param name: Name of the extra option
     :param description: Description of the extra option
     :param schema: Schema definition for the extra option
+    :param nullable: Whether the field allows unset values.
     :return: None
     """
-    _NEEDS_CONFIG.add_extra_option(name, description, schema=schema)
+    _NEEDS_CONFIG.add_extra_option(name, description, schema=schema, nullable=nullable)
 
 
 # TODO(mh) add extra link api

--- a/sphinx_needs/config.py
+++ b/sphinx_needs/config.py
@@ -39,6 +39,8 @@ class ExtraOptionParams:
 
     description: str
     """A description of the option."""
+    nullable: bool | None = None
+    """Whether the field allows unset values."""
     schema: (
         ExtraOptionStringSchemaType
         | ExtraOptionBooleanSchemaType
@@ -112,6 +114,7 @@ class _Config:
         | ExtraOptionNumberSchemaType
         | ExtraOptionMultiValueSchemaType
         | None = None,
+        nullable: None | bool = None,
         override: bool = False,
     ) -> None:
         """Adds an extra option to the configuration."""
@@ -142,6 +145,7 @@ class _Config:
         self._extra_options[name] = ExtraOptionParams(
             description=description,
             schema=schema,
+            nullable=nullable,
         )
 
     @property
@@ -306,6 +310,8 @@ class NeedFields(TypedDict):
     If given, the schema will apply to all needs that use this option.
     For more granular control, use the `needs_schema_definitions` configuration.
     """
+    nullable: NotRequired[bool]
+    """Whether the field allows unset values."""
     default: NotRequired[Any]
     """Default value for the field."""
     predicates: NotRequired[list[tuple[str, Any]]]

--- a/tests/schema/__snapshots__/test_schema.ambr
+++ b/tests/schema/__snapshots__/test_schema.ambr
@@ -487,6 +487,9 @@
 # name: test_schema_config[title_wrong_type]
   "Invalid `needs_fields` core option override for 'title': Child 'type' 'number' does not match parent 'type' 'string'."
 # ---
+# name: test_schema_config[title_nullable]
+  "Invalid `needs_fields` core option override for 'title': Cannot change 'nullable' from False to True in child."
+# ---
 # name: test_schema_config[status_wrong_type]
   "Invalid `needs_fields` core option override for 'status': Child 'type' 'integer' does not match parent 'type' 'string'."
 # ---
@@ -3576,6 +3579,19 @@
     }),
   })
 # ---
+# name: test_schemas[schema/fixtures/fields-string_non_nullable]
+  '''
+  <srcdir>/index.rst:1: WARNING: Need could not be created: Extra option 'asil' is not nullable, but no value or default was given. [needs.create_need]
+  
+  '''
+# ---
+# name: test_schemas[schema/fixtures/fields-string_non_nullable].1
+  dict({
+    'validated_needs_count': 0,
+    'validation_warnings': dict({
+    }),
+  })
+# ---
 # name: test_schemas[schema/fixtures/fields-string_format_date]
   ''
 # ---
@@ -3963,6 +3979,19 @@
     }),
   })
 
+# ---
+# name: test_schemas[schema/fixtures/fields-status_non_nullable]
+  '''
+  <srcdir>/index.rst:5: WARNING: Need could not be created: status is not nullable, but no value was given. [needs.create_need]
+  
+  '''
+# ---
+# name: test_schemas[schema/fixtures/fields-status_non_nullable].1
+  dict({
+    'validated_needs_count': 1,
+    'validation_warnings': dict({
+    }),
+  })
 # ---
 # name: test_schemas[schema/fixtures/fields-status_enum]
   '''

--- a/tests/schema/fixtures/config.yml
+++ b/tests/schema/fixtures/config.yml
@@ -7,6 +7,16 @@ title_wrong_type:
     schema.type = "number"
   rst: ""
 
+title_nullable:
+  conf: |
+    extensions = ["sphinx_needs"]
+    needs_from_toml = "ubproject.toml"
+  ubproject: |
+    [needs.fields.title]
+    schema.type = "string"
+    nullable = true
+  rst: ""
+
 status_wrong_type:
   conf: |
     extensions = ["sphinx_needs"]

--- a/tests/schema/fixtures/fields.yml
+++ b/tests/schema/fixtures/fields.yml
@@ -279,6 +279,18 @@ string_type:
         :id: IMPL_1
         :asil: QM
 
+string_non_nullable:
+  conf: |
+    extensions = ["sphinx_needs"]
+    needs_from_toml = "ubproject.toml"
+  ubproject: |
+    [needs.fields.asil]
+    schema.type = "string"
+    nullable = false
+  rst: |
+    .. impl:: title
+        :id: IMPL_1
+
 string_format_date:
   conf: |
     extensions = ["sphinx_needs"]
@@ -708,6 +720,21 @@ title_length:
 
     .. impl:: this title is too long
         :id: IMPL_3
+
+status_non_nullable:
+  conf: |
+    extensions = ["sphinx_needs"]
+    needs_from_toml = "ubproject.toml"
+  ubproject: |
+    [needs.fields.status]
+    nullable = false
+  rst: |
+    .. impl:: title
+        :id: IMPL_1
+        :status: open
+
+    .. impl:: title
+        :id: IMPL_2
 
 status_enum:
   conf: |


### PR DESCRIPTION
This pull request introduces support for a `nullable` property in need field definitions, allowing fields to be explicitly marked as allowing or disallowing unset (None) values. The changes affect the configuration, schema validation, and documentation, and include updates to both the codebase and the test suite to ensure correct handling and enforcement of field nullability.

For example:

```python
needs_fields = {
   "introduced": {
      "description": "Date when the need was introduced",
      "schema": {
         "type": "string",
         "format": "date",
      },
      "nullable": False,
   },
}
```