### PR TITLE
🔧 Use `get_links(as_str=False)` in needextend to avoid round-trip serialization

### DIFF
--- a/sphinx_needs/directives/needextend.py
+++ b/sphinx_needs/directives/needextend.py
@@ -11,7 +11,7 @@ from sphinx_needs.data import ExtendType, NeedsExtendType, NeedsMutable, SphinxN
 from sphinx_needs.exceptions import NeedsInvalidFilter
 from sphinx_needs.filter_common import filter_needs_mutable
 from sphinx_needs.logging import WarningSubTypes, get_logger, log_warning
-from sphinx_needs.need_item import NeedLink, NeedModification
+from sphinx_needs.need_item import NeedModification
 from sphinx_needs.needs_schema import (
     FieldFunctionArray,
     FieldLiteralValue,
@@ -268,9 +268,7 @@ def extend_needs_data(
                             )
                             need[option_name] = []
                         else:
-                            existing = [
-                                NeedLink.from_string(s) for s in need[option_name]
-                            ]
+                            existing = need.get_links(option_name, as_str=False)
                             need[option_name] = [
                                 *existing,
                                 *(  # keep unique
@@ -287,9 +285,7 @@ def extend_needs_data(
                             )
                             need[option_name] = []
                         else:
-                            existing = [
-                                NeedLink.from_string(s) for s in need[option_name]
-                            ]
+                            existing = need.get_links(option_name, as_str=False)
                             need._dynamic_fields[option_name] = LinksFunctionArray(
                                 (
                                     *existing,


### PR DESCRIPTION
In `extend_needs_data`, when appending to link fields, existing links were fetched via `need[option_name]` (which serializes `NeedLink` → `str`) then immediately parsed back with `NeedLink.from_string()`. This round-trip is wasteful and lossy — `to_filter_string()` discards the `condition` field, so `from_string()` can't restore it.

Replaced both occurrences with `need.get_links(option_name, as_str=False)`, which returns the internal `NeedLink` objects directly. Removed the now-unused `NeedLink` import.
