### PR TITLE
🔧 Use `NeedLink` directly in `update_back_links` function

### DIFF
--- a/sphinx_needs/directives/need.py
+++ b/sphinx_needs/directives/need.py
@@ -23,7 +23,7 @@ from sphinx_needs.functions.functions import (
 from sphinx_needs.layout import build_need_repr
 from sphinx_needs.logging import WarningSubTypes, get_logger, log_warning
 from sphinx_needs.need_constraints import process_constraints
-from sphinx_needs.need_item import NeedItem, NeedItemSourceDirective
+from sphinx_needs.need_item import NeedItem, NeedItemSourceDirective, NeedLink
 from sphinx_needs.needs_schema import FieldsSchema
 from sphinx_needs.nodes import Need
 from sphinx_needs.utils import (
@@ -32,7 +32,6 @@ from sphinx_needs.utils import (
     coerce_to_boolean,
     profile,
     remove_node_from_tree,
-    split_need_id,
 )
 
 LOGGER = get_logger(__name__)
@@ -440,22 +439,21 @@ def update_back_links(
         need.reset_backlinks()
 
     for key, need in needs.items():
-        dead_links = []
+        dead_links: list[tuple[str, NeedLink]] = []
 
-        for link_type, references in need.iter_links_items():
-            for need_id_full in references:
-                need_id_main, need_id_part = split_need_id(need_id_full)
-                if linked_need := needs.get(need_id_main):
-                    linked_need.add_backlink(link_type, key)
-                    if need_id_part is not None:
-                        if linked_part := linked_need.get_part(need_id_part):
+        for link_type, references in need.iter_links_items(as_str=False):
+            for need_link in references:
+                if linked_need := needs.get(need_link.id):
+                    linked_need.add_backlink(link_type, NeedLink(id=key))
+                    if need_link.part is not None:
+                        if linked_part := linked_need.get_part(need_link.part):
                             if link_type not in linked_part.backlinks:
                                 linked_part.backlinks[link_type] = []
                             linked_part.backlinks[link_type].append(key)
                         else:
-                            dead_links.append((link_type, need_id_full))
+                            dead_links.append((link_type, need_link))
                 else:
-                    dead_links.append((link_type, need_id_full))
+                    dead_links.append((link_type, need_link))
 
         need["has_dead_links"] = bool(dead_links)
         allow_dead_links = {
@@ -465,8 +463,8 @@ def update_back_links(
             any(not allow_dead_links.get(lt, False) for lt, _ in dead_links)
         )
         if need["has_forbidden_dead_links"] and config.report_dead_links:
-            for link_type, need_id_full in dead_links:
-                message = f"Need '{need.id}' has unknown outgoing link '{need_id_full}' in field '{link_type}'"
+            for link_type, need_link in dead_links:
+                message = f"Need '{need.id}' has unknown outgoing link '{need_link.to_filter_string()}' in field '{link_type}'"
                 # if the need has been imported from an external URL,
                 # we want to provide that URL as the location of the warning,
                 # otherwise we use the location of the need in the source file

--- a/sphinx_needs/need_item.py
+++ b/sphinx_needs/need_item.py
@@ -816,12 +816,27 @@ class NeedItem:
         """Yield all link_type keys."""
         yield from self._links.keys()
 
-    def iter_links_items(self) -> Iterable[tuple[str, list[str]]]:
+    @overload
+    def iter_links_items(
+        self, as_str: Literal[True] = True
+    ) -> Iterable[tuple[str, list[str]]]: ...
+
+    @overload
+    def iter_links_items(
+        self, as_str: Literal[False] = False
+    ) -> Iterable[tuple[str, list[NeedLink]]]: ...
+
+    def iter_links_items(
+        self, as_str: bool = True
+    ) -> Iterable[tuple[str, list[str]]] | Iterable[tuple[str, list[NeedLink]]]:
         """Yield all links as (link_type, references) pairs."""
-        yield from (
-            (key, [li.to_filter_string() for li in value])
-            for key, value in self._links.items()
-        )
+        if as_str:
+            yield from (
+                (key, [li.to_filter_string() for li in value])
+                for key, value in self._links.items()
+            )
+        else:
+            yield from self._links.items()
 
     def get_backlinks(self, link_type: str) -> list[str]:
         """Get backlink references by link_type key.
@@ -830,12 +845,27 @@ class NeedItem:
         """
         return [li.to_filter_string() for li in self._backlinks[link_type]]
 
-    def iter_backlinks_items(self) -> Iterable[tuple[str, list[str]]]:
+    @overload
+    def iter_backlinks_items(
+        self, as_str: Literal[True] = True
+    ) -> Iterable[tuple[str, list[str]]]: ...
+
+    @overload
+    def iter_backlinks_items(
+        self, as_str: Literal[False] = False
+    ) -> Iterable[tuple[str, list[NeedLink]]]: ...
+
+    def iter_backlinks_items(
+        self, as_str: bool = True
+    ) -> Iterable[tuple[str, list[str]]] | Iterable[tuple[str, list[NeedLink]]]:
         """Yield all backlinks as (link_type, references) pairs."""
-        yield from (
-            (key, [li.to_filter_string() for li in value])
-            for key, value in self._backlinks.items()
-        )
+        if as_str:
+            yield from (
+                (key, [li.to_filter_string() for li in value])
+                for key, value in self._backlinks.items()
+            )
+        else:
+            yield from self._backlinks.items()
 
     def set_content(self, content: NeedsContent) -> None:
         """Replace the content of the need item.
@@ -1154,10 +1184,26 @@ class NeedPartItem:
         """Yield all link_type keys."""
         yield from self._need._links.keys()
 
-    def iter_links_items(self) -> Iterable[tuple[str, list[str]]]:
+    @overload
+    def iter_links_items(
+        self, as_str: Literal[True] = True
+    ) -> Iterable[tuple[str, list[str]]]: ...
+
+    @overload
+    def iter_links_items(
+        self, as_str: Literal[False] = False
+    ) -> Iterable[tuple[str, list[NeedLink]]]: ...
+
+    def iter_links_items(
+        self, as_str: bool = True
+    ) -> Iterable[tuple[str, list[str]]] | Iterable[tuple[str, list[NeedLink]]]:
         """Yield all links as (link_type, references) pairs."""
-        for key in self._need._links:
-            yield (key, self[key])
+        if as_str:
+            for key in self._need._links:
+                yield (key, self[key])
+        else:
+            # parts cannot link to anything, so return empty lists
+            yield from ((key, []) for key in self._need._links)
 
     def get_backlinks(self, link_type: str) -> list[str]:
         """Get backlink references by link_type key.
@@ -1168,7 +1214,28 @@ class NeedPartItem:
             raise KeyError(link_type)
         return self[f"{link_type}_back"]  # type: ignore[no-any-return]
 
-    def iter_backlinks_items(self) -> Iterable[tuple[str, list[str]]]:
+    @overload
+    def iter_backlinks_items(
+        self, as_str: Literal[True] = True
+    ) -> Iterable[tuple[str, list[str]]]: ...
+
+    @overload
+    def iter_backlinks_items(
+        self, as_str: Literal[False] = False
+    ) -> Iterable[tuple[str, list[NeedLink]]]: ...
+
+    def iter_backlinks_items(
+        self, as_str: bool = True
+    ) -> Iterable[tuple[str, list[str]]] | Iterable[tuple[str, list[NeedLink]]]:
         """Yield all backlinks as (link_type, references) pairs."""
-        for key in self._need._backlinks:
-            yield (key, self.get_backlinks(key))
+        if as_str:
+            for key in self._need._backlinks:
+                yield (key, self.get_backlinks(key))
+        else:
+            for key in self._need._backlinks:
+                part = self._need.get_part(self.part_id)
+                assert part is not None
+                yield (
+                    key,
+                    [NeedLink.from_string(v) for v in part.backlinks.get(key, [])],
+                )

--- a/sphinx_needs/need_item.py
+++ b/sphinx_needs/need_item.py
@@ -805,12 +805,26 @@ class NeedItem:
         """Yield all extras as key-value pairs."""
         yield from self._extras.items()
 
-    def get_links(self, link_type: str) -> list[str]:
+    @overload
+    def get_links(
+        self, link_type: str, *, as_str: Literal[True] = True
+    ) -> list[str]: ...
+
+    @overload
+    def get_links(
+        self, link_type: str, *, as_str: Literal[False]
+    ) -> list[NeedLink]: ...
+
+    def get_links(
+        self, link_type: str, *, as_str: bool = True
+    ) -> list[str] | list[NeedLink]:
         """Get link references by link_type key.
 
         :raises KeyError: If the link_type is not a link type.
         """
-        return [li.to_filter_string() for li in self._links[link_type]]
+        if as_str:
+            return [li.to_filter_string() for li in self._links[link_type]]
+        return self._links[link_type]
 
     def iter_links_keys(self) -> Iterable[str]:
         """Yield all link_type keys."""
@@ -838,12 +852,26 @@ class NeedItem:
         else:
             yield from self._links.items()
 
-    def get_backlinks(self, link_type: str) -> list[str]:
+    @overload
+    def get_backlinks(
+        self, link_type: str, *, as_str: Literal[True] = True
+    ) -> list[str]: ...
+
+    @overload
+    def get_backlinks(
+        self, link_type: str, *, as_str: Literal[False]
+    ) -> list[NeedLink]: ...
+
+    def get_backlinks(
+        self, link_type: str, *, as_str: bool = True
+    ) -> list[str] | list[NeedLink]:
         """Get backlink references by link_type key.
 
         :raises KeyError: If the link_type is not a backlink type.
         """
-        return [li.to_filter_string() for li in self._backlinks[link_type]]
+        if as_str:
+            return [li.to_filter_string() for li in self._backlinks[link_type]]
+        return self._backlinks[link_type]
 
     @overload
     def iter_backlinks_items(
@@ -1171,14 +1199,27 @@ class NeedPartItem:
         for key in self._need._extras:
             yield (key, self[key])
 
-    def get_links(self, link_type: str) -> list[str]:
+    @overload
+    def get_links(
+        self, link_type: str, *, as_str: Literal[True] = True
+    ) -> list[str]: ...
+
+    @overload
+    def get_links(
+        self, link_type: str, *, as_str: Literal[False]
+    ) -> list[NeedLink]: ...
+
+    def get_links(
+        self, link_type: str, *, as_str: bool = True
+    ) -> list[str] | list[NeedLink]:
         """Get link references by link_type key.
 
         :raises KeyError: If the link_type is not a link type.
         """
         if link_type not in self._need._links:
             raise KeyError(link_type)
-        return self[link_type]  # type: ignore[no-any-return]
+        # parts cannot link to anything, so return empty list
+        return []
 
     def iter_links_keys(self) -> Iterable[str]:
         """Yield all link_type keys."""
@@ -1205,14 +1246,30 @@ class NeedPartItem:
             # parts cannot link to anything, so return empty lists
             yield from ((key, []) for key in self._need._links)
 
-    def get_backlinks(self, link_type: str) -> list[str]:
+    @overload
+    def get_backlinks(
+        self, link_type: str, *, as_str: Literal[True] = True
+    ) -> list[str]: ...
+
+    @overload
+    def get_backlinks(
+        self, link_type: str, *, as_str: Literal[False]
+    ) -> list[NeedLink]: ...
+
+    def get_backlinks(
+        self, link_type: str, *, as_str: bool = True
+    ) -> list[str] | list[NeedLink]:
         """Get backlink references by link_type key.
 
         :raises KeyError: If the link_type is not a backlink type.
         """
         if link_type not in self._need._backlinks:
             raise KeyError(link_type)
-        return self[f"{link_type}_back"]  # type: ignore[no-any-return]
+        if as_str:
+            return self[f"{link_type}_back"]  # type: ignore[no-any-return]
+        part = self._need.get_part(self.part_id)
+        assert part is not None
+        return [NeedLink.from_string(v) for v in part.backlinks.get(link_type, [])]
 
     @overload
     def iter_backlinks_items(

--- a/tests/test_need_item_api.py
+++ b/tests/test_need_item_api.py
@@ -6,6 +6,7 @@ from sphinx_needs.data import NeedsInfoType
 from sphinx_needs.need_item import (
     NeedConstraintResults,
     NeedItem,
+    NeedLink,
     NeedModification,
     NeedPartData,
     NeedsContent,
@@ -179,10 +180,26 @@ def test_need_item_get(snapshot):
         item.get_extra("unknown_extra")
     assert sorted(item.iter_links_keys()) == ["link1", "link2"]
     assert sorted(item.iter_links_items()) == [("link1", ["ref1"]), ("link2", ["ref2"])]
+    assert sorted(item.iter_links_items(as_str=True)) == [
+        ("link1", ["ref1"]),
+        ("link2", ["ref2"]),
+    ]
+    assert sorted(item.iter_links_items(as_str=False)) == [
+        ("link1", [NeedLink(id="ref1")]),
+        ("link2", [NeedLink(id="ref2")]),
+    ]
     assert item.get_links("link1") == ["ref1"]
     with pytest.raises(KeyError, match="'unknown_link'"):
         item.get_links("unknown_link")
     assert sorted(item.iter_backlinks_items()) == [("link1", ["ref3"]), ("link2", [])]
+    assert sorted(item.iter_backlinks_items(as_str=True)) == [
+        ("link1", ["ref3"]),
+        ("link2", []),
+    ]
+    assert sorted(item.iter_backlinks_items(as_str=False)) == [
+        ("link1", [NeedLink(id="ref3")]),
+        ("link2", []),
+    ]
     assert item.get_backlinks("link1") == ["ref3"]
     with pytest.raises(KeyError, match="'unknown_link'"):
         item.get_backlinks("unknown_link")
@@ -377,10 +394,26 @@ def test_need_part_item(snapshot):
         part.get_extra("unknown_extra")
     assert sorted(part.iter_links_keys()) == ["links", "other"]
     assert sorted(part.iter_links_items()) == [("links", []), ("other", [])]
+    assert sorted(part.iter_links_items(as_str=True)) == [
+        ("links", []),
+        ("other", []),
+    ]
+    assert sorted(part.iter_links_items(as_str=False)) == [
+        ("links", []),
+        ("other", []),
+    ]
     assert part.get_links("other") == []
     with pytest.raises(KeyError, match="'unknown_link'"):
         part.get_links("unknown_link")
     assert sorted(part.iter_backlinks_items()) == [("links", ["ref3"]), ("other", [])]
+    assert sorted(part.iter_backlinks_items(as_str=True)) == [
+        ("links", ["ref3"]),
+        ("other", []),
+    ]
+    assert sorted(part.iter_backlinks_items(as_str=False)) == [
+        ("links", [NeedLink(id="ref3")]),
+        ("other", []),
+    ]
     assert part.get_backlinks("links") == ["ref3"]
     with pytest.raises(KeyError, match="'unknown_link'"):
         part.get_backlinks("unknown_link")

--- a/tests/test_need_item_api.py
+++ b/tests/test_need_item_api.py
@@ -189,8 +189,12 @@ def test_need_item_get(snapshot):
         ("link2", [NeedLink(id="ref2")]),
     ]
     assert item.get_links("link1") == ["ref1"]
+    assert item.get_links("link1", as_str=True) == ["ref1"]
+    assert item.get_links("link1", as_str=False) == [NeedLink(id="ref1")]
     with pytest.raises(KeyError, match="'unknown_link'"):
         item.get_links("unknown_link")
+    with pytest.raises(KeyError, match="'unknown_link'"):
+        item.get_links("unknown_link", as_str=False)
     assert sorted(item.iter_backlinks_items()) == [("link1", ["ref3"]), ("link2", [])]
     assert sorted(item.iter_backlinks_items(as_str=True)) == [
         ("link1", ["ref3"]),
@@ -201,8 +205,13 @@ def test_need_item_get(snapshot):
         ("link2", []),
     ]
     assert item.get_backlinks("link1") == ["ref3"]
+    assert item.get_backlinks("link1", as_str=True) == ["ref3"]
+    assert item.get_backlinks("link1", as_str=False) == [NeedLink(id="ref3")]
+    assert item.get_backlinks("link2", as_str=False) == []
     with pytest.raises(KeyError, match="'unknown_link'"):
         item.get_backlinks("unknown_link")
+    with pytest.raises(KeyError, match="'unknown_link'"):
+        item.get_backlinks("unknown_link", as_str=False)
 
 
 def test_need_item_set():
@@ -403,8 +412,12 @@ def test_need_part_item(snapshot):
         ("other", []),
     ]
     assert part.get_links("other") == []
+    assert part.get_links("other", as_str=True) == []
+    assert part.get_links("other", as_str=False) == []
     with pytest.raises(KeyError, match="'unknown_link'"):
         part.get_links("unknown_link")
+    with pytest.raises(KeyError, match="'unknown_link'"):
+        part.get_links("unknown_link", as_str=False)
     assert sorted(part.iter_backlinks_items()) == [("links", ["ref3"]), ("other", [])]
     assert sorted(part.iter_backlinks_items(as_str=True)) == [
         ("links", ["ref3"]),
@@ -415,5 +428,10 @@ def test_need_part_item(snapshot):
         ("other", []),
     ]
     assert part.get_backlinks("links") == ["ref3"]
+    assert part.get_backlinks("links", as_str=True) == ["ref3"]
+    assert part.get_backlinks("links", as_str=False) == [NeedLink(id="ref3")]
+    assert part.get_backlinks("other", as_str=False) == []
     with pytest.raises(KeyError, match="'unknown_link'"):
         part.get_backlinks("unknown_link")
+    with pytest.raises(KeyError, match="'unknown_link'"):
+        part.get_backlinks("unknown_link", as_str=False)


### PR DESCRIPTION
Add `as_str` parameter to link/backlink accessor methods on `NeedItem` and `NeedPartItem`, enabling direct access to `NeedLink` objects without string conversion. 
Use this in `update_back_links` to work with structured `NeedLink` data instead of parsing strings.

## Changes

### need_item.py
- **`NeedItem.get_links` / `get_backlinks`**: Add `as_str: bool = True` keyword arg. When `as_str=False`, returns `list[NeedLink]` instead of `list[str]`.
- **`NeedItem.iter_links_items` / `iter_backlinks_items`**: Add `as_str` parameter with the same semantics.
- **`NeedPartItem`**: Mirror the same `as_str` overloads on `get_links`, `get_backlinks`, `iter_links_items`, and `iter_backlinks_items`.

All methods default to `as_str=True` for full backward compatibility. Type narrowing via `@overload` ensures correct return types at the call site.

### need.py
- **`update_back_links`**: Use `iter_links_items(as_str=False)` to iterate over `NeedLink` objects directly, replacing the previous pattern of iterating string references and calling `split_need_id()`. Removes the `split_need_id` import.

### test_need_item_api.py
- Add test coverage for `as_str=True` and `as_str=False` variants of all four methods on both `NeedItem` and `NeedPartItem`.