### PR TITLE
🐛 Fix Docker build by switching PlantUML source to GitHub releases

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get -y install \
   default-jre
 
 # Install PlantUML
-RUN wget -c https://netcologne.dl.sourceforge.net/project/plantuml/plantuml.jar -O /tmp/plantuml.jar && \
+RUN wget -c https://github.com/plantuml/plantuml/releases/latest/download/plantuml.jar -O /tmp/plantuml.jar && \
     mkdir -p /usr/share/plantuml && \
     mv /tmp/plantuml.jar /usr/share/plantuml/plantuml.jar
 


### PR DESCRIPTION
## Summary

- The Docker-Image workflow has been failing because the Dockerfile hardcodes a specific Sourceforge mirror (`netcologne.dl.sourceforge.net`) that is no longer reachable, causing `wget` to exit with code 4 (network failure). See [failed run](https://github.com/useblocks/sphinx-needs/actions/runs/26152538995/job/76923393653).
- Switched the download URL to the official GitHub releases endpoint `https://github.com/plantuml/plantuml/releases/latest/download/plantuml.jar`, which is mirror-free and always serves the latest `plantuml.jar` asset.
- Preserves unpinned-latest behavior of the original line.

## Test plan

- [x] CI Docker-Image workflow triggered by this PR (path filter `docker/**`) completes successfully for both `sphinxdoc/sphinx:latest` and `sphinxdoc/sphinx-latexpdf:latest` base images.