### PR TITLE
⚡️ Add `NeedItem.filter_context()` to avoid costly `{**need}` unpacking

### DIFF
--- a/sphinx_needs/api/need.py
+++ b/sphinx_needs/api/need.py
@@ -468,7 +468,7 @@ def generate_need(
     if jinja_content or _template or _pre_template or _post_template:
         # TODO ideally perform all these content alterations before creating the need item
         if jinja_content:
-            need_content_context: dict[str, Any] = {**needs_info}
+            need_content_context: dict[str, Any] = needs_info.filter_context()
             need_content_context.update(**needs_config.filter_data)
             need_content_context.update(**needs_config.render_context)
             try:
@@ -972,7 +972,7 @@ def _prepare_template(
     try:
         new_content = render_template_string(
             template_content,
-            {**needs_info, **needs_config.render_context},
+            {**needs_info.filter_context(), **needs_config.render_context},
             autoescape=False,
         )
     except Exception as e:

--- a/sphinx_needs/directives/needflow/_graphviz.py
+++ b/sphinx_needs/directives/needflow/_graphviz.py
@@ -296,7 +296,7 @@ def _render_node(
         color = str(
             match_variants(
                 node["border_color"],
-                {**need},
+                need.filter_context(),
                 config.variants,
                 location=node,
             )
@@ -347,7 +347,7 @@ def _render_subgraph(
         color = str(
             match_variants(
                 node["border_color"],
-                {**need},
+                need.filter_context(),
                 config.variants,
                 location=node,
             )

--- a/sphinx_needs/directives/needflow/_plantuml.py
+++ b/sphinx_needs/directives/needflow/_plantuml.py
@@ -46,7 +46,7 @@ def get_need_node_rep_for_plantuml(
 
     node_text = render_template_string(
         needs_config.diagram_template,
-        {**need_info, **needs_config.render_context},
+        {**need_info.filter_context(), **needs_config.render_context},
         autoescape=False,
     )
 
@@ -65,7 +65,7 @@ def get_need_node_rep_for_plantuml(
     elif current_needflow["border_color"]:
         color = match_variants(
             current_needflow["border_color"],
-            {**need_info},
+            need_info.filter_context(),
             needs_config.variants,
             location=(current_needflow["docname"], current_needflow["lineno"]),
         )

--- a/sphinx_needs/directives/needuml.py
+++ b/sphinx_needs/directives/needuml.py
@@ -436,7 +436,7 @@ class JinjaFunctions:
 
         node_text = render_template_string(
             self.needs_config.diagram_template,
-            {**need_info, **self.needs_config.render_context},
+            {**need_info.filter_context(), **self.needs_config.render_context},
             autoescape=False,
             # new_env=True because flow() is called from within a template callback
             # (e.g. {{ flow("ID") }}) while the outer jinja2uml render holds a lock

--- a/sphinx_needs/filter_common.py
+++ b/sphinx_needs/filter_common.py
@@ -711,7 +711,7 @@ def filter_single_need(
             raise NeedsInvalidFilter(f"Filter {filter_string!r} not valid. Error: {e}.")
 
     # === Slow path: fall back to eval() ===
-    filter_context: dict[str, Any] = {**need}
+    filter_context: dict[str, Any] = need.filter_context()
     if needs:
         filter_context["needs"] = needs
     if current_need:

--- a/sphinx_needs/need_item.py
+++ b/sphinx_needs/need_item.py
@@ -1091,6 +1091,26 @@ class NeedItem:
         if _recompute:
             self._recompute()
 
+    def filter_context(self) -> dict[str, Any]:
+        """Build a flat dict of all need fields, suitable for use as an eval/template context.
+
+        This is more efficient than ``{**need}`` because it avoids the per-key
+        multi-namespace lookup chain and materializes link string lists only once.
+        """
+        ctx: dict[str, Any] = {}
+        ctx.update(self._core)
+        ctx.update(self._extras)
+        for key, links in self._links.items():
+            ctx[key] = [li.to_filter_string() for li in links]
+        for exposed_key, link_key in self._backlinks_keymap.items():
+            ctx[exposed_key] = [
+                li.to_filter_string() for li in self._backlinks[link_key]
+            ]
+        ctx.update(self._source.dict_repr)
+        ctx.update(self._content.dict_repr)
+        ctx.update(self._computed)
+        return ctx
+
 
 class NeedPartItem:
     """A class representing a part of a need, which is a sub-need, merged with the parent need.
@@ -1288,6 +1308,16 @@ class NeedPartItem:
                 yield (key, self._overrides[key])
             else:
                 yield (key, self._need[key])
+
+    def filter_context(self) -> dict[str, Any]:
+        """Build a flat dict of all need part fields, suitable for use as an eval/template context.
+
+        This is more efficient than ``{**need_part}`` because it avoids
+        per-key lookup overhead.
+        """
+        ctx = self._need.filter_context()
+        ctx.update(self._overrides)
+        return ctx
 
     def get_extra(self, key: str) -> str:
         """Get an extra by key.


### PR DESCRIPTION
The `{**need}` pattern triggers `__getitem__` for every key (including link fields which allocate fresh `list[str]` each call), resulting in O(N_keys × M_links) allocations per need per filter/render invocation.

The new `filter_context()` method on both `NeedItem` and `NeedPartItem` builds a flat dict by directly combining internal data structures, bypassing the 7-namespace lookup chain and materializing link string lists only once.

Replace all `{**need}` / `{**need_info}` usages in:
- filter_common.py (eval slow-path)
- needflow/_graphviz.py (match_variants context)
- needflow/_plantuml.py (template rendering + match_variants)
- needuml.py (template rendering)
- api/need.py (jinja content + template rendering)

Partially addresses #1699