### PR TITLE
⚠️ Separate reduced vs full need representation for schema validation

### DIFF
--- a/sphinx_needs/need_item.py
+++ b/sphinx_needs/need_item.py
@@ -669,6 +669,25 @@ class NeedItem:
             self._computed.items(),
         )
 
+    def iter_schema_items(self) -> Iterable[tuple[str, Any]]:
+        """Return the items of the need item that are relevant for schema validation."""
+        # TODO - this should be reworked to be more robust;
+        # e.g. probably all core fields should be included
+        return chain(
+            (
+                (k, v)
+                for k, v in self._core.items()
+                if k in ("id", "type", "title", "status", "tags")
+            ),
+            (
+                (k, v)
+                for k, v in self._source.dict_repr.items()
+                if k in ("docname", "is_import", "is_external")
+            ),
+            self._extras.items(),
+            self._links.items(),
+        )
+
     def iter_core_items(self) -> Iterable[tuple[str, Any]]:
         """Return the core items of the need item."""
         return chain(

--- a/sphinx_needs/schema/core.py
+++ b/sphinx_needs/schema/core.py
@@ -584,7 +584,7 @@ def get_ontology_warnings(
         needs_json = reduce_need(need, field_properties, validator.properties)
     else:
         # we always remove null values, since we currently do not allow for `{"string", "null"}` type definitions and so null values would cause validation errors
-        needs_json = {k: v for k, v in need.items() if v is not None}
+        needs_json = {k: v for k, v in need.iter_schema_items() if v is not None}
     warnings: list[OntologyWarning] = []
     warning: OntologyWarning
     try:

--- a/sphinx_needs/schema/process.py
+++ b/sphinx_needs/schema/process.py
@@ -14,8 +14,8 @@ from sphinx_needs.needsfile import generate_needs_schema
 from sphinx_needs.schema.config import NeedFieldsSchemaType, SchemasRootType
 from sphinx_needs.schema.core import (
     NeedFieldProperties,
-    validate_link_options,
-    validate_option_fields,
+    validate_fields,
+    validate_links,
     validate_type_schema,
 )
 from sphinx_needs.schema.reporting import (
@@ -69,16 +69,12 @@ def process_schemas(app: Sphinx, builder: Builder) -> None:
     need_2_warnings: dict[str, list[OntologyWarning]] = {}
 
     if fields_schema["properties"]:
-        extra_warnings = validate_option_fields(
-            config, fields_schema, field_properties, needs
-        )
+        extra_warnings = validate_fields(config, fields_schema, field_properties, needs)
         for key, warnings in extra_warnings.items():
             need_2_warnings.setdefault(key, []).extend(warnings)
 
     if links_schema["properties"]:
-        link_warnings = validate_link_options(
-            config, links_schema, field_properties, needs
-        )
+        link_warnings = validate_links(config, links_schema, field_properties, needs)
         for key, warnings in link_warnings.items():
             need_2_warnings.setdefault(key, []).extend(warnings)
 

--- a/tests/schema/__snapshots__/test_schema.ambr
+++ b/tests/schema/__snapshots__/test_schema.ambr
@@ -2948,17 +2948,47 @@
   })
 # ---
 # name: test_schemas[schema/fixtures/extra_links-contains]
-  ''
+  '''
+  ERROR: Need 'SPEC_1' has schema violations:
+    Severity:       violation
+    Field:          links
+    Need path:      SPEC_1
+    Schema path:    extra_links > schema > properties > links > contains
+    Schema message: None of [] are valid under the given schema [sn_schema_violation.extra_link_fail]
+  
+  '''
 # ---
 # name: test_schemas[schema/fixtures/extra_links-contains].1
   dict({
     'validated_needs_count': 2,
     'validation_warnings': dict({
+      'SPEC_1': list([
+        dict({
+          'children': list([
+          ]),
+          'details': dict({
+            'field': 'links',
+            'need_path': 'SPEC_1',
+            'schema_path': 'extra_links > schema > properties > links > contains',
+            'severity': 'violation',
+            'validation_msg': 'None of [] are valid under the given schema',
+          }),
+          'log_lvl': 'error',
+          'subtype': 'extra_link_fail',
+          'type': 'sn_schema_violation',
+        }),
+      ]),
     }),
   })
 # ---
 # name: test_schemas[schema/fixtures/extra_links-contains_error]
   '''
+  ERROR: Need 'SPEC_1' has schema violations:
+    Severity:       violation
+    Field:          links
+    Need path:      SPEC_1
+    Schema path:    extra_links > schema > properties > links > contains
+    Schema message: None of [] are valid under the given schema [sn_schema_violation.extra_link_fail]
   ERROR: Need 'IMPL_1' has schema violations:
     Severity:       violation
     Field:          links
@@ -2988,11 +3018,33 @@
           'type': 'sn_schema_violation',
         }),
       ]),
+      'SPEC_1': list([
+        dict({
+          'children': list([
+          ]),
+          'details': dict({
+            'field': 'links',
+            'need_path': 'SPEC_1',
+            'schema_path': 'extra_links > schema > properties > links > contains',
+            'severity': 'violation',
+            'validation_msg': 'None of [] are valid under the given schema',
+          }),
+          'log_lvl': 'error',
+          'subtype': 'extra_link_fail',
+          'type': 'sn_schema_violation',
+        }),
+      ]),
     }),
   })
 # ---
 # name: test_schemas[schema/fixtures/extra_links-inject_array]
   '''
+  ERROR: Need 'SPEC_1' has schema violations:
+    Severity:       violation
+    Field:          links
+    Need path:      SPEC_1
+    Schema path:    extra_links > schema > properties > links > minItems
+    Schema message: [] has less than 2 items [sn_schema_violation.extra_link_fail]
   ERROR: Need 'IMPL_1' has schema violations:
     Severity:       violation
     Field:          links
@@ -3016,6 +3068,22 @@
             'schema_path': 'extra_links > schema > properties > links > minItems',
             'severity': 'violation',
             'validation_msg': '["SPEC_1"] has less than 2 items',
+          }),
+          'log_lvl': 'error',
+          'subtype': 'extra_link_fail',
+          'type': 'sn_schema_violation',
+        }),
+      ]),
+      'SPEC_1': list([
+        dict({
+          'children': list([
+          ]),
+          'details': dict({
+            'field': 'links',
+            'need_path': 'SPEC_1',
+            'schema_path': 'extra_links > schema > properties > links > minItems',
+            'severity': 'violation',
+            'validation_msg': '[] has less than 2 items',
           }),
           'log_lvl': 'error',
           'subtype': 'extra_link_fail',
@@ -3070,17 +3138,75 @@
   })
 # ---
 # name: test_schemas[schema/fixtures/extra_links-max_contains]
-  ''
+  '''
+  ERROR: Need 'SPEC_1' has schema violations:
+    Severity:       violation
+    Field:          links
+    Need path:      SPEC_1
+    Schema path:    extra_links > schema > properties > links > maxContains
+    Schema message: None of [] are valid under the given schema [sn_schema_violation.extra_link_fail]
+  ERROR: Need 'SPEC_2' has schema violations:
+    Severity:       violation
+    Field:          links
+    Need path:      SPEC_2
+    Schema path:    extra_links > schema > properties > links > maxContains
+    Schema message: None of [] are valid under the given schema [sn_schema_violation.extra_link_fail]
+  
+  '''
 # ---
 # name: test_schemas[schema/fixtures/extra_links-max_contains].1
   dict({
     'validated_needs_count': 3,
     'validation_warnings': dict({
+      'SPEC_1': list([
+        dict({
+          'children': list([
+          ]),
+          'details': dict({
+            'field': 'links',
+            'need_path': 'SPEC_1',
+            'schema_path': 'extra_links > schema > properties > links > maxContains',
+            'severity': 'violation',
+            'validation_msg': 'None of [] are valid under the given schema',
+          }),
+          'log_lvl': 'error',
+          'subtype': 'extra_link_fail',
+          'type': 'sn_schema_violation',
+        }),
+      ]),
+      'SPEC_2': list([
+        dict({
+          'children': list([
+          ]),
+          'details': dict({
+            'field': 'links',
+            'need_path': 'SPEC_2',
+            'schema_path': 'extra_links > schema > properties > links > maxContains',
+            'severity': 'violation',
+            'validation_msg': 'None of [] are valid under the given schema',
+          }),
+          'log_lvl': 'error',
+          'subtype': 'extra_link_fail',
+          'type': 'sn_schema_violation',
+        }),
+      ]),
     }),
   })
 # ---
 # name: test_schemas[schema/fixtures/extra_links-max_contains_error]
   '''
+  ERROR: Need 'SPEC_1' has schema violations:
+    Severity:       violation
+    Field:          links
+    Need path:      SPEC_1
+    Schema path:    extra_links > schema > properties > links > maxContains
+    Schema message: None of [] are valid under the given schema [sn_schema_violation.extra_link_fail]
+  ERROR: Need 'SPEC_2' has schema violations:
+    Severity:       violation
+    Field:          links
+    Need path:      SPEC_2
+    Schema path:    extra_links > schema > properties > links > maxContains
+    Schema message: None of [] are valid under the given schema [sn_schema_violation.extra_link_fail]
   ERROR: Need 'IMPL_1' has schema violations:
     Severity:       violation
     Field:          links
@@ -3104,6 +3230,38 @@
             'schema_path': 'extra_links > schema > properties > links > maxContains',
             'severity': 'violation',
             'validation_msg': 'None of ["SPEC_1","SPEC_2"] are valid under the given schema',
+          }),
+          'log_lvl': 'error',
+          'subtype': 'extra_link_fail',
+          'type': 'sn_schema_violation',
+        }),
+      ]),
+      'SPEC_1': list([
+        dict({
+          'children': list([
+          ]),
+          'details': dict({
+            'field': 'links',
+            'need_path': 'SPEC_1',
+            'schema_path': 'extra_links > schema > properties > links > maxContains',
+            'severity': 'violation',
+            'validation_msg': 'None of [] are valid under the given schema',
+          }),
+          'log_lvl': 'error',
+          'subtype': 'extra_link_fail',
+          'type': 'sn_schema_violation',
+        }),
+      ]),
+      'SPEC_2': list([
+        dict({
+          'children': list([
+          ]),
+          'details': dict({
+            'field': 'links',
+            'need_path': 'SPEC_2',
+            'schema_path': 'extra_links > schema > properties > links > maxContains',
+            'severity': 'violation',
+            'validation_msg': 'None of [] are valid under the given schema',
           }),
           'log_lvl': 'error',
           'subtype': 'extra_link_fail',
@@ -3158,17 +3316,47 @@
   })
 # ---
 # name: test_schemas[schema/fixtures/extra_links-min_contains]
-  ''
+  '''
+  ERROR: Need 'SPEC_1' has schema violations:
+    Severity:       violation
+    Field:          links
+    Need path:      SPEC_1
+    Schema path:    extra_links > schema > properties > links > minContains
+    Schema message: None of [] are valid under the given schema [sn_schema_violation.extra_link_fail]
+  
+  '''
 # ---
 # name: test_schemas[schema/fixtures/extra_links-min_contains].1
   dict({
     'validated_needs_count': 2,
     'validation_warnings': dict({
+      'SPEC_1': list([
+        dict({
+          'children': list([
+          ]),
+          'details': dict({
+            'field': 'links',
+            'need_path': 'SPEC_1',
+            'schema_path': 'extra_links > schema > properties > links > minContains',
+            'severity': 'violation',
+            'validation_msg': 'None of [] are valid under the given schema',
+          }),
+          'log_lvl': 'error',
+          'subtype': 'extra_link_fail',
+          'type': 'sn_schema_violation',
+        }),
+      ]),
     }),
   })
 # ---
 # name: test_schemas[schema/fixtures/extra_links-min_contains_error]
   '''
+  ERROR: Need 'SPEC_1' has schema violations:
+    Severity:       violation
+    Field:          links
+    Need path:      SPEC_1
+    Schema path:    extra_links > schema > properties > links > minContains
+    Schema message: None of [] are valid under the given schema [sn_schema_violation.extra_link_fail]
   ERROR: Need 'IMPL_1' has schema violations:
     Severity:       violation
     Field:          links
@@ -3198,21 +3386,67 @@
           'type': 'sn_schema_violation',
         }),
       ]),
+      'SPEC_1': list([
+        dict({
+          'children': list([
+          ]),
+          'details': dict({
+            'field': 'links',
+            'need_path': 'SPEC_1',
+            'schema_path': 'extra_links > schema > properties > links > minContains',
+            'severity': 'violation',
+            'validation_msg': 'None of [] are valid under the given schema',
+          }),
+          'log_lvl': 'error',
+          'subtype': 'extra_link_fail',
+          'type': 'sn_schema_violation',
+        }),
+      ]),
     }),
   })
 # ---
 # name: test_schemas[schema/fixtures/extra_links-min_items]
-  ''
+  '''
+  ERROR: Need 'SPEC_1' has schema violations:
+    Severity:       violation
+    Field:          links
+    Need path:      SPEC_1
+    Schema path:    extra_links > schema > properties > links > minItems
+    Schema message: [] has less than 1 item [sn_schema_violation.extra_link_fail]
+  
+  '''
 # ---
 # name: test_schemas[schema/fixtures/extra_links-min_items].1
   dict({
     'validated_needs_count': 2,
     'validation_warnings': dict({
+      'SPEC_1': list([
+        dict({
+          'children': list([
+          ]),
+          'details': dict({
+            'field': 'links',
+            'need_path': 'SPEC_1',
+            'schema_path': 'extra_links > schema > properties > links > minItems',
+            'severity': 'violation',
+            'validation_msg': '[] has less than 1 item',
+          }),
+          'log_lvl': 'error',
+          'subtype': 'extra_link_fail',
+          'type': 'sn_schema_violation',
+        }),
+      ]),
     }),
   })
 # ---
 # name: test_schemas[schema/fixtures/extra_links-min_items_error]
   '''
+  ERROR: Need 'SPEC_1' has schema violations:
+    Severity:       violation
+    Field:          links
+    Need path:      SPEC_1
+    Schema path:    extra_links > schema > properties > links > minItems
+    Schema message: [] has less than 2 items [sn_schema_violation.extra_link_fail]
   ERROR: Need 'IMPL_1' has schema violations:
     Severity:       violation
     Field:          links
@@ -3236,6 +3470,22 @@
             'schema_path': 'extra_links > schema > properties > links > minItems',
             'severity': 'violation',
             'validation_msg': '["SPEC_1"] has less than 2 items',
+          }),
+          'log_lvl': 'error',
+          'subtype': 'extra_link_fail',
+          'type': 'sn_schema_violation',
+        }),
+      ]),
+      'SPEC_1': list([
+        dict({
+          'children': list([
+          ]),
+          'details': dict({
+            'field': 'links',
+            'need_path': 'SPEC_1',
+            'schema_path': 'extra_links > schema > properties > links > minItems',
+            'severity': 'violation',
+            'validation_msg': '[] has less than 2 items',
           }),
           'log_lvl': 'error',
           'subtype': 'extra_link_fail',

--- a/tests/schema/__snapshots__/test_schema.ambr
+++ b/tests/schema/__snapshots__/test_schema.ambr
@@ -3991,6 +3991,138 @@
     }),
   })
 # ---
+# name: test_schemas[schema/fixtures/fields-select_by_docname]
+  '''
+  ERROR: Need 'IMPL_1' has schema violations:
+    Severity:       violation
+    Field:          asil
+    Need path:      IMPL_1
+    Schema path:    [0] > local > properties > asil > const
+    Schema message: "B" was expected [sn_schema_violation.local_fail]
+  
+  '''
+# ---
+# name: test_schemas[schema/fixtures/fields-select_by_docname].1
+  dict({
+    'validated_needs_count': 1,
+    'validation_warnings': dict({
+      'IMPL_1': list([
+        dict({
+          'children': list([
+          ]),
+          'details': dict({
+            'field': 'asil',
+            'need_path': 'IMPL_1',
+            'schema_path': '[0] > local > properties > asil > const',
+            'severity': 'violation',
+            'validation_msg': '"B" was expected',
+          }),
+          'log_lvl': 'error',
+          'subtype': 'local_fail',
+          'type': 'sn_schema_violation',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_schemas[schema/fixtures/fields-select_by_docname_no_match]
+  ''
+# ---
+# name: test_schemas[schema/fixtures/fields-select_by_docname_no_match].1
+  dict({
+    'validated_needs_count': 1,
+    'validation_warnings': dict({
+    }),
+  })
+# ---
+# name: test_schemas[schema/fixtures/fields-select_by_is_external_false]
+  '''
+  ERROR: Need 'IMPL_1' has schema violations:
+    Severity:       violation
+    Field:          asil
+    Need path:      IMPL_1
+    Schema path:    [0] > local > properties > asil > const
+    Schema message: "B" was expected [sn_schema_violation.local_fail]
+  
+  '''
+# ---
+# name: test_schemas[schema/fixtures/fields-select_by_is_external_false].1
+  dict({
+    'validated_needs_count': 1,
+    'validation_warnings': dict({
+      'IMPL_1': list([
+        dict({
+          'children': list([
+          ]),
+          'details': dict({
+            'field': 'asil',
+            'need_path': 'IMPL_1',
+            'schema_path': '[0] > local > properties > asil > const',
+            'severity': 'violation',
+            'validation_msg': '"B" was expected',
+          }),
+          'log_lvl': 'error',
+          'subtype': 'local_fail',
+          'type': 'sn_schema_violation',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_schemas[schema/fixtures/fields-select_by_is_external_true_no_match]
+  ''
+# ---
+# name: test_schemas[schema/fixtures/fields-select_by_is_external_true_no_match].1
+  dict({
+    'validated_needs_count': 1,
+    'validation_warnings': dict({
+    }),
+  })
+# ---
+# name: test_schemas[schema/fixtures/fields-select_by_is_import_false]
+  '''
+  ERROR: Need 'IMPL_1' has schema violations:
+    Severity:       violation
+    Field:          asil
+    Need path:      IMPL_1
+    Schema path:    [0] > local > properties > asil > const
+    Schema message: "B" was expected [sn_schema_violation.local_fail]
+  
+  '''
+# ---
+# name: test_schemas[schema/fixtures/fields-select_by_is_import_false].1
+  dict({
+    'validated_needs_count': 1,
+    'validation_warnings': dict({
+      'IMPL_1': list([
+        dict({
+          'children': list([
+          ]),
+          'details': dict({
+            'field': 'asil',
+            'need_path': 'IMPL_1',
+            'schema_path': '[0] > local > properties > asil > const',
+            'severity': 'violation',
+            'validation_msg': '"B" was expected',
+          }),
+          'log_lvl': 'error',
+          'subtype': 'local_fail',
+          'type': 'sn_schema_violation',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_schemas[schema/fixtures/fields-select_by_is_import_true_no_match]
+  ''
+# ---
+# name: test_schemas[schema/fixtures/fields-select_by_is_import_true_no_match].1
+  dict({
+    'validated_needs_count': 1,
+    'validation_warnings': dict({
+    }),
+  })
+# ---
 # name: test_schemas[schema/fixtures/fields-set_type_string]
   ''
 # ---

--- a/tests/schema/fixtures/fields.yml
+++ b/tests/schema/fixtures/fields.yml
@@ -201,6 +201,156 @@ auto_inject_type_wrong_const:
               asil:
                 const: QM
 
+select_by_docname:
+  conf: |
+    extensions = ["sphinx_needs"]
+    needs_from_toml = "ubproject.toml"
+    needs_schema_definitions_from_json = "schemas.json"
+  ubproject: |
+    [needs.fields.asil]
+    nullable = true
+  rst: |
+    .. impl:: title
+        :id: IMPL_1
+        :asil: QM
+  schemas:
+    $defs: []
+    schemas:
+      - select:
+          properties:
+            docname:
+              const: "index"
+        validate:
+          local:
+            properties:
+              asil:
+                const: "B"
+
+select_by_docname_no_match:
+  conf: |
+    extensions = ["sphinx_needs"]
+    needs_from_toml = "ubproject.toml"
+    needs_schema_definitions_from_json = "schemas.json"
+  ubproject: |
+    [needs.fields.asil]
+    nullable = true
+  rst: |
+    .. impl:: title
+        :id: IMPL_1
+        :asil: QM
+  schemas:
+    $defs: []
+    schemas:
+      - select:
+          properties:
+            docname:
+              const: "other_doc"
+        validate:
+          local:
+            properties:
+              asil:
+                const: "B"
+
+select_by_is_external_false:
+  conf: |
+    extensions = ["sphinx_needs"]
+    needs_from_toml = "ubproject.toml"
+    needs_schema_definitions_from_json = "schemas.json"
+  ubproject: |
+    [needs.fields.asil]
+    nullable = true
+  rst: |
+    .. impl:: title
+        :id: IMPL_1
+        :asil: QM
+  schemas:
+    $defs: []
+    schemas:
+      - select:
+          properties:
+            is_external:
+              const: false
+        validate:
+          local:
+            properties:
+              asil:
+                const: "B"
+
+select_by_is_external_true_no_match:
+  conf: |
+    extensions = ["sphinx_needs"]
+    needs_from_toml = "ubproject.toml"
+    needs_schema_definitions_from_json = "schemas.json"
+  ubproject: |
+    [needs.fields.asil]
+    nullable = true
+  rst: |
+    .. impl:: title
+        :id: IMPL_1
+        :asil: QM
+  schemas:
+    $defs: []
+    schemas:
+      - select:
+          properties:
+            is_external:
+              const: true
+        validate:
+          local:
+            properties:
+              asil:
+                const: "B"
+
+select_by_is_import_false:
+  conf: |
+    extensions = ["sphinx_needs"]
+    needs_from_toml = "ubproject.toml"
+    needs_schema_definitions_from_json = "schemas.json"
+  ubproject: |
+    [needs.fields.asil]
+    nullable = true
+  rst: |
+    .. impl:: title
+        :id: IMPL_1
+        :asil: QM
+  schemas:
+    $defs: []
+    schemas:
+      - select:
+          properties:
+            is_import:
+              const: false
+        validate:
+          local:
+            properties:
+              asil:
+                const: "B"
+
+select_by_is_import_true_no_match:
+  conf: |
+    extensions = ["sphinx_needs"]
+    needs_from_toml = "ubproject.toml"
+    needs_schema_definitions_from_json = "schemas.json"
+  ubproject: |
+    [needs.fields.asil]
+    nullable = true
+  rst: |
+    .. impl:: title
+        :id: IMPL_1
+        :asil: QM
+  schemas:
+    $defs: []
+    schemas:
+      - select:
+          properties:
+            is_import:
+              const: true
+        validate:
+          local:
+            properties:
+              asil:
+                const: "B"
+
 required_based_on_select_field_missing:
   conf: |
     extensions = ["sphinx_needs"]


### PR DESCRIPTION
## Changes

- **Rename** `validate_option_fields` → `validate_fields` and `validate_link_options` → `validate_links`
- **Add `reduce` parameter** to `get_ontology_warnings()`:
  - `True` (type-specific `local`/`network` schemas): uses `reduce_need()` — strips empty link lists and defaulted core fields. Required for `unevaluatedProperties` (extra fields don't cause false failures) and `required` (fields at their default are absent, so `required` enforces explicit setting) to work correctly.
  - `False` (global field/link constraint validation): uses `NeedItem.iter_schema_items()` — returns a curated subset of fields (core: `id`, `type`, `title`, `status`, `tags`; source: `docname`, `is_import`, `is_external`; all extra fields; all links), filtering only `None` values. This retains empty `[]` values for links and `tags`, so constraints are evaluated against every need.

## Behavioral change

Previously, fields with default `[]` values (link fields like `links`, and core fields like `tags`) were stripped before validation, silently bypassing constraints like `minItems`, `contains`, and `minContains`. Now with `reduce=False`, these fields are retained as `[]`, causing them to **fail** those constraints.

This applies to both:
- **Link fields** (e.g. `links`, `implements`) — always default to `[]`
- **Core fields** with `[]` defaults (e.g. `tags`) — previously stripped when matching the default

**Example**: A schema with `schema.minItems = 1` on `links` will now warn for *every* need that doesn't set any links, not just those that explicitly set links but provided too few.

## Decision needed

**Is this the correct strictness?** Two reasonable interpretations:

1. ✅ **"All needs must satisfy field/link constraints"** — the new behavior. If you declare `minItems: 1` on a link type or `tags`, every need must have at least one value. Users who want optional fields should not set `minItems`.

2. ❌ **"Only needs that explicitly set a field must satisfy its constraints"** — the old behavior. Unset/default fields are treated as absent, not as empty arrays.

If (1) is intended, this should be noted in the changelog as a behavior change. If (2) is preferred, the fix would be to keep `reduce_need=True` for field/link validation, or to conditionally skip default-valued fields when `reduce_need=False`.

### Known limitation of `reduce_need=True`

The reduction logic strips fields whose value matches the default — but it cannot distinguish between "never set (defaulted)" and "explicitly set to the default value." For example, if a user actively sets `:tags:` to `[]` and the schema has `minItems: 1`, the field is stripped because `[]` matches the default, and the violation is **silently ignored**. This is a fundamental limitation of comparing values to defaults at validation time, since the provenance of the value (explicit vs implicit) is not tracked.
