### PR TITLE
✨ Add `<{...}>` variant data syntax for field values

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -218,7 +218,7 @@ For new fields the following can be defined:
     If specified, these will be evaluated in order for any need that does not explicitly set the field, with the first match setting the field value.
 - ``default``: A default value for the field (optional).
     If specified, this value will be used for any need that does not explicitly set the field and does not match any predicates.
-- ``parse_variants``: If set to ``True``, the field will support :ref:`variant options <needs_variant_support>`.
+- ``parse_variants``: If set to ``True``, the field will support :ref:`variant options <needs_variant_support>` and :ref:`variant data references <needs_variant_data_references>`.
     Default: ``False``.
 - ``parse_dynamic_functions``: If set to ``True``, the field will support :ref:`dynamic_functions`.
     Default: the value of :ref:`needs_parse_dynamic_functions` (``True``).
@@ -378,7 +378,7 @@ Each configured link can define:
     If specified, these will be evaluated in order for any need that does not explicitly set the field, with the first match setting the field value.
 - ``default`` (optional): A default value for the field.
     If specified, this value will be used for any need that does not explicitly set the field and does not match any predicates.
-- ``parse_variants``: If set to ``True``, the field will support :ref:`variant options <needs_variant_support>`.
+- ``parse_variants``: If set to ``True``, the field will support :ref:`variant options <needs_variant_support>` and :ref:`variant data references <needs_variant_data_references>`.
     Default: ``False``.
 - ``parse_dynamic_functions``: If set to ``True``, the field will support :ref:`dynamic_functions`.
     Default: the value of :ref:`needs_parse_dynamic_functions` (``True``).
@@ -617,6 +617,9 @@ The data is then available in filter expressions via the ``var`` namespace:
 - No ``None`` values, no dictionaries inside arrays.
 
 Accessing a missing key raises an ``AttributeError``, which helps catch typos in filter expressions.
+
+The ``var`` namespace can also be referenced directly within need field values using the
+:ref:`<{ ... }> syntax <needs_variant_data_references>`.
 
 Default: ``{}``
 
@@ -2905,7 +2908,7 @@ Each configured link should define:
     If specified, these will be evaluated in order for any need that does not explicitly set the field, with the first match setting the field value.
 - ``default`` (optional): A default value for the field.
     If specified, this value will be used for any need that does not explicitly set the field and does not match any predicates.
-- ``parse_variants``: If set to ``True``, the field will support :ref:`variant options <needs_variant_support>`.
+- ``parse_variants``: If set to ``True``, the field will support :ref:`variant options <needs_variant_support>` and :ref:`variant data references <needs_variant_data_references>`.
     Default: ``False``.
 - ``parse_dynamic_functions``: If set to ``True``, the field will support :ref:`dynamic_functions`.
     Default: the value of :ref:`needs_parse_dynamic_functions` (``True``).

--- a/docs/dynamic_functions.rst
+++ b/docs/dynamic_functions.rst
@@ -298,7 +298,7 @@ Variant data references
 In addition to :ref:`variant functions <needs_variant_support>` (``<<...>>``),
 you can inject values directly from :ref:`needs_variant_data` into a need field
 using the ``<{ ... }>`` syntax.
-The inner expression is evaluated and its result is substituted into the field value.
+The referenced value is looked up and substituted into the field value.
 
 .. important::
 
@@ -310,14 +310,10 @@ Rules for variant data references
 ---------------------------------
 
 * References must be wrapped in ``<{`` and ``}>`` symbols, like ``<{ var.cpu }>``.
-* The expression is evaluated using Python syntax, with the
-  :ref:`needs_variant_data` exposed under the ``var`` namespace as the *only*
-  available name.
-  Unlike :ref:`variant functions <needs_variant_support>`, the need's own fields,
-  Sphinx-Tags (``build_tags``), and Python builtins are **not** available in the
-  expression.
-* Values are accessed using dot notation (``var.build.optimization``).
-  Accessing a missing key raises an error.
+* The reference must be a dotted path rooted at the ``var`` namespace, which
+  exposes the :ref:`needs_variant_data`,
+  via key lookup via dot notation (``var.build.optimization``).
+* Accessing a missing key, or a path that does not resolve to a leaf value will emit a warning.
 * The resolved value is type-validated against the schema of the field
   (or, for array fields, against the schema of the array items).
   A warning is emitted if the type does not match.

--- a/docs/dynamic_functions.rst
+++ b/docs/dynamic_functions.rst
@@ -287,3 +287,88 @@ Below is an implementation of variants for need options:
       :collapse:
 
       Variants for need options in action
+
+.. _needs_variant_data_references:
+
+Variant data references
+=======================
+
+.. versionadded:: 8.2.0
+
+In addition to :ref:`variant functions <needs_variant_support>` (``<<...>>``),
+you can inject values directly from :ref:`needs_variant_data` into a need field
+using the ``<{ ... }>`` syntax.
+The inner expression is evaluated and its result is substituted into the field value.
+
+.. important::
+
+   This feature uses the same enablement as variant functions:
+   you must set the :ref:`needs_fields` or :ref:`needs_links` configuration
+   parameter's ``parse_variants`` option to ``True`` for the specific field.
+
+Rules for variant data references
+---------------------------------
+
+* References must be wrapped in ``<{`` and ``}>`` symbols, like ``<{ var.cpu }>``.
+* The expression is evaluated using Python syntax, with the
+  :ref:`needs_variant_data` exposed under the ``var`` namespace as the *only*
+  available name.
+  Unlike :ref:`variant functions <needs_variant_support>`, the need's own fields,
+  Sphinx-Tags (``build_tags``), and Python builtins are **not** available in the
+  expression.
+* Values are accessed using dot notation (``var.build.optimization``).
+  Accessing a missing key raises an error.
+* The resolved value is type-validated against the schema of the field
+  (or, for array fields, against the schema of the array items).
+  A warning is emitted if the type does not match.
+* References can be used for scalar, string, array, and link fields.
+* For string fields, a reference can be embedded within surrounding text, and the
+  parts are joined with spaces.
+  For non-string scalar fields, the reference must make up the entire value, so
+  that the resolved value keeps its native type (e.g. an integer).
+
+Use Cases
+---------
+
+In your ``conf.py``, enable ``parse_variants`` for the fields you want to use
+references in, and define the :ref:`needs_variant_data`:
+
+.. code-block:: python
+
+   needs_variant_data = {
+       "platform": "arm",
+       "build": {"opt_level": 2},
+   }
+
+   needs_fields = {
+       "arch": {
+           "schema": {"type": "string"},
+           "parse_variants": True,
+       },
+       "opt": {
+           "schema": {"type": "integer"},
+           "parse_variants": True,
+       },
+   }
+
+In your ``.rst`` file, reference the variant data within field values:
+
+.. code-block:: rst
+
+   .. req:: Example
+      :id: VD_001
+      :arch: <{ var.platform }>
+      :opt: <{ var.build.opt_level }>
+
+In the example above, ``arch`` resolves to the string ``"arm"`` and ``opt``
+resolves to the integer ``2``.
+
+A reference can also be embedded within a larger string value:
+
+.. code-block:: rst
+
+   .. req:: Example
+      :id: VD_002
+      :arch: platform is <{ var.platform }>
+
+Here ``arch`` resolves to ``"platform is arm"``.

--- a/sphinx_needs/api/need.py
+++ b/sphinx_needs/api/need.py
@@ -53,6 +53,7 @@ from sphinx_needs.needs_schema import (
 from sphinx_needs.nodes import Need
 from sphinx_needs.roles.need_part import find_parts, update_need_with_parts
 from sphinx_needs.utils import jinja_parse
+from sphinx_needs.variant_data import VariantDataParsed
 from sphinx_needs.variants import VariantFunctionParsed
 from sphinx_needs.views import NeedsView
 
@@ -1002,14 +1003,18 @@ def _copy_links(
     """Implement 'copy' logic for links."""
     if "links" not in links:
         return  # should not happen, but be defensive
-    copy_links: list[NeedLink | DynamicFunctionParsed | VariantFunctionParsed] = []
+    copy_links: list[
+        NeedLink | DynamicFunctionParsed | VariantFunctionParsed | VariantDataParsed
+    ] = []
     for link_field in schema.iter_link_fields():
         if link_field.copy and link_field.name != "links":
             other = links[link_field.name]
             if isinstance(other, LinksLiteralValue | LinksFunctionArray):
                 copy_links.extend(other.value)
     if any(
-        isinstance(li, DynamicFunctionParsed | VariantFunctionParsed)
+        isinstance(
+            li, DynamicFunctionParsed | VariantFunctionParsed | VariantDataParsed
+        )
         for li in copy_links
     ):
         if links["links"] is None:

--- a/sphinx_needs/functions/functions.py
+++ b/sphinx_needs/functions/functions.py
@@ -26,6 +26,7 @@ from sphinx_needs.logging import get_logger, log_warning
 from sphinx_needs.need_item import NeedItem, NeedLink, NeedPartItem
 from sphinx_needs.nodes import Need
 from sphinx_needs.roles.need_func import NeedFunc
+from sphinx_needs.variant_data import VariantDataParsed
 from sphinx_needs.variants import VariantFunctionParsed
 from sphinx_needs.views import NeedsView
 
@@ -344,6 +345,27 @@ def resolve_functions(
                                 resolved.extend(var_return)
                             else:
                                 resolved.append(var_return)
+                    elif isinstance(item, VariantDataParsed):
+                        vd_return = _get_variant_data(item, var_proxy)
+                        if not (
+                            field_schema.type_check(vd_return)
+                            or (
+                                field_schema.type == "array"
+                                and field_schema.type_check_item(vd_return)
+                            )
+                        ):
+                            raise ValueError(
+                                f"variant data value {type(vd_return)} is not of type {field_schema.type!r}"
+                                + (
+                                    ""
+                                    if field_schema.type != "array"
+                                    else f" or item type {field_schema.item_type!r}"
+                                )
+                            )
+                        if isinstance(vd_return, list | tuple):
+                            resolved.extend(vd_return)
+                        else:
+                            resolved.append(vd_return)
                     else:
                         resolved.append(item)
 
@@ -377,6 +399,35 @@ def _get_variant(
         if bool(eval(expr, context.copy())):
             return value
     return variant.final_value
+
+
+def _get_variant_data(
+    variant_data: VariantDataParsed,
+    var_proxy: Any,
+) -> Any:
+    """Evaluate a variant data expression against the ``var`` context.
+
+    The expression is evaluated with ``var`` bound to the variant data proxy,
+    and no other names available.
+
+    :param variant_data: The parsed variant data reference.
+    :param var_proxy: The variant data proxy, or ``None`` if not configured.
+    :returns: The evaluated value.
+    :raises ValueError: if no variant data is configured,
+        or the expression fails to evaluate.
+    """
+    if var_proxy is None:
+        raise ValueError(
+            f"variant data {variant_data.expression!r} cannot be resolved: "
+            "no variant data is configured"
+        )
+    try:
+        return eval(variant_data.expression, {"__builtins__": {}, "var": var_proxy})
+    except Exception as exc:
+        raise ValueError(
+            f"variant data expression {variant_data.expression!r} "
+            f"failed to evaluate: {exc}"
+        ) from exc
 
 
 def check_and_get_content(

--- a/sphinx_needs/functions/functions.py
+++ b/sphinx_needs/functions/functions.py
@@ -26,7 +26,11 @@ from sphinx_needs.logging import get_logger, log_warning
 from sphinx_needs.need_item import NeedItem, NeedLink, NeedPartItem
 from sphinx_needs.nodes import Need
 from sphinx_needs.roles.need_func import NeedFunc
-from sphinx_needs.variant_data import VariantDataParsed
+from sphinx_needs.variant_data import (
+    VariantDataError,
+    VariantDataParsed,
+    lookup_variant_data,
+)
 from sphinx_needs.variants import VariantFunctionParsed
 from sphinx_needs.views import NeedsView
 
@@ -346,7 +350,7 @@ def resolve_functions(
                             else:
                                 resolved.append(var_return)
                     elif isinstance(item, VariantDataParsed):
-                        vd_return = _get_variant_data(item, var_proxy)
+                        vd_return = _get_variant_data(item, needs_config.variant_data)
                         if not (
                             field_schema.type_check(vd_return)
                             or (
@@ -403,31 +407,22 @@ def _get_variant(
 
 def _get_variant_data(
     variant_data: VariantDataParsed,
-    var_proxy: Any,
+    variant_data_context: dict[str, Any],
 ) -> Any:
-    """Evaluate a variant data expression against the ``var`` context.
+    """Resolve a variant data reference against the ``var`` namespace.
 
-    The expression is evaluated with ``var`` bound to the variant data proxy,
-    and no other names available.
+    The reference is a constrained dotted ``var.*`` path (no arbitrary
+    expression evaluation); it is resolved by walking the variant data mapping.
 
     :param variant_data: The parsed variant data reference.
-    :param var_proxy: The variant data proxy, or ``None`` if not configured.
-    :returns: The evaluated value.
-    :raises ValueError: if no variant data is configured,
-        or the expression fails to evaluate.
+    :param variant_data_context: The resolved variant data mapping.
+    :returns: The resolved value.
+    :raises ValueError: if the reference is invalid or cannot be resolved.
     """
-    if var_proxy is None:
-        raise ValueError(
-            f"variant data {variant_data.expression!r} cannot be resolved: "
-            "no variant data is configured"
-        )
     try:
-        return eval(variant_data.expression, {"__builtins__": {}, "var": var_proxy})
-    except Exception as exc:
-        raise ValueError(
-            f"variant data expression {variant_data.expression!r} "
-            f"failed to evaluate: {exc}"
-        ) from exc
+        return lookup_variant_data(variant_data_context, variant_data.expression)
+    except VariantDataError as exc:
+        raise ValueError(str(exc)) from exc
 
 
 def check_and_get_content(

--- a/sphinx_needs/needs_schema.py
+++ b/sphinx_needs/needs_schema.py
@@ -23,6 +23,7 @@ from sphinx_needs.schema.config import (
     validate_link_schema_type,
 )
 from sphinx_needs.schema.core import validate_object_schema_compiles
+from sphinx_needs.variant_data import VariantDataParsed
 from sphinx_needs.variants import VariantFunctionParsed
 
 if TYPE_CHECKING:
@@ -291,6 +292,14 @@ class FieldSchema:
                             ),
                         )
                     )
+                elif (
+                    self.parse_variants
+                    and value.lstrip().startswith("<{")
+                    and value.rstrip().endswith("}>")
+                ):
+                    return FieldFunctionArray(
+                        (VariantDataParsed.from_string(value.strip()[2:-2]),)
+                    )
                 else:
                     return FieldLiteralValue(_from_string_item(value, self.type))
             case "string":
@@ -299,7 +308,12 @@ class FieldSchema:
                 )
                 if len(parsed_items) == 1 and parsed_items[0][1] == ListItemType.STD:
                     return FieldLiteralValue(parsed_items[0][0])
-                result: list[DynamicFunctionParsed | VariantFunctionParsed | str] = []
+                result: list[
+                    DynamicFunctionParsed
+                    | VariantFunctionParsed
+                    | VariantDataParsed
+                    | str
+                ] = []
                 for item, item_type in parsed_items:
                     match item_type:
                         case ListItemType.STD:
@@ -310,6 +324,9 @@ class FieldSchema:
                         case ListItemType.VF | ListItemType.VF_U:
                             # TODO warn on unclosed variant function
                             result.append(VariantFunctionParsed.from_string(item))
+                        case ListItemType.VD | ListItemType.VD_U:
+                            # TODO warn on unclosed variant data
+                            result.append(VariantDataParsed.from_string(item))
                 return FieldFunctionArray(tuple(result))
             case "array":
                 if self.item_type is None:
@@ -323,6 +340,7 @@ class FieldSchema:
                     | float
                     | DynamicFunctionParsed
                     | VariantFunctionParsed
+                    | VariantDataParsed
                 ] = []
                 for parsed in _split_list(
                     value, self.parse_dynamic_functions, self.parse_variants
@@ -350,6 +368,10 @@ class FieldSchema:
                                     ),
                                 )
                             )
+                        case ListItemType.VD | ListItemType.VD_U:
+                            # TODO warn on unclosed variant data
+                            has_df_or_vf = True
+                            array.append(VariantDataParsed.from_string(item))
 
                 if has_df_or_vf:
                     return FieldFunctionArray(tuple(array))  # type: ignore[arg-type]
@@ -390,7 +412,10 @@ class FieldSchema:
                 from sphinx_needs.functions.functions import DynamicFunctionParsed
 
                 new_value: list[
-                    str | DynamicFunctionParsed | VariantFunctionParsed
+                    str
+                    | DynamicFunctionParsed
+                    | VariantFunctionParsed
+                    | VariantDataParsed
                 ] = []
                 has_function = False
                 item: str
@@ -412,6 +437,15 @@ class FieldSchema:
                         has_function = True
                         new_value.append(
                             VariantFunctionParsed.from_string(item.strip()[2:-2])
+                        )
+                    elif (
+                        self.parse_variants
+                        and item.lstrip().startswith("<{")
+                        and item.rstrip().endswith("}>")
+                    ):
+                        has_function = True
+                        new_value.append(
+                            VariantDataParsed.from_string(item.strip()[2:-2])
                         )
                     else:
                         new_value.append(item)
@@ -446,16 +480,32 @@ class LinksLiteralValue:
 @dataclass(frozen=True, slots=True)
 class FieldFunctionArray:
     value: (
-        tuple[DynamicFunctionParsed | VariantFunctionParsed | str, ...]
-        | tuple[DynamicFunctionParsed | VariantFunctionParsed | bool, ...]
-        | tuple[DynamicFunctionParsed | VariantFunctionParsed | int, ...]
-        | tuple[DynamicFunctionParsed | VariantFunctionParsed | float, ...]
+        tuple[
+            DynamicFunctionParsed | VariantFunctionParsed | VariantDataParsed | str, ...
+        ]
+        | tuple[
+            DynamicFunctionParsed | VariantFunctionParsed | VariantDataParsed | bool,
+            ...,
+        ]
+        | tuple[
+            DynamicFunctionParsed | VariantFunctionParsed | VariantDataParsed | int, ...
+        ]
+        | tuple[
+            DynamicFunctionParsed | VariantFunctionParsed | VariantDataParsed | float,
+            ...,
+        ]
     )
 
     def __iter__(
         self,
     ) -> Iterator[
-        DynamicFunctionParsed | VariantFunctionParsed | str | bool | int | float
+        DynamicFunctionParsed
+        | VariantFunctionParsed
+        | VariantDataParsed
+        | str
+        | bool
+        | int
+        | float
     ]:
         return iter(self.value)
 
@@ -465,17 +515,25 @@ _ValueType = TypeVar("_ValueType", str, bool, int, float)
 
 @dataclass(frozen=True, slots=True)
 class FunctionArrayTyped(Generic[_ValueType]):
-    value: tuple[DynamicFunctionParsed | VariantFunctionParsed | _ValueType, ...]
+    value: tuple[
+        DynamicFunctionParsed | VariantFunctionParsed | VariantDataParsed | _ValueType,
+        ...,
+    ]
 
     def __iter__(
         self,
-    ) -> Iterator[DynamicFunctionParsed | VariantFunctionParsed | _ValueType]:
+    ) -> Iterator[
+        DynamicFunctionParsed | VariantFunctionParsed | VariantDataParsed | _ValueType
+    ]:
         return iter(self.value)
 
 
 @dataclass(frozen=True, slots=True)
 class LinksFunctionArray:
-    value: tuple[NeedLink | DynamicFunctionParsed | VariantFunctionParsed, ...]
+    value: tuple[
+        NeedLink | DynamicFunctionParsed | VariantFunctionParsed | VariantDataParsed,
+        ...,
+    ]
 
 
 @lru_cache(maxsize=128)
@@ -728,7 +786,9 @@ class LinkSchema:
             raise TypeError(f"Value '{value}' is not a string.")
 
         has_df_or_vf = False
-        array: list[NeedLink | DynamicFunctionParsed | VariantFunctionParsed] = []
+        array: list[
+            NeedLink | DynamicFunctionParsed | VariantFunctionParsed | VariantDataParsed
+        ] = []
         for item in _split_link_list(
             value,
             self.parse_dynamic_functions,
@@ -773,7 +833,10 @@ class LinkSchema:
                 from sphinx_needs.functions.functions import DynamicFunctionParsed
 
                 new_value: list[
-                    NeedLink | DynamicFunctionParsed | VariantFunctionParsed
+                    NeedLink
+                    | DynamicFunctionParsed
+                    | VariantFunctionParsed
+                    | VariantDataParsed
                 ] = []
                 has_function = False
                 item: str
@@ -795,6 +858,15 @@ class LinkSchema:
                         has_function = True
                         new_value.append(
                             VariantFunctionParsed.from_string(item.strip()[2:-2])
+                        )
+                    elif (
+                        self.parse_variants
+                        and item.lstrip().startswith("<{")
+                        and item.rstrip().endswith("}>")
+                    ):
+                        has_function = True
+                        new_value.append(
+                            VariantDataParsed.from_string(item.strip()[2:-2])
                         )
                     else:
                         new_value.append(
@@ -937,6 +1009,8 @@ class ListItemType(enum.Enum):
     DF_U = "df_unclosed"
     VF = "vf"
     VF_U = "vf_unclosed"
+    VD = "vd"
+    VD_U = "vd_unclosed"
 
 
 def _split_list(
@@ -945,7 +1019,7 @@ def _split_list(
     parse_variants: bool,
     allow_delimiters: bool = True,
 ) -> Iterator[list[tuple[str, ListItemType]]]:
-    """Split a ``;|,`` delimited string that may contain ``[[...]]`` dynamic functions or ``<<...>>`` variant functions.
+    """Split a ``;|,`` delimited string that may contain ``[[...]]`` dynamic functions, ``<<...>>`` variant functions, or ``<{...}>`` variant data.
 
     :param text: The string to split.
 
@@ -974,6 +1048,26 @@ def _split_list(
                 (
                     _current_element,
                     ListItemType.DF if text.startswith("]]") else ListItemType.DF_U,
+                )
+            )
+            _current_element = ""
+            text = text[2:]
+        elif parse_variants and text.startswith("<{"):
+            if not _current_elements:
+                _current_element = _current_element.lstrip()
+            if _current_element:
+                _current_elements.append((_current_element, ListItemType.STD))
+            _current_element = ""
+            text = text[2:]
+            while text and not text.startswith("}>"):
+                _current_element += text[0]
+                text = text[1:]
+            if _current_element.endswith("}"):
+                _current_element = _current_element[:-1]
+            _current_elements.append(
+                (
+                    _current_element,
+                    ListItemType.VD if text.startswith("}>") else ListItemType.VD_U,
                 )
             )
             _current_element = ""
@@ -1034,19 +1128,24 @@ def _split_link_list(
     *,
     parse_conditions: bool = True,
 ) -> Iterator[
-    NeedLink | DynamicFunctionParsed | VariantFunctionParsed | LinkSplitWarning
+    NeedLink
+    | DynamicFunctionParsed
+    | VariantFunctionParsed
+    | VariantDataParsed
+    | LinkSplitWarning
 ]:
     """Split a ``;|,`` delimited link string, directly yielding typed objects.
 
     Handles ``[[...]]`` dynamic functions, ``<<...>>`` variant functions,
-    and plain link IDs with optional ``[condition]`` syntax.
+    ``<{...}>`` variant data, and plain link IDs with optional ``[condition]`` syntax.
 
     Parsing is done left-to-right in a single pass with these priority rules:
 
     1. ``[[...]]`` → ``DynamicFunctionParsed``
     2. ``<<...>>`` → ``VariantFunctionParsed``
-    3. ``;|,`` → flush accumulated text as a ``NeedLink``
-    4. Otherwise → accumulate character
+    3. ``<{...}>`` → ``VariantDataParsed``
+    4. ``;|,`` → flush accumulated text as a ``NeedLink``
+    5. Otherwise → accumulate character
 
     Plain link items support the format ``ID``, ``ID.part``,
     ``ID[condition]``, or ``ID.part[condition]``.
@@ -1055,7 +1154,7 @@ def _split_link_list(
 
     :param text: The string to split.
     :param parse_dynamic_functions: Whether to parse ``[[...]]`` dynamic functions.
-    :param parse_variants: Whether to parse ``<<...>>`` variant functions.
+    :param parse_variants: Whether to parse ``<<...>>`` variant functions and ``<{...}>`` variant data.
     :param parse_conditions: Whether to parse ``[condition]`` brackets.
     :yields: Parsed link items, or ``LinkSplitWarning`` for non-fatal issues
         (e.g. text adjacent to a dynamic/variant function, unclosed brackets).
@@ -1063,7 +1162,7 @@ def _split_link_list(
     from sphinx_needs.functions.functions import DynamicFunctionParsed
 
     _current = ""  # text accumulated for the current plain-text item
-    _has_special = False  # whether current slot has yielded a DF/VF
+    _has_special = False  # whether current slot has yielded a DF/VF/VD
 
     def _flush_current() -> NeedLink | LinkSplitWarning | None:
         """Flush accumulated plain text as a NeedLink, or None if empty."""
@@ -1109,6 +1208,21 @@ def _split_link_list(
                 content = content[:-1]
             yield VariantFunctionParsed.from_string(content)
             if text.startswith(">>"):
+                text = text[2:]
+        elif parse_variants and text.startswith("<{") and not _current.strip():
+            # <{ at start of slot (no preceding non-whitespace text) → variant data
+            _current = ""  # discard any leading whitespace
+            _has_special = True
+            # Consume until closing }>
+            text = text[2:]
+            content = ""
+            while text and not text.startswith("}>"):
+                content += text[0]
+                text = text[1:]
+            if content.endswith("}"):
+                content = content[:-1]
+            yield VariantDataParsed.from_string(content)
+            if text.startswith("}>"):
                 text = text[2:]
         elif text[0] in ";|,":
             # Delimiter: flush current item

--- a/sphinx_needs/variant_data.py
+++ b/sphinx_needs/variant_data.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Iterator
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -20,6 +21,28 @@ _SCALAR_TYPES = (str, bool, int, float)
 
 class VariantDataError(Exception):
     """Raised when variant data fails validation."""
+
+
+@dataclass(frozen=True, slots=True)
+class VariantDataParsed:
+    """A parsed variant data reference, e.g. ``<{ var.a.b }>``.
+
+    Holds the inner expression (without the ``<{`` and ``}>`` delimiters),
+    which is evaluated against the variant data context (``var``)
+    when dynamic fields are resolved.
+    """
+
+    expression: str
+    """The inner expression, stripped of surrounding whitespace."""
+
+    @classmethod
+    def from_string(cls, text: str) -> VariantDataParsed:
+        """Create a :class:`VariantDataParsed` from a raw inner string.
+
+        :param text: The inner expression text (without delimiters).
+        :returns: The parsed variant data reference.
+        """
+        return cls(text.strip())
 
 
 def validate_variant_data(data: dict[str, Any], path: str = "var") -> None:

--- a/sphinx_needs/variant_data.py
+++ b/sphinx_needs/variant_data.py
@@ -28,7 +28,8 @@ class VariantDataParsed:
     """A parsed variant data reference, e.g. ``<{ var.a.b }>``.
 
     Holds the inner expression (without the ``<{`` and ``}>`` delimiters),
-    which is evaluated against the variant data context (``var``)
+    which must be a dotted path rooted at ``var`` (e.g. ``var.build.opt_level``).
+    The reference is resolved against the variant data context (``var``)
     when dynamic fields are resolved.
     """
 
@@ -43,6 +44,51 @@ class VariantDataParsed:
         :returns: The parsed variant data reference.
         """
         return cls(text.strip())
+
+
+def lookup_variant_data(data: dict[str, Any], expression: str) -> Any:
+    """Resolve a ``var.*`` dotted-path reference against variant data.
+
+    This is a constrained lookup, not an arbitrary expression evaluation:
+    the expression must be a dotted path rooted at ``var``
+    (e.g. ``var.build.opt_level``), with no operators, function calls,
+    or item access. Each segment selects a key from the (nested) variant
+    data mapping.
+
+    :param data: The resolved variant data mapping.
+    :param expression: The reference expression, e.g. ``var.build.debug``.
+    :returns: The resolved leaf value (a scalar or list).
+    :raises VariantDataError: If the expression is not a valid ``var.*`` path,
+        a key along the path is missing, or an intermediate/leaf value has the
+        wrong shape (e.g. selecting into a non-mapping, or resolving to a mapping).
+    """
+    segments = [segment.strip() for segment in expression.split(".")]
+    if len(segments) < 2 or segments[0] != "var" or any(not s for s in segments):
+        raise VariantDataError(
+            f"variant data reference {expression!r} is invalid: "
+            "expected a dotted 'var.*' path"
+        )
+    current: Any = data
+    traversed: list[str] = []
+    for segment in segments[1:]:
+        if not isinstance(current, dict):
+            raise VariantDataError(
+                f"variant data reference {expression!r} is invalid: "
+                f"'var.{'.'.join(traversed)}' is not a mapping"
+            )
+        if segment not in current:
+            traversed.append(segment)
+            raise VariantDataError(
+                f"Unknown variant data key: 'var.{'.'.join(traversed)}'"
+            )
+        traversed.append(segment)
+        current = current[segment]
+    if isinstance(current, dict):
+        raise VariantDataError(
+            f"variant data reference {expression!r} resolves to a mapping "
+            f"('var.{'.'.join(traversed)}'); access a leaf value instead"
+        )
+    return current
 
 
 def validate_variant_data(data: dict[str, Any], path: str = "var") -> None:

--- a/tests/__snapshots__/test_variant_data_integration/test_variant_data_field_errors_html[test_app0].json
+++ b/tests/__snapshots__/test_variant_data_integration/test_variant_data_field_errors_html[test_app0].json
@@ -3,7 +3,7 @@
     "docname": "index",
     "external_css": "external_link",
     "id": "REQ_BADTYPE_ARRAY",
-    "lineno": 20,
+    "lineno": 24,
     "section_name": "Variant Data Field Errors Test",
     "sections": [
       "Variant Data Field Errors Test"
@@ -22,6 +22,19 @@
       "Variant Data Field Errors Test"
     ],
     "title": "Type mismatch (integer into string field)",
+    "type": "req",
+    "type_name": "Requirement"
+  },
+  "REQ_BADTYPE_STRING": {
+    "docname": "index",
+    "external_css": "external_link",
+    "id": "REQ_BADTYPE_STRING",
+    "lineno": 20,
+    "section_name": "Variant Data Field Errors Test",
+    "sections": [
+      "Variant Data Field Errors Test"
+    ],
+    "title": "Type mismatch (integer into array of strings)",
     "type": "req",
     "type_name": "Requirement"
   },

--- a/tests/__snapshots__/test_variant_data_integration/test_variant_data_field_errors_html[test_app0].json
+++ b/tests/__snapshots__/test_variant_data_integration/test_variant_data_field_errors_html[test_app0].json
@@ -60,7 +60,7 @@
     "sections": [
       "Variant Data Field Errors Test"
     ],
-    "title": "Bad expression syntax",
+    "title": "Invalid variant data path",
     "type": "req",
     "type_name": "Requirement"
   }

--- a/tests/__snapshots__/test_variant_data_integration/test_variant_data_field_errors_html[test_app0].json
+++ b/tests/__snapshots__/test_variant_data_integration/test_variant_data_field_errors_html[test_app0].json
@@ -1,0 +1,67 @@
+{
+  "REQ_BADTYPE_ARRAY": {
+    "docname": "index",
+    "external_css": "external_link",
+    "id": "REQ_BADTYPE_ARRAY",
+    "lineno": 20,
+    "section_name": "Variant Data Field Errors Test",
+    "sections": [
+      "Variant Data Field Errors Test"
+    ],
+    "title": "Type mismatch (integer into array of strings)",
+    "type": "req",
+    "type_name": "Requirement"
+  },
+  "REQ_BADTYPE_STR": {
+    "docname": "index",
+    "external_css": "external_link",
+    "id": "REQ_BADTYPE_STR",
+    "lineno": 16,
+    "section_name": "Variant Data Field Errors Test",
+    "sections": [
+      "Variant Data Field Errors Test"
+    ],
+    "title": "Type mismatch (integer into string field)",
+    "type": "req",
+    "type_name": "Requirement"
+  },
+  "REQ_MISSING": {
+    "docname": "index",
+    "external_css": "external_link",
+    "id": "REQ_MISSING",
+    "lineno": 8,
+    "section_name": "Variant Data Field Errors Test",
+    "sections": [
+      "Variant Data Field Errors Test"
+    ],
+    "title": "Missing variant attribute",
+    "type": "req",
+    "type_name": "Requirement"
+  },
+  "REQ_MISSING_NESTED": {
+    "docname": "index",
+    "external_css": "external_link",
+    "id": "REQ_MISSING_NESTED",
+    "lineno": 12,
+    "section_name": "Variant Data Field Errors Test",
+    "sections": [
+      "Variant Data Field Errors Test"
+    ],
+    "title": "Missing nested variant attribute",
+    "type": "req",
+    "type_name": "Requirement"
+  },
+  "REQ_SYNTAX": {
+    "docname": "index",
+    "external_css": "external_link",
+    "id": "REQ_SYNTAX",
+    "lineno": 4,
+    "section_name": "Variant Data Field Errors Test",
+    "sections": [
+      "Variant Data Field Errors Test"
+    ],
+    "title": "Bad expression syntax",
+    "type": "req",
+    "type_name": "Requirement"
+  }
+}

--- a/tests/__snapshots__/test_variant_data_integration/test_variant_data_fields_html[test_app0].json
+++ b/tests/__snapshots__/test_variant_data_integration/test_variant_data_fields_html[test_app0].json
@@ -1,0 +1,62 @@
+{
+  "REQ_001": {
+    "docname": "index",
+    "external_css": "external_link",
+    "id": "REQ_001",
+    "lineno": 4,
+    "mystring": "arm",
+    "section_name": "Variant Data Fields Test",
+    "sections": [
+      "Variant Data Fields Test"
+    ],
+    "title": "Scalar string from variant data",
+    "type": "req",
+    "type_name": "Requirement"
+  },
+  "REQ_002": {
+    "docname": "index",
+    "external_css": "external_link",
+    "id": "REQ_002",
+    "lineno": 8,
+    "mystring": "platform is  arm !",
+    "section_name": "Variant Data Fields Test",
+    "sections": [
+      "Variant Data Fields Test"
+    ],
+    "title": "Embedded string from variant data",
+    "type": "req",
+    "type_name": "Requirement"
+  },
+  "REQ_003": {
+    "docname": "index",
+    "external_css": "external_link",
+    "id": "REQ_003",
+    "lineno": 12,
+    "myint": 2,
+    "section_name": "Variant Data Fields Test",
+    "sections": [
+      "Variant Data Fields Test"
+    ],
+    "title": "Integer from variant data",
+    "type": "req",
+    "type_name": "Requirement"
+  },
+  "REQ_004": {
+    "docname": "index",
+    "external_css": "external_link",
+    "id": "REQ_004",
+    "lineno": 16,
+    "myarray": [
+      "a",
+      "arm",
+      "c"
+    ],
+    "section_name": "Variant Data Fields Test",
+    "sections": [
+      "Variant Data Fields Test"
+    ],
+    "title": "Array from variant data",
+    "type": "req",
+    "type_name": "Requirement"
+  }
+}

--- a/tests/__snapshots__/test_variant_data_integration/test_variant_data_fields_html[test_app0].json
+++ b/tests/__snapshots__/test_variant_data_integration/test_variant_data_fields_html[test_app0].json
@@ -58,5 +58,19 @@
     "title": "Array from variant data",
     "type": "req",
     "type_name": "Requirement"
+  },
+  "REQ_005": {
+    "docname": "index",
+    "external_css": "external_link",
+    "id": "REQ_005",
+    "lineno": 20,
+    "mynoparse": "<{ var.platform }>",
+    "section_name": "Variant Data Fields Test",
+    "sections": [
+      "Variant Data Fields Test"
+    ],
+    "title": "Syntax not parsed when parse_variants is False",
+    "type": "req",
+    "type_name": "Requirement"
   }
 }

--- a/tests/__snapshots__/test_variant_data_integration/test_variant_data_fields_html[test_app0].json
+++ b/tests/__snapshots__/test_variant_data_integration/test_variant_data_fields_html[test_app0].json
@@ -4,6 +4,9 @@
     "external_css": "external_link",
     "id": "REQ_001",
     "lineno": 4,
+    "links_back": [
+      "REQ_006"
+    ],
     "mystring": "arm",
     "section_name": "Variant Data Fields Test",
     "sections": [
@@ -18,6 +21,9 @@
     "external_css": "external_link",
     "id": "REQ_002",
     "lineno": 8,
+    "links_back": [
+      "REQ_006"
+    ],
     "mystring": "platform is  arm !",
     "section_name": "Variant Data Fields Test",
     "sections": [
@@ -70,6 +76,23 @@
       "Variant Data Fields Test"
     ],
     "title": "Syntax not parsed when parse_variants is False",
+    "type": "req",
+    "type_name": "Requirement"
+  },
+  "REQ_006": {
+    "docname": "index",
+    "external_css": "external_link",
+    "id": "REQ_006",
+    "lineno": 24,
+    "links": [
+      "REQ_001",
+      "REQ_002"
+    ],
+    "section_name": "Variant Data Fields Test",
+    "sections": [
+      "Variant Data Fields Test"
+    ],
+    "title": "Links from variant data",
     "type": "req",
     "type_name": "Requirement"
   }

--- a/tests/doc_test/doc_variant_data_field_errors/conf.py
+++ b/tests/doc_test/doc_variant_data_field_errors/conf.py
@@ -1,0 +1,37 @@
+extensions = ["sphinx_needs"]
+
+needs_types = [
+    {
+        "directive": "req",
+        "title": "Requirement",
+        "prefix": "REQ_",
+        "color": "#BFD8D2",
+        "style": "node",
+    },
+]
+
+needs_variant_data = {
+    "platform": "arm",
+    "build": {
+        "debug": True,
+        "opt_level": 2,
+    },
+    "archs": ["arm", "x86"],
+}
+
+needs_fields = {
+    "mystring": {
+        "schema": {"type": "string"},
+        "parse_variants": True,
+        "nullable": True,
+    },
+    "myint": {"schema": {"type": "integer"}, "parse_variants": True, "nullable": True},
+    "myarray": {
+        "schema": {"type": "array", "items": {"type": "string"}},
+        "parse_variants": True,
+        "nullable": True,
+    },
+}
+
+needs_build_json = True
+needs_json_remove_defaults = True

--- a/tests/doc_test/doc_variant_data_field_errors/index.rst
+++ b/tests/doc_test/doc_variant_data_field_errors/index.rst
@@ -1,9 +1,9 @@
 Variant Data Field Errors Test
 ==============================
 
-.. req:: Bad expression syntax
+.. req:: Invalid variant data path
    :id: REQ_SYNTAX
-   :mystring: <{ var.platform + }>
+   :mystring: <{ platform }>
 
 .. req:: Missing variant attribute
    :id: REQ_MISSING

--- a/tests/doc_test/doc_variant_data_field_errors/index.rst
+++ b/tests/doc_test/doc_variant_data_field_errors/index.rst
@@ -18,5 +18,9 @@ Variant Data Field Errors Test
    :myint: <{ var.platform }>
 
 .. req:: Type mismatch (integer into array of strings)
+   :id: REQ_BADTYPE_STRING
+   :mystring: <{ var.build }>
+
+.. req:: Type mismatch (integer into array of strings)
    :id: REQ_BADTYPE_ARRAY
    :myarray: a, <{ var.build.opt_level }>, c

--- a/tests/doc_test/doc_variant_data_field_errors/index.rst
+++ b/tests/doc_test/doc_variant_data_field_errors/index.rst
@@ -1,0 +1,22 @@
+Variant Data Field Errors Test
+==============================
+
+.. req:: Bad expression syntax
+   :id: REQ_SYNTAX
+   :mystring: <{ var.platform + }>
+
+.. req:: Missing variant attribute
+   :id: REQ_MISSING
+   :mystring: <{ var.nonexistent }>
+
+.. req:: Missing nested variant attribute
+   :id: REQ_MISSING_NESTED
+   :mystring: <{ var.build.missing }>
+
+.. req:: Type mismatch (integer into string field)
+   :id: REQ_BADTYPE_STR
+   :myint: <{ var.platform }>
+
+.. req:: Type mismatch (integer into array of strings)
+   :id: REQ_BADTYPE_ARRAY
+   :myarray: a, <{ var.build.opt_level }>, c

--- a/tests/doc_test/doc_variant_data_fields/conf.py
+++ b/tests/doc_test/doc_variant_data_fields/conf.py
@@ -31,6 +31,11 @@ needs_fields = {
         "parse_variants": True,
         "nullable": True,
     },
+    "mynoparse": {
+        "schema": {"type": "string"},
+        "parse_variants": False,
+        "nullable": True,
+    },
 }
 
 needs_build_json = True

--- a/tests/doc_test/doc_variant_data_fields/conf.py
+++ b/tests/doc_test/doc_variant_data_fields/conf.py
@@ -1,0 +1,37 @@
+extensions = ["sphinx_needs"]
+
+needs_types = [
+    {
+        "directive": "req",
+        "title": "Requirement",
+        "prefix": "REQ_",
+        "color": "#BFD8D2",
+        "style": "node",
+    },
+]
+
+needs_variant_data = {
+    "platform": "arm",
+    "build": {
+        "debug": True,
+        "opt_level": 2,
+    },
+    "archs": ["arm", "x86"],
+}
+
+needs_fields = {
+    "mystring": {
+        "schema": {"type": "string"},
+        "parse_variants": True,
+        "nullable": True,
+    },
+    "myint": {"schema": {"type": "integer"}, "parse_variants": True, "nullable": True},
+    "myarray": {
+        "schema": {"type": "array", "items": {"type": "string"}},
+        "parse_variants": True,
+        "nullable": True,
+    },
+}
+
+needs_build_json = True
+needs_json_remove_defaults = True

--- a/tests/doc_test/doc_variant_data_fields/conf.py
+++ b/tests/doc_test/doc_variant_data_fields/conf.py
@@ -17,6 +17,7 @@ needs_variant_data = {
         "opt_level": 2,
     },
     "archs": ["arm", "x86"],
+    "links": ["REQ_001", "REQ_002"],
 }
 
 needs_fields = {
@@ -36,6 +37,12 @@ needs_fields = {
         "parse_variants": False,
         "nullable": True,
     },
+}
+
+needs_links = {
+    "links": {
+        "parse_variants": True,
+    }
 }
 
 needs_build_json = True

--- a/tests/doc_test/doc_variant_data_fields/index.rst
+++ b/tests/doc_test/doc_variant_data_fields/index.rst
@@ -1,0 +1,18 @@
+Variant Data Fields Test
+========================
+
+.. req:: Scalar string from variant data
+   :id: REQ_001
+   :mystring: <{ var.platform }>
+
+.. req:: Embedded string from variant data
+   :id: REQ_002
+   :mystring: platform is <{ var.platform }>!
+
+.. req:: Integer from variant data
+   :id: REQ_003
+   :myint: <{ var.build.opt_level }>
+
+.. req:: Array from variant data
+   :id: REQ_004
+   :myarray: a, <{ var.platform }>, c

--- a/tests/doc_test/doc_variant_data_fields/index.rst
+++ b/tests/doc_test/doc_variant_data_fields/index.rst
@@ -16,3 +16,7 @@ Variant Data Fields Test
 .. req:: Array from variant data
    :id: REQ_004
    :myarray: a, <{ var.platform }>, c
+
+.. req:: Syntax not parsed when parse_variants is False
+   :id: REQ_005
+   :mynoparse: <{ var.platform }>

--- a/tests/doc_test/doc_variant_data_fields/index.rst
+++ b/tests/doc_test/doc_variant_data_fields/index.rst
@@ -20,3 +20,7 @@ Variant Data Fields Test
 .. req:: Syntax not parsed when parse_variants is False
    :id: REQ_005
    :mynoparse: <{ var.platform }>
+
+.. req:: Links from variant data
+   :id: REQ_006
+   :links: <{ var.links }>

--- a/tests/test_needs_schema.py
+++ b/tests/test_needs_schema.py
@@ -17,6 +17,7 @@ from sphinx_needs.needs_schema import (
     create_inherited_field,
     inherit_schema,
 )
+from sphinx_needs.variant_data import VariantDataParsed
 from sphinx_needs.variants import VariantFunctionParsed
 
 
@@ -471,6 +472,67 @@ def test_convert_directive_option_vf(type_, item_type, input, expected):
 
 
 @pytest.mark.parametrize(
+    "type_,item_type,input,expected",
+    [
+        (
+            "string",
+            None,
+            "<{ var.a.b }>",
+            FieldFunctionArray((VariantDataParsed("var.a.b"),)),
+        ),
+        (
+            "string",
+            None,
+            "x <{ var.a }>y<{ var.b }>z",
+            FieldFunctionArray(
+                (
+                    "x ",
+                    VariantDataParsed("var.a"),
+                    "y",
+                    VariantDataParsed("var.b"),
+                    "z",
+                )
+            ),
+        ),
+        (
+            "integer",
+            None,
+            "<{ var.a }>",
+            FieldFunctionArray((VariantDataParsed("var.a"),)),
+        ),
+        (
+            "array",
+            "string",
+            "<{ var.a }>",
+            FieldFunctionArray((VariantDataParsed("var.a"),)),
+        ),
+        (
+            "array",
+            "string",
+            "a, <{ var.b }>, c",
+            FieldFunctionArray(
+                (
+                    "a",
+                    VariantDataParsed("var.b"),
+                    "c",
+                )
+            ),
+        ),
+    ],
+)
+def test_convert_directive_option_vd(type_, item_type, input, expected):
+    schema = {"type": type_}
+    if item_type is not None:
+        schema["items"] = {"type": item_type}
+    field = FieldSchema(
+        name="test_field",
+        schema=schema,
+        parse_variants=True,
+    )
+    assert field.convert_directive_option(input) == expected
+
+
+@pytest.mark.parametrize(
     "type_,item_type,allow_df,allow_vf,input",
     [
         ("boolean", None, False, False, "a"),
@@ -714,6 +776,31 @@ def test_convert_directive_option_df_errors(type_, item_type, input):
                 [("d", ListItemType.STD)],
             ],
         ),
+        # --- variant data <{...}> ---
+        ("<{a}>", [[("a", ListItemType.VD)]]),
+        ("<{ var.a.b }>", [[(" var.a.b ", ListItemType.VD)]]),
+        ("<{a}", [[("a", ListItemType.VD_U)]]),
+        ("<{a", [[("a", ListItemType.VD_U)]]),
+        (
+            "a,<{b}>,c",
+            [
+                [("a", ListItemType.STD)],
+                [("b", ListItemType.VD)],
+                [("c", ListItemType.STD)],
+            ],
+        ),
+        ("<{a}>b", [[("a", ListItemType.VD), ("b", ListItemType.STD)]]),
+        ("b<{a}>", [[("b", ListItemType.STD), ("a", ListItemType.VD)]]),
+        (
+            "a,[[b]],<<c>>,<{d}>;e",
+            [
+                [("a", ListItemType.STD)],
+                [("b", ListItemType.DF)],
+                [("c", ListItemType.VF)],
+                [("d", ListItemType.VD)],
+                [("e", ListItemType.STD)],
+            ],
+        ),
     ],
 )
 def test_split_list(text, expected):
@@ -731,6 +818,10 @@ def test_split_list(text, expected):
         ("<<a>", [("a", ListItemType.VF_U)]),
         ("[[a", [("a", ListItemType.DF_U)]),
         ("<<a", [("a", ListItemType.VF_U)]),
+        ("<{a}>", [("a", ListItemType.VD)]),
+        ("<{ var.a }>", [(" var.a ", ListItemType.VD)]),
+        ("<{a}", [("a", ListItemType.VD_U)]),
+        ("<{a", [("a", ListItemType.VD_U)]),
         (
             " a << b >> c [[ d ]] e ",
             [

--- a/tests/test_variant_data_integration.py
+++ b/tests/test_variant_data_integration.py
@@ -79,3 +79,41 @@ def test_variant_data_file_html(test_app):
 
     # var.region == "us-east" still works (from file, not overridden)
     assert "US East Needs" in index_html
+
+
+@pytest.mark.parametrize(
+    "test_app",
+    [
+        {
+            "buildername": "html",
+            "srcdir": "doc_test/doc_variant_data_fields",
+            "no_plantuml": True,
+        }
+    ],
+    indirect=True,
+)
+def test_variant_data_fields_html(test_app):
+    """Test resolving ``<{...}>`` variant data references in need fields."""
+    import json
+
+    app = test_app
+    app.build()
+
+    warnings = strip_colors(
+        app._warning.getvalue().replace(str(app.srcdir) + os.sep, "srcdir/")
+    ).splitlines()
+    assert warnings == []
+
+    needs = json.loads(Path(app.outdir, "needs.json").read_text())
+    versions = needs["versions"]
+    data = versions[next(iter(versions))]["needs"]
+
+    # scalar string resolves to the variant data value
+    assert data["REQ_001"]["mystring"] == "arm"
+    # embedded string substitutes the resolved value
+    # (string parts are joined with a space, as for variant functions)
+    assert data["REQ_002"]["mystring"] == "platform is  arm !"
+    # integer field resolves to the variant data integer
+    assert data["REQ_003"]["myint"] == 2
+    # array field substitutes the resolved value as an item
+    assert data["REQ_004"]["myarray"] == ["a", "arm", "c"]

--- a/tests/test_variant_data_integration.py
+++ b/tests/test_variant_data_integration.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 from sphinx.util.console import strip_colors
+from syrupy.extensions.json import JSONSnapshotExtension
 
 
 @pytest.mark.parametrize(
@@ -81,6 +82,11 @@ def test_variant_data_file_html(test_app):
     assert "US East Needs" in index_html
 
 
+@pytest.fixture
+def snapshot_json(snapshot):
+    return snapshot.use_extension(JSONSnapshotExtension)
+
+
 @pytest.mark.parametrize(
     "test_app",
     [
@@ -92,7 +98,7 @@ def test_variant_data_file_html(test_app):
     ],
     indirect=True,
 )
-def test_variant_data_fields_html(test_app):
+def test_variant_data_fields_html(test_app, snapshot_json):
     """Test resolving ``<{...}>`` variant data references in need fields."""
     import json
 
@@ -104,16 +110,5 @@ def test_variant_data_fields_html(test_app):
     ).splitlines()
     assert warnings == []
 
-    needs = json.loads(Path(app.outdir, "needs.json").read_text())
-    versions = needs["versions"]
-    data = versions[next(iter(versions))]["needs"]
-
-    # scalar string resolves to the variant data value
-    assert data["REQ_001"]["mystring"] == "arm"
-    # embedded string substitutes the resolved value
-    # (string parts are joined with a space, as for variant functions)
-    assert data["REQ_002"]["mystring"] == "platform is  arm !"
-    # integer field resolves to the variant data integer
-    assert data["REQ_003"]["myint"] == 2
-    # array field substitutes the resolved value as an item
-    assert data["REQ_004"]["myarray"] == ["a", "arm", "c"]
+    data = json.loads(Path(app.outdir, "needs.json").read_text())
+    assert data["versions"][""]["needs"] == snapshot_json

--- a/tests/test_variant_data_integration.py
+++ b/tests/test_variant_data_integration.py
@@ -142,7 +142,8 @@ def test_variant_data_field_errors_html(test_app, snapshot_json):
         "srcdir/index.rst:8: WARNING: Error while resolving dynamic values for field 'mystring', of need 'REQ_MISSING': Unknown variant data key: 'var.nonexistent' [needs.dynamic_function]",
         "srcdir/index.rst:12: WARNING: Error while resolving dynamic values for field 'mystring', of need 'REQ_MISSING_NESTED': Unknown variant data key: 'var.build.missing' [needs.dynamic_function]",
         "srcdir/index.rst:16: WARNING: Error while resolving dynamic values for field 'myint', of need 'REQ_BADTYPE_STR': variant data value <class 'str'> is not of type 'integer' [needs.dynamic_function]",
-        "srcdir/index.rst:20: WARNING: Error while resolving dynamic values for field 'myarray', of need 'REQ_BADTYPE_ARRAY': variant data value <class 'int'> is not of type 'array' or item type 'string' [needs.dynamic_function]",
+        "srcdir/index.rst:20: WARNING: Error while resolving dynamic values for field 'mystring', of need 'REQ_BADTYPE_STRING': variant data reference 'var.build' resolves to a mapping ('var.build'); access a leaf value instead [needs.dynamic_function]",
+        "srcdir/index.rst:24: WARNING: Error while resolving dynamic values for field 'myarray', of need 'REQ_BADTYPE_ARRAY': variant data value <class 'int'> is not of type 'array' or item type 'string' [needs.dynamic_function]",
     ]
 
     data = json.loads(Path(app.outdir, "needs.json").read_text())

--- a/tests/test_variant_data_integration.py
+++ b/tests/test_variant_data_integration.py
@@ -127,7 +127,7 @@ def test_variant_data_fields_html(test_app, snapshot_json):
 def test_variant_data_field_errors_html(test_app, snapshot_json):
     """Test warnings for problematic ``<{...}>`` variant data references.
 
-    Covers bad expression syntax, missing variant attributes (top-level and
+    Covers invalid ``var.*`` paths, missing variant keys (top-level and
     nested), and resolved values whose type does not match the field schema.
     """
     app = test_app
@@ -138,9 +138,9 @@ def test_variant_data_field_errors_html(test_app, snapshot_json):
     ).splitlines()
 
     assert warnings == [
-        "srcdir/index.rst:4: WARNING: Error while resolving dynamic values for field 'mystring', of need 'REQ_SYNTAX': variant data expression 'var.platform +' failed to evaluate: invalid syntax (<string>, line 1) [needs.dynamic_function]",
-        "srcdir/index.rst:8: WARNING: Error while resolving dynamic values for field 'mystring', of need 'REQ_MISSING': variant data expression 'var.nonexistent' failed to evaluate: Unknown variant key: var.nonexistent [needs.dynamic_function]",
-        "srcdir/index.rst:12: WARNING: Error while resolving dynamic values for field 'mystring', of need 'REQ_MISSING_NESTED': variant data expression 'var.build.missing' failed to evaluate: Unknown variant key: var.build.missing [needs.dynamic_function]",
+        "srcdir/index.rst:4: WARNING: Error while resolving dynamic values for field 'mystring', of need 'REQ_SYNTAX': variant data reference 'platform' is invalid: expected a dotted 'var.*' path [needs.dynamic_function]",
+        "srcdir/index.rst:8: WARNING: Error while resolving dynamic values for field 'mystring', of need 'REQ_MISSING': Unknown variant data key: 'var.nonexistent' [needs.dynamic_function]",
+        "srcdir/index.rst:12: WARNING: Error while resolving dynamic values for field 'mystring', of need 'REQ_MISSING_NESTED': Unknown variant data key: 'var.build.missing' [needs.dynamic_function]",
         "srcdir/index.rst:16: WARNING: Error while resolving dynamic values for field 'myint', of need 'REQ_BADTYPE_STR': variant data value <class 'str'> is not of type 'integer' [needs.dynamic_function]",
         "srcdir/index.rst:20: WARNING: Error while resolving dynamic values for field 'myarray', of need 'REQ_BADTYPE_ARRAY': variant data value <class 'int'> is not of type 'array' or item type 'string' [needs.dynamic_function]",
     ]

--- a/tests/test_variant_data_integration.py
+++ b/tests/test_variant_data_integration.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 from pathlib import Path
 
@@ -100,8 +101,6 @@ def snapshot_json(snapshot):
 )
 def test_variant_data_fields_html(test_app, snapshot_json):
     """Test resolving ``<{...}>`` variant data references in need fields."""
-    import json
-
     app = test_app
     app.build()
 
@@ -109,6 +108,42 @@ def test_variant_data_fields_html(test_app, snapshot_json):
         app._warning.getvalue().replace(str(app.srcdir) + os.sep, "srcdir/")
     ).splitlines()
     assert warnings == []
+
+    data = json.loads(Path(app.outdir, "needs.json").read_text())
+    assert data["versions"][""]["needs"] == snapshot_json
+
+
+@pytest.mark.parametrize(
+    "test_app",
+    [
+        {
+            "buildername": "html",
+            "srcdir": "doc_test/doc_variant_data_field_errors",
+            "no_plantuml": True,
+        }
+    ],
+    indirect=True,
+)
+def test_variant_data_field_errors_html(test_app, snapshot_json):
+    """Test warnings for problematic ``<{...}>`` variant data references.
+
+    Covers bad expression syntax, missing variant attributes (top-level and
+    nested), and resolved values whose type does not match the field schema.
+    """
+    app = test_app
+    app.build()
+
+    warnings = strip_colors(
+        app._warning.getvalue().replace(str(app.srcdir) + os.sep, "srcdir/")
+    ).splitlines()
+
+    assert warnings == [
+        "srcdir/index.rst:4: WARNING: Error while resolving dynamic values for field 'mystring', of need 'REQ_SYNTAX': variant data expression 'var.platform +' failed to evaluate: invalid syntax (<string>, line 1) [needs.dynamic_function]",
+        "srcdir/index.rst:8: WARNING: Error while resolving dynamic values for field 'mystring', of need 'REQ_MISSING': variant data expression 'var.nonexistent' failed to evaluate: Unknown variant key: var.nonexistent [needs.dynamic_function]",
+        "srcdir/index.rst:12: WARNING: Error while resolving dynamic values for field 'mystring', of need 'REQ_MISSING_NESTED': variant data expression 'var.build.missing' failed to evaluate: Unknown variant key: var.build.missing [needs.dynamic_function]",
+        "srcdir/index.rst:16: WARNING: Error while resolving dynamic values for field 'myint', of need 'REQ_BADTYPE_STR': variant data value <class 'str'> is not of type 'integer' [needs.dynamic_function]",
+        "srcdir/index.rst:20: WARNING: Error while resolving dynamic values for field 'myarray', of need 'REQ_BADTYPE_ARRAY': variant data value <class 'int'> is not of type 'array' or item type 'string' [needs.dynamic_function]",
+    ]
 
     data = json.loads(Path(app.outdir, "needs.json").read_text())
     assert data["versions"][""]["needs"] == snapshot_json


### PR DESCRIPTION
This PR adds a new `<{ ... }>` syntax for injecting values from [`needs_variant_data`](https://sphinx-needs.readthedocs.io/en/latest/configuration.html#needs-variant-data) directly into need field values.

### What it does

Within a field value, `<{ var.<path> }>` is replaced by the corresponding value looked up from the configured `needs_variant_data`, e.g.:

```python
# conf.py
needs_variant_data = {
    "platform": "arm",
    "build": {"opt_level": 2},
}

needs_fields = {
    "arch": {"schema": {"type": "string"}, "parse_variants": True},
    "opt": {"schema": {"type": "integer"}, "parse_variants": True},
}
```

```rst
.. req:: Example
   :id: VD_001
   :arch: <{ var.platform }>
   :opt: <{ var.build.opt_level }>
```

Here `arch` resolves to the string `"arm"` and `opt` to the integer `2`.

### Semantics

- Enablement follows the existing variant mechanism: the field must set `parse_variants: True` in `needs_fields` / `needs_links`. When `parse_variants` is `False`, the syntax is left untouched as a literal.
- The reference is a **constrained dotted `var.*` path lookup** — *not* arbitrary `eval()`. Operators, function calls, item access (`var["cpu"]`), need fields, `build_tags`, and Python builtins are **not** available. This keeps the semantics simple, safe, and replicable by other tooling (it mirrors the ubcode implementation).
- The resolved value is type-validated against the field schema (or array item schema); a warning is emitted on mismatch.
- Works for scalar, string, array, and link fields. For string fields a reference can be embedded in surrounding text (parts joined with spaces); for non-string scalars the reference must constitute the whole value so the native type is preserved.
- Clear warnings are emitted for invalid paths, missing keys (top-level and nested), and values that don't resolve to a leaf.

### Changes

- New `lookup_variant_data()` in variant_data.py implementing the eval-free dotted-path resolution.
- `resolve_functions()` resolves `<{...}>` references against `needs_config.variant_data` (the `VariantDataProxy` remains for variant-function `<<...>>` and `needif` filter expressions).
- Documentation in dynamic_functions.rst (new "Variant data references" section) and cross-references in configuration.rst.
- Tests: field resolution (snapshot), error cases (invalid path, missing/nested-missing keys, type mismatches), and a `parse_variants: False` case asserting the syntax stays literal.