### PR TITLE
👌 Default values of extra fields now checked against schema definitions

### DIFF
--- a/sphinx_needs/schema/core.py
+++ b/sphinx_needs/schema/core.py
@@ -465,10 +465,7 @@ def reduce_need(
         if value is None:
             # value is not provided
             continue
-        schema_field = field_properties[field]
-        if not ("default" in schema_field and value == schema_field["default"]):
-            # keep explicitly set fields
-            reduced_need[field] = value
+        reduced_need[field] = value
 
     for field, value in need.iter_links_items():
         if value:

--- a/tests/schema/__snapshots__/test_schema.ambr
+++ b/tests/schema/__snapshots__/test_schema.ambr
@@ -4627,6 +4627,40 @@
     }),
   })
 # ---
+# name: test_schemas[schema/fixtures/reporting-report_invalid_extra_field_default]
+  '''
+  ERROR: Need 'IMPL_1' has schema violations:
+    Severity:       violation
+    Field:          asil
+    Need path:      IMPL_1
+    Schema path:    [0] > local > properties > asil > const
+    Schema message: "A" was expected [sn_schema_violation.local_fail]
+  
+  '''
+# ---
+# name: test_schemas[schema/fixtures/reporting-report_invalid_extra_field_default].1
+  dict({
+    'validated_needs_count': 1,
+    'validation_warnings': dict({
+      'IMPL_1': list([
+        dict({
+          'children': list([
+          ]),
+          'details': dict({
+            'field': 'asil',
+            'need_path': 'IMPL_1',
+            'schema_path': '[0] > local > properties > asil > const',
+            'severity': 'violation',
+            'validation_msg': '"A" was expected',
+          }),
+          'log_lvl': 'error',
+          'subtype': 'local_fail',
+          'type': 'sn_schema_violation',
+        }),
+      ]),
+    }),
+  })
+# ---
 # name: test_schemas[schema/fixtures/reporting-severity_default_suppress_severity]
   '''
   WARNING: Need 'IMPL_1' has schema infos:

--- a/tests/schema/fixtures/reporting.yml
+++ b/tests/schema/fixtures/reporting.yml
@@ -140,3 +140,24 @@ severity_default_suppress_severity_and_rule:
             properties:
               asil:
                 const: B
+
+report_invalid_extra_field_default:
+  conf: |
+    extensions = ["sphinx_needs"]
+    needs_from_toml = "ubproject.toml"
+    needs_schema_definitions_from_json = "schemas.json"
+  ubproject: |
+    [needs.fields.asil]
+    default = "other"
+  rst: |
+    .. impl:: title
+        :id: IMPL_1
+        :asil: QM
+  schemas:
+    $defs: []
+    schemas:
+      - validate:
+          local:
+            properties:
+              asil:
+                const: A

--- a/tests/schema/fixtures/reporting.yml
+++ b/tests/schema/fixtures/reporting.yml
@@ -152,7 +152,6 @@ report_invalid_extra_field_default:
   rst: |
     .. impl:: title
         :id: IMPL_1
-        :asil: QM
   schemas:
     $defs: []
     schemas:


### PR DESCRIPTION
Previously, user set defaults were not being checked against schema, which is not intuitive.
As can be seen in this PR, this does not actually break any tests, principally due to the preceding #1644 and #1645