### PR TITLE
🐛 Fix needpie crash on matplotlib 3.11+ for zero-data pies

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -24,6 +24,10 @@ Improvements
 Bug fixes
 .........
 
+- 🐛 Fix ``needpie`` raising ``All wedge sizes are zero`` on matplotlib 3.11+
+  when a pie has no data (e.g. zero matching needs); an empty pie with its
+  legend is now rendered instead (:issue:`1727`)
+
 - 🐛 Sort need link and backlink lists in ``needs.json`` and HTML output using
   natural, case-insensitive ordering (e.g. ``REQ_2`` < ``REQ_9`` < ``REQ_10``)
   and collapse duplicate entries, so build outputs are reproducible regardless

--- a/sphinx_needs/directives/needpie.py
+++ b/sphinx_needs/directives/needpie.py
@@ -249,9 +249,24 @@ def process_needpie(
         if text_color:
             pie_kwargs["textprops"] = {"color": text_color}
 
-        wedges, _texts, autotexts = axes.pie(
-            sizes, normalize=sum(float(s) for s in sizes) >= 1, **pie_kwargs
-        )
+        total = sum(float(s) for s in sizes)
+        if total > 0:
+            wedges, _texts, autotexts = axes.pie(
+                sizes, normalize=total >= 1, **pie_kwargs
+            )
+        elif sizes:
+            # matplotlib >= 3.11 raises "All wedge sizes are zero" when every value
+            # is 0 (e.g. a pie over zero needs). Draw equal placeholder wedges so
+            # the pie and its legend still render, then hide them so no misleading
+            # proportions are shown.
+            wedges, _texts, autotexts = axes.pie(
+                [1.0] * len(sizes), normalize=True, **pie_kwargs
+            )
+            for wedge in wedges:
+                wedge.set_visible(False)
+        else:
+            # no data at all (a configuration error was already logged above)
+            wedges, _texts, autotexts = [], [], []
 
         ratio = 20  # we will remove all labels with size smaller 5%
         legend_enforced = False


### PR DESCRIPTION
Fixes #1727.

## Problem

**matplotlib 3.11.0** changed `Axes.pie` to raise `ValueError: All wedge sizes are zero` when every value is `0`, where it previously drew zero-angle (invisible) wedges. This breaks `needpie` whenever a pie has no data — e.g. a pie over zero matching needs:

```
sphinx.errors.ExtensionError: Handler ... for event 'doctree-resolved' threw an exception
(exception: All wedge sizes are zero)
```

It is a **project-wide regression on `master`** (red across the whole Core test matrix — py3.12/3.13/3.14, all sphinx versions, ubuntu + windows), surfaced by CI but reproducible on a clean `master` checkout.

## Fix

`sphinx_needs/directives/needpie.py` — when all values are `0`, draw equal **placeholder** wedges so the pie and its legend still render (the legend code already special-cases `sum == 0` to format `0.0%` labels, so zero-data pies are *meant* to render), then **hide** the wedges so no misleading proportions are shown. An empty `sizes` list (a misconfigured directive, already logged as an error) is also guarded so it no longer hits matplotlib at all.

This keeps the downstream per-wedge logic — which indexes `_texts[i]`/`autotexts[i]` over `range(len(sizes))` — working unchanged.

## Verification

```
uv run --extra test --extra plotting pytest \
  tests/test_needpie_with_zero_needs.py tests/test_filter.py \
  tests/test_needpie.py tests/test_needbar.py
# 55 passed (previously: test_needpie_with_zero_needs + test_filter failed)
```

- `mypy --strict` on `needpie.py` — clean
- `ruff check` / `ruff format` — clean
- Confirmed against matplotlib 3.11.0 locally

## Notes

- This unblocks #1726 (and every other PR) once merged.
- Behavior choice: an empty pie + legend (wedges hidden). Happy to switch to *visible* equal-grey placeholder slices instead if you'd prefer the categories to be visible — let me know.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016hgF7RDxmXvBnFhCkP3sNh

---
_Generated by [Claude Code](https://claude.ai/code/session_016hgF7RDxmXvBnFhCkP3sNh)_