### PR TITLE
🔧 Allow links in needservice directive

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,12 @@ Unreleased
 
 :Released: Unreleased
 
+Improvements
+............
+
+- 👌 Allow link fields in :ref:`needservice` directive options, so needs
+  created via a custom service can declare links to other needs (:pr:`1632`)
+
 Bug fixes
 .........
 

--- a/sphinx_needs/directives/needservice.py
+++ b/sphinx_needs/directives/needservice.py
@@ -93,6 +93,7 @@ class NeedserviceDirective(SphinxDirective):
                 "constraints",
                 "content",
                 *needs_schema.iter_extra_field_names(),
+                *needs_schema.iter_link_field_names(),
             }
             for datum in service_data:
                 options = {}

--- a/tests/test_open_needs_service.py
+++ b/tests/test_open_needs_service.py
@@ -104,6 +104,9 @@ def test_ons_service(test_app):
     assert "Test rocket power" in html
     assert "ONS_TEST_NEP_004" in html
     assert "NEP_003" in html
+    assert "links outgoing" in html
+    assert "ONS_TEST_NEP_001" in html
+    assert "ONS_TEST_NEP_002" in html
 
     assert "open" in html
     assert "Debug data" in html


### PR DESCRIPTION
Hi! I noticed that it was not possible to create needs with links (custom or otherwise) through a custom service.

Looking a bit deeper into the existing open-needs service, it seems like it should support links 
e.g. from the tests:
```
    {
        "key": "NEP_003",
        "type": "Requirement",
        "title": "Rocket painting",
        "description": "Red and blue. No other colors please.",
        "format": "txt",
        "project_id": 1,
        "options": {
            "status": "open",
            "priority": "low",
            "costs": 20000,
            "approved": 1,
        },
        "references": {"links": ["NEP_001", "NEP_002"]},
    },
```
Just added the link keys to the allowed options, similarly to what's done in the [need.py directive](https://github.com/useblocks/sphinx-needs/blob/81b20436cf5d8627f7402664499ca6668528c6ca/sphinx_needs/directives/need.py#L120)
