### PR TITLE
🔧 Type the BuildEnvironment attributes used by SphinxNeedsData (Tier 2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,10 +133,6 @@ module = [
 ]
 ignore_missing_imports = true
 
-[[tool.mypy.overrides]]
-module = ["sphinx_needs.data"]
-disable_error_code = ["attr-defined", "no-any-return"]
-
 [tool.tox]
 # To use tox, see https://tox.readthedocs.io
 # $ pipx install tox

--- a/sphinx_needs/data.py
+++ b/sphinx_needs/data.py
@@ -13,6 +13,7 @@ from typing import (
     Literal,
     NewType,
     TypedDict,
+    cast,
 )
 
 from sphinx.util.logging import getLogger
@@ -36,6 +37,29 @@ if TYPE_CHECKING:
     from sphinx_needs.nodes import Need
     from sphinx_needs.schema.config import SchemasRootType
     from sphinx_needs.services.manager import ServiceManager
+
+    class _NeedsApp(Sphinx):
+        """Sphinx application, annotated with the private attributes sphinx-needs stores on it."""
+
+        _needs_services: ServiceManager
+
+    class _NeedsEnv(BuildEnvironment):
+        """Build environment, annotated with the private attributes sphinx-needs stores on it.
+
+        These are accessed lazily via :class:`SphinxNeedsData`; declaring them here
+        keeps that access type-checked, instead of suppressing ``attr-defined``.
+        """
+
+        app: _NeedsApp
+        _needs_schema: FieldsSchema
+        _needs_resolved_schemas: list[SchemasRootType]
+        _needs_all_needs: dict[str, NeedItem]
+        _needs_view: NeedsView
+        _needs_all_docs: dict[str, list[str]]
+        _needs_is_post_processed: bool
+        _need_all_needextend: dict[str, NeedsExtendType]
+        _needs_all_needumls: dict[str, NeedsUmlType]
+        _needs_all_nodes: dict[str, Need]
 
 
 LOGGER = getLogger(__name__)
@@ -772,7 +796,7 @@ class SphinxNeedsData:
     """Centralised access to sphinx-needs data, stored within the Sphinx environment."""
 
     def __init__(self, env: BuildEnvironment) -> None:
-        self.env = env
+        self.env = cast("_NeedsEnv", env)
 
     def get_schema(self) -> FieldsSchema:
         """Get the schema for all fields.


### PR DESCRIPTION
Tier 2 of #1725 (first item).

## Problem

`SphinxNeedsData` stashes all of its data as private attributes on the Sphinx `BuildEnvironment` (e.g. `env._needs_all_needs`, `env._needs_view`, `env._needs_schema`, …) and `_needs_services` on the `Sphinx` app. mypy can't see these, so `data.py` carried an override masking the fallout:

```toml
[[tool.mypy.overrides]]
module = ["sphinx_needs.data"]
disable_error_code = ["attr-defined", "no-any-return"]
```

That override hid **45 errors** (9 dynamic env attributes + 1 app attribute, each generating an `attr-defined` and, where returned, a `no-any-return`).

## Fix

Declare the stashed attributes on `TYPE_CHECKING`-only subclasses — `_NeedsEnv(BuildEnvironment)` and `_NeedsApp(Sphinx)` — and `cast` `self.env` to `_NeedsEnv` once in `__init__`. Every accessor body is left untouched.

- The two helper classes exist only under `TYPE_CHECKING`, so there's **no runtime footprint**.
- `cast("_NeedsEnv", env)` is a **runtime no-op** — it returns `env` unchanged.
- `_NeedsEnv` is-a `BuildEnvironment`, so nothing that consumes `.env` is affected.

This removes the **last** per-module `disable_error_code` override from the mypy config — `data.py` is now type-checked under full `--strict` with no suppressions.

## Verification

- `mypy --strict` — **clean** (78 files); all 45 previously-suppressed errors resolved with the override deleted
- `ruff check` / `ruff format` — clean
- **56 tests pass** across `test_basic_doc`, `test_api_usage`, `test_need_item_api`, `test_needpie_with_zero_needs`, `test_service_github`, `test_needs_builder` (exercise need creation, views, services, umls, and the github app-attribute path)

No changelog entry: internal type-checking change, no runtime behaviour difference (consistent with the Tier 1 PR #1726).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016hgF7RDxmXvBnFhCkP3sNh

---
_Generated by [Claude Code](https://claude.ai/code/session_016hgF7RDxmXvBnFhCkP3sNh)_