### PR TITLE
📚 Add context7.json for Context7 documentation discovery

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/websites/sphinx-needs_readthedocs_io_en_stable",
+  "public_key": "pk_xNc0ZKQprjyeHmufy5Kfi"
+}

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,10 @@ Unreleased
 Improvements
 ............
 
+- 🔧 Add a root ``context7.json`` configuration file so AI assistants using
+  Context7 can discover the live Sphinx-Needs documentation and use the
+  project-specific reference instead of stale training data (:issue:`1719`)
+
 - 👌 Allow link fields in :ref:`needservice` directive options, so needs
   created via a custom service can declare links to other needs (:pr:`1632`)
 


### PR DESCRIPTION
## Summary
- add the root context7.json configuration requested in #1719
- add an unreleased changelog entry describing the new Context7 integration

## Validation
- uvx --from tox-uv tox -e ruff-check
- uvx --from tox-uv tox -e mypy

## Notes
- no tests were added because this change only adds repository configuration and a changelog entry

Closes #1719