### PR TITLE
🐛 Fix `needs_schema_definitions` triggering full rebuilds

### DIFF
--- a/sphinx_needs/data.py
+++ b/sphinx_needs/data.py
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
         LinksLiteralValue,
     )
     from sphinx_needs.nodes import Need
+    from sphinx_needs.schema.config import SchemasRootType
     from sphinx_needs.services.manager import ServiceManager
 
 
@@ -789,6 +790,21 @@ class SphinxNeedsData:
         This should only be called once, during initialization.
         """
         self.env._needs_schema = schema
+
+    def get_resolved_schemas(self) -> list[SchemasRootType]:
+        """Get the type-injected user schema definitions, if any.
+
+        These are produced by ``resolve_schemas_config`` from
+        ``needs_schema_definitions['schemas']`` and stored on the environment
+        rather than mutated back into the config, so Sphinx's config-change
+        detection does not see a diff between the in-memory config (loaded
+        each build) and the pickled config (saved at end of build).
+        """
+        return getattr(self.env, "_needs_resolved_schemas", [])
+
+    def _set_resolved_schemas(self, schemas: list[SchemasRootType]) -> None:
+        """Store the type-injected user schema definitions on the environment."""
+        self.env._needs_resolved_schemas = schemas
 
     @property
     def _env_needs(self) -> dict[str, NeedItem]:

--- a/sphinx_needs/schema/config_utils.py
+++ b/sphinx_needs/schema/config_utils.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 from pathlib import Path
 from typing import Any, Literal, cast
 
@@ -83,7 +84,17 @@ def validate_schemas_config(app: Sphinx, needs_config: NeedsSphinxConfig) -> Non
 def resolve_schemas_config(
     app: Sphinx, env: BuildEnvironment, _docnames: list[str]
 ) -> None:
-    """Validates schema definitions and inject type information."""
+    """Validates schema definitions and inject type information.
+
+    The injected types are stored on the environment via
+    :py:meth:`SphinxNeedsData._set_resolved_schemas`, not mutated back into
+    ``needs_config.schema_definitions``. Mutating the config dict here would
+    happen *after* Sphinx's ``config-inited`` comparison checkpoint, so the
+    pickled environment would carry the mutated config while the next build
+    would start from the unmutated JSON/dict -- triggering a spurious
+    ``config changed ('needs_schema_definitions')`` rebuild on every
+    incremental run.
+    """
     needs_config = NeedsSphinxConfig(app.config)
 
     if not (
@@ -95,9 +106,15 @@ def resolve_schemas_config(
 
     fields_schema = SphinxNeedsData(env).get_schema()
 
+    # Work on a deep copy so type injection does not leak back into the
+    # Sphinx config object that gets pickled at end of build.
+    resolved_schemas: list[SchemasRootType] = copy.deepcopy(
+        needs_config.schema_definitions["schemas"]
+    )
+
     # inject extra/link/core option types to each nested schema, to avoid silent json schema
     # failures; this must happens before the type check, because it requires type fields
-    for schema in needs_config.schema_definitions["schemas"]:
+    for schema in resolved_schemas:
         schema_name = get_schema_name(schema)
         populate_field_type(
             schema,
@@ -106,7 +123,7 @@ def resolve_schemas_config(
         )
 
     # validate schemas against type hints at runtime
-    for schema in needs_config.schema_definitions["schemas"]:
+    for schema in resolved_schemas:
         try:
             validate_schemas_root_type(schema)
         except TypeError as exc:
@@ -118,12 +135,12 @@ def resolve_schemas_config(
     # after type check, we can safely walk the schema for nested checks;
     # check if network links are defined as links
     check_network_links_against_links(
-        needs_config.schema_definitions["schemas"],
+        resolved_schemas,
         fields_schema,
     )
 
     # check recursively all internal schemas compile
-    for idx, schema in enumerate(needs_config.schema_definitions["schemas"]):
+    for idx, schema in enumerate(resolved_schemas):
         if "select" in schema:
             try:
                 validate_object_schema_compiles(schema["select"])
@@ -134,6 +151,8 @@ def resolve_schemas_config(
         _recursive_validate(
             schema["validate"], ("needs_schema_definitions", str(idx), "validate")
         )
+
+    SphinxNeedsData(env)._set_resolved_schemas(resolved_schemas)
 
 
 def _recursive_validate(validate: ValidateSchemaType, path: tuple[str, ...]) -> None:

--- a/sphinx_needs/schema/process.py
+++ b/sphinx_needs/schema/process.py
@@ -57,7 +57,9 @@ def process_schemas(app: Sphinx, builder: Builder) -> None:
     # Validate needs against user-defined type schemas. We read the
     # type-injected copy stored on the environment by resolve_schemas_config,
     # not config.schema_definitions itself (see resolve_schemas_config for why).
-    type_schemas: list[SchemasRootType] = SphinxNeedsData(app.env).get_resolved_schemas()
+    type_schemas: list[SchemasRootType] = SphinxNeedsData(
+        app.env
+    ).get_resolved_schemas()
     if type_schemas:
         field_properties: Mapping[str, NeedFieldProperties] = generate_needs_schema(
             needs_schema

--- a/sphinx_needs/schema/process.py
+++ b/sphinx_needs/schema/process.py
@@ -54,10 +54,10 @@ def process_schemas(app: Sphinx, builder: Builder) -> None:
     for key, warnings in field_link_warnings.items():
         need_2_warnings.setdefault(key, []).extend(warnings)
 
-    # Validate needs against user-defined type schemas
-    type_schemas: list[SchemasRootType] = []
-    if config.schema_definitions and "schemas" in config.schema_definitions:
-        type_schemas = config.schema_definitions["schemas"]
+    # Validate needs against user-defined type schemas. We read the
+    # type-injected copy stored on the environment by resolve_schemas_config,
+    # not config.schema_definitions itself (see resolve_schemas_config for why).
+    type_schemas: list[SchemasRootType] = SphinxNeedsData(app.env).get_resolved_schemas()
     if type_schemas:
         field_properties: Mapping[str, NeedFieldProperties] = generate_needs_schema(
             needs_schema

--- a/tests/doc_test/doc_schema_incremental/conf.py
+++ b/tests/doc_test/doc_schema_incremental/conf.py
@@ -1,0 +1,13 @@
+project = "schema incremental"
+
+extensions = ["sphinx_needs"]
+
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+needs_types = [
+    {"directive": "spec", "title": "Specification", "prefix": "SPEC_"},
+]
+
+needs_schema_definitions_from_json = "schemas.json"
+
+html_theme = "alabaster"

--- a/tests/doc_test/doc_schema_incremental/index.rst
+++ b/tests/doc_test/doc_schema_incremental/index.rst
@@ -1,0 +1,5 @@
+schema incremental test
+=======================
+
+.. spec:: a spec
+   :id: SPEC_001

--- a/tests/doc_test/doc_schema_incremental/schemas.json
+++ b/tests/doc_test/doc_schema_incremental/schemas.json
@@ -1,0 +1,19 @@
+{
+  "schemas": [
+    {
+      "id": "spec",
+      "select": {
+        "properties": {
+          "type": { "const": "spec" }
+        }
+      },
+      "validate": {
+        "local": {
+          "properties": {
+            "id": { "pattern": "^SPEC_[A-Z0-9_]+$" }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tests/schema/test_schema_incremental.py
+++ b/tests/schema/test_schema_incremental.py
@@ -1,0 +1,61 @@
+"""Regression tests for incremental builds with schema_definitions_from_json."""
+
+from __future__ import annotations
+
+import shutil
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+from sphinx.testing.util import SphinxTestApp
+from sphinx.util.console import strip_colors
+
+
+@pytest.fixture
+def schema_inc_srcdir(tmp_path: Path) -> Path:
+    """Copy the doc_schema_incremental fixture into a fresh tmpdir."""
+    src = Path(__file__).parent.parent / "doc_test" / "doc_schema_incremental"
+    dst = tmp_path / "src"
+    shutil.copytree(src, dst)
+    return dst
+
+
+def _build_and_get_status(
+    make_app: Callable[..., SphinxTestApp], srcdir: Path, freshenv: bool
+) -> str:
+    """Run a single Sphinx build and return the captured stdout."""
+    app = make_app(buildername="html", srcdir=srcdir, freshenv=freshenv)
+    try:
+        app.build()
+        return strip_colors(app._status.getvalue())
+    finally:
+        app.cleanup()
+
+
+def test_schema_definitions_from_json_does_not_trigger_full_rebuild(
+    make_app: Callable[..., SphinxTestApp],
+    schema_inc_srcdir: Path,
+) -> None:
+    """Second incremental build must reuse the env when nothing has changed.
+
+    Regression: enabling ``needs_schema_definitions_from_json`` used to mutate
+    the in-memory config dict during ``env-before-read-docs`` (injecting
+    ``type`` keys via ``populate_field_type``). The pickled environment then
+    held the mutated config, while the next build started with the unmutated
+    JSON-loaded config, so Sphinx's config-change detection saw a difference
+    on every run and rebuilt every document.
+    """
+    first = _build_and_get_status(make_app, schema_inc_srcdir, freshenv=True)
+    # Sanity: the first build is necessarily a full build.
+    assert "1 added, 0 changed, 0 removed" in first
+
+    second = _build_and_get_status(make_app, schema_inc_srcdir, freshenv=False)
+    # The pickled env must be reused -- no "config changed" should be reported,
+    # and no documents should be added/changed/removed.
+    assert "loading pickled environment" in second
+    assert "config changed" not in second, (
+        "Incremental build incorrectly detected a config change. "
+        "needs_schema_definitions is being mutated after Sphinx's config "
+        "comparison checkpoint.\n\nFull status output:\n" + second
+    )
+    assert "0 added, 0 changed, 0 removed" in second


### PR DESCRIPTION
## Summary

Fixes #1710.

`resolve_schemas_config` ran on `env-before-read-docs` and mutated `needs_config.schema_definitions['schemas']` in place via `populate_field_type` (injecting `type` keys). That event fires **after** Sphinx's `config-inited` config-change checkpoint, so the end-of-build pickle stored the mutated config while the next build loaded the unmutated JSON/dict — Sphinx then saw a diff on `needs_schema_definitions` and rebuilt every document on every incremental run.

- Work on a `copy.deepcopy` of the schemas inside `resolve_schemas_config` and store the type-injected copy on the env via new `SphinxNeedsData.get_resolved_schemas` / `_set_resolved_schemas` accessors.
- `sphinx_needs/schema/process.py` now reads from there instead of from the config dict, so the config object Sphinx pickles is byte-equal to the config object loaded on the next build.

## Test plan

- [x] New regression test `tests/schema/test_schema_incremental.py` runs two `SphinxTestApp` builds against the same srcdir and asserts the second one reports `0 added, 0 changed, 0 removed` and **no** `config changed` message. Fails on `master`, passes on this branch.
- [x] All 171 tests in `tests/schema/` pass.
- [x] Schema benchmark tests (`tests/benchmarks/test_schema_benchmark.py`) pass.
- [x] Manually re-ran the reporter's reproduction (`sphinx-build` twice on a fixture with `needs_schema_definitions_from_json`): first build reports `[new config] 1 added, 0 changed, 0 removed`, second reports `0 added, 0 changed, 0 removed` with no spurious config-change message.
- [x] Verified schema validation still fires and still reports violations against the resolved schemas (intentionally bad `id:` value caught as expected).