### PR TITLE
🔧 Refactor schema validation: separate select filtering from local validation

### DIFF
--- a/sphinx_needs/need_item.py
+++ b/sphinx_needs/need_item.py
@@ -669,25 +669,6 @@ class NeedItem:
             self._computed.items(),
         )
 
-    def iter_schema_items(self) -> Iterable[tuple[str, Any]]:
-        """Return the items of the need item that are relevant for schema validation."""
-        # TODO - this should be reworked to be more robust;
-        # e.g. probably all core fields should be included
-        return chain(
-            (
-                (k, v)
-                for k, v in self._core.items()
-                if k in ("id", "type", "title", "status", "tags")
-            ),
-            (
-                (k, v)
-                for k, v in self._source.dict_repr.items()
-                if k in ("docname", "is_import", "is_external")
-            ),
-            self._extras.items(),
-            self._links.items(),
-        )
-
     def iter_core_items(self) -> Iterable[tuple[str, Any]]:
         """Return the core items of the need item."""
         return chain(

--- a/sphinx_needs/schema/process.py
+++ b/sphinx_needs/schema/process.py
@@ -64,7 +64,11 @@ def process_schemas(app: Sphinx, builder: Builder) -> None:
         )["properties"]
         for type_schema in type_schemas:
             type_warnings = validate_type_schema(
-                config, type_schema, needs, field_properties
+                config,
+                type_schema,
+                needs,
+                field_properties,
+                fields_schema=needs_schema,
             )
             for key, warnings in type_warnings.items():
                 need_2_warnings.setdefault(key, []).extend(warnings)


### PR DESCRIPTION
### Motivation

`get_ontology_warnings` served two fundamentally different purposes — **select filtering** and **local validation** — distinguished only by a `reduce: bool` flag, with different parameter conventions (select never used `field_properties`, `user_message`, or `user_severity`). This made the function's contract unclear and coupled the two code paths unnecessarily.

Separately, `NeedItem.iter_schema_items()` hardcoded a fragile list of 5 core field names (`id`, `type`, `title`, `status`, `tags`) plus 3 source fields, with a TODO noting it should be reworked. It missed 8 core fields that have `add_to_field_schema=True` (e.g. `collapse`, `hide`, `layout`, `style`, `constraints`, `template`, `pre_template`, `post_template`).

### Changes

#### Split `get_ontology_warnings` → two private functions (`sphinx_needs/schema/core.py`)

- **`_check_select_match`** — returns `bool`. Builds a projection of the need via `need.items()` filtered by a caller-provided `select_field_names` set, then calls `validator.compiled.is_valid()`. When `schema_debug_active` is enabled, writes debug files using the existing `select_success`/`select_fail` rules (including the projected need and compiled schema), guarded so no `OntologyWarning` construction occurs unless debug mode is on. Both rules are in the default `schema_debug_ignore` list, so no new files appear unless the user opts in.

- **`_validate_need_local`** — local/network-local validation path. Accepts `field_properties`, `fail_rule`, `success_rule`, and optional `user_message`/`user_severity`. Uses `reduce_need()` for data shaping.

- **Removed** the original `get_ontology_warnings` and its `reduce: bool` parameter.

#### Remove `iter_schema_items` (`sphinx_needs/need_item.py`)

- **Removed** `iter_schema_items()` with its hardcoded field list.
- Select projection now uses `NeedItem.items()` filtered by `select_field_names` in the caller — `NeedItem` no longer encodes any schema policy.

#### Wire up the field names (`sphinx_needs/schema/core.py`, `sphinx_needs/schema/process.py`)

- `validate_type_schema` now accepts `fields_schema: FieldsSchema` instead of a pre-computed `select_field_names` frozenset. It derives the select field name set internally (only when a `select` schema is present), keeping the select projection logic self-contained in `core.py`.
- `process_schemas` simply passes `needs_schema` through — no manual field-name construction.

### Design notes

- **Select vs validate are now structurally separate**, making it easier to apply different `required`/`unevaluatedProperties` semantics to each.
- **No hardcoded field names** — the set is derived from `FieldsSchema` at runtime, automatically picking up new core, extra, and link fields.
- The split positions future work on reinterpreting `required` as "value is not `None`" to be scoped to `_validate_need_local` without affecting select semantics.

### Verification

All 162 schema tests pass, 220 snapshots unchanged, mypy clean, ruff clean.
