### PR TITLE
♻️ Add add_field API; deprecate add_extra_option

### DIFF
--- a/sphinx_needs/api/__init__.py
+++ b/sphinx_needs/api/__init__.py
@@ -3,6 +3,7 @@ from sphinx_needs.exceptions import InvalidNeedException
 from .configuration import (
     add_dynamic_function,
     add_extra_option,
+    add_field,
     add_need_type,
     get_need_types,
 )
@@ -13,6 +14,7 @@ __all__ = (
     "add_dynamic_function",
     "add_external_need",
     "add_extra_option",
+    "add_field",
     "add_need",
     "add_need_type",
     "del_need",

--- a/sphinx_needs/api/configuration.py
+++ b/sphinx_needs/api/configuration.py
@@ -6,6 +6,7 @@ All functions here are available under ``sphinx_needs.api``.
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Callable
 
 from sphinx.application import Sphinx
@@ -100,6 +101,9 @@ def add_extra_option(
 
     Same impact as using :ref:`needs_extra_options` manually.
 
+    .. deprecated::
+        Use :func:`add_field` instead.
+
     **Usage**::
 
         from sphinx_needs.api import add_extra_option
@@ -112,9 +116,48 @@ def add_extra_option(
     :param schema: Schema definition for the extra option
     :param nullable: Whether the field allows unset values.
     :param parse_variants: Whether variants are parsed in this field.
-    :return: None
     """
-    _NEEDS_CONFIG.add_extra_option(
+    warnings.warn(
+        "add_extra_option is deprecated, use add_field instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    add_field(
+        name,
+        description=description,
+        schema=schema,
+        nullable=nullable,
+        parse_variants=parse_variants,
+    )
+
+
+def add_field(
+    name: str,
+    /,
+    description: str,
+    *,
+    schema: ExtraOptionSchemaTypes | None = None,
+    nullable: bool | None = None,
+    parse_variants: bool | None = None,
+) -> None:
+    """
+    Adds an need field to the configured need schema.
+
+    Same impact as using :ref:`needs_fields` manually.
+
+    **Usage**::
+
+        from sphinx_needs.api import add_field
+
+        add_field('my_field')
+
+    :param name: Name of the extra option
+    :param description: Description of the extra option
+    :param schema: Schema definition for the extra option
+    :param nullable: Whether the field allows unset values.
+    :param parse_variants: Whether variants are parsed in this field.
+    """
+    _NEEDS_CONFIG.add_field(
         name,
         description,
         schema=schema,

--- a/sphinx_needs/api/need.py
+++ b/sphinx_needs/api/need.py
@@ -115,7 +115,7 @@ def generate_need(
 
     ``kwargs`` can contain options defined in ``needs_extra_options`` and ``needs_extra_links``.
     If an entry is found in ``kwargs``, which *is not* specified in the configuration or registered e.g. via
-    ``add_extra_option``, an exception is raised.
+    ``add_field``, an exception is raised.
 
     If the need is within the current project, i.e. not an external need,
     the following parameters are used to help provide source mapped warnings and errors:
@@ -767,7 +767,7 @@ def add_need(
 
     ``kwargs`` can contain options defined in ``needs_extra_options`` and ``needs_extra_links``.
     If an entry is found in ``kwargs``, which *is not* specified in the configuration or registered e.g. via
-    ``add_extra_option``, an exception is raised.
+    ``add_field``, an exception is raised.
 
     If ``is_external`` is set to ``True``, no node will be created.
     Instead, the need is referencing an external url.

--- a/sphinx_needs/needs.py
+++ b/sphinx_needs/needs.py
@@ -534,7 +534,7 @@ def load_config(app: Sphinx, *_args: Any) -> None:
             )
             continue
 
-        _NEEDS_CONFIG.add_extra_option(name, description, schema=schema, override=True)
+        _NEEDS_CONFIG.add_field(name, description, schema=schema, override=True)
 
     if not isinstance(needs_config._fields, dict):
         raise NeedsConfigException("Config option 'needs_fields' must be a dict.")
@@ -562,7 +562,7 @@ def load_config(app: Sphinx, *_args: Any) -> None:
         schema = option_params.get("schema")
         nullable = option_params.get("nullable")
         parse_variants = option_params.get("parse_variants")
-        _NEEDS_CONFIG.add_extra_option(
+        _NEEDS_CONFIG.add_field(
             option_name,
             description,
             schema=schema,
@@ -574,13 +574,13 @@ def load_config(app: Sphinx, *_args: Any) -> None:
     # ensure options for `needgantt` functionality are added to the extra options
     for option in (needs_config.duration_option, needs_config.completion_option):
         default_schema: ExtraOptionIntegerSchemaType = {"type": "integer"}
-        if option not in _NEEDS_CONFIG.extra_options:
-            _NEEDS_CONFIG.add_extra_option(
+        if option not in _NEEDS_CONFIG.fields:
+            _NEEDS_CONFIG.add_field(
                 option, "Added for needgantt functionality", schema=default_schema
             )
         else:
             # ensure schema is correct
-            existing = _NEEDS_CONFIG.extra_options[option]
+            existing = _NEEDS_CONFIG.fields[option]
             if existing.schema is None:
                 existing.schema = default_schema
             else:
@@ -738,7 +738,7 @@ def check_configuration(app: Sphinx, config: Config) -> None:
     E.g. defined need-option, which is already defined internally
     """
     needs_config = NeedsSphinxConfig(config)
-    extra_options = _NEEDS_CONFIG.extra_options
+    extra_options = _NEEDS_CONFIG.fields
     link_types = [x["option"] for x in needs_config._extra_links]
 
     external_filter = needs_config.filter_data
@@ -890,7 +890,7 @@ def create_schema(app: Sphinx, env: BuildEnvironment, _docnames: list[str]) -> N
         except Exception as exc:
             raise NeedsConfigException(f"Invalid core option {name!r}: {exc}") from exc
 
-    for name, extra in _NEEDS_CONFIG.extra_options.items():
+    for name, extra in _NEEDS_CONFIG.fields.items():
         try:
             _schema = (
                 deepcopy(extra.schema)  # type: ignore[arg-type]

--- a/sphinx_needs/services/manager.py
+++ b/sphinx_needs/services/manager.py
@@ -31,9 +31,9 @@ class ServiceManager:
                 # TODO this should probably be done a bit more systematically;
                 # the github service adds a "type" option, but this is related to the core need field NOT an extra option
                 pass
-            elif option not in _NEEDS_CONFIG.extra_options:
+            elif option not in _NEEDS_CONFIG.fields:
                 self.log.debug(f'Register option "{option}" for service "{name}"')
-                _NEEDS_CONFIG.add_extra_option(option, f"Added by service {name}")
+                _NEEDS_CONFIG.add_field(option, f"Added by service {name}")
 
         # Init service with custom config
         self.services[name] = klass(self.app, name, config, **kwargs)

--- a/tests/__snapshots__/test_api_usage.ambr
+++ b/tests/__snapshots__/test_api_usage.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_api_add_extra_option_schema_wrong
+# name: test_api_add_field_schema_wrong
   '''
   Invalid extra option 'my_extra_option': Invalid schema: Additional properties are not allowed ('not_exist' was unexpected)
   

--- a/tests/__snapshots__/test_extra_options.ambr
+++ b/tests/__snapshots__/test_extra_options.ambr
@@ -209,7 +209,7 @@
             }),
             'introduced': dict({
               'default': '',
-              'description': 'Added by needs_fields config',
+              'description': 'When was this need introduced?',
               'field_type': 'extra',
               'type': 'string',
             }),

--- a/tests/doc_test/extra_options/conf.py
+++ b/tests/doc_test/extra_options/conf.py
@@ -3,7 +3,7 @@ extensions = ["sphinx_needs"]
 needs_extra_options = ["updated"]
 
 needs_fields = {
-    "introduced": {},
+    "introduced": {"description": "When was this need introduced?"},
     "impacts": {"description": "What is the impact of this need?"},
     1: {},
     "a": 1,
@@ -15,10 +15,10 @@ needs_json_remove_defaults = True
 
 
 def setup(app):
-    from sphinx_needs.api.configuration import add_extra_option
+    from sphinx_needs.api.configuration import add_field
 
-    add_extra_option(app, "introduced")
-    add_extra_option(app, "modified", description="When was this need last modified?")
+    add_field("introduced", description="When was this need introduced?")
+    add_field("modified", description="When was this need last modified?")
 
 
 needs_template_collapse = """

--- a/tests/test_api_usage.py
+++ b/tests/test_api_usage.py
@@ -125,7 +125,7 @@ def test_api_add_type(test_app: SphinxTestApp, snapshot):
     assert "my awesome need" in html
 
 
-def test_api_add_extra_option(
+def test_api_add_field(
     tmpdir: Path,
     make_app: Callable[[], SphinxTestApp],
     write_fixture_files: Callable[[Path, dict[str, Any]], None],
@@ -137,8 +137,8 @@ def test_api_add_extra_option(
             extensions = ['sphinx_needs']
             
             def setup(app):
-                from sphinx_needs.api import add_extra_option
-                add_extra_option(app, 'my_extra_option', description='My extra option')
+                from sphinx_needs.api import add_field
+                add_field('my_extra_option', description='My extra option')
                 return {'version': '0.1'}
             """
         ),
@@ -167,7 +167,7 @@ def test_api_add_extra_option(
     assert app.statuscode == 0
 
 
-def test_api_add_extra_option_schema(
+def test_api_add_field_schema(
     tmpdir: Path,
     make_app: Callable[[], SphinxTestApp],
     write_fixture_files: Callable[[Path, dict[str, Any]], None],
@@ -179,9 +179,8 @@ def test_api_add_extra_option_schema(
             extensions = ['sphinx_needs']
             
             def setup(app):
-                from sphinx_needs.api import add_extra_option
-                add_extra_option(
-                    app,
+                from sphinx_needs.api import add_field
+                add_field(
                     'my_extra_option',
                     description='My extra option',
                     schema={
@@ -217,7 +216,7 @@ def test_api_add_extra_option_schema(
     assert app.statuscode == 0
 
 
-def test_api_add_extra_option_schema_wrong(
+def test_api_add_field_schema_wrong(
     tmpdir: Path,
     make_app: Callable[[], SphinxTestApp],
     write_fixture_files: Callable[[Path, dict[str, Any]], None],
@@ -229,9 +228,8 @@ def test_api_add_extra_option_schema_wrong(
             extensions = ['sphinx_needs']
             
             def setup(app):
-                from sphinx_needs.api import add_extra_option
-                add_extra_option(
-                    app,
+                from sphinx_needs.api import add_field
+                add_field(
                     'my_extra_option',
                     description='My extra option',
                     schema={

--- a/tests/test_extra_options.py
+++ b/tests/test_extra_options.py
@@ -19,7 +19,7 @@ def test_custom_attributes_appear(test_app, snapshot):
     warnings = strip_colors(app._warning.getvalue()).splitlines()
     assert warnings == [
         'WARNING: Config option "needs_extra_options" is deprecated. Please use "needs_fields" instead. [needs.deprecated]',
-        'WARNING: extra_option "introduced" already registered. [needs.config]',
+        "WARNING: Need field 'introduced' already registered (existing description: 'When was this need introduced?') [needs.config]",
         "WARNING: needs_fields key is not a string: 1 [needs.config]",
         "WARNING: needs_fields entry for 'a' is not a dict: 1 [needs.config]",
     ]


### PR DESCRIPTION
Inline with moving from `needs_extra_options` to `needs_fields`

Introduce `add_field` as the new API to register need fields and mark `add_extra_option` as deprecated (it now emits a `DeprecationWarning` and forwards to `add_field`).

Internals renamed from extra-option terminology to fields (`ExtraOptionParams` -> `NewFieldParams`, `_extra_options` -> `_fields`, `extra_options` -> `fields`) and all usages updated across codebase and tests. 
Updated services, configuration loading, schema creation, docs/tests and snapshots to reflect the new naming while preserving backward compatibility via the deprecated wrapper.