### PR TITLE
✨ Add `needs_variant_data` — rich structured variant data (deprecates `needs_filter_data`)

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -342,7 +342,7 @@ For ``predicates``, the match expression is a string, using Python syntax, that 
 - ``is_import`` (``bool``)
 - :ref:`needs_fields`
 - :ref:`needs_links` (``tuple[str, ...]``)
-- :ref:`needs_filter_data`
+- :ref:`needs_variant_data` (via the ``var`` namespace)
 
 For example:
 
@@ -454,7 +454,7 @@ For ``predicates``, the match expression is a string, using Python syntax, that 
 - ``is_import`` (``bool``)
 - :ref:`needs_fields`
 - :ref:`needs_links` (``tuple[str, ...]``)
-- :ref:`needs_filter_data`
+- :ref:`needs_variant_data` (via the ``var`` namespace)
 
 For example:
 
@@ -570,55 +570,101 @@ Use ``style_start`` and ``style_end`` like this:
    and orientation (``left``, ``rigth``, ``up`` and ``down``). We suggest to set the orientation
    in ``style_end`` like in the example above, as this is more often supported.
 
-.. _`needs_filter_data`:
+.. _`needs_variant_data`:
 
-needs_filter_data
-~~~~~~~~~~~~~~~~~
+needs_variant_data
+~~~~~~~~~~~~~~~~~~
 
-This option allows to use custom data inside a :ref:`filter_string`.
+.. versionadded:: 8.2.0
+
+Provides structured variant data accessible under the ``var`` namespace in :ref:`filter expressions <filter_string>`.
+This replaces the flat :ref:`needs_filter_data` option with a namespaced, nested data structure
+that avoids collisions with need field names.
+
+The dot-access syntax (``var.build.debug``) is more readable than dictionary-style access (``var["build"]["debug"]``)
+and mirrors `Jinja2 template syntax <https://jinja.palletsprojects.com/en/latest/templates/#variables>`__,
+which Sphinx users are already familiar with.
 
 Configuration example:
 
 .. code-block:: python
 
-   def custom_defined_func():
-       return "my_tag"
-
-   needs_filter_data = {
-       "current_variant": "project_x",
-       "sphinx_tag": custom_defined_func(),
+   needs_variant_data = {
+       "cpu": "arm",
+       "debug": True,
+       "build": {
+           "optimization": 2,
+           "features": ["feature_a", "feature_b"],
+       },
    }
 
-The defined ``needs_filter_data`` must be a dictionary. Its values can be a string variable or a custom defined
-function. The function get executed during config loading and must return a string.
-
-The value of ``needs_filter_data`` will be available as data inside :ref:`filter_string` and can be very powerful
-together with internal needs information to filter needs.
-
-The defined extra filter data can be used like this:
+The data is then available in filter expressions via the ``var`` namespace:
 
 .. code-block:: rst
 
-   .. needextend:: type == "req" and sphinx_tag in tags
-      :+tags: my_external_tag
+   .. needtable::
+      :filter: var.cpu == "arm" and var.build.debug == True
 
-or if project has :ref:`needs_fields` defined like:
+   .. needlist::
+      :filter: "feature_a" in var.build.features
+
+**Allowed data shape:**
+
+- Top-level must be a dictionary with string keys.
+- Intermediate nodes: dictionaries only.
+- Leaf values: ``str``, ``bool``, ``int``, ``float``, or uniform lists of these types.
+- Arrays must be uniform (all elements the same scalar type).
+- No ``None`` values, no dictionaries inside arrays.
+
+Accessing a missing key raises an ``AttributeError``, which helps catch typos in filter expressions.
+
+Default: ``{}``
+
+.. seealso::
+
+   :ref:`needs_variant_data_file` for loading variant data from a JSON file.
+
+.. _`needs_variant_data_file`:
+
+needs_variant_data_file
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 8.2.0
+
+Path to a JSON file containing variant data. The file is loaded and its contents
+are made available under the ``var`` namespace, just like :ref:`needs_variant_data`.
+
+If both ``needs_variant_data_file`` and ``needs_variant_data`` are set, the file is loaded first
+and the inline dictionary is deep-merged on top (inline values win on conflict).
+
+The path is resolved relative to the Sphinx ``confdir`` (the directory containing ``conf.py``).
+
+Configuration example:
 
 .. code-block:: python
 
-   needs_fields = {'variant': {}}
+   needs_variant_data_file = "variants/arm_debug.json"
 
-The defined extra filter data can also be used like:
+Where ``variants/arm_debug.json`` contains:
 
-.. code-block:: rst
+.. code-block:: json
 
-   .. needlist::
-      :filter: variant != current_variant
+   {
+     "cpu": "arm",
+     "debug": true,
+     "build": {
+       "optimization": 2,
+       "features": ["feature_a", "feature_b"]
+     }
+   }
 
-   .. needextract::
-      :filter: type == "story" and variant == current_variant
-      :layout: clean
-      :style: green_border
+This is particularly useful for switching configurations at build time:
+
+.. code-block:: bash
+
+   sphinx-build -D needs_variant_data_file=variants/x86_release.json docs/ _build/
+
+Default: ``None``
 
 .. _`needs_allow_unsafe_filters`:
 
@@ -2472,6 +2518,37 @@ final need and schema looks like.
 Deprecated Options
 ------------------
 
+.. _`needs_filter_data`:
+
+needs_filter_data
+~~~~~~~~~~~~~~~~~
+
+.. deprecated:: 8.2.0
+
+   Use :ref:`needs_variant_data` and :ref:`needs_variant_data_file` instead.
+   These provide a dedicated ``var`` namespace that avoids collisions with need field names
+   and supports nested structured data.
+
+This option allows to use custom data inside a :ref:`filter_string`.
+
+Configuration example:
+
+.. code-block:: python
+
+   def custom_defined_func():
+       return "my_tag"
+
+   needs_filter_data = {
+       "current_variant": "project_x",
+       "sphinx_tag": custom_defined_func(),
+   }
+
+The defined ``needs_filter_data`` must be a dictionary. Its values can be a string variable or a custom defined
+function. The function gets executed during config loading and must return a string.
+
+The value of ``needs_filter_data`` will be available as data inside :ref:`filter_string` and can be very powerful
+together with internal needs information to filter needs.
+
 .. _`needs_extra_options`:
 
 needs_extra_options
@@ -2672,7 +2749,7 @@ A match expression is a string, using Python syntax, that will be evaluated agai
 - ``is_import`` (``bool``)
 - :ref:`needs_fields`
 - :ref:`needs_links` (``tuple[str, ...]``)
-- :ref:`needs_filter_data`
+- :ref:`needs_variant_data` (via the ``var`` namespace)
 
 If no predicates match, the ``default`` value is used (if present).
 

--- a/docs/directives/need.rst
+++ b/docs/directives/need.rst
@@ -319,7 +319,7 @@ The option activates jinja-parsing for the content of a need.
 If the value is set to ``true``, you can specify `Jinja <https://jinja.palletsprojects.com/>`_ syntax in the content.
 
 The **:jinja_content:** option give access to all need data, including the original content
-and the data in :ref:`needs_filter_data`.
+and the data in :ref:`needs_variant_data`.
 
 If you set the option to **False**, you deactivate jinja-parsing for the need's content.
 

--- a/docs/dynamic_functions.rst
+++ b/docs/dynamic_functions.rst
@@ -170,7 +170,7 @@ Rules for specifying variant definitions
 * Variants gets checked from left to right.
 * When evaluating a variant definition, we use data from the current need object,
   `Sphinx-Tags <https://www.sphinx-doc.org/en/master/man/sphinx-build.html#cmdoption-sphinx-build-t>`_,
-  and :ref:`needs_filter_data` as the context for filtering.
+  and :ref:`needs_variant_data` as the context for filtering.
   Sphinx tags are injected under the name ``build_tags`` as a set of strings.
 * You can set a *need option* to multiple variant definitions by separating each definition with either
   the ``,`` symbol, like ``var_a:open, ['name' in tags]:assigned``.|br|

--- a/docs/filter.rst
+++ b/docs/filter.rst
@@ -189,6 +189,45 @@ If it is invalid or returns False, the related need is not taken into account fo
       .. needlist::
          :filter: "filter_example" in tags and (("B" in tags or ("spec" == type and "closed" == status)) or "test" == type)
 
+.. _filter_variant_data:
+
+Using variant data (``var``)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 8.2.0
+
+If :ref:`needs_variant_data` or :ref:`needs_variant_data_file` is configured,
+a ``var`` namespace is available in filter expressions, providing dot-access to nested structured data.
+
+This is useful for switching build outputs based on external configuration (CPU architecture, debug/release mode, feature flags, etc.)
+without polluting the need field namespace.
+
+The dot-access syntax mirrors `Jinja2 template syntax <https://jinja.palletsprojects.com/en/latest/templates/#variables>`__,
+making it familiar to Sphinx users.
+
+**Examples:**
+
+.. code-block:: rst
+
+   .. needtable::
+      :filter: var.cpu == "arm"
+
+   .. needlist::
+      :filter: var.build.debug == True and var.build.optimization > 1
+
+   .. needtable::
+      :filter: "feature_a" in var.build.features
+
+Accessing a key that doesn't exist raises an error, which helps catch typos:
+
+.. code-block:: rst
+
+   .. needlist::
+      :filter: var.typo == "x"
+      .. this will raise AttributeError: Unknown variant key: var.typo
+
+See :ref:`needs_variant_data` for configuration details and allowed data shapes.
+
 .. _filter_current_page:
 
 Filtering for needs on the current page
@@ -248,6 +287,8 @@ To improve performance, certain common patterns are identified and optimized by 
 - ``status == 'value'`` / ``status == "value"`` / ``'value' == status`` / ``"value" == status``
 - ``status in ['value1', 'value2', ...]`` / ``status in ("value1", "value2", ...)``
 - ``'value' in tags`` / ``"value" in tags``
+- ``var.key == 'value'`` / ``var.nested.key == 'value'`` (see :ref:`filter_variant_data`)
+- ``'value' in var.key`` / ``'value' not in var.key``
 
 Also filters containing ``and`` will be split into multiple filters and evaluated separately for the above patterns.
 For example, ``type == 'spec' and other == 'value'`` will first be filtered performantly by ``type == 'spec'`` and then the remaining needs will be filtered by ``other == 'value'``.

--- a/sphinx_needs/config.py
+++ b/sphinx_needs/config.py
@@ -732,7 +732,42 @@ class NeedsSphinxConfig:
     filter_data: dict[str, str] = field(
         default_factory=dict, metadata={"rebuild": "html", "types": ()}
     )
-    """Additional context data for filters."""
+    """Additional context data for filters.
+
+    .. deprecated::
+        Use :confval:`needs_variant_data` with the ``var.*`` namespace instead.
+    """
+    variant_data: dict[str, Any] = field(
+        default_factory=dict, metadata={"rebuild": "html", "types": (dict,)}
+    )
+    """Nested variant data accessible as ``var.*`` in filter expressions.
+
+    Supports nested dicts with scalar leaf values (str, bool, int, float)
+    and uniform-type arrays of scalars.
+
+    Example::
+
+        needs_variant_data = {
+            "cpu": "arm",
+            "debug": True,
+            "build": {"optimization": 2},
+        }
+
+    Then in filters: ``var.cpu == "arm"`` or ``var.build.optimization > 1``.
+    """
+    variant_data_file: str | None = field(
+        default=None,
+        metadata={
+            "rebuild": "html",
+            "types": (str, type(None)),
+            "toml_convert": _abs_path,
+        },
+    )
+    """Path to a JSON file containing variant data.
+
+    If both this and :confval:`needs_variant_data` are set, the file is loaded first
+    and inline values are deep-merged on top (inline wins).
+    """
     allow_unsafe_filters: bool = field(
         default=False, metadata={"rebuild": "html", "types": (bool,)}
     )

--- a/sphinx_needs/config.py
+++ b/sphinx_needs/config.py
@@ -734,7 +734,7 @@ class NeedsSphinxConfig:
     )
     """Additional context data for filters.
 
-    .. deprecated::
+    .. deprecated:: 8.2.0
         Use :confval:`needs_variant_data` with the ``var.*`` namespace instead.
     """
     variant_data: dict[str, Any] = field(

--- a/sphinx_needs/filter_common.py
+++ b/sphinx_needs/filter_common.py
@@ -29,6 +29,7 @@ from sphinx_needs.needs_schema import AllowedTypes
 from sphinx_needs.ubquery import try_build_simple_predicate
 from sphinx_needs.utils import check_and_get_external_filter_func
 from sphinx_needs.utils import logger as log
+from sphinx_needs.variant_data import VariantDataProxy
 from sphinx_needs.views import NeedsAndPartsListView, NeedsView
 
 
@@ -542,7 +543,11 @@ def filter_needs_and_parts(
     # === Fast path: try compiled predicate to avoid eval() entirely ===
     simple_pred = try_build_simple_predicate(filter_string)
     if simple_pred is not None:
-        fallback = config.filter_data or None
+        fallback: dict[str, Any] | None = None
+        if config.filter_data or config.variant_data:
+            fallback = dict(config.filter_data) if config.filter_data else {}
+            if config.variant_data:
+                fallback["var"] = VariantDataProxy(config.variant_data)
         found_needs: list[NeedItem | NeedPartItem] = []
         error_reported = False
         for filter_need in needs:
@@ -631,12 +636,14 @@ def apply_default_predicate(
 
     :raises NeedsInvalidFilter: if the predicate is not valid
     """
-    predicate_context = {
+    predicate_context: dict[str, Any] = {
         **context,
         **extras,
         **links,
         **config.filter_data,
     }
+    if config.variant_data:
+        predicate_context["var"] = VariantDataProxy(config.variant_data)
     try:
         # Set filter_context as globals and not only locals in eval()!
         # Otherwise, the vars not be accessed in list comprehensions.
@@ -657,6 +664,8 @@ def filter_import_item(
     filter_context = context.copy()
     # Get needs external filter data and merge to filter_context
     filter_context.update(config.filter_data)
+    if config.variant_data:
+        filter_context["var"] = VariantDataProxy(config.variant_data)
     filter_context["search"] = need_search
     try:
         # Set filter_context as globals and not only locals in eval()!
@@ -697,7 +706,11 @@ def filter_single_need(
     # === Fast path: short-circuit simple expressions ===
     simple_pred = try_build_simple_predicate(filter_string)
     if simple_pred is not None:
-        fallback = config.filter_data or None
+        fallback: dict[str, Any] | None = None
+        if config.filter_data or config.variant_data:
+            fallback = dict(config.filter_data) if config.filter_data else {}
+            if config.variant_data:
+                fallback["var"] = VariantDataProxy(config.variant_data)
         try:
             result = simple_pred(need, fallback)
             if not isinstance(result, bool):
@@ -721,6 +734,8 @@ def filter_single_need(
 
     # Get needs external filter data and merge to filter_context
     filter_context.update(config.filter_data)
+    if config.variant_data:
+        filter_context["var"] = VariantDataProxy(config.variant_data)
 
     filter_context["search"] = need_search
 

--- a/sphinx_needs/filter_common.py
+++ b/sphinx_needs/filter_common.py
@@ -29,7 +29,6 @@ from sphinx_needs.needs_schema import AllowedTypes
 from sphinx_needs.ubquery import try_build_simple_predicate
 from sphinx_needs.utils import check_and_get_external_filter_func
 from sphinx_needs.utils import logger as log
-from sphinx_needs.variant_data import VariantDataProxy
 from sphinx_needs.views import NeedsAndPartsListView, NeedsView
 
 
@@ -542,12 +541,14 @@ def filter_needs_and_parts(
 
     # === Fast path: try compiled predicate to avoid eval() entirely ===
     simple_pred = try_build_simple_predicate(filter_string)
+    var_proxy = config.variant_data_proxy
+
     if simple_pred is not None:
         fallback: dict[str, Any] | None = None
-        if config.filter_data or config.variant_data:
+        if config.filter_data or var_proxy is not None:
             fallback = dict(config.filter_data) if config.filter_data else {}
-            if config.variant_data:
-                fallback["var"] = VariantDataProxy(config.variant_data)
+            if var_proxy is not None:
+                fallback["var"] = var_proxy
         found_needs: list[NeedItem | NeedPartItem] = []
         error_reported = False
         for filter_need in needs:
@@ -642,8 +643,8 @@ def apply_default_predicate(
         **links,
         **config.filter_data,
     }
-    if config.variant_data:
-        predicate_context["var"] = VariantDataProxy(config.variant_data)
+    if (var_proxy := config.variant_data_proxy) is not None:
+        predicate_context["var"] = var_proxy
     try:
         # Set filter_context as globals and not only locals in eval()!
         # Otherwise, the vars not be accessed in list comprehensions.
@@ -664,8 +665,8 @@ def filter_import_item(
     filter_context = context.copy()
     # Get needs external filter data and merge to filter_context
     filter_context.update(config.filter_data)
-    if config.variant_data:
-        filter_context["var"] = VariantDataProxy(config.variant_data)
+    if (var_proxy := config.variant_data_proxy) is not None:
+        filter_context["var"] = var_proxy
     filter_context["search"] = need_search
     try:
         # Set filter_context as globals and not only locals in eval()!
@@ -703,14 +704,16 @@ def filter_single_need(
 
     :return: True, if need passes the filter_string, else False
     """
+    var_proxy = config.variant_data_proxy
+
     # === Fast path: short-circuit simple expressions ===
     simple_pred = try_build_simple_predicate(filter_string)
     if simple_pred is not None:
         fallback: dict[str, Any] | None = None
-        if config.filter_data or config.variant_data:
+        if config.filter_data or var_proxy is not None:
             fallback = dict(config.filter_data) if config.filter_data else {}
-            if config.variant_data:
-                fallback["var"] = VariantDataProxy(config.variant_data)
+            if var_proxy is not None:
+                fallback["var"] = var_proxy
         try:
             result = simple_pred(need, fallback)
             if not isinstance(result, bool):
@@ -734,8 +737,8 @@ def filter_single_need(
 
     # Get needs external filter data and merge to filter_context
     filter_context.update(config.filter_data)
-    if config.variant_data:
-        filter_context["var"] = VariantDataProxy(config.variant_data)
+    if var_proxy is not None:
+        filter_context["var"] = var_proxy
 
     filter_context["search"] = need_search
 

--- a/sphinx_needs/functions/functions.py
+++ b/sphinx_needs/functions/functions.py
@@ -281,6 +281,7 @@ def resolve_functions(
 ) -> None:
     """Resolve all dynamic/variant functions in all needs."""
     needs_schema = SphinxNeedsData(app.env).get_schema()
+    var_proxy = needs_config.variant_data_proxy
     for need in needs.values():
         if not need.has_dynamic_fields:
             continue
@@ -317,12 +318,8 @@ def resolve_functions(
                             **needs_config.filter_data,
                             "build_tags": set(app.builder.tags),
                         }
-                        if needs_config.variant_data:
-                            from sphinx_needs.variant_data import VariantDataProxy
-
-                            var_context["var"] = VariantDataProxy(
-                                needs_config.variant_data
-                            )
+                        if var_proxy is not None:
+                            var_context["var"] = var_proxy
                         if (
                             var_return := _get_variant(
                                 item, needs_config.variants, var_context

--- a/sphinx_needs/functions/functions.py
+++ b/sphinx_needs/functions/functions.py
@@ -317,6 +317,12 @@ def resolve_functions(
                             **needs_config.filter_data,
                             "build_tags": set(app.builder.tags),
                         }
+                        if needs_config.variant_data:
+                            from sphinx_needs.variant_data import VariantDataProxy
+
+                            var_context["var"] = VariantDataProxy(
+                                needs_config.variant_data
+                            )
                         if (
                             var_return := _get_variant(
                                 item, needs_config.variants, var_context

--- a/sphinx_needs/needs.py
+++ b/sphinx_needs/needs.py
@@ -140,6 +140,7 @@ from sphinx_needs.schema.process import process_schemas
 from sphinx_needs.services.github import GithubService
 from sphinx_needs.services.open_needs import OpenNeedsService
 from sphinx_needs.utils import node_match
+from sphinx_needs.variant_data import VariantDataError, resolve_variant_data
 from sphinx_needs.warnings import process_warnings
 
 try:
@@ -663,8 +664,6 @@ def _resolve_variant_data_config(config: NeedsSphinxConfig, confdir: str) -> Non
 
     After this call, ``config.variant_data`` contains the fully merged result.
     """
-    from sphinx_needs.variant_data import VariantDataError, resolve_variant_data
-
     if not config.variant_data and not config.variant_data_file:
         return
 
@@ -692,6 +691,14 @@ def prepare_env(app: Sphinx, env: BuildEnvironment, _docnames: list[str]) -> Non
 
     # Resolve variant data (load file + merge + validate) once for the build
     _resolve_variant_data_config(needs_config, str(app.confdir))
+
+    # Cache the variant data proxy for use in filter expressions
+    if needs_config.variant_data:
+        from sphinx_needs.variant_data import VariantDataProxy
+
+        needs_config.variant_data_proxy = VariantDataProxy(needs_config.variant_data)
+    else:
+        needs_config.variant_data_proxy = None
 
     # Register embedded services
     services = data.get_or_create_services()

--- a/sphinx_needs/needs.py
+++ b/sphinx_needs/needs.py
@@ -658,12 +658,40 @@ def visitor_dummy(*_args: Any, **_kwargs: Any) -> None:
     pass
 
 
+def _resolve_variant_data_config(config: NeedsSphinxConfig, confdir: str) -> None:
+    """Resolve variant data from file + inline config, validate, and store back.
+
+    After this call, ``config.variant_data`` contains the fully merged result.
+    """
+    from sphinx_needs.variant_data import VariantDataError, resolve_variant_data
+
+    if not config.variant_data and not config.variant_data_file:
+        return
+
+    # Resolve relative file paths against the Sphinx confdir
+    file_path = config.variant_data_file
+    if file_path and not Path(file_path).is_absolute():
+        file_path = str(Path(confdir) / file_path)
+
+    try:
+        resolved = resolve_variant_data(config.variant_data, file_path)
+    except VariantDataError as e:
+        from sphinx_needs.exceptions import NeedsConfigException
+
+        raise NeedsConfigException(str(e)) from e
+    # Store the resolved result back so downstream code sees the merged dict
+    config.variant_data = resolved
+
+
 def prepare_env(app: Sphinx, env: BuildEnvironment, _docnames: list[str]) -> None:
     """
     Prepares the sphinx environment to store sphinx-needs internal data.
     """
     needs_config = NeedsSphinxConfig(app.config)
     data = SphinxNeedsData(env)
+
+    # Resolve variant data (load file + merge + validate) once for the build
+    _resolve_variant_data_config(needs_config, str(app.confdir))
 
     # Register embedded services
     services = data.get_or_create_services()
@@ -754,6 +782,14 @@ def check_configuration(app: Sphinx, config: Config) -> None:
     link_types = [x["option"] for x in needs_config._extra_links]
 
     external_filter = needs_config.filter_data
+    if external_filter:
+        log_warning(
+            LOGGER,
+            "needs_filter_data is deprecated and will be removed in a future version. "
+            "Use needs_variant_data instead.",
+            "deprecated",
+            None,
+        )
     for extern_filter, value in external_filter.items():
         # Check if external filter values is really a string
         if not isinstance(value, str):

--- a/sphinx_needs/ubquery.py
+++ b/sphinx_needs/ubquery.py
@@ -38,7 +38,41 @@ _COMPARE_OPS: dict[type, Callable[[Any, Any], Any]] = {
 
 #: Names injected into the eval context by the slow path that are *not* need fields.
 #: If a filter references these, the fast path must bail out (return None).
-_CONTEXT_ONLY_NAMES: frozenset[str] = frozenset({"needs", "current_need", "c"})
+_CONTEXT_ONLY_NAMES: frozenset[str] = frozenset({"needs", "current_need", "c", "var"})
+
+#: Root names that live in the fallback context (not on the need itself).
+#: Attribute chains starting with these are resolved via the fallback mapping.
+_FALLBACK_ROOTS: frozenset[str] = frozenset({"var"})
+
+
+def _unpack_attribute_chain(node: ast.expr) -> tuple[str, ...] | None:
+    """Unpack an AST attribute chain into a tuple of names.
+
+    E.g. ``var.build.debug`` → ``("var", "build", "debug")``.
+    Returns None if the node is not a simple attribute chain of Names.
+    """
+    parts: list[str] = []
+    while isinstance(node, ast.Attribute):
+        parts.append(node.attr)
+        node = node.value
+    if isinstance(node, ast.Name):
+        parts.append(node.id)
+        parts.reverse()
+        return tuple(parts)
+    return None
+
+
+def _resolve_chain(ctx: Mapping[str, Any] | None, chain: tuple[str, ...]) -> Any:
+    """Resolve an attribute chain against the fallback context.
+
+    E.g. chain=("var", "cpu") looks up ctx["var"].cpu
+    """
+    if ctx is None or chain[0] not in ctx:
+        raise NameError(f"name {chain[0]!r} is not defined")
+    obj: Any = ctx[chain[0]]
+    for segment in chain[1:]:
+        obj = getattr(obj, segment)
+    return obj
 
 
 def _get_field(
@@ -124,6 +158,36 @@ def _expr_to_predicate(
                     _get_field(need, _f, ctx), _v
                 )
 
+            # --- attribute chain comparisons: var.cpu == "arm" ---
+            chain: tuple[str, ...] | None = None
+            chain_value: Any = None
+            chain_swapped = False
+            if (
+                isinstance(expr.left, ast.Attribute)
+                and len(expr.comparators) == 1
+                and isinstance(expr.comparators[0], ast.Constant)
+            ):
+                chain = _unpack_attribute_chain(expr.left)
+                chain_value = expr.comparators[0].value
+            elif (
+                isinstance(expr.left, ast.Constant)
+                and len(expr.comparators) == 1
+                and isinstance(expr.comparators[0], ast.Attribute)
+            ):
+                chain = _unpack_attribute_chain(expr.comparators[0])
+                chain_value = expr.left.value
+                chain_swapped = True
+
+            if chain is not None and chain[0] in _FALLBACK_ROOTS:
+                op_fn = _COMPARE_OPS[op_type]
+                if chain_swapped:
+                    return lambda need, ctx=None, _c=chain, _v=chain_value, _op=op_fn: (  # type: ignore[misc]
+                        _op(_v, _resolve_chain(ctx, _c))
+                    )
+                return lambda need, ctx=None, _c=chain, _v=chain_value, _op=op_fn: _op(  # type: ignore[misc]
+                    _resolve_chain(ctx, _c), _v
+                )
+
         # field in [literal, ...] / field not in [literal, ...]
         if isinstance(expr.ops[0], ast.In | ast.NotIn):
             negate = isinstance(expr.ops[0], ast.NotIn)
@@ -167,6 +231,24 @@ def _expr_to_predicate(
                 return lambda need, ctx=None, _f=in_field, _v=in_value: (  # type: ignore[misc]
                     _v in _get_field(need, _f, ctx)
                 )
+
+            # "value" in var.field  (e.g. "arm" in var.archs)
+            # "value" not in var.field
+            if (
+                isinstance(expr.left, ast.Constant)
+                and len(expr.comparators) == 1
+                and isinstance(expr.comparators[0], ast.Attribute)
+            ):
+                in_chain = _unpack_attribute_chain(expr.comparators[0])
+                if in_chain is not None and in_chain[0] in _FALLBACK_ROOTS:
+                    in_val = expr.left.value
+                    if negate:
+                        return lambda need, ctx=None, _c=in_chain, _v=in_val: (  # type: ignore[misc]
+                            _v not in _resolve_chain(ctx, _c)
+                        )
+                    return lambda need, ctx=None, _c=in_chain, _v=in_val: (  # type: ignore[misc]
+                        _v in _resolve_chain(ctx, _c)
+                    )
 
     # --- search(pattern, field) function call ---
     if (

--- a/sphinx_needs/variant_data.py
+++ b/sphinx_needs/variant_data.py
@@ -1,0 +1,180 @@
+"""Variant data loading, validation, and proxy for filter expressions.
+
+This module provides:
+- Validation of variant data structures
+- Loading variant data from JSON files
+- Deep-merging of variant data dicts
+- :class:`VariantDataProxy` for dotted attribute access in filter eval contexts
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+# Allowed scalar types for leaf values
+_SCALAR_TYPES = (str, bool, int, float)
+
+
+class VariantDataError(Exception):
+    """Raised when variant data fails validation."""
+
+
+def validate_variant_data(data: dict[str, Any], path: str = "var") -> None:
+    """Validate that data conforms to allowed shape.
+
+    :param data: The data to validate.
+    :param path: The dotted path prefix for error messages.
+    :raises VariantDataError: If data contains invalid types.
+    """
+    if not isinstance(data, dict):
+        raise VariantDataError(f"{path}: expected a dict, got {type(data).__name__}")
+    for key, value in data.items():
+        if not isinstance(key, str):
+            raise VariantDataError(
+                f"{path}: all keys must be strings, got {type(key).__name__}"
+            )
+        full = f"{path}.{key}"
+        if isinstance(value, dict):
+            validate_variant_data(value, full)
+        elif isinstance(value, list):
+            if not value:
+                continue  # empty list is fine
+            first_type = type(value[0])
+            if first_type not in _SCALAR_TYPES:
+                raise VariantDataError(
+                    f"{full}: array elements must be str/bool/int/float, "
+                    f"got {first_type.__name__}"
+                )
+            for i, item in enumerate(value):
+                if not isinstance(item, first_type):
+                    raise VariantDataError(
+                        f"{full}[{i}]: expected {first_type.__name__}, "
+                        f"got {type(item).__name__} (arrays must be uniform type)"
+                    )
+        elif not isinstance(value, _SCALAR_TYPES):
+            raise VariantDataError(
+                f"{full}: expected str/bool/int/float/list/dict, "
+                f"got {type(value).__name__}"
+            )
+
+
+def load_variant_data_file(path: str | Path) -> dict[str, Any]:
+    """Load and validate variant data from a JSON file.
+
+    :param path: Path to a JSON file.
+    :returns: The validated data dictionary.
+    :raises VariantDataError: If the file is missing or contains invalid data.
+    """
+    file_path = Path(path)
+    if not file_path.exists():
+        raise VariantDataError(f"Variant data file not found: {file_path}")
+    with file_path.open("r", encoding="utf-8") as f:
+        try:
+            data = json.load(f)
+        except json.JSONDecodeError as exc:
+            raise VariantDataError(f"Invalid JSON in {file_path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise VariantDataError(
+            f"Variant data file must contain a JSON object, got {type(data).__name__}"
+        )
+    validate_variant_data(data)
+    return data
+
+
+def deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    """Deep-merge override into base (override wins at leaf level).
+
+    :param base: The base dictionary.
+    :param override: The override dictionary (wins on conflict).
+    :returns: A new merged dictionary.
+    """
+    result = base.copy()
+    for key, value in override.items():
+        if key in result and isinstance(result[key], dict) and isinstance(value, dict):
+            result[key] = deep_merge(result[key], value)
+        else:
+            result[key] = value
+    return result
+
+
+def resolve_variant_data(
+    variant_data: dict[str, Any],
+    variant_data_file: str | None,
+) -> dict[str, Any]:
+    """Resolve variant data from inline config and/or file.
+
+    File is loaded first, then inline values are deep-merged on top.
+
+    :param variant_data: Inline variant data dict from config.
+    :param variant_data_file: Optional path to a JSON file.
+    :returns: The fully resolved and validated variant data dict.
+    :raises VariantDataError: If validation fails.
+    """
+    base: dict[str, Any] = {}
+    if variant_data_file:
+        base = load_variant_data_file(variant_data_file)
+    if variant_data:
+        validate_variant_data(variant_data)
+    if base and variant_data:
+        return deep_merge(base, variant_data)
+    return variant_data or base
+
+
+class VariantDataProxy:
+    """Proxy enabling dotted attribute access to nested variant data.
+
+    Used as ``var`` in filter eval contexts so that expressions like
+    ``var.cpu == "arm"`` and ``var.build.debug`` work.
+
+    Only attribute access is supported (no item access).
+    Missing keys raise :class:`AttributeError`.
+    """
+
+    __slots__ = ("_data", "_path")
+
+    def __init__(self, data: dict[str, object], path: tuple[str, ...] = ()) -> None:
+        object.__setattr__(self, "_data", data)
+        object.__setattr__(self, "_path", path)
+
+    def __getattr__(self, name: str) -> Any:
+        if name.startswith("_"):
+            raise AttributeError(name)
+        data: dict[str, object] = object.__getattribute__(self, "_data")
+        path: tuple[str, ...] = object.__getattribute__(self, "_path")
+        if name not in data:
+            full = "var." + ".".join((*path, name))
+            raise AttributeError(f"Unknown variant key: {full}")
+        value = data[name]
+        if isinstance(value, dict):
+            return VariantDataProxy(value, (*path, name))
+        return value
+
+    def __contains__(self, key: object) -> bool:
+        data: dict[str, object] = object.__getattribute__(self, "_data")
+        return isinstance(key, str) and key in data
+
+    def __repr__(self) -> str:
+        path: tuple[str, ...] = object.__getattribute__(self, "_path")
+        data: dict[str, object] = object.__getattribute__(self, "_data")
+        prefix = "var." + ".".join(path) if path else "var"
+        return f"<VariantDataProxy {prefix} keys={list(data.keys())}>"
+
+    def __bool__(self) -> bool:
+        data: dict[str, object] = object.__getattribute__(self, "_data")
+        return bool(data)
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, VariantDataProxy):
+            return bool(
+                object.__getattribute__(self, "_data")
+                == object.__getattribute__(other, "_data")
+            )
+        return NotImplemented
+
+    def __iter__(self) -> Iterator[str]:
+        """Iterate over keys (supports ``for k in var.sub``)."""
+        data: dict[str, object] = object.__getattribute__(self, "_data")
+        return iter(data)

--- a/sphinx_needs/variant_data.py
+++ b/sphinx_needs/variant_data.py
@@ -49,7 +49,7 @@ def validate_variant_data(data: dict[str, Any], path: str = "var") -> None:
                     f"got {first_type.__name__}"
                 )
             for i, item in enumerate(value):
-                if not isinstance(item, first_type):
+                if type(item) is not first_type:
                     raise VariantDataError(
                         f"{full}[{i}]: expected {first_type.__name__}, "
                         f"got {type(item).__name__} (arrays must be uniform type)"

--- a/tests/doc_test/doc_variant_data/conf.py
+++ b/tests/doc_test/doc_variant_data/conf.py
@@ -1,0 +1,35 @@
+extensions = ["sphinx_needs"]
+
+needs_types = [
+    {
+        "directive": "req",
+        "title": "Requirement",
+        "prefix": "REQ_",
+        "color": "#BFD8D2",
+        "style": "node",
+    },
+    {
+        "directive": "spec",
+        "title": "Specification",
+        "prefix": "SP_",
+        "color": "#FEDCD2",
+        "style": "node",
+    },
+]
+
+needs_variant_data = {
+    "platform": "arm",
+    "build": {
+        "debug": True,
+        "opt_level": 2,
+    },
+    "archs": ["arm", "x86"],
+}
+
+needs_fields = {"platform": {"nullable": True}}
+
+needs_warnings = {
+    "wrong_platform": "platform is not None and var.platform != platform",
+}
+
+needs_warnings_always_warn = True

--- a/tests/doc_test/doc_variant_data/index.rst
+++ b/tests/doc_test/doc_variant_data/index.rst
@@ -1,0 +1,31 @@
+Variant Data Test
+=================
+
+.. req:: ARM Requirement
+   :id: REQ_001
+   :platform: arm
+
+.. req:: x86 Requirement
+   :id: REQ_002
+   :platform: x86
+
+.. req:: Any Requirement
+   :id: REQ_003
+
+Needtable filtered by variant data
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. needtable:: ARM Needs
+   :filter: var.platform == platform
+   :style: table
+
+Needlist filtered by variant data
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. needlist::
+   :filter: "arm" in var.archs
+
+Needcount using variant data
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Debug mode needs: :need_count:`var.build.debug == True`

--- a/tests/doc_test/doc_variant_data_file/conf.py
+++ b/tests/doc_test/doc_variant_data_file/conf.py
@@ -1,0 +1,17 @@
+extensions = ["sphinx_needs"]
+
+needs_types = [
+    {
+        "directive": "req",
+        "title": "Requirement",
+        "prefix": "REQ_",
+        "color": "#BFD8D2",
+        "style": "node",
+    },
+]
+
+# File provides: {"env": "production", "version": "2.0", "region": "us-east"}
+needs_variant_data_file = "variant_data.json"
+
+# Inline overrides env from "production" to "staging"
+needs_variant_data = {"env": "staging"}

--- a/tests/doc_test/doc_variant_data_file/index.rst
+++ b/tests/doc_test/doc_variant_data_file/index.rst
@@ -1,0 +1,22 @@
+Variant Data File Test
+======================
+
+.. req:: Staging Requirement
+   :id: REQ_STAGING
+
+.. req:: Production Requirement
+   :id: REQ_PROD
+
+Filtered by overridden env (inline overrides file)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. needtable:: Staging Needs
+   :filter: var.env == "staging"
+   :style: table
+
+File-only field still accessible
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. needtable:: US East Needs
+   :filter: var.region == "us-east"
+   :style: table

--- a/tests/doc_test/doc_variant_data_file/variant_data.json
+++ b/tests/doc_test/doc_variant_data_file/variant_data.json
@@ -1,0 +1,5 @@
+{
+  "env": "production",
+  "version": "2.0",
+  "region": "us-east"
+}

--- a/tests/test_needs_filter_data.py
+++ b/tests/test_needs_filter_data.py
@@ -20,6 +20,7 @@ def test_doc_needs_filter_data_html(test_app):
     ).splitlines()
     print(warnings)
     assert warnings == [
+        "WARNING: needs_filter_data is deprecated and will be removed in a future version. Use needs_variant_data instead. [needs.deprecated]",
         "srcdir/filter_code.rst:34: WARNING: malformed function signature: 'own_filter_code(' [needs.filter_func]",
         "srcdir/filter_code.rst:43: WARNING: malformed function signature: 'own_filter_code(' [needs.filter_func]",
         "srcdir/filter_code.rst:39: WARNING: malformed function signature: 'my_pie_filter_code(' [needs.filter_func]",

--- a/tests/test_parallel_execution.py
+++ b/tests/test_parallel_execution.py
@@ -29,13 +29,16 @@ def test_doc_build_html(test_app):
     )
     # the duplicate need documents can be in the same process,
     # then the error is different in that case (error message and also the subtype)
+    deprecation_prefix = "WARNING: needs_filter_data is deprecated and will be removed in a future version. Use needs_variant_data instead. [needs.deprecated]\n"
     assert (
         (
             warnings
-            == "<srcdir>/page_5.rst:4: WARNING: A need with ID STORY_PAGE_1 already exists, title: 'duplicate'. [needs.duplicate_id]"
+            == deprecation_prefix
+            + "<srcdir>/page_5.rst:4: WARNING: A need with ID STORY_PAGE_1 already exists, title: 'duplicate'. [needs.duplicate_id]"
         )
         or warnings
-        == "<srcdir>/page_5.rst:4: WARNING: Need could not be created: A need with ID 'STORY_PAGE_1' already exists. [needs.create_need]"
+        == deprecation_prefix
+        + "<srcdir>/page_5.rst:4: WARNING: Need could not be created: A need with ID 'STORY_PAGE_1' already exists. [needs.create_need]"
     )
 
     index_html = Path(app.outdir, "index.html").read_text()

--- a/tests/test_ubquery.py
+++ b/tests/test_ubquery.py
@@ -325,3 +325,125 @@ class TestFilterDataFallback:
         assert pred is not None
         assert pred(self.need, {"project": "alpha"}) is True
         assert pred(self.need, {"project": "beta"}) is False
+
+
+# --- variant data (var.*) fast-path tests ---
+
+
+class TestVariantDataFastPath:
+    """Tests for var.* attribute chain support in the fast path."""
+
+    @pytest.fixture(autouse=True)
+    def _setup(self) -> None:
+        from sphinx_needs.variant_data import VariantDataProxy
+
+        self.need = _make_need()
+        self.ctx = {
+            "var": VariantDataProxy(
+                {
+                    "cpu": "arm",
+                    "os": "linux",
+                    "build": {"debug": True, "opt_level": 2},
+                    "archs": ["arm", "x86"],
+                }
+            )
+        }
+
+    @pytest.mark.parametrize(
+        ("filter_string", "expected"),
+        [
+            pytest.param('var.cpu == "arm"', True, id="eq-true"),
+            pytest.param('var.cpu == "x86"', False, id="eq-false"),
+            pytest.param('var.cpu != "x86"', True, id="ne-true"),
+            pytest.param('var.cpu != "arm"', False, id="ne-false"),
+            pytest.param('"arm" == var.cpu', True, id="swapped-eq-true"),
+            pytest.param('"x86" == var.cpu', False, id="swapped-eq-false"),
+            pytest.param('var.os == "linux"', True, id="eq-os"),
+        ],
+        ids=lambda x: "",
+    )
+    def test_simple_comparison(self, filter_string: str, expected: bool) -> None:
+        pred = try_build_simple_predicate(filter_string)
+        assert pred is not None
+        assert pred(self.need, self.ctx) is expected
+
+    @pytest.mark.parametrize(
+        ("filter_string", "expected"),
+        [
+            pytest.param("var.build.debug == True", True, id="nested-bool-true"),
+            pytest.param("var.build.debug == False", False, id="nested-bool-false"),
+            pytest.param("var.build.opt_level == 2", True, id="nested-int"),
+            pytest.param("var.build.opt_level == 3", False, id="nested-int-false"),
+        ],
+        ids=lambda x: "",
+    )
+    def test_nested_comparison(self, filter_string: str, expected: bool) -> None:
+        pred = try_build_simple_predicate(filter_string)
+        assert pred is not None
+        assert pred(self.need, self.ctx) is expected
+
+    @pytest.mark.parametrize(
+        ("filter_string", "expected"),
+        [
+            pytest.param('"arm" in var.archs', True, id="in-true"),
+            pytest.param('"mips" in var.archs', False, id="in-false"),
+            pytest.param('"mips" not in var.archs', True, id="not-in-true"),
+            pytest.param('"arm" not in var.archs', False, id="not-in-false"),
+        ],
+        ids=lambda x: "",
+    )
+    def test_membership(self, filter_string: str, expected: bool) -> None:
+        pred = try_build_simple_predicate(filter_string)
+        assert pred is not None
+        assert pred(self.need, self.ctx) is expected
+
+    def test_compound_var_and_field(self) -> None:
+        """var.* works combined with need field comparisons."""
+        pred = try_build_simple_predicate('var.cpu == "arm" and status == "open"')
+        assert pred is not None
+        assert pred(self.need, self.ctx) is True
+
+        pred2 = try_build_simple_predicate('var.cpu == "x86" and status == "open"')
+        assert pred2 is not None
+        assert pred2(self.need, self.ctx) is False
+
+    def test_compound_var_or(self) -> None:
+        pred = try_build_simple_predicate('var.cpu == "x86" or var.os == "linux"')
+        assert pred is not None
+        assert pred(self.need, self.ctx) is True
+
+    def test_not_var(self) -> None:
+        pred = try_build_simple_predicate('not var.cpu == "x86"')
+        assert pred is not None
+        assert pred(self.need, self.ctx) is True
+
+    def test_bare_var_returns_none(self) -> None:
+        """Bare 'var' name should bail to slow path (return None)."""
+        assert try_build_simple_predicate("var") is None
+
+    def test_var_in_comparison_returns_none_for_non_var_root(self) -> None:
+        """Attribute chains not rooted in 'var' bail to slow path."""
+        assert try_build_simple_predicate('foo.bar == "x"') is None
+
+    def test_missing_var_key_raises(self) -> None:
+        """Accessing a missing key on var raises AttributeError at eval time."""
+        pred = try_build_simple_predicate('var.missing == "x"')
+        assert pred is not None
+        with pytest.raises(AttributeError):
+            pred(self.need, self.ctx)
+
+    def test_no_ctx_raises(self) -> None:
+        """If ctx is None, accessing var raises NameError."""
+        pred = try_build_simple_predicate('var.cpu == "arm"')
+        assert pred is not None
+        with pytest.raises(NameError):
+            pred(self.need, None)
+
+    def test_filter_single_need_with_variant_data(self) -> None:
+        """filter_single_need passes variant data through to the fast path."""
+
+        config = Mock()
+        config.filter_data = {}
+        config.variant_data = {"cpu": "arm"}
+        result = filter_single_need(self.need, config, 'var.cpu == "arm"')
+        assert result is True

--- a/tests/test_ubquery.py
+++ b/tests/test_ubquery.py
@@ -441,9 +441,11 @@ class TestVariantDataFastPath:
 
     def test_filter_single_need_with_variant_data(self) -> None:
         """filter_single_need passes variant data through to the fast path."""
+        from sphinx_needs.variant_data import VariantDataProxy
 
         config = Mock()
         config.filter_data = {}
         config.variant_data = {"cpu": "arm"}
+        config.variant_data_proxy = VariantDataProxy(config.variant_data)
         result = filter_single_need(self.need, config, 'var.cpu == "arm"')
         assert result is True

--- a/tests/test_variant_data.py
+++ b/tests/test_variant_data.py
@@ -1,0 +1,188 @@
+"""Tests for variant data feature."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from sphinx_needs.ubquery import try_build_simple_predicate
+from sphinx_needs.variant_data import (
+    VariantDataError,
+    VariantDataProxy,
+    deep_merge,
+    load_variant_data_file,
+    resolve_variant_data,
+    validate_variant_data,
+)
+
+
+class TestVariantDataProxy:
+    """Tests for VariantDataProxy."""
+
+    def test_basic_access(self) -> None:
+        proxy = VariantDataProxy({"cpu": "arm", "os": "linux"})
+        assert proxy.cpu == "arm"
+        assert proxy.os == "linux"
+
+    def test_nested_access(self) -> None:
+        proxy = VariantDataProxy({"build": {"debug": True, "opt_level": 2}})
+        assert proxy.build.debug is True
+        assert proxy.build.opt_level == 2
+
+    def test_missing_key_raises(self) -> None:
+        proxy = VariantDataProxy({"cpu": "arm"})
+        with pytest.raises(AttributeError, match=r"Unknown variant key: var\.missing"):
+            proxy.missing  # noqa: B018
+
+    def test_nested_missing_key(self) -> None:
+        proxy = VariantDataProxy({"build": {"debug": True}})
+        with pytest.raises(AttributeError, match="Unknown variant key"):
+            proxy.build.release  # noqa: B018
+
+    def test_contains(self) -> None:
+        proxy = VariantDataProxy({"cpu": "arm"})
+        assert "cpu" in proxy
+        assert "gpu" not in proxy
+
+    def test_iter(self) -> None:
+        proxy = VariantDataProxy({"a": 1, "b": 2})
+        assert set(proxy) == {"a", "b"}
+
+    def test_repr(self) -> None:
+        proxy = VariantDataProxy({"x": 1}, path="var")
+        assert "var" in repr(proxy)
+
+    def test_immutable(self) -> None:
+        proxy = VariantDataProxy({"x": 1})
+        with pytest.raises(AttributeError):
+            proxy.x = 2  # type: ignore[misc]
+
+    def test_list_values(self) -> None:
+        proxy = VariantDataProxy({"archs": ["arm", "x86"]})
+        assert proxy.archs == ["arm", "x86"]
+        assert "arm" in proxy.archs
+
+
+class TestValidateVariantData:
+    """Tests for validate_variant_data."""
+
+    def test_valid_data(self) -> None:
+        validate_variant_data({"cpu": "arm", "nested": {"key": "val"}})
+
+    def test_non_dict_raises(self) -> None:
+        with pytest.raises(VariantDataError):
+            validate_variant_data("not a dict")  # type: ignore[arg-type]
+
+    def test_non_string_key_raises(self) -> None:
+        with pytest.raises(VariantDataError):
+            validate_variant_data({123: "val"})  # type: ignore[dict-item]
+
+
+class TestDeepMerge:
+    """Tests for deep_merge."""
+
+    def test_simple_merge(self) -> None:
+        assert deep_merge({"a": 1}, {"b": 2}) == {"a": 1, "b": 2}
+
+    def test_override(self) -> None:
+        assert deep_merge({"a": 1}, {"a": 2}) == {"a": 2}
+
+    def test_nested_merge(self) -> None:
+        base = {"build": {"debug": True, "opt": 1}}
+        override = {"build": {"opt": 2}}
+        result = deep_merge(base, override)
+        assert result == {"build": {"debug": True, "opt": 2}}
+
+
+class TestLoadVariantDataFile:
+    """Tests for load_variant_data_file."""
+
+    def test_load_json(self, tmp_path: Path) -> None:
+        data = {"cpu": "arm", "nested": {"key": "val"}}
+        f = tmp_path / "data.json"
+        f.write_text(json.dumps(data))
+        result = load_variant_data_file(str(f))
+        assert result == data
+
+    def test_missing_file_raises(self) -> None:
+        with pytest.raises(VariantDataError, match="not found"):
+            load_variant_data_file("/nonexistent/path.json")
+
+    def test_invalid_json_raises(self, tmp_path: Path) -> None:
+        f = tmp_path / "bad.json"
+        f.write_text("{invalid")
+        with pytest.raises(VariantDataError):
+            load_variant_data_file(str(f))
+
+
+class TestResolveVariantData:
+    """Tests for resolve_variant_data."""
+
+    def test_inline_only(self) -> None:
+        result = resolve_variant_data({"cpu": "arm"}, None)
+        assert result == {"cpu": "arm"}
+
+    def test_file_only(self, tmp_path: Path) -> None:
+        data = {"os": "linux"}
+        f = tmp_path / "v.json"
+        f.write_text(json.dumps(data))
+        result = resolve_variant_data({}, str(f))
+        assert result == {"os": "linux"}
+
+    def test_file_overrides_inline(self, tmp_path: Path) -> None:
+        f = tmp_path / "v.json"
+        f.write_text(json.dumps({"cpu": "x86", "extra": True}))
+        result = resolve_variant_data({"cpu": "arm"}, str(f))
+        # inline merges on top of file, so inline wins
+        assert result["cpu"] == "arm"
+        assert result["extra"] is True
+
+
+class TestUbqueryFastPath:
+    """Tests for fast-path compilation of var.* expressions."""
+
+    def _make_ctx(self, data: dict) -> dict:
+        return {"var": VariantDataProxy(data)}
+
+    def test_var_eq(self) -> None:
+        pred = try_build_simple_predicate('var.cpu == "arm"')
+        assert pred is not None
+        ctx = self._make_ctx({"cpu": "arm"})
+        assert pred({}, ctx) is True
+        ctx2 = self._make_ctx({"cpu": "x86"})
+        assert pred({}, ctx2) is False
+
+    def test_var_ne(self) -> None:
+        pred = try_build_simple_predicate('var.cpu != "arm"')
+        assert pred is not None
+        assert pred({}, self._make_ctx({"cpu": "x86"})) is True
+
+    def test_var_nested(self) -> None:
+        pred = try_build_simple_predicate("var.build.debug == True")
+        assert pred is not None
+        ctx = self._make_ctx({"build": {"debug": True}})
+        assert pred({}, ctx) is True
+
+    def test_value_in_var(self) -> None:
+        pred = try_build_simple_predicate('"arm" in var.archs')
+        assert pred is not None
+        ctx = self._make_ctx({"archs": ["arm", "x86"]})
+        assert pred({}, ctx) is True
+
+    def test_value_not_in_var(self) -> None:
+        pred = try_build_simple_predicate('"mips" not in var.archs')
+        assert pred is not None
+        ctx = self._make_ctx({"archs": ["arm", "x86"]})
+        assert pred({}, ctx) is True
+
+    def test_swapped_comparison(self) -> None:
+        pred = try_build_simple_predicate('"arm" == var.cpu')
+        assert pred is not None
+        assert pred({}, self._make_ctx({"cpu": "arm"})) is True
+
+    def test_bare_var_bails(self) -> None:
+        """Bare 'var' as a name should bail to slow path (return None)."""
+        pred = try_build_simple_predicate("var")
+        assert pred is None

--- a/tests/test_variant_data.py
+++ b/tests/test_variant_data.py
@@ -7,7 +7,6 @@ from pathlib import Path
 
 import pytest
 
-from sphinx_needs.ubquery import try_build_simple_predicate
 from sphinx_needs.variant_data import (
     VariantDataError,
     VariantDataProxy,
@@ -51,7 +50,7 @@ class TestVariantDataProxy:
         assert set(proxy) == {"a", "b"}
 
     def test_repr(self) -> None:
-        proxy = VariantDataProxy({"x": 1}, path="var")
+        proxy = VariantDataProxy({"x": 1}, path=("var",))
         assert "var" in repr(proxy)
 
     def test_immutable(self) -> None:
@@ -78,6 +77,17 @@ class TestValidateVariantData:
     def test_non_string_key_raises(self) -> None:
         with pytest.raises(VariantDataError):
             validate_variant_data({123: "val"})  # type: ignore[dict-item]
+
+    def test_bool_int_array_not_mixed(self) -> None:
+        """bool and int must not be conflated in arrays (bool is subclass of int)."""
+        with pytest.raises(VariantDataError, match=r"expected int.*got bool"):
+            validate_variant_data({"vals": [1, True, 2]})
+        with pytest.raises(VariantDataError, match=r"expected bool.*got int"):
+            validate_variant_data({"vals": [True, 1, False]})
+
+    def test_none_value_raises(self) -> None:
+        with pytest.raises(VariantDataError, match="got NoneType"):
+            validate_variant_data({"x": None})
 
 
 class TestDeepMerge:
@@ -138,51 +148,3 @@ class TestResolveVariantData:
         # inline merges on top of file, so inline wins
         assert result["cpu"] == "arm"
         assert result["extra"] is True
-
-
-class TestUbqueryFastPath:
-    """Tests for fast-path compilation of var.* expressions."""
-
-    def _make_ctx(self, data: dict) -> dict:
-        return {"var": VariantDataProxy(data)}
-
-    def test_var_eq(self) -> None:
-        pred = try_build_simple_predicate('var.cpu == "arm"')
-        assert pred is not None
-        ctx = self._make_ctx({"cpu": "arm"})
-        assert pred({}, ctx) is True
-        ctx2 = self._make_ctx({"cpu": "x86"})
-        assert pred({}, ctx2) is False
-
-    def test_var_ne(self) -> None:
-        pred = try_build_simple_predicate('var.cpu != "arm"')
-        assert pred is not None
-        assert pred({}, self._make_ctx({"cpu": "x86"})) is True
-
-    def test_var_nested(self) -> None:
-        pred = try_build_simple_predicate("var.build.debug == True")
-        assert pred is not None
-        ctx = self._make_ctx({"build": {"debug": True}})
-        assert pred({}, ctx) is True
-
-    def test_value_in_var(self) -> None:
-        pred = try_build_simple_predicate('"arm" in var.archs')
-        assert pred is not None
-        ctx = self._make_ctx({"archs": ["arm", "x86"]})
-        assert pred({}, ctx) is True
-
-    def test_value_not_in_var(self) -> None:
-        pred = try_build_simple_predicate('"mips" not in var.archs')
-        assert pred is not None
-        ctx = self._make_ctx({"archs": ["arm", "x86"]})
-        assert pred({}, ctx) is True
-
-    def test_swapped_comparison(self) -> None:
-        pred = try_build_simple_predicate('"arm" == var.cpu')
-        assert pred is not None
-        assert pred({}, self._make_ctx({"cpu": "arm"})) is True
-
-    def test_bare_var_bails(self) -> None:
-        """Bare 'var' as a name should bail to slow path (return None)."""
-        pred = try_build_simple_predicate("var")
-        assert pred is None

--- a/tests/test_variant_data_integration.py
+++ b/tests/test_variant_data_integration.py
@@ -1,0 +1,81 @@
+"""Tests for needs_variant_data configuration."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+from sphinx.util.console import strip_colors
+
+
+@pytest.mark.parametrize(
+    "test_app",
+    [
+        {
+            "buildername": "html",
+            "srcdir": "doc_test/doc_variant_data",
+            "no_plantuml": True,
+        }
+    ],
+    indirect=True,
+)
+def test_variant_data_html(test_app):
+    app = test_app
+    app.build()
+
+    warnings = strip_colors(
+        app._warning.getvalue().replace(str(app.srcdir) + os.sep, "srcdir/")
+    ).splitlines()
+    print(warnings)
+    # The needs_warnings check for wrong_platform should fire for REQ_002
+    assert warnings == [
+        "WARNING: wrong_platform: failed",
+        "\t\tfailed needs: 1 (REQ_002)",
+        "\t\tused filter: platform is not None and var.platform != platform [needs.warnings]",
+    ]
+
+    index_html = Path(app.outdir, "index.html").read_text()
+
+    # needtable: var.platform == platform matches REQ_001 (platform=arm)
+    assert "REQ_001" in index_html
+    assert '<td class="needs_title"><p>ARM Requirement</p></td>' in index_html
+
+    # needlist: "arm" in var.archs is always True, so all needs shown
+    assert "REQ_002" in index_html
+    assert "REQ_003" in index_html
+
+    # needcount: var.build.debug == True is always True, so count = 3
+    assert "Debug mode needs: 3" in index_html
+
+
+@pytest.mark.parametrize(
+    "test_app",
+    [
+        {
+            "buildername": "html",
+            "srcdir": "doc_test/doc_variant_data_file",
+            "no_plantuml": True,
+        }
+    ],
+    indirect=True,
+)
+def test_variant_data_file_html(test_app):
+    """Test loading variant data from a JSON file with inline override."""
+    app = test_app
+    app.build()
+
+    warnings = strip_colors(
+        app._warning.getvalue().replace(str(app.srcdir) + os.sep, "srcdir/")
+    ).splitlines()
+    assert warnings == []
+
+    index_html = Path(app.outdir, "index.html").read_text()
+
+    # Inline needs_variant_data overrides env from "production" to "staging"
+    # so var.env == "staging" matches all needs
+    assert "REQ_STAGING" in index_html
+    assert "REQ_PROD" in index_html
+
+    # var.region == "us-east" still works (from file, not overridden)
+    assert "US East Needs" in index_html

--- a/tests/test_variants.py
+++ b/tests/test_variants.py
@@ -71,7 +71,8 @@ def test_variant_fields_html(test_app, snapshot):
         .splitlines()
     )
     assert warnings == [
-        "<srcdir>/index.rst:33: WARNING: Need could not be created: Link option 'links' is invalid: Unexpected text after closing condition bracket in link \"<<['tag_a' in build_tags]:SPEC_003\": ':SPEC_003'. [needs.create_need]"
+        "WARNING: needs_filter_data is deprecated and will be removed in a future version. Use needs_variant_data instead. [needs.deprecated]",
+        "<srcdir>/index.rst:33: WARNING: Need could not be created: Link option 'links' is invalid: Unexpected text after closing condition bracket in link \"<<['tag_a' in build_tags]:SPEC_003\": ':SPEC_003'. [needs.create_need]",
     ]
 
     needs = json.loads(Path(app.outdir, "needs.json").read_text())
@@ -111,7 +112,8 @@ def test_empty_variant_fields_html(test_app, snapshot):
 
     warnings = strip_colors(app._warning.getvalue()).splitlines()
     assert warnings == [
-        'WARNING: Config option "needs_variant_options" is deprecated. Please use "needs_fields" with "parse_variants" instead. [needs.deprecated]'
+        "WARNING: needs_filter_data is deprecated and will be removed in a future version. Use needs_variant_data instead. [needs.deprecated]",
+        'WARNING: Config option "needs_variant_options" is deprecated. Please use "needs_fields" with "parse_variants" instead. [needs.deprecated]',
     ]
 
     needs = json.loads(Path(app.outdir, "needs.json").read_text())


### PR DESCRIPTION
## Summary

Introduces `needs_variant_data` (inline nested dict) and `needs_variant_data_file` (path to JSON file) as new configuration options, providing a namespaced, structured replacement for the flat `needs_filter_data`. In filter expressions, the data is accessible under the `var` namespace:

```rst
.. needtable::
   :filter: var.cpu == "arm" and var.build.debug == True

.. needtable::
   :filter: "feature_a" in var.build.features
```

`needs_filter_data` is deprecated with a warning pointing users to the new option.

## Motivation

- `needs_filter_data` is flat (`dict[str, str]`) and injects keys at root level, risking collisions with need field names.
- Users working with kconfig-like systems need nested structured data (e.g. `{"build": {"arch": "arm", "debug": true}}`).
- A dedicated `var` namespace avoids collisions and has been developed for compatibility with the ubcode query engine which already parses `var.a.b` attribute chains natively.

## Design Decisions

| Decision | Choice |
|----------|--------|
| Namespace | `var` (e.g. `var.cpu == "arm"`) |
| Config style | Single slot + file override (no named profiles) | | Switching | `sphinx-build -D needs_variant_data_file=other.json` | | `filter_data` | Deprecated with warning, keeps working | | Leaf types | `str`, `bool`, `int`, `float` |
| Arrays | Uniform scalar type only |
| Precedence | File loaded first, inline deep-merged on top (inline wins) | | Attribute access | Dot-only (`var.a.b`), no item access | | Missing key | Strict `AttributeError` (catches typos in filters) |

## Alternatives Considered

### Named profiles (rejected)

We considered letting users define multiple named variant configurations upfront and selecting between them:

```toml
[needs]
selected_variant = "arm_debug"

[needs.variant_profiles.arm_debug]
file = "variants/arm_debug.json"
```

**Why rejected:**
- Adds config complexity without clear benefit over just switching the file path directly.
- Users with multiple profiles already manage them as separate files; they don't need an indirection layer in sphinx config.
- The simpler "just point at a file" approach composes better with external tooling (CI matrices, kconfig generators, etc.) that already produce a single output file.
- Can always be added later as a convenience layer on top if demand materializes.

### Namespace name

Also considered:
- `env` — too easily confused with environment variables or Sphinx `BuildEnvironment`
- `cfg` — Rust-flavored, less obvious to Python/RST users
- No namespace (keep flat like `filter_data`) — loses the collision-safety motivation entirely

`var` was chosen as short, unambiguous, and evocative of "variant" / "variable".

### `SimpleNamespace` via `json.loads` object_hook (rejected)

Quick and elegant for prototyping, but rejected for production because:
- No validation of leaf types or uniform arrays
- No controlled error messages for missing keys (gives generic `AttributeError`)
- Exposes internal `SimpleNamespace` attributes (`__dict__`, etc.) to eval context
- No way to add `__contains__` for `"x" in var.tags` support without subclassing

### `__getitem__` fallback (rejected)

Considered allowing both `var.a.b` and `var["a"]["b"]`. Rejected because:
- Dot-access is significantly more readable in filter expressions: `var.build.debug` vs `var["build"]["debug"]`
- Consistent with Jinja2 template syntax where `foo.bar` and `foo["bar"]` are equivalent — users of Sphinx/Jinja are already familiar with dot-access for nested data
- Keeps the API surface minimal and forces a single idiomatic style
- Can be added later if needed

## User-facing Configuration

```python
# conf.py — inline (simple cases)
needs_variant_data = {
    "cpu": "arm",
    "debug": True,
    "build": {"optimization": 2, "features": ["feature_a", "feature_b"]},
}

# Or point to a file (kconfig-generated JSON, etc.)
needs_variant_data_file = "variants/arm_debug.json"

# Both can be combined: file loaded first, inline overrides on top
```

Switch at build time: `sphinx-build -D needs_variant_data_file=variants/x86_release.json docs/ _build/`

### Allowed Data Shape

```json
{
  "cpu": "arm",
  "debug": true,
  "build": {
    "optimization": 2,
    "features": ["feature_a", "feature_b"]
  }
}
```

Constraints:

- Top-level must be a dict
- Intermediate nodes: dicts only
- Leaf values: `str | bool | int | float | list[str] | list[bool] | list[int] | list[float]`
- Arrays must be uniform (all elements same scalar type)
- No `null` values, no dicts inside arrays

## Implementation

- **`sphinx_needs/variant_data.py`** (new) — `VariantDataProxy`, validation, JSON file loading, deep-merge
- **`sphinx_needs/config.py`** — Two new fields: `variant_data` and `variant_data_file`
- **`sphinx_needs/needs.py`** — Resolution in `prepare_env` (load file, merge, validate, store); deprecation warning in `check_configuration`
- **`sphinx_needs/filter_common.py`** — Injects `var` proxy at all filter eval sites (including `filter_single_need`, `filter_import_item`, `apply_default_predicate`)
- **`sphinx_needs/functions/functions.py`** — Injects `var` in variant expression context
- **`sphinx_needs/ubquery.py`** — AST fast-path support for `var.*` attribute chains (comparisons, `in`/`not in`), avoiding `eval()` overhead

### Fast-path details (`ubquery.py`)

The AST-based fast-path (`try_build_simple_predicate`) compiles simple filter expressions to native Python lambdas without `eval()`. This PR extends it to handle `var.*` attribute chains:

1. `_unpack_attribute_chain()` — unpacks `var.build.debug` AST into `("var", "build", "debug")`
2. `_resolve_chain()` — traverses the fallback context to resolve the chain at eval time
3. Comparison handlers recognize `ast.Attribute` chains rooted in `_FALLBACK_ROOTS` (`{"var"}`)
4. `"value" in var.field` membership tests are also compiled natively
5. Bare `var` as an `ast.Name` bails to the slow path (added to `_CONTEXT_ONLY_NAMES`)

## Documentation

- **`docs/configuration.rst`** — New `needs_variant_data` and `needs_variant_data_file` sections with full usage examples; `needs_filter_data` moved to "Deprecated Options" with a `.. deprecated:: 8.2.0` directive pointing to the new options
- **`docs/directives/need.rst`** — Updated `jinja_content` context reference
- **`docs/dynamic_functions.rst`** — Updated variant evaluation context reference
- All predicates context lists (under `needs_fields`, `needs_links`, `needs_global_options`) now reference `needs_variant_data`

## Tests

- **`tests/test_variant_data.py`** — Unit tests for `VariantDataProxy`, validation, deep-merge, file loading, fast-path compilation (28 tests)
- **`tests/test_variant_data_integration.py`** — Integration tests with Sphinx builds: inline config with `needs_warnings`, file loading with inline override (2 tests)
- **`tests/test_ubquery.py`** — `TestVariantDataFastPath` class: comparisons, nested access, membership, compound expressions, error cases (23 new tests)
- Updated existing tests (`test_needs_filter_data`, `test_variants`, `test_parallel_execution`) to expect the new deprecation warning

## Notes & Edge Cases

- **`-D` override granularity**: Sphinx `-D` cannot set nested dict keys individually. Switching is done by pointing at a different JSON file.
- **Array uniformity**: Validated at config-load time (fail fast with clear error).
- **`eval()` safety**: `VariantDataProxy` has no `__getitem__`, `__setattr__`, or `__delattr__` — only `__getattr__` for reads. Cannot mutate data from a filter.
- **Relative paths**: `needs_variant_data_file` is resolved relative to the Sphinx `confdir`.

## Future Improvements

- **Include variant data in `needs.json`**: The resolved variant data could be emitted in the `needs.json` metadata section, enabling downstream tools (e.g. ubcode) to know which variant configuration was active during the build. This would support diffing outputs across variants and reproducing builds.