### PR TITLE
♻️ Store `NeedLink` instead of `str` in `LinksLiteralValue` and `LinksFunctionArray`

### DIFF
--- a/sphinx_needs/api/need.py
+++ b/sphinx_needs/api/need.py
@@ -36,6 +36,7 @@ from sphinx_needs.need_item import (
     NeedItem,
     NeedItemSourceProtocol,
     NeedItemSourceUnknown,
+    NeedLink,
     NeedPartData,
     NeedsContent,
 )
@@ -320,7 +321,9 @@ def generate_need(
         for k, v in extras_no_defaults.items()
     }
     defaults_links_ctx = {
-        k: copy(v.value) if isinstance(v, LinksLiteralValue) else []
+        k: [nl.to_filter_string() for nl in v.value]
+        if isinstance(v, LinksLiteralValue)
+        else []
         for k, v in links_no_defaults.items()
     }
 
@@ -426,7 +429,7 @@ def generate_need(
         if _func is not None:
             dynamic_fields[k] = _func
 
-    links_pre: dict[str, list[str]] = {}
+    links_pre: dict[str, list[NeedLink]] = {}
     for lk, lv in links.items():
         if lv is None:
             # TODO currently no link_schema.nullable
@@ -999,7 +1002,7 @@ def _copy_links(
     """Implement 'copy' logic for links."""
     if "links" not in links:
         return  # should not happen, but be defensive
-    copy_links: list[str | DynamicFunctionParsed | VariantFunctionParsed] = []
+    copy_links: list[NeedLink | DynamicFunctionParsed | VariantFunctionParsed] = []
     for link_field in schema.iter_link_fields():
         if link_field.copy and link_field.name != "links":
             other = links[link_field.name]
@@ -1016,7 +1019,7 @@ def _copy_links(
                 tuple(links["links"].value) + tuple(copy_links)
             )
     else:
-        copy_links_literal = cast(list[str], copy_links)
+        copy_links_literal = cast(list[NeedLink], copy_links)
         if links["links"] is None:
             links["links"] = LinksLiteralValue(copy_links_literal)
         elif isinstance(links["links"], LinksLiteralValue):

--- a/sphinx_needs/directives/needextend.py
+++ b/sphinx_needs/directives/needextend.py
@@ -11,7 +11,7 @@ from sphinx_needs.data import ExtendType, NeedsExtendType, NeedsMutable, SphinxN
 from sphinx_needs.exceptions import NeedsInvalidFilter
 from sphinx_needs.filter_common import filter_needs_mutable
 from sphinx_needs.logging import WarningSubTypes, get_logger, log_warning
-from sphinx_needs.need_item import NeedModification
+from sphinx_needs.need_item import NeedLink, NeedModification
 from sphinx_needs.needs_schema import (
     FieldFunctionArray,
     FieldLiteralValue,
@@ -268,12 +268,13 @@ def extend_needs_data(
                             )
                             need[option_name] = []
                         else:
+                            existing = [
+                                NeedLink.from_string(s) for s in need[option_name]
+                            ]
                             need[option_name] = [
-                                *need[option_name],
+                                *existing,
                                 *(  # keep unique
-                                    v
-                                    for v in link_value.value
-                                    if v not in need[option_name]
+                                    v for v in link_value.value if v not in existing
                                 ),
                             ]
                     case (ExtendType.APPEND, LinksFunctionArray()):
@@ -286,13 +287,14 @@ def extend_needs_data(
                             )
                             need[option_name] = []
                         else:
+                            existing = [
+                                NeedLink.from_string(s) for s in need[option_name]
+                            ]
                             need._dynamic_fields[option_name] = LinksFunctionArray(
                                 (
-                                    *need[option_name],
+                                    *existing,
                                     *(  # keep unique
-                                        v
-                                        for v in link_value.value
-                                        if v not in need[option_name]
+                                        v for v in link_value.value if v not in existing
                                     ),
                                 )
                             )

--- a/sphinx_needs/needs_schema.py
+++ b/sphinx_needs/needs_schema.py
@@ -10,6 +10,7 @@ import jsonschema_rs
 
 from sphinx_needs.config import NeedFields
 from sphinx_needs.exceptions import VariantParsingException
+from sphinx_needs.need_item import NeedLink
 from sphinx_needs.schema.config import (
     FieldBooleanSchemaType,
     FieldIntegerSchemaType,
@@ -439,7 +440,7 @@ class FieldLiteralValue:
 
 @dataclass(frozen=True, slots=True)
 class LinksLiteralValue:
-    value: list[str]
+    value: list[NeedLink]
 
 
 @dataclass(frozen=True, slots=True)
@@ -474,7 +475,7 @@ class FunctionArrayTyped(Generic[_ValueType]):
 
 @dataclass(frozen=True, slots=True)
 class LinksFunctionArray:
-    value: tuple[str | DynamicFunctionParsed | VariantFunctionParsed, ...]
+    value: tuple[NeedLink | DynamicFunctionParsed | VariantFunctionParsed, ...]
 
 
 @lru_cache(maxsize=128)
@@ -692,7 +693,7 @@ class LinkSchema:
         if self.description:
             schema["description"] = self.description
         if isinstance(self.default, LinksLiteralValue):
-            schema["default"] = self.default.value
+            schema["default"] = [nl.to_filter_string() for nl in self.default.value]
         return schema
 
     def type_check(self, value: Any) -> bool:
@@ -722,7 +723,7 @@ class LinkSchema:
             raise TypeError(f"Value '{value}' is not a string.")
 
         has_df_or_vf = False
-        array: list[str | DynamicFunctionParsed | VariantFunctionParsed] = []
+        array: list[NeedLink | DynamicFunctionParsed | VariantFunctionParsed] = []
         for parsed in _split_list(
             value, self.parse_dynamic_functions, self.parse_variants
         ):
@@ -733,7 +734,7 @@ class LinkSchema:
             item, item_type = parsed[0]
             match item_type:
                 case ListItemType.STD:
-                    array.append(item)
+                    array.append(NeedLink.from_string(item))
                 case ListItemType.DF | ListItemType.DF_U:
                     from sphinx_needs.functions.functions import DynamicFunctionParsed
 
@@ -774,7 +775,7 @@ class LinkSchema:
                 from sphinx_needs.functions.functions import DynamicFunctionParsed
 
                 new_value: list[
-                    str | DynamicFunctionParsed | VariantFunctionParsed
+                    NeedLink | DynamicFunctionParsed | VariantFunctionParsed
                 ] = []
                 has_function = False
                 item: str
@@ -798,13 +799,13 @@ class LinkSchema:
                             VariantFunctionParsed.from_string(item.strip()[2:-2])
                         )
                     else:
-                        new_value.append(item)
+                        new_value.append(NeedLink.from_string(item))
                 if has_function:
                     return LinksFunctionArray(tuple(new_value))
                 else:
-                    return LinksLiteralValue(value)
+                    return LinksLiteralValue([NeedLink.from_string(v) for v in value])
             else:
-                return LinksLiteralValue(value)
+                return LinksLiteralValue([NeedLink.from_string(v) for v in value])
 
 
 class FieldsSchema:

--- a/tests/__snapshots__/test_field_defaults.ambr
+++ b/tests/__snapshots__/test_field_defaults.ambr
@@ -813,20 +813,20 @@
       ),
     }),
     'link1': dict({
-      'default': LinksLiteralValue(value=['SPEC_1']),
+      'default': LinksLiteralValue(value=[NeedLink(id='SPEC_1', part=None)]),
       'predicate_defaults': tuple(
       ),
     }),
     'link2': dict({
-      'default': LinksLiteralValue(value=['SPEC_1']),
+      'default': LinksLiteralValue(value=[NeedLink(id='SPEC_1', part=None)]),
       'predicate_defaults': tuple(
         tuple(
           'status == "implemented"',
-          LinksFunctionArray(value=('SPEC_2', DynamicFunctionParsed(name='copy', args=('link1',), kwargs=()))),
+          LinksFunctionArray(value=(NeedLink(id='SPEC_2', part=None), DynamicFunctionParsed(name='copy', args=('link1',), kwargs=()))),
         ),
         tuple(
           'status == "closed"',
-          LinksLiteralValue(value=['SPEC_3']),
+          LinksLiteralValue(value=[NeedLink(id='SPEC_3', part=None)]),
         ),
       ),
     }),


### PR DESCRIPTION
## Summary

Change `LinksLiteralValue` and `LinksFunctionArray` to store `NeedLink` objects instead of raw strings. This aligns the schema layer with `NeedItem._links` (which already stores `dict[str, list[NeedLink]]`), parsing link strings into structured `NeedLink` objects at the schema conversion boundary rather than deferring conversion to `NeedItem.__init__`.

## Motivation

- **Type consistency**: `NeedItem._links` already stores `list[NeedLink]`, but `LinksLiteralValue` stored `list[str]` and `LinksFunctionArray` was constructed with raw `str` items despite its type annotation declaring `NeedLink`. This mismatch meant link strings were parsed to `NeedLink` redundantly in `NeedItem.__init__`.
- **Single parsing boundary**: Link strings are now parsed to `NeedLink` once in `convert_directive_option` / `convert_or_type_check`, rather than being deferred.
- **Cleaner mixing**: When `LinksLiteralValue` items flow into `LinksFunctionArray` (e.g. in `_copy_links`, needextend APPEND), both now use `NeedLink`, eliminating conversion at every mixing point.
- **Future extensibility**: Storing structured `NeedLink` objects (rather than plain strings) opens the door to attaching richer data to links in the future — such as validation constraints and edge properties (e.g. weight, labels, or metadata for graph-based tooling). A structured object is the natural place to carry this information through the pipeline.

## Changes

### `sphinx_needs/needs_schema.py`

- `LinksLiteralValue.value`: `list[str]` → `list[NeedLink]`
- `LinkSchema.convert_directive_option()`: STD items now wrapped via `NeedLink.from_string(item)`; array type annotation updated to `list[NeedLink | DynamicFunctionParsed | VariantFunctionParsed]`
- `LinkSchema.convert_or_type_check()`: Same `NeedLink.from_string()` conversion for both the coercion path and the plain list path
- `LinkSchema.json_schema()`: Converts back to strings via `to_filter_string()` for JSON output

### `sphinx_needs/api/need.py`

- `defaults_links_ctx`: Converts `NeedLink` items back to strings via `to_filter_string()` for predicate filter context (preserves backward-compatible `dict[str, list[str]]`)
- `links_pre`: Type changed to `dict[str, list[NeedLink]]`; `lv.value` passed directly since `NeedItem.__init__` accepts `list[NeedLink]`
- `_copy_links()`: Updated type annotations; `NeedLink` items flow naturally between `LinksLiteralValue` and `LinksFunctionArray`

### `sphinx_needs/directives/needextend.py`

- APPEND + `LinksLiteralValue` without existing DF: `link_value.value` items (now `NeedLink`) passed to `__setitem__` which accepts `list[str | NeedLink]`
- APPEND + `LinksFunctionArray` without existing DF: `need[option_name]` (returns `list[str]`) converted to `NeedLink` via `from_string()` when building `LinksFunctionArray` tuples
- REPLACE/DELETE + `LinksLiteralValue`: `list[NeedLink]` accepted by `__setitem__`

### Snapshots

- `LinksLiteralValue(value=['SPEC_1'])` → `LinksLiteralValue(value=[NeedLink(id='SPEC_1', part=None)])`
- `LinksFunctionArray(value=('SPEC_2', ...))` → `LinksFunctionArray(value=(NeedLink(id='SPEC_2', part=None), ...))`

## Backward compatibility

- **Public API unchanged**: `NeedItem.__getitem__` still returns `list[str]` for link fields (via `to_filter_string()`). User-facing filter predicates continue to work with string comparisons.
- **`NeedItem.__setitem__`** already accepts both `str` and `NeedLink` items.
- **`resolve_functions`**: Resolved `NeedLink` items from `LinksFunctionArray` are passed to `need[field] = resolved`, which handles `NeedLink` natively.