### PR TITLE
⚡️ Add `NeedItem.is_in_document()`

### DIFF
--- a/sphinx_needs/data.py
+++ b/sphinx_needs/data.py
@@ -835,7 +835,7 @@ class SphinxNeedsData:
         if self.needs_is_post_processed:
             raise RuntimeError("Needs have already been post-processed and frozen.")
         for need_id in list(self._env_needs):
-            if self._env_needs[need_id]["docname"] == docname:
+            if self._env_needs[need_id].is_in_document(docname):
                 del self._env_needs[need_id]
                 self.remove_need_node(need_id)
         docs = self.get_or_create_docs()

--- a/sphinx_needs/filter_common.py
+++ b/sphinx_needs/filter_common.py
@@ -753,4 +753,4 @@ class NeedCheckContext:
     def this_doc(self) -> bool:
         if self._origin_docname is None:
             raise ValueError("`this_doc` can not be used in this context")
-        return self._need["docname"] == self._origin_docname
+        return self._need.is_in_document(self._origin_docname)

--- a/sphinx_needs/need_item.py
+++ b/sphinx_needs/need_item.py
@@ -1119,6 +1119,10 @@ class NeedItem:
         ctx.update(self._computed)
         return ctx
 
+    def is_in_document(self, docname: str) -> bool:
+        """Check if the need is in a given document."""
+        return self._source.dict_repr.get("docname") == docname
+
 
 class NeedPartItem:
     """A class representing a part of a need, which is a sub-need, merged with the parent need.
@@ -1442,3 +1446,7 @@ class NeedPartItem:
                     key,
                     part.backlinks.get(key, []),
                 )
+
+    def is_in_document(self, docname: str) -> bool:
+        """Check if the need is in a given document."""
+        return self._need.is_in_document(docname)


### PR DESCRIPTION
Replace direct `need["docname"] == docname` comparisons with a method on `NeedItem` and `NeedPartItem`, encapsulating the document membership logic behind a single access point.

In particular this should speed up document purges, for projects with lots of needs