### PR TITLE
Track JSON files imported via needimport as dependencies

### DIFF
--- a/docs/directives/needimport.rst
+++ b/docs/directives/needimport.rst
@@ -56,6 +56,10 @@ The directive argument can be one of the following formats:
 
      .. needimport:: c:\absolute\path\to\needs.json
 
+.. note::
+
+   If you are rebuilding documentation incrementally (for example, when using ``sphinx-autobuild``), Sphinx  automatically detects changes to the *local* JSON files. However, with remote URLs, you must run a Sphinx build with the ``-E`` flag to rebuild the environment from scratch when the remote file changes.
+
 Options
 -------
 

--- a/sphinx_needs/directives/needimport.py
+++ b/sphinx_needs/directives/needimport.py
@@ -116,7 +116,7 @@ class NeedimportDirective(SphinxDirective):
             except (OSError, json.JSONDecodeError) as e:
                 # TODO: Add exception handling
                 raise SphinxNeedsFileException(correct_need_import_path) from e
-            
+
             self.env.note_dependency(correct_need_import_path)
 
             errors = check_needs_data(needs_import_list)

--- a/sphinx_needs/directives/needimport.py
+++ b/sphinx_needs/directives/needimport.py
@@ -116,6 +116,8 @@ class NeedimportDirective(SphinxDirective):
             except (OSError, json.JSONDecodeError) as e:
                 # TODO: Add exception handling
                 raise SphinxNeedsFileException(correct_need_import_path) from e
+            
+            self.env.note_dependency(correct_need_import_path)
 
             errors = check_needs_data(needs_import_list)
             if errors.schema:

--- a/tests/test_needimport.py
+++ b/tests/test_needimport.py
@@ -511,16 +511,19 @@ def test_doc_needimport_noindex(test_app):
     assert len(latex) > 0
     assert "AAA" in latex
 
+
 @pytest.mark.parametrize(
     "test_app",
-    [{
-        "buildername": "html",
-        "files": [
-            ("conf.py", 'extensions = ["sphinx_needs"]'),
-            ("needs.json", needs_json),  # reuse the existing needs_json string
-        ],
-        "no_plantuml": True,
-    }],
+    [
+        {
+            "buildername": "html",
+            "files": [
+                ("conf.py", 'extensions = ["sphinx_needs"]'),
+                ("needs.json", needs_json),  # reuse the existing needs_json string
+            ],
+            "no_plantuml": True,
+        }
+    ],
     indirect=True,
 )
 def test_needimport_registers_dependency(test_app):
@@ -531,7 +534,7 @@ def test_needimport_registers_dependency(test_app):
     app.build()
 
     assert app.statuscode == 0
-    
+
     deps = app.env.dependencies.get("index", set())
     assert any("needs.json" in str(dep) for dep in deps), (
         f"needs.json not found in dependencies: {deps}"

--- a/tests/test_needimport.py
+++ b/tests/test_needimport.py
@@ -510,3 +510,29 @@ def test_doc_needimport_noindex(test_app):
     assert Path(latex_path).exists()
     assert len(latex) > 0
     assert "AAA" in latex
+
+@pytest.mark.parametrize(
+    "test_app",
+    [{
+        "buildername": "html",
+        "files": [
+            ("conf.py", 'extensions = ["sphinx_needs"]'),
+            ("needs.json", needs_json),  # reuse the existing needs_json string
+        ],
+        "no_plantuml": True,
+    }],
+    indirect=True,
+)
+def test_needimport_registers_dependency(test_app):
+    index_path = Path(test_app.srcdir, "index.rst")
+    index_path.write_text(".. needimport:: needs.json")
+
+    app = test_app
+    app.build()
+
+    assert app.statuscode == 0
+    
+    deps = app.env.dependencies.get("index", set())
+    assert any("needs.json" in str(dep) for dep in deps), (
+        f"needs.json not found in dependencies: {deps}"
+    )


### PR DESCRIPTION
## Problem
When JSON files are imported via `needimport`, sphinx-build imports the file once and doesn't pick up changes to these external files unless the RST file where the directive is declared changes or you rebuild the entire Sphinx environment. It's a little annoying when working with documentation incrementally/using `sphinx-autobuild` (make a small change -> rebuild to see how it looks). 

## Fix
[BuildEnvironment.note_dependency](https://www.sphinx-doc.org/en/master/extdev/envapi.html#sphinx.environment.BuildEnvironment.note_dependency) seems to be the way to declare an external file as a dependency, it makes Sphinx track changes to the file and rebuild it if the file timestamp changes. 

## Notes
I'm not sure how to handle changes to the remote files fetched from URLs, sorry, I am not a programmer. :( But I added a note about it to docs. I can open an issue for it too.

Let me know if I missed anything, thank you!