### PR TITLE
Fix: needs_schema_definitions_from_json triggers full rebuild on every incremental build

### DIFF
--- a/sphinx_needs/schema/config_utils.py
+++ b/sphinx_needs/schema/config_utils.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 from pathlib import Path
 from typing import Any, Literal, cast
 
@@ -97,10 +98,11 @@ def resolve_schemas_config(
 
     # inject extra/link/core option types to each nested schema, to avoid silent json schema
     # failures; this must happens before the type check, because it requires type fields
+    # Use deepcopy to avoid mutating the original config (which is pickled for incremental builds)
     for schema in needs_config.schema_definitions["schemas"]:
         schema_name = get_schema_name(schema)
         populate_field_type(
-            schema,
+            copy.deepcopy(schema),
             schema_name,
             fields_schema,
         )


### PR DESCRIPTION
## Summary

**Bug:** When `needs_schema_definitions_from_json` is set, every incremental `sphinx-build` rebuilds ALL documents because Sphinx detects a spurious `[config changed ('needs_schema_definitions')]`.

**Root Cause:** `resolve_schemas_config` is connected to `env-before-read-docs`, and via `populate_field_type` mutates `needs_config.schema_definitions['schemas']` in place — injecting `"type": "string"` / `"object"` etc. into every nested schema. This event fires AFTER Sphinx's `config-inited` config-change checkpoint:

1. `config-inited` — `schemas.json` loaded → `{"const": "role"}`
2. Sphinx compares pickled config vs in-memory config ← still sees `{"const": "role"}`
3. `env-before-read-docs` → `populate_field_type` mutates in place → `{"const": "role", "type": "string"}`
4. End of build → pickle persists the mutated config

Next build: step 2 compares fresh JSON (`{"const": "role"}`) vs pickled mutated config (`{"const": "role", "type": "string"}`) → mismatch → full rebuild → permanent loop.

**Fix:** In `resolve_schemas_config`, deep-copy each schema with `copy.deepcopy()` before passing it to `populate_field_type()`, so the original config remains unchanged and the pickled config matches the fresh load.

## Changes

- **File:** `sphinx_needs/schema/config_utils.py`
- **Lines:** Added `import copy` at line 5, modified `resolve_schemas_config()` (around line 103) to pass `copy.deepcopy(schema)` instead of `schema` directly to `populate_field_type()`

## Testing

The fix was verified by understanding the mutation flow: `populate_field_type` injects `type` fields into schemas, and by deep-copying before mutation, the original pickled config remains identical across builds.

Fixes #1711