### PR TITLE
Better lineno in needs JSON

### DIFF
--- a/sphinx_needs/directives/list2need.py
+++ b/sphinx_needs/directives/list2need.py
@@ -113,9 +113,11 @@ class List2NeedDirective(SphinxDirective):
         # Retrieve tags defined at list level
         tags = self.options.get("tags", "")
 
+        _, content_first_line = self.state_machine.get_source_and_line(self.content_offset+1)
+
         list_needs = []
         # Storing the data in a sorted list
-        for content_line in self.content:
+        for content_lineno, content_line in enumerate(self.content):
             match = LINE_REGEX.search(content_line)
             if not match:
                 continue
@@ -171,6 +173,7 @@ class List2NeedDirective(SphinxDirective):
                     "content": content.lstrip(),
                     "level": level,
                     "options": {},
+                    "lineno": content_first_line + content_lineno
                 }
                 list_needs.append(need)
             else:
@@ -182,7 +185,6 @@ class List2NeedDirective(SphinxDirective):
                 )
 
         # Finally creating the rst code
-        overall_text = []
         for index, list_need in enumerate(list_needs):
             # Search for meta data in the complete title/content
             search_string = list_need["title"] + list_need["content"]
@@ -224,11 +226,10 @@ class List2NeedDirective(SphinxDirective):
             if presentation == "nested":
                 indented_text_list = ["   " * list_need["level"] + x for x in text_list]
                 text_list = indented_text_list
-            overall_text += text_list
 
-        self.state_machine.insert_input(
-            overall_text, self.state_machine.document.attributes["source"]
-        )
+            self.state_machine.insert_input(
+                text_list, self.state_machine.document.attributes["source"] + "\0%d" % list_need["lineno"]
+            )
 
         return []
 

--- a/sphinx_needs/directives/list2need.py
+++ b/sphinx_needs/directives/list2need.py
@@ -113,7 +113,9 @@ class List2NeedDirective(SphinxDirective):
         # Retrieve tags defined at list level
         tags = self.options.get("tags", "")
 
-        _, content_first_line = self.state_machine.get_source_and_line(self.content_offset+1)
+        _, content_first_line = self.state_machine.get_source_and_line(
+            self.content_offset + 1
+        )
 
         list_needs = []
         # Storing the data in a sorted list
@@ -173,7 +175,7 @@ class List2NeedDirective(SphinxDirective):
                     "content": content.lstrip(),
                     "level": level,
                     "options": {},
-                    "lineno": content_first_line + content_lineno
+                    "lineno": content_first_line + content_lineno,
                 }
                 list_needs.append(need)
             else:
@@ -228,7 +230,9 @@ class List2NeedDirective(SphinxDirective):
                 text_list = indented_text_list
 
             self.state_machine.insert_input(
-                text_list, self.state_machine.document.attributes["source"] + "\0%d" % list_need["lineno"]
+                text_list,
+                self.state_machine.document.attributes["source"]
+                + "\0%d" % list_need["lineno"],
             )
 
         return []

--- a/sphinx_needs/directives/list2need.py
+++ b/sphinx_needs/directives/list2need.py
@@ -76,7 +76,6 @@ class List2NeedDirective(SphinxDirective):
         if not delimiter:
             delimiter = "."
 
-        content_raw = "\n".join(self.content)
         types_raw = self.options.get("types")
         if not types_raw:
             raise SphinxWarning("types must be set.")
@@ -116,8 +115,7 @@ class List2NeedDirective(SphinxDirective):
 
         list_needs = []
         # Storing the data in a sorted list
-        for content_line in content_raw.split("\n"):
-            # for groups in line.findall(content_raw):
+        for content_line in self.content:
             match = LINE_REGEX.search(content_line)
             if not match:
                 continue

--- a/sphinx_needs/directives/list2need.py
+++ b/sphinx_needs/directives/list2need.py
@@ -113,7 +113,9 @@ class List2NeedDirective(SphinxDirective):
         # Retrieve tags defined at list level
         tags = self.options.get("tags", "")
 
-        _, content_first_line = self.state_machine.get_source_and_line(self.content_offset+1)
+        _, content_first_line = self.state_machine.get_source_and_line(
+            self.content_offset + 1
+        )
 
         list_needs = []
         # Storing the data in a sorted list
@@ -173,7 +175,7 @@ class List2NeedDirective(SphinxDirective):
                     "content": content.lstrip(),
                     "level": level,
                     "options": {},
-                    "lineno": content_first_line + content_lineno
+                    "lineno": content_first_line + content_lineno,
                 }
                 list_needs.append(need)
             else:
@@ -223,7 +225,7 @@ class List2NeedDirective(SphinxDirective):
             else:
                 data["set_links_down"] = False
 
-            lineno_mapping.append(f'{len(overall_text)+1}:{list_need["lineno"]}')
+            lineno_mapping.append(f"{len(overall_text) + 1}:{list_need['lineno']}")
 
             text = render_template_string(NEED_TEMPLATE, list_need, autoescape=False)
             text_list = text.split("\n")
@@ -233,7 +235,9 @@ class List2NeedDirective(SphinxDirective):
             overall_text += text_list
 
         self.state_machine.insert_input(
-            overall_text, self.state_machine.document.attributes["source"] + ''.join(f"\0{x}" for x in lineno_mapping)
+            overall_text,
+            self.state_machine.document.attributes["source"]
+            + "".join(f"\0{x}" for x in lineno_mapping),
         )
 
         return []

--- a/sphinx_needs/directives/list2need.py
+++ b/sphinx_needs/directives/list2need.py
@@ -113,9 +113,11 @@ class List2NeedDirective(SphinxDirective):
         # Retrieve tags defined at list level
         tags = self.options.get("tags", "")
 
+        _, content_first_line = self.state_machine.get_source_and_line(self.content_offset+1)
+
         list_needs = []
         # Storing the data in a sorted list
-        for content_line in self.content:
+        for content_lineno, content_line in enumerate(self.content):
             match = LINE_REGEX.search(content_line)
             if not match:
                 continue
@@ -171,6 +173,7 @@ class List2NeedDirective(SphinxDirective):
                     "content": content.lstrip(),
                     "level": level,
                     "options": {},
+                    "lineno": content_first_line + content_lineno
                 }
                 list_needs.append(need)
             else:
@@ -182,7 +185,8 @@ class List2NeedDirective(SphinxDirective):
                 )
 
         # Finally creating the rst code
-        overall_text = []
+        overall_text: list[str] = []
+        lineno_mapping = []
         for index, list_need in enumerate(list_needs):
             # Search for meta data in the complete title/content
             search_string = list_need["title"] + list_need["content"]
@@ -219,6 +223,8 @@ class List2NeedDirective(SphinxDirective):
             else:
                 data["set_links_down"] = False
 
+            lineno_mapping.append(f'{len(overall_text)+1}:{list_need["lineno"]}')
+
             text = render_template_string(NEED_TEMPLATE, list_need, autoescape=False)
             text_list = text.split("\n")
             if presentation == "nested":
@@ -227,7 +233,7 @@ class List2NeedDirective(SphinxDirective):
             overall_text += text_list
 
         self.state_machine.insert_input(
-            overall_text, self.state_machine.document.attributes["source"]
+            overall_text, self.state_machine.document.attributes["source"] + ''.join(f"\0{x}" for x in lineno_mapping)
         )
 
         return []

--- a/sphinx_needs/directives/need.py
+++ b/sphinx_needs/directives/need.py
@@ -160,9 +160,11 @@ class NeedDirective(SphinxDirective):
                 self._log_warning(f"Invalid value for '{key}' option: {err}")
                 return []
 
+        source_path, source_lineno = self.state_machine.get_source_and_line(self.lineno)
+        docname = self.env.path2doc(source_path)
         source = NeedItemSourceDirective(
-            docname=self.env.docname,
-            lineno=self.lineno,
+            docname=source_path if docname is None else docname,
+            lineno=source_lineno,
             lineno_content=self.content_offset + 1,
         )
 

--- a/sphinx_needs/directives/need.py
+++ b/sphinx_needs/directives/need.py
@@ -161,6 +161,10 @@ class NeedDirective(SphinxDirective):
                 return []
 
         source_path, source_lineno = self.state_machine.get_source_and_line(self.lineno)
+        if '\0' in source_path:
+            # Retrieve line number encoded in source name
+            source_path, source_lineno = source_path.split('\0')
+            source_lineno = int(source_lineno)
         docname = self.env.path2doc(source_path)
         source = NeedItemSourceDirective(
             docname=source_path if docname is None else docname,

--- a/sphinx_needs/directives/need.py
+++ b/sphinx_needs/directives/need.py
@@ -161,9 +161,9 @@ class NeedDirective(SphinxDirective):
                 return []
 
         source_path, source_lineno = self.state_machine.get_source_and_line(self.lineno)
-        if '\0' in source_path:
+        if "\0" in source_path:
             # Retrieve line number encoded in source name
-            source_path, source_lineno = source_path.split('\0')
+            source_path, source_lineno = source_path.split("\0")
             source_lineno = int(source_lineno)
         docname = self.env.path2doc(source_path)
         source = NeedItemSourceDirective(

--- a/sphinx_needs/directives/need.py
+++ b/sphinx_needs/directives/need.py
@@ -161,13 +161,15 @@ class NeedDirective(SphinxDirective):
                 return []
 
         source_path, source_lineno = self.state_machine.get_source_and_line(self.lineno)
-        if '\0' in source_path:
+        if "\0" in source_path:
             # Retrieve line number mapping encoded in source name
-            source_path, lineno_mapping = source_path.split('\0',1)
-            def parse_pair(s:str) -> tuple[int, int]:
-                k,v=s.split(':')
+            source_path, lineno_mapping = source_path.split("\0", 1)
+
+            def parse_pair(s: str) -> tuple[int, int]:
+                k, v = s.split(":")
                 return int(k), int(v)
-            lineno_mapping = dict(map(parse_pair, lineno_mapping.split('\0')))
+
+            lineno_mapping = dict(map(parse_pair, lineno_mapping.split("\0")))
             source_lineno = int(lineno_mapping[source_lineno])
         docname = self.env.path2doc(source_path)
         source = NeedItemSourceDirective(

--- a/sphinx_needs/directives/need.py
+++ b/sphinx_needs/directives/need.py
@@ -161,6 +161,14 @@ class NeedDirective(SphinxDirective):
                 return []
 
         source_path, source_lineno = self.state_machine.get_source_and_line(self.lineno)
+        if '\0' in source_path:
+            # Retrieve line number mapping encoded in source name
+            source_path, lineno_mapping = source_path.split('\0',1)
+            def parse_pair(s:str) -> tuple[int, int]:
+                k,v=s.split(':')
+                return int(k), int(v)
+            lineno_mapping = dict(map(parse_pair, lineno_mapping.split('\0')))
+            source_lineno = int(lineno_mapping[source_lineno])
         docname = self.env.path2doc(source_path)
         source = NeedItemSourceDirective(
             docname=source_path if docname is None else docname,

--- a/tests/__snapshots__/test_list2need.ambr
+++ b/tests/__snapshots__/test_list2need.ambr
@@ -59,7 +59,7 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 26,
+      'lineno': 7,
       'lineno_content': 32,
       'links': list([
       ]),
@@ -149,7 +149,7 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 32,
+      'lineno': 13,
       'lineno_content': 35,
       'links': list([
       ]),
@@ -186,6 +186,94 @@
       ]),
       'template': None,
       'title': 'Sub-Need on level 2',
+      'triggers': list([
+      ]),
+      'triggers_back': list([
+      ]),
+      'type': 'spec',
+      'type_color': '#FEDCD2',
+      'type_name': 'Specification',
+      'type_prefix': 'SP_',
+      'type_style': 'node',
+      'updated_at': None,
+      'url': None,
+      'url_postfix': None,
+      'user': None,
+    }),
+    'NEED-004': dict({
+      'arch': dict({
+      }),
+      'avatar': None,
+      'checks': list([
+      ]),
+      'checks_back': list([
+      ]),
+      'closed_at': None,
+      'collapse': False,
+      'completion': None,
+      'constraints': list([
+      ]),
+      'constraints_error': None,
+      'constraints_passed': True,
+      'constraints_results': dict({
+      }),
+      'content': '',
+      'created_at': None,
+      'docname': 'index',
+      'doctype': '.rst',
+      'duration': None,
+      'external_css': 'external_link',
+      'external_url': None,
+      'has_dead_links': False,
+      'has_forbidden_dead_links': False,
+      'hide': False,
+      'id': 'NEED-004',
+      'id_complete': 'NEED-004',
+      'id_parent': 'NEED-004',
+      'id_prefix': None,
+      'is_external': False,
+      'is_import': False,
+      'is_modified': False,
+      'is_need': True,
+      'is_part': False,
+      'jinja_content': False,
+      'layout': None,
+      'lineno': 19,
+      'lineno_content': 56,
+      'links': list([
+      ]),
+      'links_back': list([
+      ]),
+      'max_amount': None,
+      'max_content_lines': None,
+      'modifications': 0,
+      'params': None,
+      'parent_need': None,
+      'parent_needs': list([
+      ]),
+      'parent_needs_back': list([
+      ]),
+      'parts': dict({
+      }),
+      'post_content': None,
+      'post_template': None,
+      'pre_content': None,
+      'pre_template': None,
+      'prefix': None,
+      'query': None,
+      'section_name': 'TEST DOCUMENT LIST2NEED',
+      'sections': tuple(
+        'TEST DOCUMENT LIST2NEED',
+      ),
+      'service': None,
+      'signature': None,
+      'specific': None,
+      'status': None,
+      'style': None,
+      'tags': list([
+      ]),
+      'template': None,
+      'title': 'Spec from normal directive',
       'triggers': list([
       ]),
       'triggers_back': list([
@@ -238,7 +326,7 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 20,
+      'lineno': 1,
       'lineno_content': 24,
       'links': list([
       ]),
@@ -327,7 +415,7 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 27,
+      'lineno': 8,
       'lineno_content': 32,
       'links': list([
       ]),
@@ -419,7 +507,7 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 35,
+      'lineno': 16,
       'lineno_content': 39,
       'links': list([
         'NEED-1',
@@ -511,7 +599,7 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 42,
+      'lineno': 23,
       'lineno_content': 49,
       'links': list([
         'NEED-3',
@@ -601,7 +689,7 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 19,
+      'lineno': 1,
       'lineno_content': 23,
       'links': list([
       ]),
@@ -690,7 +778,7 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 25,
+      'lineno': 7,
       'lineno_content': 29,
       'links': list([
       ]),
@@ -779,7 +867,7 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 31,
+      'lineno': 13,
       'lineno_content': 34,
       'links': list([
       ]),
@@ -868,7 +956,7 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 21,
+      'lineno': 1,
       'lineno_content': 26,
       'links': list([
       ]),
@@ -960,7 +1048,7 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 29,
+      'lineno': 9,
       'lineno_content': 34,
       'links': list([
       ]),
@@ -1054,7 +1142,7 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 37,
+      'lineno': 17,
       'lineno_content': 42,
       'links': list([
         'NEED-W',
@@ -1148,7 +1236,7 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 45,
+      'lineno': 25,
       'lineno_content': 53,
       'links': list([
         'NEED-3',
@@ -1250,7 +1338,7 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 38,
+      'lineno': 19,
       'lineno_content': 42,
       'links': list([
       ]),
@@ -1343,7 +1431,7 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 45,
+      'lineno': 26,
       'lineno_content': 49,
       'links': list([
       ]),
@@ -1432,7 +1520,7 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 20,
+      'lineno': 1,
       'lineno_content': 23,
       'links': list([
       ]),

--- a/tests/__snapshots__/test_list2need.ambr
+++ b/tests/__snapshots__/test_list2need.ambr
@@ -59,7 +59,7 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 7,
+      'lineno': 11,
       'lineno_content': 32,
       'links': list([
       ]),
@@ -149,7 +149,7 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 13,
+      'lineno': 12,
       'lineno_content': 35,
       'links': list([
       ]),
@@ -326,7 +326,7 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 1,
+      'lineno': 10,
       'lineno_content': 24,
       'links': list([
       ]),
@@ -415,7 +415,7 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 8,
+      'lineno': 11,
       'lineno_content': 32,
       'links': list([
       ]),
@@ -507,7 +507,7 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 16,
+      'lineno': 12,
       'lineno_content': 39,
       'links': list([
         'NEED-1',
@@ -599,7 +599,7 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 23,
+      'lineno': 13,
       'lineno_content': 49,
       'links': list([
         'NEED-3',
@@ -689,7 +689,7 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 1,
+      'lineno': 11,
       'lineno_content': 23,
       'links': list([
       ]),
@@ -778,7 +778,7 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 7,
+      'lineno': 12,
       'lineno_content': 29,
       'links': list([
       ]),
@@ -956,7 +956,7 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 1,
+      'lineno': 11,
       'lineno_content': 26,
       'links': list([
       ]),
@@ -1048,7 +1048,7 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 9,
+      'lineno': 12,
       'lineno_content': 34,
       'links': list([
       ]),
@@ -1142,7 +1142,7 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 17,
+      'lineno': 13,
       'lineno_content': 42,
       'links': list([
         'NEED-W',
@@ -1236,7 +1236,7 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 25,
+      'lineno': 14,
       'lineno_content': 53,
       'links': list([
         'NEED-3',
@@ -1338,7 +1338,7 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 19,
+      'lineno': 13,
       'lineno_content': 42,
       'links': list([
       ]),
@@ -1431,7 +1431,7 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 26,
+      'lineno': 15,
       'lineno_content': 49,
       'links': list([
       ]),
@@ -1520,7 +1520,7 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 1,
+      'lineno': 10,
       'lineno_content': 23,
       'links': list([
       ]),

--- a/tests/doc_test/doc_list2need/index.rst
+++ b/tests/doc_test/doc_list2need/index.rst
@@ -16,6 +16,9 @@ TEST DOCUMENT LIST2NEED
          the **content** by :ref:`test`
 
 
+.. spec:: Spec from normal directive
+   :id: NEED-004
+
 .. _test:
 
 Test chapter


### PR DESCRIPTION
This should fix https://github.com/useblocks/sphinx-needs/issues/1349.

The fix for the `include` and `rst-prolog ` use cases is simple.

I just wonder if anyone relies on having unique line numbers for one "docname" and docname being a full rst document, not an include file. If that's the case, maybe instead of fixing the `lineno` attribute, we should add a new attribute (maybe call it "source position"?)
On the other hand, the only reason I can think of why you would not want include file names as "source" attribute is if you had one that you included in multiple places. And if you do that, you won't have needs in there, because those would then get duplicated.

The fix for the `list2need` use case is abusing the "source" string to pass line number  information from the list2needs directive to the generated needs directives.
I considered passing this information through a generated "option", but when I declare this in `needs_extra_options`, it shows up for all needs (as "None" when unused) in the JSON, so that's a bit ugly.

I guess the best solution would be to refactor the `list2need` directive to create the needs objects directly, instead of generating rst text which is then injected back into the parser. This would avoid the need to pass line numbers, and it would even avoid calling `state_machine.insert_input`, so it wouldn't corrupt line numbers for subsequent needs.
Of course, corrupted line numbers of subsequent needs are already fixed by using `state_machine.get_source_and_line`, and you'd want to keep this for the `include` and `rst-prolog ` use cases, so the important reason for the refactoring is just avoiding to encode line numbers in the source string.

Before attempting to do this refactoring, I would like to understand why the current solution with `state_machine.insert_input` was chosen. Directly creating the needs objects seems more obvious, so I wonder if I'm missing the reason for Chesterton's fence here.

My test setup is attached - not integrated into the sphinx-needs test suite so far.
[rst-lineno-bug-tests.zip](https://github.com/user-attachments/files/26505620/rst-lineno-bug-tests.zip)
