### PR TITLE
♻️ Fix `links_from_content` to use parsed doctree nodes instead of regex

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,7 +65,7 @@ jobs:
         run: sudo apt-get install graphviz
       - name: Install graphviz (windows)
         if: matrix.os == 'windows-latest'
-        run: choco install --no-progress graphviz
+        run: choco install -y --no-progress graphviz
       - name: Set Up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:

--- a/sphinx_needs/functions/common.py
+++ b/sphinx_needs/functions/common.py
@@ -7,8 +7,10 @@ Collection of common sphinx-needs functions for dynamic values
 from __future__ import annotations
 
 import contextlib
+from collections.abc import Iterator
 from typing import Any
 
+from docutils import nodes
 from sphinx.application import Sphinx
 
 from sphinx_needs.config import NeedsSphinxConfig
@@ -19,7 +21,9 @@ from sphinx_needs.filter_common import (
     filter_single_need,
 )
 from sphinx_needs.logging import log_warning
-from sphinx_needs.need_item import NeedItem, NeedPartItem
+from sphinx_needs.need_item import NeedItem, NeedLink, NeedPartItem
+from sphinx_needs.nodes import Need
+from sphinx_needs.roles.need_ref import NeedRef
 from sphinx_needs.utils import logger
 from sphinx_needs.views import NeedsView
 
@@ -402,13 +406,22 @@ def calc_sum(
     return calculated_sum
 
 
+def _find_need_refs(node: nodes.Node) -> Iterator[NeedRef]:
+    """Yield ``NeedRef`` nodes, without descending into nested ``Need`` nodes."""
+    for child in node.children:
+        if isinstance(child, NeedRef):
+            yield child
+        elif not isinstance(child, Need):
+            yield from _find_need_refs(child)
+
+
 def links_from_content(
     app: Sphinx,
     need: NeedItem | NeedPartItem | None,
     needs: NeedsMutable | NeedsView,
     need_id: str | None = None,
     filter: str | None = None,
-) -> list[str]:
+) -> list[NeedLink]:
     """
     Extracts need references from the content of a need.
 
@@ -467,8 +480,6 @@ def links_from_content(
     :param filter: :ref:`filter_string`, which a found need-link must pass.
     :return: List of linked need-ids in content
     """
-    from sphinx_needs.roles.need_ref import NeedRef
-
     if need_id:
         source_need_id = need_id
     elif need is None:
@@ -506,18 +517,21 @@ def links_from_content(
         )
         return []
 
-    raw_links: list[str] = []
-    for ref_node in need_node.findall(NeedRef):
-        ref_id = ref_node["need_link"].id
-        if ref_id not in raw_links:
-            raw_links.append(ref_id)
+    raw_links: list[NeedLink] = []
+    for ref_node in _find_need_refs(need_node):
+        need_link: NeedLink = ref_node["need_link"]
+        if need_link not in raw_links:
+            raw_links.append(need_link)
 
     if filter:
         needs_config = NeedsSphinxConfig(app.config)
-        filtered_links = []
+        filtered_links: list[NeedLink] = []
         for link in raw_links:
-            if link not in filtered_links and filter_single_need(
-                needs[link], needs_config, filter
+            target = needs.get(link.id)
+            if (
+                target is not None
+                and link not in filtered_links
+                and filter_single_need(target, needs_config, filter)
             ):
                 filtered_links.append(link)
         return filtered_links

--- a/sphinx_needs/functions/common.py
+++ b/sphinx_needs/functions/common.py
@@ -7,13 +7,12 @@ Collection of common sphinx-needs functions for dynamic values
 from __future__ import annotations
 
 import contextlib
-import re
 from typing import Any
 
 from sphinx.application import Sphinx
 
 from sphinx_needs.config import NeedsSphinxConfig
-from sphinx_needs.data import NeedsMutable
+from sphinx_needs.data import NeedsMutable, SphinxNeedsData
 from sphinx_needs.exceptions import NeedsInvalidFilter
 from sphinx_needs.filter_common import (
     filter_needs_and_parts,
@@ -411,11 +410,18 @@ def links_from_content(
     filter: str | None = None,
 ) -> list[str]:
     """
-    Extracts links from content of a need.
+    Extracts need references from the content of a need.
 
-    All need-links set by using ``:need:`NEED_ID``` get extracted.
+    All need-links set by using ``:need:`NEED_ID``` are extracted
+    from the parsed doctree node of the source need.
 
     Same links are only added once.
+
+    .. note::
+
+       This function requires the source need to have a stored doctree node.
+       It will emit a warning and return an empty list for needs without a
+       stored node (e.g. external needs or need parts).
 
     Example:
 
@@ -461,18 +467,50 @@ def links_from_content(
     :param filter: :ref:`filter_string`, which a found need-link must pass.
     :return: List of linked need-ids in content
     """
-    source_need = needs[need_id] if need_id else need
+    from sphinx_needs.roles.need_ref import NeedRef
 
-    if source_need is None:
+    if need_id:
+        source_need_id = need_id
+    elif need is None:
         raise ValueError("No need found for links_from_content")
+    elif isinstance(need, NeedPartItem):
+        location = (need["docname"], need["lineno"]) if need["docname"] else None
+        log_warning(
+            logger,
+            "links_from_content does not support need parts",
+            "dynamic_function",
+            location=location,
+        )
+        return []
+    else:
+        source_need_id = need["id"]
 
-    links = re.findall(r":need:`(\w+)`|:need:`.+\<(.+)\>`", source_need["content"])
-    raw_links = []
-    for link in links:
-        if link[0] and link[0] not in raw_links:
-            raw_links.append(link[0])
-        elif link[1] and link[0] not in raw_links:
-            raw_links.append(link[1])
+    need_node = SphinxNeedsData(app.env).get_need_node(source_need_id)
+    if need_node is None:
+        # This can happen for external needs or hidden needs,
+        # which do not have a stored doctree node.
+        source_need = needs.get(source_need_id)
+        if source_need is not None:
+            location = (
+                (source_need["docname"], source_need["lineno"])
+                if source_need["docname"]
+                else None
+            )
+        else:
+            location = None
+        log_warning(
+            logger,
+            f"links_from_content: no stored node for need {source_need_id!r}",
+            "dynamic_function",
+            location=location,
+        )
+        return []
+
+    raw_links: list[str] = []
+    for ref_node in need_node.findall(NeedRef):
+        ref_id = ref_node["need_link"].id
+        if ref_id not in raw_links:
+            raw_links.append(ref_id)
 
     if filter:
         needs_config = NeedsSphinxConfig(app.config)

--- a/sphinx_needs/functions/functions.py
+++ b/sphinx_needs/functions/functions.py
@@ -23,7 +23,7 @@ from sphinx_needs.data import NeedsMutable, SphinxNeedsData
 from sphinx_needs.debug import measure_time_func
 from sphinx_needs.exceptions import FunctionParsingException
 from sphinx_needs.logging import get_logger, log_warning
-from sphinx_needs.need_item import NeedItem, NeedPartItem
+from sphinx_needs.need_item import NeedItem, NeedLink, NeedPartItem
 from sphinx_needs.nodes import Need
 from sphinx_needs.roles.need_func import NeedFunc
 from sphinx_needs.variants import VariantFunctionParsed
@@ -45,7 +45,9 @@ class DynamicFunction(Protocol):
         needs: NeedsView | NeedsMutable,
         *args: Any,
         **kwargs: Any,
-    ) -> str | int | float | list[str] | list[int] | list[float] | None: ...
+    ) -> (
+        str | int | float | list[str] | list[int] | list[float] | list[NeedLink] | None
+    ): ...
 
 
 def _execute_dynamic_func(
@@ -53,7 +55,7 @@ def _execute_dynamic_func(
     need: NeedItem | NeedPartItem | None,
     needs: NeedsView | NeedsMutable,
     df: DynamicFunctionParsed,
-) -> str | int | float | list[str] | list[int] | list[float] | None:
+) -> str | int | float | list[str] | list[int] | list[float] | list[NeedLink] | None:
     """Executes a given function string.
 
     :param env: Sphinx environment
@@ -101,7 +103,7 @@ def execute_func(
     needs: NeedsView | NeedsMutable,
     df: str | DynamicFunctionParsed,
     location: str | tuple[str | None, int | None] | nodes.Node | None,
-) -> str | int | float | list[str] | list[int] | list[float] | None:
+) -> str | int | float | list[str] | list[int] | list[float] | list[NeedLink] | None:
     """Executes a given function string.
 
     :param env: Sphinx environment
@@ -180,10 +182,10 @@ def execute_func(
         return "??"
     if isinstance(func_return, list):
         for i, element in enumerate(func_return):
-            if not isinstance(element, str | int | float):
+            if not isinstance(element, str | int | float | NeedLink):
                 log_warning(
                     logger,
-                    f"Return value item {i} of function {df.name!r} is of type {type(element)}. Allowed are str, int, float",
+                    f"Return value item {i} of function {df.name!r} is of type {type(element)}. Allowed are str, int, float, NeedLink",
                     "dynamic_function",
                     location=location,
                 )
@@ -412,7 +414,10 @@ def check_and_get_content(
 
 def _detect_and_execute_field(
     content: Any, need: NeedItem, needs: NeedsMutable, app: Sphinx
-) -> tuple[str | None, str | int | float | list[str] | list[int] | list[float] | None]:
+) -> tuple[
+    str | None,
+    str | int | float | list[str] | list[int] | list[float] | list[NeedLink] | None,
+]:
     """Detects if given need field value is a function call and executes it."""
     content = str(content)
 

--- a/sphinx_needs/needs_schema.py
+++ b/sphinx_needs/needs_schema.py
@@ -701,7 +701,9 @@ class LinkSchema:
 
     def type_check(self, value: Any) -> bool:
         """Check if a value is of the correct type for this field."""
-        return isinstance(value, list) and all(isinstance(i, str) for i in value)
+        return isinstance(value, list) and all(
+            isinstance(i, str | NeedLink) for i in value
+        )
 
     def type_check_item(self, value: Any) -> bool:
         """Check if a value is of the correct item type for this field.
@@ -709,7 +711,7 @@ class LinkSchema:
         For 'array' fields, this checks the type of the array items.
         For other fields, this checks the type of the field itself.
         """
-        return isinstance(value, str)
+        return isinstance(value, str | NeedLink)
 
     def convert_directive_option(
         self, value: str

--- a/tests/__snapshots__/test_dynamic_functions.ambr
+++ b/tests/__snapshots__/test_dynamic_functions.ambr
@@ -1,4 +1,625 @@
 # serializer version: 1
+# name: test_doc_df_links_from_content[test_app0]
+  dict({
+    'current_version': '',
+    'versions': dict({
+      '': dict({
+        'needs': dict({
+          'CON-REQ-3': dict({
+            'docname': 'index',
+            'external_css': 'external_link',
+            'id': 'CON-REQ-3',
+            'lineno': 10,
+            'links_back': list([
+              'CON_SPEC_1',
+              'CON_SPEC_2',
+            ]),
+            'section_name': 'LINKS FROM CONTENT',
+            'sections': list([
+              'LINKS FROM CONTENT',
+            ]),
+            'title': 'Requirement with hyphens',
+            'type': 'req',
+            'type_name': 'Requirement',
+          }),
+          'CON_REQ_1': dict({
+            'docname': 'index',
+            'external_css': 'external_link',
+            'id': 'CON_REQ_1',
+            'lineno': 4,
+            'links_back': list([
+              'CON_SPEC_1',
+              'CON_SPEC_2',
+              'CON_SPEC_3',
+            ]),
+            'section_name': 'LINKS FROM CONTENT',
+            'sections': list([
+              'LINKS FROM CONTENT',
+            ]),
+            'title': 'Requirement 1',
+            'type': 'req',
+            'type_name': 'Requirement',
+          }),
+          'CON_REQ_2': dict({
+            'docname': 'index',
+            'external_css': 'external_link',
+            'id': 'CON_REQ_2',
+            'lineno': 7,
+            'links_back': list([
+              'CON_SPEC_1',
+              'CON_SPEC_2',
+            ]),
+            'section_name': 'LINKS FROM CONTENT',
+            'sections': list([
+              'LINKS FROM CONTENT',
+            ]),
+            'title': 'Requirement 2',
+            'type': 'req',
+            'type_name': 'Requirement',
+          }),
+          'CON_SPEC_1': dict({
+            'content': '''
+              This specification cares about the realisation of:
+              
+              * :need:`CON_REQ_1`
+              * :need:`My need <CON_REQ_2>`
+              * :need:`CON-REQ-3`
+            ''',
+            'docname': 'index',
+            'external_css': 'external_link',
+            'id': 'CON_SPEC_1',
+            'lineno': 13,
+            'links': list([
+              'CON_REQ_1',
+              'CON_REQ_2',
+              'CON-REQ-3',
+            ]),
+            'section_name': 'LINKS FROM CONTENT',
+            'sections': list([
+              'LINKS FROM CONTENT',
+            ]),
+            'title': 'Spec that extracts links from own content',
+            'type': 'spec',
+            'type_name': 'Specification',
+          }),
+          'CON_SPEC_2': dict({
+            'content': 'Links retrieved from content of :need:`CON_SPEC_1`.',
+            'docname': 'index',
+            'external_css': 'external_link',
+            'id': 'CON_SPEC_2',
+            'lineno': 23,
+            'links': list([
+              'CON_REQ_1',
+              'CON_REQ_2',
+              'CON-REQ-3',
+            ]),
+            'section_name': 'LINKS FROM CONTENT',
+            'sections': list([
+              'LINKS FROM CONTENT',
+            ]),
+            'title': 'Spec that extracts links from another need',
+            'type': 'spec',
+            'type_name': 'Specification',
+          }),
+          'CON_SPEC_3': dict({
+            'content': '''
+              This also references:
+              
+              * :need:`CON_REQ_1`
+              * :need:`CON_SPEC_1`
+              
+              But only requirements should pass the filter.
+            ''',
+            'docname': 'index',
+            'external_css': 'external_link',
+            'id': 'CON_SPEC_3',
+            'lineno': 29,
+            'links': list([
+              'CON_REQ_1',
+            ]),
+            'section_name': 'LINKS FROM CONTENT',
+            'sections': list([
+              'LINKS FROM CONTENT',
+            ]),
+            'title': 'Spec with filter',
+            'type': 'spec',
+            'type_name': 'Specification',
+          }),
+        }),
+        'needs_amount': 6,
+        'needs_defaults_removed': True,
+        'needs_schema': dict({
+          '$schema': 'http://json-schema.org/draft-07/schema#',
+          'properties': dict({
+            'arch': dict({
+              'additionalProperties': dict({
+                'type': 'string',
+              }),
+              'default': dict({
+              }),
+              'description': 'Mapping of uml key to uml content.',
+              'field_type': 'core',
+              'type': 'object',
+            }),
+            'avatar': dict({
+              'default': None,
+              'description': 'Added by service github-issues',
+              'field_type': 'extra',
+              'type': list([
+                'string',
+                'null',
+              ]),
+            }),
+            'closed_at': dict({
+              'default': None,
+              'description': 'Added by service github-issues',
+              'field_type': 'extra',
+              'type': list([
+                'string',
+                'null',
+              ]),
+            }),
+            'completion': dict({
+              'default': None,
+              'description': 'Added for needgantt functionality',
+              'field_type': 'extra',
+              'type': list([
+                'integer',
+                'null',
+              ]),
+            }),
+            'constraints': dict({
+              'default': list([
+              ]),
+              'description': 'List of constraint names, which are defined for this need.',
+              'field_type': 'core',
+              'items': dict({
+                'type': 'string',
+              }),
+              'type': 'array',
+            }),
+            'constraints_error': dict({
+              'default': None,
+              'description': 'An error message set if any constraint failed, and `error_message` field is set in config.',
+              'field_type': 'core',
+              'type': list([
+                'string',
+                'null',
+              ]),
+            }),
+            'constraints_passed': dict({
+              'default': True,
+              'description': 'True if all constraints passed, False if any failed, None if not yet checked.',
+              'field_type': 'core',
+              'type': list([
+                'boolean',
+                'null',
+              ]),
+            }),
+            'constraints_results': dict({
+              'additionalProperties': dict({
+                'type': 'object',
+              }),
+              'default': dict({
+              }),
+              'description': 'Mapping of constraint name, to check name, to result, None if not yet checked.',
+              'field_type': 'core',
+              'type': list([
+                'object',
+                'null',
+              ]),
+            }),
+            'content': dict({
+              'default': '',
+              'description': 'The main content of the need.',
+              'field_type': 'core',
+              'type': 'string',
+            }),
+            'created_at': dict({
+              'default': None,
+              'description': 'Added by service github-issues',
+              'field_type': 'extra',
+              'type': list([
+                'string',
+                'null',
+              ]),
+            }),
+            'docname': dict({
+              'default': None,
+              'description': 'Name of the document where the need is defined (None if external).',
+              'field_type': 'core',
+              'type': list([
+                'string',
+                'null',
+              ]),
+            }),
+            'doctype': dict({
+              'default': '.rst',
+              'description': "The markup type of the content, denoted by the suffix of the source file, e.g. '.rst'.",
+              'field_type': 'core',
+              'type': 'string',
+            }),
+            'duration': dict({
+              'default': None,
+              'description': 'Added for needgantt functionality',
+              'field_type': 'extra',
+              'type': list([
+                'integer',
+                'null',
+              ]),
+            }),
+            'external_css': dict({
+              'default': '',
+              'description': 'CSS class name, added to the external reference.',
+              'field_type': 'core',
+              'type': 'string',
+            }),
+            'external_url': dict({
+              'default': None,
+              'description': 'URL of the need, if it is an external need.',
+              'field_type': 'core',
+              'type': list([
+                'string',
+                'null',
+              ]),
+            }),
+            'has_dead_links': dict({
+              'default': False,
+              'description': 'True if any links reference need ids that are not found in the need list.',
+              'field_type': 'core',
+              'type': 'boolean',
+            }),
+            'has_forbidden_dead_links': dict({
+              'default': False,
+              'description': 'True if any links reference need ids that are not found in the need list, and the link type does not allow dead links.',
+              'field_type': 'core',
+              'type': 'boolean',
+            }),
+            'id': dict({
+              'description': 'ID of the data.',
+              'field_type': 'core',
+              'type': 'string',
+            }),
+            'id_prefix': dict({
+              'default': None,
+              'description': 'Added by service github-issues',
+              'field_type': 'extra',
+              'type': list([
+                'string',
+                'null',
+              ]),
+            }),
+            'is_external': dict({
+              'default': False,
+              'description': 'If true, no node is created and need is referencing external url.',
+              'field_type': 'core',
+              'type': 'boolean',
+            }),
+            'is_import': dict({
+              'default': False,
+              'description': 'If true, the need was derived from an import.',
+              'field_type': 'core',
+              'type': 'boolean',
+            }),
+            'is_modified': dict({
+              'default': False,
+              'description': 'Whether the need was modified by needextend.',
+              'field_type': 'core',
+              'type': 'boolean',
+            }),
+            'jinja_content': dict({
+              'default': False,
+              'description': 'Whether the content was pre-processed by jinja.',
+              'field_type': 'core',
+              'type': 'boolean',
+            }),
+            'layout': dict({
+              'default': None,
+              'description': 'Key of the layout, which is used to render the need.',
+              'field_type': 'core',
+              'type': list([
+                'string',
+                'null',
+              ]),
+            }),
+            'lineno': dict({
+              'default': None,
+              'description': 'Line number where the need is defined (None if external).',
+              'field_type': 'core',
+              'type': list([
+                'integer',
+                'null',
+              ]),
+            }),
+            'links': dict({
+              'default': list([
+              ]),
+              'description': 'Link field',
+              'field_type': 'links',
+              'items': dict({
+                'type': 'string',
+              }),
+              'type': 'array',
+            }),
+            'links_back': dict({
+              'default': list([
+              ]),
+              'description': 'Backlink field',
+              'field_type': 'backlinks',
+              'items': dict({
+                'type': 'string',
+              }),
+              'type': 'array',
+            }),
+            'max_amount': dict({
+              'default': None,
+              'description': 'Added by service github-issues',
+              'field_type': 'extra',
+              'type': list([
+                'string',
+                'null',
+              ]),
+            }),
+            'max_content_lines': dict({
+              'default': None,
+              'description': 'Added by service github-issues',
+              'field_type': 'extra',
+              'type': list([
+                'string',
+                'null',
+              ]),
+            }),
+            'modifications': dict({
+              'default': 0,
+              'description': 'Number of modifications by needextend.',
+              'field_type': 'core',
+              'type': 'integer',
+            }),
+            'params': dict({
+              'default': None,
+              'description': 'Added by service open-needs',
+              'field_type': 'extra',
+              'type': list([
+                'string',
+                'null',
+              ]),
+            }),
+            'parent_need': dict({
+              'default': None,
+              'description': 'Simply the first parent id.',
+              'field_type': 'core',
+              'type': list([
+                'string',
+                'null',
+              ]),
+            }),
+            'parent_needs': dict({
+              'default': list([
+              ]),
+              'description': 'Link field',
+              'field_type': 'links',
+              'items': dict({
+                'type': 'string',
+              }),
+              'type': 'array',
+            }),
+            'parent_needs_back': dict({
+              'default': list([
+              ]),
+              'description': 'Backlink field',
+              'field_type': 'backlinks',
+              'items': dict({
+                'type': 'string',
+              }),
+              'type': 'array',
+            }),
+            'parts': dict({
+              'additionalProperties': dict({
+                'type': 'object',
+              }),
+              'default': dict({
+              }),
+              'description': "Mapping of parts, a.k.a. sub-needs, IDs to data that overrides the need's data",
+              'field_type': 'core',
+              'type': 'object',
+            }),
+            'post_content': dict({
+              'default': None,
+              'description': 'Additional content after the need.',
+              'field_type': 'core',
+              'type': list([
+                'string',
+                'null',
+              ]),
+            }),
+            'post_template': dict({
+              'default': None,
+              'description': 'The template key, if the post_content was created from a jinja template.',
+              'field_type': 'core',
+              'type': list([
+                'string',
+                'null',
+              ]),
+            }),
+            'pre_content': dict({
+              'default': None,
+              'description': 'Additional content before the need.',
+              'field_type': 'core',
+              'type': list([
+                'string',
+                'null',
+              ]),
+            }),
+            'pre_template': dict({
+              'default': None,
+              'description': 'The template key, if the pre_content was created from a jinja template.',
+              'field_type': 'core',
+              'type': list([
+                'string',
+                'null',
+              ]),
+            }),
+            'prefix': dict({
+              'default': None,
+              'description': 'Added by service open-needs',
+              'field_type': 'extra',
+              'type': list([
+                'string',
+                'null',
+              ]),
+            }),
+            'query': dict({
+              'default': None,
+              'description': 'Added by service github-issues',
+              'field_type': 'extra',
+              'type': list([
+                'string',
+                'null',
+              ]),
+            }),
+            'section_name': dict({
+              'default': None,
+              'description': 'Simply the first section.',
+              'field_type': 'core',
+              'type': list([
+                'string',
+                'null',
+              ]),
+            }),
+            'sections': dict({
+              'default': list([
+              ]),
+              'description': 'Sections of the need.',
+              'field_type': 'core',
+              'items': dict({
+                'type': 'string',
+              }),
+              'type': 'array',
+            }),
+            'service': dict({
+              'default': None,
+              'description': 'Added by service github-issues',
+              'field_type': 'extra',
+              'type': list([
+                'string',
+                'null',
+              ]),
+            }),
+            'signature': dict({
+              'default': None,
+              'description': 'Derived from a docutils desc_name node.',
+              'field_type': 'core',
+              'type': list([
+                'string',
+                'null',
+              ]),
+            }),
+            'specific': dict({
+              'default': None,
+              'description': 'Added by service github-issues',
+              'field_type': 'extra',
+              'type': list([
+                'string',
+                'null',
+              ]),
+            }),
+            'status': dict({
+              'default': None,
+              'description': 'Status of the need.',
+              'field_type': 'core',
+              'type': list([
+                'string',
+                'null',
+              ]),
+            }),
+            'style': dict({
+              'default': None,
+              'description': 'Comma-separated list of CSS classes (all appended by `needs_style_`).',
+              'field_type': 'core',
+              'type': list([
+                'string',
+                'null',
+              ]),
+            }),
+            'tags': dict({
+              'default': list([
+              ]),
+              'description': 'List of tags.',
+              'field_type': 'core',
+              'items': dict({
+                'type': 'string',
+              }),
+              'type': 'array',
+            }),
+            'template': dict({
+              'default': None,
+              'description': 'The template key, if the content was created from a jinja template.',
+              'field_type': 'core',
+              'type': list([
+                'string',
+                'null',
+              ]),
+            }),
+            'title': dict({
+              'description': 'Title of the need.',
+              'field_type': 'core',
+              'type': 'string',
+            }),
+            'type': dict({
+              'default': '',
+              'description': 'Type of the need.',
+              'field_type': 'core',
+              'type': 'string',
+            }),
+            'type_name': dict({
+              'default': '',
+              'description': 'Name of the type.',
+              'field_type': 'core',
+              'type': 'string',
+            }),
+            'updated_at': dict({
+              'default': None,
+              'description': 'Added by service github-issues',
+              'field_type': 'extra',
+              'type': list([
+                'string',
+                'null',
+              ]),
+            }),
+            'url': dict({
+              'default': None,
+              'description': 'Added by service github-issues',
+              'field_type': 'extra',
+              'type': list([
+                'string',
+                'null',
+              ]),
+            }),
+            'url_postfix': dict({
+              'default': None,
+              'description': 'Added by service open-needs',
+              'field_type': 'extra',
+              'type': list([
+                'string',
+                'null',
+              ]),
+            }),
+            'user': dict({
+              'default': None,
+              'description': 'Added by service github-issues',
+              'field_type': 'extra',
+              'type': list([
+                'string',
+                'null',
+              ]),
+            }),
+          }),
+          'type': 'object',
+        }),
+      }),
+    }),
+  })
+# ---
 # name: test_doc_dynamic_functions[test_app0]
   dict({
     'current_version': '',

--- a/tests/__snapshots__/test_dynamic_functions.ambr
+++ b/tests/__snapshots__/test_dynamic_functions.ambr
@@ -31,6 +31,7 @@
               'CON_SPEC_1',
               'CON_SPEC_2',
               'CON_SPEC_3',
+              'CON_SPEC_4',
             ]),
             'section_name': 'LINKS FROM CONTENT',
             'sections': list([
@@ -54,6 +55,24 @@
               'LINKS FROM CONTENT',
             ]),
             'title': 'Requirement 2',
+            'type': 'req',
+            'type_name': 'Requirement',
+          }),
+          'CON_REQ_4': dict({
+            'content': 'This nested need references :need:`CON_REQ_2` which should NOT be collected.',
+            'docname': 'index',
+            'external_css': 'external_link',
+            'id': 'CON_REQ_4',
+            'lineno': 46,
+            'parent_need': 'CON_SPEC_4',
+            'parent_needs': list([
+              'CON_SPEC_4',
+            ]),
+            'section_name': 'LINKS FROM CONTENT',
+            'sections': list([
+              'LINKS FROM CONTENT',
+            ]),
+            'title': 'Nested requirement',
             'type': 'req',
             'type_name': 'Requirement',
           }),
@@ -125,8 +144,35 @@
             'type': 'spec',
             'type_name': 'Specification',
           }),
+          'CON_SPEC_4': dict({
+            'content': '''
+              This references :need:`CON_REQ_1` but also contains a nested need:
+              
+              .. req:: Nested requirement
+                 :id: CON_REQ_4
+              
+                 This nested need references :need:`CON_REQ_2` which should NOT be collected.
+            ''',
+            'docname': 'index',
+            'external_css': 'external_link',
+            'id': 'CON_SPEC_4',
+            'lineno': 40,
+            'links': list([
+              'CON_REQ_1',
+            ]),
+            'parent_needs_back': list([
+              'CON_REQ_4',
+            ]),
+            'section_name': 'LINKS FROM CONTENT',
+            'sections': list([
+              'LINKS FROM CONTENT',
+            ]),
+            'title': 'Spec with nested need',
+            'type': 'spec',
+            'type_name': 'Specification',
+          }),
         }),
-        'needs_amount': 6,
+        'needs_amount': 8,
         'needs_defaults_removed': True,
         'needs_schema': dict({
           '$schema': 'http://json-schema.org/draft-07/schema#',

--- a/tests/doc_test/doc_df_links_from_content/conf.py
+++ b/tests/doc_test/doc_df_links_from_content/conf.py
@@ -1,0 +1,23 @@
+extensions = ["sphinx_needs"]
+
+needs_id_regex = "^[A-Za-z0-9_-]{5,}"
+
+needs_types = [
+    {
+        "directive": "req",
+        "title": "Requirement",
+        "prefix": "R_",
+        "color": "#BFD8D2",
+        "style": "node",
+    },
+    {
+        "directive": "spec",
+        "title": "Specification",
+        "prefix": "S_",
+        "color": "#FEDCD2",
+        "style": "node",
+    },
+]
+
+needs_build_json = True
+needs_json_remove_defaults = True

--- a/tests/doc_test/doc_df_links_from_content/index.rst
+++ b/tests/doc_test/doc_df_links_from_content/index.rst
@@ -36,3 +36,14 @@ LINKS FROM CONTENT
    * :need:`CON_SPEC_1`
 
    But only requirements should pass the filter.
+
+.. spec:: Spec with nested need
+   :id: CON_SPEC_4
+   :links: [[links_from_content()]]
+
+   This references :need:`CON_REQ_1` but also contains a nested need:
+
+   .. req:: Nested requirement
+      :id: CON_REQ_4
+
+      This nested need references :need:`CON_REQ_2` which should NOT be collected.

--- a/tests/doc_test/doc_df_links_from_content/index.rst
+++ b/tests/doc_test/doc_df_links_from_content/index.rst
@@ -1,0 +1,38 @@
+LINKS FROM CONTENT
+==================
+
+.. req:: Requirement 1
+   :id: CON_REQ_1
+
+.. req:: Requirement 2
+   :id: CON_REQ_2
+
+.. req:: Requirement with hyphens
+   :id: CON-REQ-3
+
+.. spec:: Spec that extracts links from own content
+   :id: CON_SPEC_1
+   :links: [[links_from_content()]]
+
+   This specification cares about the realisation of:
+
+   * :need:`CON_REQ_1`
+   * :need:`My need <CON_REQ_2>`
+   * :need:`CON-REQ-3`
+
+.. spec:: Spec that extracts links from another need
+   :id: CON_SPEC_2
+   :links: [[links_from_content('CON_SPEC_1')]]
+
+   Links retrieved from content of :need:`CON_SPEC_1`.
+
+.. spec:: Spec with filter
+   :id: CON_SPEC_3
+   :links: [[links_from_content(filter='type == "req"')]]
+
+   This also references:
+
+   * :need:`CON_REQ_1`
+   * :need:`CON_SPEC_1`
+
+   But only requirements should pass the filter.

--- a/tests/test_dynamic_functions.py
+++ b/tests/test_dynamic_functions.py
@@ -210,6 +210,28 @@ def test_doc_df_linked_values(test_app):
     [
         {
             "buildername": "html",
+            "srcdir": "doc_test/doc_df_links_from_content",
+            "no_plantuml": True,
+        }
+    ],
+    indirect=True,
+)
+def test_doc_df_links_from_content(test_app, snapshot):
+    app = test_app
+    app.build()
+    warnings = strip_colors(app._warning.getvalue()).splitlines()
+    assert warnings == []
+
+    json_data = Path(app.outdir, "needs.json").read_text()
+    needs = json.loads(json_data)
+    assert needs == snapshot(exclude=props("created", "project", "creator"))
+
+
+@pytest.mark.parametrize(
+    "test_app",
+    [
+        {
+            "buildername": "html",
             "srcdir": "doc_test/doc_df_user_functions",
             "no_plantuml": True,
         }


### PR DESCRIPTION
Closes #1668

### Problem

`links_from_content` used a regex (`` r":need:\`(\w+)\`" ``) on the raw content string to extract need references. This was brittle:

- `\w+` doesn't match IDs containing hyphens, dots, or other valid characters
- Titled references like `` :need:`My title <SOME_ID>` `` weren't reliably matched
- The regex doesn't support MyST Markdown
- The regex duplicated parsing logic that Sphinx already performs

### Solution

Replace the regex with doctree node traversal:

1. Retrieve the stored `Need` node via `SphinxNeedsData.get_need_node()`
2. Walk the node tree with a custom traversal (`_find_need_refs`) that yields `NeedRef` nodes but skips nested `Need` nodes (mirroring the `find_parts` pattern)
3. Return `NeedLink` objects directly from `ref_node["need_link"]` — the already-parsed, authoritative reference created via `NeedLink.parse_address`

This uses the same parsed representation that Sphinx uses for cross-references, so it handles all valid ID formats and role syntax correctly. Returning `NeedLink` directly avoids a lossy `to_filter_string()` → `from_string()` round-trip (since `parse_address` and `from_string` handle edge cases differently, e.g. IDs containing `[`).

### Trade-offs

Needs without a stored doctree node will now emit a `[needs.dynamic_function]` warning and return an empty list. This affects:

- **External needs** (from `needs_external_needs`) — no parsed node available
- **Need parts** (`NeedPartItem`) — no per-part node stored
- **Hidden needs** — node not stored due to early return in `_create_need_node` (see issue #1321)

### Changes

- **`sphinx_needs/functions/common.py`** — Rewrote `links_from_content()` to use node traversal; returns `list[NeedLink]` instead of `list[str]`; added `_find_need_refs()` helper that skips nested `Need` nodes; removed `import re`
- **`sphinx_needs/functions/functions.py`** — Updated `DynamicFunction` protocol return type and runtime type checks to accept `NeedLink` in list returns
- **`sphinx_needs/needs_schema.py`** — Updated `LinkSchema.type_check` / `type_check_item` to accept `NeedLink` alongside `str`
- **`tests/doc_test/doc_df_links_from_content/`** — New test doc project exercising self-content extraction, cross-need extraction, hyphenated IDs, titled refs, filtered extraction, and nested needs (refs in nested needs are not collected)
- **`tests/test_dynamic_functions.py`** — Added `test_doc_df_links_from_content`
