### PR TITLE
🔧 Tighten mypy config: drop redundant overrides, narrow ignores

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,32 +126,16 @@ disallow_subclassing_any = true
 [[tool.mypy.overrides]]
 module = [
   "matplotlib.*",
-  "numpy.*",
   "requests_file",
   "sphinx_data_viewer.*",
   "sphinxcontrib.plantuml.*",
-  "tomllib.*",
   "tomli.*",
 ]
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
-module = [
-  "sphinx_needs.directives.needextend",
-  "sphinx_needs.functions.functions",
-  "sphinx_needs.api.need",
-]
-# TODO dynamically overriding TypeDict keys is a bit tricky
-disable_error_code = "literal-required"
-
-[[tool.mypy.overrides]]
 module = ["sphinx_needs.data"]
 disable_error_code = ["attr-defined", "no-any-return"]
-
-[[tool.mypy.overrides]]
-module = ["sphinx_needs.needs"]
-# issue with importing tomllib/tomli based on python version
-disable_error_code = ["no-redef"]
 
 [tool.tox]
 # To use tox, see https://tox.readthedocs.io

--- a/sphinx_needs/api/need.py
+++ b/sphinx_needs/api/need.py
@@ -930,7 +930,7 @@ def add_external_need(
         content=content,
         # TODO a title being None is not "type compatible" with other parts of the code base,
         # however, at present changing it to an empty string breaks some existing tests.
-        title=title,  # type: ignore
+        title=title,  # type: ignore[arg-type]
         status=status,
         tags=tags,
         constraints=constraints,

--- a/sphinx_needs/debug.py
+++ b/sphinx_needs/debug.py
@@ -121,7 +121,7 @@ def measure_time(
             runtime_dict["avg"] = runtime_dict["overall"] / runtime_dict["amount"]
             return result
 
-        return wrapper  # type: ignore
+        return wrapper  # type: ignore[return-value]
 
     return inner
 

--- a/sphinx_needs/diagrams_common.py
+++ b/sphinx_needs/diagrams_common.py
@@ -159,7 +159,7 @@ def get_debug_container(puml_node: nodes.Element) -> nodes.container:
     """Return container containing the raw plantuml code"""
     debug_container = nodes.container()
     if isinstance(puml_node, nodes.figure):
-        data = puml_node.children[0]["uml"]  # type: ignore
+        data = puml_node.children[0]["uml"]  # type: ignore[index]
     else:
         data = puml_node["uml"]
     data = "\n".join([html.escape(line) for line in data.split("\n")])

--- a/sphinx_needs/directives/needflow/_plantuml.py
+++ b/sphinx_needs/directives/needflow/_plantuml.py
@@ -378,7 +378,7 @@ def process_needflow_plantuml(
             # Otherwise it was not been set, or we get outdated data
             debug_container = nodes.container()
             if isinstance(puml_node, nodes.figure):
-                data = puml_node.children[0]["uml"]  # type: ignore
+                data = puml_node.children[0]["uml"]  # type: ignore[index]
             else:
                 data = puml_node["uml"]
             data = "\n".join([html.escape(line) for line in data.split("\n")])

--- a/sphinx_needs/directives/needsequence.py
+++ b/sphinx_needs/directives/needsequence.py
@@ -260,7 +260,7 @@ def get_message_needs(
     if tracked_receivers is None:
         tracked_receivers = []
     for link_type in link_types:
-        msg_needs += [all_needs_dict[x] for x in sender[link_type]]  # type: ignore
+        msg_needs += [all_needs_dict[x] for x in sender[link_type]]  # type: ignore[misc]
 
     messages: dict[str, dict[str, Any]] = {}
     p_string = ""

--- a/sphinx_needs/layout.py
+++ b/sphinx_needs/layout.py
@@ -83,7 +83,7 @@ def build_need_repr(
 def _generate_inline_parser() -> tuple[Values, Inliner]:
     doc_settings = OptionParser(components=(Parser,)).get_default_values()
     inline_parser = Inliner()
-    inline_parser.init_customizations(doc_settings)  # type: ignore
+    inline_parser.init_customizations(doc_settings)  # type: ignore[attr-defined]
     return doc_settings, inline_parser
 
 
@@ -359,7 +359,7 @@ class LayoutHandler:
         :param line: string to parse
         :return: nodes
         """
-        result, message = self.inline_parser.parse(  # type: ignore
+        result, message = self.inline_parser.parse(  # type: ignore[attr-defined]
             line, 0, self.doc_memo, self.dummy_doc
         )
         if message:

--- a/sphinx_needs/needs.py
+++ b/sphinx_needs/needs.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import json
+import sys
 from collections.abc import Callable
 from copy import deepcopy
 from itertools import chain
@@ -144,9 +145,9 @@ from sphinx_needs.utils import node_match
 from sphinx_needs.variant_data import VariantDataError, resolve_variant_data
 from sphinx_needs.warnings import process_warnings
 
-try:
+if sys.version_info >= (3, 11):
     import tomllib  # added in python 3.11
-except ImportError:
+else:
     import tomli as tomllib
 
 

--- a/sphinx_needs/services/github.py
+++ b/sphinx_needs/services/github.py
@@ -132,7 +132,7 @@ class GithubService(BaseService):
 
         auth: tuple[str, str] | None
         # TODO token can be None
-        auth = (self.username, self.token) if self.username else None  # type: ignore
+        auth = (self.username, self.token) if self.username else None  # type: ignore[assignment]
 
         resp = requests.get(url, params=params, auth=auth, headers=headers)
 
@@ -170,7 +170,7 @@ class GithubService(BaseService):
 
         if specific:
             return {"items": [resp.json()]}
-        return resp.json()  # type: ignore
+        return resp.json()  # type: ignore[no-any-return]
 
     def request_from_directive(
         self, directive: SphinxDirective, /

--- a/sphinx_needs/utils.py
+++ b/sphinx_needs/utils.py
@@ -292,9 +292,9 @@ def profile(keyword: str) -> Callable[[FuncT], FuncT]:
     Activation only happens, if given keyword is part of ``needs_profiling``.
     """
 
-    def inner(func):  # type: ignore
+    def inner(func):  # type: ignore[no-untyped-def]
         @wraps(func)
-        def wrapper(*args, **kwargs):  # type: ignore
+        def wrapper(*args, **kwargs):  # type: ignore[no-untyped-def]
             with cProfile.Profile() as pr:
                 result = func(*args, **kwargs)
 


### PR DESCRIPTION
Tier 1 of #1725 — remove `mypy` escape hatches in the production code (`sphinx_needs/`) that no longer pull their weight. All changes are config/typing-comment cleanup with one runtime-identical import refactor.

## Changes

- **Delete the `literal-required` override** (`directives.needextend`, `functions.functions`, `api.need`) — verified redundant; the code no longer triggers that error.
- **Delete the `needs` `no-redef` override** by switching the `tomllib`/`tomli` import from `try/except ImportError` to a `sys.version_info >= (3, 11)` guard, which mypy resolves natively.
- **Trim `ignore_missing_imports`**: drop `numpy` (never imported anywhere in `sphinx_needs`) and `tomllib` (stdlib in 3.11+, resolved natively). Kept `tomli`, `requests_file`, `matplotlib`, `sphinx_data_viewer`, `sphinxcontrib.plantuml` (genuinely unstubbed / optional).
- **Narrow all 11 bare `# type: ignore`** to explicit error codes so each suppresses a single diagnostic instead of masking everything: `[return-value]`, `[no-untyped-def]` ×2, `[attr-defined]` ×2, `[index]` ×2, `[misc]`, `[arg-type]`, `[assignment]`, `[no-any-return]`.

Net result: the `[tool.mypy]` config drops from 3 per-module `disable_error_code` blocks to 1 (the `data` block, which is the headline item for Tier 2), and `sphinx_needs/` has **zero** bare ignores left.

## Verification

- `mypy --strict` — clean (78 source files, 0 issues)
- `ruff check` — clean
- `ruff format --check` — clean
- `import sphinx_needs.needs` confirmed working (covers the only runtime-touching change)

No changelog entry: this is internal type-checking/tooling cleanup with no user-facing behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016hgF7RDxmXvBnFhCkP3sNh

---
_Generated by [Claude Code](https://claude.ai/code/session_016hgF7RDxmXvBnFhCkP3sNh)_