### PR TITLE
🔧 Simplify `generate_needs` function

### DIFF
--- a/tests/schema/__snapshots__/test_schema.ambr
+++ b/tests/schema/__snapshots__/test_schema.ambr
@@ -3787,7 +3787,7 @@
 # ---
 # name: test_schemas[schema/fixtures/fields-status_non_nullable]
   '''
-  <srcdir>/index.rst:5: WARNING: Need could not be created: status is not nullable, but no value was given. [needs.create_need]
+  <srcdir>/index.rst:5: WARNING: Need could not be created: Field 'status' is not nullable, but no value or default was given. [needs.create_need]
   
   '''
 # ---


### PR DESCRIPTION
Replaces four stages of repetitive per-field code in `generate_need` with loops driven by the schema, matching the pattern already used for extra fields and link fields.

## Changes

**Replaced with loops:**

- 11 individual `_convert_type_core()` calls → loop over `_raw_core` dict
- 10 identical default-resolution ternary expressions → 3-line loop
- 8 type-specific unwrap calls + 8 `if *_func:` checks → loop using new `_unwrap_field_value()`
- 30-line `extras_pre` match/case block → reuses same `_unwrap_field_value()`

**Deleted 6 helper functions**, replaced by 1 generic `_unwrap_field_value()`:

- `_convert_type_core`, `_convert_to_str_none`, `_convert_to_str_func`, `_convert_to_none_str_func`, `_convert_to_bool_func`, `_convert_to_list_str_func`

**Net:** ~160 fewer lines, no public API changes.

## Behavioral difference

The placeholder value used for **nullable extra fields** with dynamic functions changed:

| Scenario | Old | New |
|---|---|---|
| Nullable extra field (e.g. `str \| None`) with a dynamic function | Type-based placeholder (`""`) | `None` |
| Nullable **core** field (e.g. `status`) with a dynamic function | `None` | `None` (unchanged) |

The old code was internally inconsistent: `_convert_to_none_str_func` (core fields) used `None` for nullable placeholders, while the extras `match` block always used a type-based placeholder regardless of nullability. The new code is consistent — nullable fields always get `None` as the placeholder.

This placeholder is temporary and is replaced during `resolve_functions`, so the impact is limited to any code that inspects extra field values between `generate_need` and function resolution.

## Snapshot update

One snapshot updated: `test_schemas[schema/fixtures/fields-status_non_nullable]` — error message changed from `status is not nullable, but no value was given.` to `Field 'status' is not nullable, but no value or default was given.` for consistency with the extras error format.
