### PR TITLE
📚 DOCS: add sphinx-ai-index to sphinx docs builder

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,6 +36,7 @@ extensions = [
     "sphinx_design",
     "sphinx.ext.duration",
     "sphinx.ext.todo",
+    "sphinx_ai_index",
 ]
 if DOCS_THEME == "sphinx_immaterial":
     extensions.append("sphinx_immaterial")

--- a/docs/ubproject.toml
+++ b/docs/ubproject.toml
@@ -42,6 +42,15 @@ content = false
 parse_content = false
 content_required = false
 
+[parse.extend_directives.page-summary]
+argument = false
+options = false
+content = true
+content_required = true
+parse_content = true
+description = "Provides a summary of the page used for building a retrieval index."
+extension = "sphinx-ai-index"
+
 [needs]
 show_link_type = false
 show_link_title = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ docs = [
   "sphinx-copybutton~=0.5",
   "sphinxcontrib-programoutput~=0.17",
   "sphinx-design~=0.6",
+  "sphinx-ai-index~=0.1.0",
 ]
 theme-im = ["sphinx-immaterial~=0.11.11"]
 theme-furo = ["furo~=2024.8.6"]


### PR DESCRIPTION
This PR adds the [sphinx-ai-index](https://github.com/useblocks/sphinx-ai-index) sphinx extension to the documentation extensions. This will automatically generate a ai_docs_index.json file, which serves as efficient retrieval interface for AI agents or other applications.
It also adds the ability to add an optional page-summary directive to a page, which will be added to this index, but will not be rendered into HTML.