### PR TITLE
🐛 Fix needextend data purging and deterministic ordering

### DIFF
--- a/sphinx_needs/data.py
+++ b/sphinx_needs/data.py
@@ -841,6 +841,14 @@ class SphinxNeedsData:
         docs = self.get_or_create_docs()
         for key, value in docs.items():
             docs[key] = [doc for doc in value if doc != docname]
+        extends = self.get_or_create_extends()
+        for extend_id in list(extends):
+            if extends[extend_id]["docname"] == docname:
+                del extends[extend_id]
+        umls = self.get_or_create_umls()
+        for uml_id in list(umls):
+            if umls[uml_id]["docname"] == docname:
+                del umls[uml_id]
 
     def get_needs_mutable(self) -> NeedsMutable:
         """Get all needs, mapped by ID.

--- a/sphinx_needs/directives/needextend.py
+++ b/sphinx_needs/directives/needextend.py
@@ -206,8 +206,12 @@ def extend_needs_data(
 ) -> None:
     """Use data gathered from needextend directives to modify fields of existing needs."""
 
+    # Sort by (docname, lineno) to ensure deterministic ordering,
+    # regardless of parallel build worker completion order.
+    sorted_extends = sorted(extends.values(), key=lambda x: (x["docname"], x["lineno"]))
+
     current_needextend: NeedsExtendType
-    for current_needextend in extends.values():
+    for current_needextend in sorted_extends:
         need_filter = current_needextend["filter"]
         location = (current_needextend["docname"], current_needextend["lineno"])
         if current_needextend["filter_is_id"]:


### PR DESCRIPTION
This PR addresses two bugs related to the `needextend` directive's interaction with incremental and parallel builds.

### Bug 1: Stale needextend/needuml data on incremental rebuilds

**Problem:** When a document containing `.. needextend::` or `.. needuml::` directives is modified or removed, Sphinx fires the `env-purge-doc` event, which calls `SphinxNeedsData.remove_doc()`. This method correctly purged **needs** and **doc tracking** data for the document, but did **not** purge **needextend** or **needuml** data. This meant stale entries persisted across incremental rebuilds, potentially causing duplicate or orphaned modifications.

**Fix:** `remove_doc()` now also iterates over the extends and umls dictionaries and removes entries whose `docname` matches the purged document — the same pattern already used for needs.

**File:** `sphinx_needs/data.py`

### Bug 2: Non-deterministic needextend application order in parallel builds

**Problem:** `extend_needs_data()` iterated over `extends.values()` — i.e., Python dict insertion order. In serial builds, this order is determined by document read order, which is generally stable but not guaranteed. In parallel builds, extends from different workers are merged via `dict.update()`, where the merge order depends on which worker finishes first. This made the application order of needextend directives **non-deterministic**, which could produce different build outputs for the same source when:

- Two `needextend` directives in different documents target the same need and modify the same field (last-write-wins for REPLACE; order-dependent for APPEND).
- Parallel builds are enabled.

**Fix:** `extend_needs_data()` now sorts the extends by `(docname, lineno)` before applying them, ensuring a deterministic and reproducible ordering regardless of build parallelism.

**File:** `sphinx_needs/directives/needextend.py`

## Changes

| File | Change |
|---|---|
| `sphinx_needs/data.py` | `remove_doc()` now purges needextend and needuml entries for the removed document | | `sphinx_needs/directives/needextend.py` | `extend_needs_data()` sorts extends by `(docname, lineno)` before application |

## Testing

All existing `test_needextend.py` tests pass. The sorting change is transparent to tests that don't involve conflicting extends across documents.

---

## Next Steps: User-controlled extension ordering via an `extend_order` option

The current `(docname, lineno)` sort provides determinism, but users have no way to explicitly control the order in which `needextend` directives are applied. This matters when multiple extends target the same need and the result depends on application order (e.g., one sets a field, another appends to it).

### Proposed: `:extend_order:` directive option

Add an optional `:extend_order:` option to the `needextend` directive that accepts an integer value (default `0`). Extensions are then sorted by `(extend_order, docname, lineno)`, with lower values applied first.

> **Why `extend_order` and not `priority`?** The `needextend` directive uses a `DummyOptionSpec` that accepts any option name as a need field modification. A generic name like `priority` could clash with a user-defined field of the same name. `extend_order` is clearly namespaced to the extension mechanism and very unlikely to collide with user fields.

**Example usage:**

```rst
.. needextend:: REQ_001
   :extend_order: 10
   :status: in_progress

.. needextend:: REQ_001
   :extend_order: 20
   :+tags: reviewed
```

This guarantees the status is set before tags are appended, regardless of source file location.

### Implementation outline

1. **Directive option:** Pop `"extend_order"` from options in `run()` (same pattern as `strict`), parse it as an integer defaulting to `0`. Store it in the `NeedsExtendType` data dict.

2. **Data schema:** Add `extend_order: int` field to `NeedsExtendType` in `sphinx_needs/data.py`.

3. **Sort key:** Update the sort in `extend_needs_data()` from: ```python sorted(extends.values(), key=lambda x: (x["docname"], x["lineno"])) ``` to: ```python sorted(extends.values(), key=lambda x: (x["extend_order"], x["docname"], x["lineno"])) ```

4. **Global default:** Optionally add a `needs_needextend_order` config option to set a default order for all needextend directives (default `0`).

5. **Documentation:** Document the `:extend_order:` option in `docs/directives/needextend.rst` with examples showing ordering control.

6. **Tests:** Add test cases verifying that priority ordering overrides source-location ordering.