### PR TITLE
🐛 Fix needflow nodes rendering as black when no type color is set

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,19 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+Bug fixes
+.........
+
+- 🐛 Fix ``needflow`` rendering very dark / black nodes when a need type has no
+  ``color`` set in ``needs_types`` (:issue:`1664`).
+  Previously a hard-coded ``#000000`` fallback was used as the fill color, which
+  produced unreadable nodes — especially under browser dark mode.
+  When no color is configured, no color is emitted and the diagram engine's
+  default node color is used.
+
 .. _`release:8.0.0`:
 
 8.0.0

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -17,6 +17,15 @@ Bug fixes
   When no color is configured, no color is emitted and the diagram engine's
   default node color is used.
 
+  .. note::
+
+     This is a minor behavior change for users with ``needs_types`` entries
+     that omit the ``color`` key: diagrams (``needflow``, ``needuml``,
+     ``needgantt``) that previously rendered such nodes as solid black will
+     now render them with the diagram engine's default node color (typically
+     light). To preserve the old appearance, set ``"color": "#000000"``
+     explicitly on the affected ``needs_types`` entry.
+
 .. _`release:8.0.0`:
 
 8.0.0

--- a/sphinx_needs/api/need.py
+++ b/sphinx_needs/api/need.py
@@ -373,7 +373,7 @@ def generate_need(
         "type": need_type,
         "type_name": need_type_data["title"],
         "type_prefix": need_type_data["prefix"],
-        "type_color": need_type_data.get("color") or "#000000",
+        "type_color": need_type_data.get("color") or "",
         "type_style": need_type_data.get("style") or "node",
         "title": core_values["title"],
         "status": core_values["status"],

--- a/sphinx_needs/config.py
+++ b/sphinx_needs/config.py
@@ -325,7 +325,8 @@ class NeedType(TypedDict):
     prefix: str
     """The prefix to use for the need ID."""
     color: NotRequired[str]
-    """The default color to use in diagrams (default: "#000000")."""
+    """The default color to use in diagrams.
+    If unset or empty, no color is applied and the diagram engine's default is used."""
     style: NotRequired[str]
     """The default node style to use in diagrams (default: "node")."""
 

--- a/sphinx_needs/directives/needflow/_graphviz.py
+++ b/sphinx_needs/directives/needflow/_graphviz.py
@@ -336,8 +336,8 @@ def _render_subgraph(
         params.append(("shape", "rectangle"))
 
     # fill color
-    params.append(("style", "filled"))
     if need["type_color"]:
+        params.append(("style", "filled"))
         params.append(("fillcolor", _quote(need["type_color"])))
 
     # outline color

--- a/sphinx_needs/directives/needflow/_plantuml.py
+++ b/sphinx_needs/directives/needflow/_plantuml.py
@@ -76,11 +76,12 @@ def get_need_node_rep_for_plantuml(
     node_style = need_info["type_style"] if need_info["is_need"] else "rectangle"
 
     # node representation for plantuml
-    need_node_code = '{style} "{node_text}" as {id} [[{link}]] #{color}'.format(
+    color_suffix = f" #{';'.join(node_colors)}" if node_colors else ""
+    need_node_code = '{style} "{node_text}" as {id} [[{link}]]{color_suffix}'.format(
         id=make_entity_name(need_info["id_complete"]),
         node_text=node_text,
         link=node_link,
-        color=";".join(node_colors),
+        color_suffix=color_suffix,
         style=node_style,
     )
     return need_node_code

--- a/sphinx_needs/directives/needgantt.py
+++ b/sphinx_needs/directives/needgantt.py
@@ -289,9 +289,10 @@ def process_needgantt(
                     need["title"], complete
                 )
 
-            el_color_string += "[{}] is colored in {}\n".format(
-                need["title"], need["type_color"]
-            )
+            if need["type_color"]:
+                el_color_string += "[{}] is colored in {}\n".format(
+                    need["title"], need["type_color"]
+                )
 
             puml_node["uml"] += gantt_element
 

--- a/sphinx_needs/directives/needuml.py
+++ b/sphinx_needs/directives/needuml.py
@@ -447,11 +447,16 @@ class JinjaFunctions:
             new_env=True,
         )
 
-        need_uml = '{style} "{node_text}" as {id} [[{link}]] #{color}'.format(
+        color_suffix = (
+            f" #{need_info['type_color'].replace('#', '')}"
+            if need_info["type_color"]
+            else ""
+        )
+        need_uml = '{style} "{node_text}" as {id} [[{link}]]{color_suffix}'.format(
             id=make_entity_name(need_id),
             node_text=node_text,
             link=link,
-            color=need_info["type_color"].replace("#", ""),
+            color_suffix=color_suffix,
             style=need_info["type_style"],
         )
 

--- a/tests/doc_test/doc_github_issue_1664/conf.py
+++ b/tests/doc_test/doc_github_issue_1664/conf.py
@@ -1,0 +1,14 @@
+extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
+
+# note, the plantuml executable command is set globally in the test suite
+plantuml_output_format = "svg"
+
+# needs_types entries without an explicit 'color' field.
+# This reproduces the situation that caused dark/black nodes in needflow.
+needs_types = [
+    {
+        "directive": "spec",
+        "title": "Specification",
+        "prefix": "S_",
+    },
+]

--- a/tests/doc_test/doc_github_issue_1664/index.rst
+++ b/tests/doc_test/doc_github_issue_1664/index.rst
@@ -1,0 +1,11 @@
+Github Issue 1664 test
+======================
+
+.. spec:: Test
+    :id: ID_SPC_1001
+    :status: open
+    :tags: test
+
+.. needflow::
+    :tags: test
+    :debug:

--- a/tests/test_github_issues.py
+++ b/tests/test_github_issues.py
@@ -80,3 +80,45 @@ def test_doc_github_160(test_app):
     app.build()
     html = Path(app.outdir, "index.html").read_text()
     assert '<a class="reference internal" href="#A-001" title="A-002">A-001</a>' in html
+
+
+@pytest.mark.parametrize(
+    "test_app",
+    [
+        {
+            "buildername": "html",
+            "srcdir": "doc_test/doc_github_issue_1664",
+            "confoverrides": {"needs_flow_engine": "plantuml"},
+        },
+        {
+            "buildername": "html",
+            "srcdir": "doc_test/doc_github_issue_1664",
+            "confoverrides": {
+                "needs_flow_engine": "graphviz",
+                "graphviz_output_format": "svg",
+            },
+        },
+    ],
+    ids=["plantuml", "graphviz"],
+    indirect=True,
+)
+def test_doc_github_1664(test_app):
+    """
+    https://github.com/useblocks/sphinx-needs/issues/1664
+
+    When a ``needs_types`` entry has no ``color`` field, needflow used to fall
+    back to ``#000000`` (black), producing very dark / unreadable nodes.
+    After the fix, no color should be emitted so the diagram engine's own
+    default is used.
+    """
+    app = test_app
+    app.build()
+    html = Path(app.outdir, "index.html").read_text()
+
+    # No #000000 fill color should appear in the rendered output when the
+    # user did not set a color in needs_types.
+    # For plantuml the rendered source is shown via :debug:; for graphviz the
+    # fill color would appear in the embedded SVG when the bug is present.
+    assert "#000000" not in html
+    for graphviz_file in Path(app.outdir, "_images").glob("graphviz-*.svg"):
+        assert "#000000" not in graphviz_file.read_text()


### PR DESCRIPTION
## Summary

Fixes #1664.

When a `needs_types` entry omitted the `color` field, `generate_need` fell back to `#000000`. That value was then forwarded to PlantUML as the node background colour and to Graphviz as `fillcolor` with `style=filled`, producing very dark, unreadable nodes — especially under browser forced dark mode.

The default is now an empty string. Each diagram emitter skips the colour suffix / `style=filled` when no colour is configured, so the diagram engine's own default node colour is used.

## Why this only surfaced recently

The `#000000` fallback has been in the code since 1.0, but it was unreachable until **3.0.0** (Aug 2024). Before PR #1185 (commit `eee2eb40`), the code used bracket access — `ntype["color"] or "#000000"` — so a `needs_types` entry missing `color` raised `KeyError` at build time and the field was *de facto* required. PR #1185 made `color` an optional `NotRequired[str]` and switched to `ntype.get("color") or "#000000"`, which silently substitutes the black fallback for users who omit the field.

Sphinx / PlantUML / Graphviz versions are not factors — the bug is purely on the Sphinx-Needs side and reproduces with every renderer version. Forced dark mode doesn't cause it; it just removes the surrounding light page that previously made the broken render mildly visible, which is why bug reports started arriving.

## Changes

- `sphinx_needs/api/need.py`: default `type_color` to `""` instead of `"#000000"`.
- `sphinx_needs/directives/needflow/_plantuml.py`: only emit the `#color` suffix when a colour is set.
- `sphinx_needs/directives/needflow/_graphviz.py` (subgraph path): only set `style=filled` when there is a fill colour. The plain-node path already had this guard.
- `sphinx_needs/directives/needuml.py`: same conditional `#color` emission as needflow.
- `sphinx_needs/directives/needgantt.py`: skip the `is colored in …` line when no colour is set.
- `sphinx_needs/config.py`: update the `NeedType.color` docstring.
- `docs/changelog.rst`: bug-fix entry under a new "Unreleased" section.

## Test plan

- [x] New parameterised regression test `tests/test_github_issues.py::test_doc_github_1664` covering both `plantuml` and `graphviz` engines with a `needs_types` entry that has no `color` field.
- [x] Verified the new test fails on the pre-fix code and passes after the fix.
- [x] Full test suite: 912 passed, 5 skipped (pre-existing benchmark errors due to a missing `sphinx_ai_index` extension are unrelated).