### PR TITLE
✨ Add `network_back` schema key to validate incoming links

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,13 @@ Unreleased
 Improvements
 ............
 
+- ✨ Add a ``network_back`` schema-validation key, the sibling of ``network``,
+  that validates a need's **incoming** links instead of its outgoing ones. It
+  reuses the same ``items`` / ``contains`` / ``minContains`` / ``maxContains``
+  structure and can be freely mixed and nested with ``network``, allowing
+  constraints like "every requirement must be covered by at least one test" to be
+  expressed once on the requirement (:pr:`1731`)
+
 - 🔧 Add a root ``context7.json`` configuration file so AI assistants using
   Context7 can discover the live Sphinx-Needs documentation and use the
   project-specific reference instead of stale training data (:issue:`1719`)

--- a/docs/schema/index.rst
+++ b/docs/schema/index.rst
@@ -353,7 +353,8 @@ A ``schemas.json`` file (or ``needs_schema_definitions`` dict) has the following
          "select": { /* Selection criteria - which needs to validate */ },
          "validate": {
            "local": { /* Local validation rules */ },
-           "network": { /* Network validation rules */ }
+           "network": { /* Outgoing-link validation rules */ },
+           "network_back": { /* Incoming-link validation rules */ }
          }
        }
      ]
@@ -378,7 +379,9 @@ Each object within the ``schemas`` array can contain:
 - ``validate`` (required): Validation rules with two subsections:
 
   - ``local``: Validates properties of the need itself (see :ref:`local_validation`)
-  - ``network``: Validates relationships with linked needs (see :ref:`network_validation`)
+  - ``network``: Validates outgoing links to other needs (see :ref:`network_validation`)
+  - ``network_back``: Validates incoming links from other needs
+    (see :ref:`network_back_validation`)
 
 See :ref:`schema_components` for detailed documentation of each component.
 
@@ -556,6 +559,57 @@ This validates that:
 1. A safe implementation links to safe specifications
 #. Those specifications in turn link to safe features
 #. Both link levels have minimum count requirements
+
+.. _`network_back_validation`:
+
+Incoming link validation (``network_back``)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+By default, ``network`` validates a need's *outgoing* links.
+Sometimes a constraint is more naturally expressed from the target's point of view —
+for example *"every requirement must be covered by at least one test"*.
+
+The ``network_back`` key mirrors ``network`` but traverses the *incoming* links of a need:
+the needs that link **to** this need via the given outgoing link type
+(i.e. the computed ``<link_type>_back`` field).
+It accepts exactly the same ``items`` / ``contains`` / ``minContains`` / ``maxContains``
+structure (and may itself nest ``local``, ``network`` and ``network_back`` rules).
+
+The coverage example, expressed once on the requirement rather than on every test:
+
+.. code-block:: json
+
+   {
+     "id": "req-covered-by-test",
+     "select": {
+       "properties": { "type": { "const": "req" } }
+     },
+     "validate": {
+       "network_back": {
+         "links": {
+           "contains": {
+             "local": {
+               "properties": { "type": { "const": "test" } }
+             }
+           },
+           "minContains": 1
+         }
+       }
+     }
+   }
+
+Here ``links`` refers to the *outgoing* ``links`` link type of the source needs;
+the rule selects every ``req`` and requires at least one ``test`` to link to it.
+
+.. note::
+
+   - A back hop and a forward hop both consume one level of the shared recursion budget
+     (see the recursion limit below), so ``network`` and ``network_back`` can be freely mixed
+     and nested within the same 4-level chain.
+   - The ``select`` predicate always selects the *validated* need (the target of the incoming
+     links), never the sources.
+   - Broken-target errors (``network_missing_target``) only apply to outgoing links;
+     incoming links are resolved from existing needs and therefore always exist.
 
 .. important::
 

--- a/sphinx_needs/schema/config.py
+++ b/sphinx_needs/schema/config.py
@@ -538,6 +538,15 @@ class ValidateSchemaType(TypedDict):
 
     local: NotRequired[RefItemType | AllOfSchemaType | NeedFieldsSchemaType]
     network: NotRequired[dict[str, ResolvedLinkSchemaType]]
+    """Validate the need's outgoing links, keyed by link type."""
+    network_back: NotRequired[dict[str, ResolvedLinkSchemaType]]
+    """
+    Validate the need's incoming links, keyed by link type.
+
+    Mirrors ``network`` but traverses the needs that link *to* this need
+    via the given outgoing link type (the computed ``<link_type>_back`` field),
+    rather than the need's own outgoing links.
+    """
 
 
 class SchemasRootType(TypedDict):

--- a/sphinx_needs/schema/config_utils.py
+++ b/sphinx_needs/schema/config_utils.py
@@ -165,11 +165,17 @@ def _recursive_validate(validate: ValidateSchemaType, path: tuple[str, ...]) -> 
             raise NeedsConfigException(
                 f"schema for '{path_str}' is not valid:\n{exc}"
             ) from exc
-    for key, value in validate.get("network", {}).items():
-        if "items" in value:
-            _recursive_validate(value["items"], (*path, "network", key, "items"))
-        if "contains" in value:
-            _recursive_validate(value["contains"], (*path, "network", key, "contains"))
+    for network_key in ("network", "network_back"):
+        network_map = cast(
+            "dict[str, ResolvedLinkSchemaType]", validate.get(network_key, {})
+        )
+        for key, value in network_map.items():
+            if "items" in value:
+                _recursive_validate(value["items"], (*path, network_key, key, "items"))
+            if "contains" in value:
+                _recursive_validate(
+                    value["contains"], (*path, network_key, key, "contains")
+                )
 
 
 def validate_severity(schemas: list[SchemasRootType]) -> None:
@@ -198,20 +204,21 @@ def check_network_links_against_links(
         validate_schemas: list[ValidateSchemaType] = [schema["validate"]]
         while validate_schemas:
             validate_schema = validate_schemas.pop()
-            if "network" in validate_schema:
-                for link_type, resolved_link_schema in validate_schema[
-                    "network"
-                ].items():
+            for network_key in ("network", "network_back"):
+                if network_key not in validate_schema:
+                    continue
+                network_map = validate_schema[network_key]
+                for link_type, resolved_link_schema in network_map.items():
                     if fields_schema.get_link_field(link_type) is None:
                         schema_name = get_schema_name(schema)
                         raise NeedsConfigException(
-                            f"Schema '{schema_name}' defines an unknown network link type"
+                            f"Schema '{schema_name}' defines an unknown {network_key} link type"
                             f" '{link_type}'."
                         )
                     if not isinstance(resolved_link_schema, dict):
                         schema_name = get_schema_name(schema)
                         raise NeedsConfigException(
-                            f"Schema '{schema_name}' defines a network link type '{link_type}' "
+                            f"Schema '{schema_name}' defines a {network_key} link type '{link_type}' "
                             "but its value a not dict."
                         )
                     nested_fields = ["contains", "items"]
@@ -220,7 +227,7 @@ def check_network_links_against_links(
                             if not isinstance(resolved_link_schema[field], dict):  # type: ignore[literal-required]
                                 schema_name = get_schema_name(schema)
                                 raise NeedsConfigException(
-                                    f"Schema '{schema_name}' defines a network link type '{link_type}' "
+                                    f"Schema '{schema_name}' defines a {network_key} link type '{link_type}' "
                                     f"but its '{field}' value is not a dict."
                                 )
                             validate_schemas.append(resolved_link_schema[field])  # type: ignore[literal-required]
@@ -338,18 +345,19 @@ def _process_validate_schema(
                 local, schema_name, fields_schema, f"{path}.local"
             )
 
-    # Handle 'network' (optional) - dict of link_name -> ResolvedLinkSchemaType
-    if "network" in validate:
-        network = validate["network"]
-        if isinstance(network, dict):
-            for link_name, resolved_link in network.items():
-                if isinstance(resolved_link, dict):
-                    _process_resolved_link(
-                        resolved_link,
-                        schema_name,
-                        fields_schema,
-                        f"{path}.network.{link_name}",
-                    )
+    # Handle 'network' / 'network_back' (optional) - dict of link_name -> ResolvedLinkSchemaType
+    for network_key in ("network", "network_back"):
+        if network_key in validate:
+            network = validate[network_key]
+            if isinstance(network, dict):
+                for link_name, resolved_link in network.items():
+                    if isinstance(resolved_link, dict):
+                        _process_resolved_link(
+                            resolved_link,
+                            schema_name,
+                            fields_schema,
+                            f"{path}.{network_key}.{link_name}",
+                        )
 
 
 def _process_resolved_link(

--- a/sphinx_needs/schema/core.py
+++ b/sphinx_needs/schema/core.py
@@ -17,6 +17,7 @@ from sphinx_needs.schema.config import (
     MessageRuleEnum,
     NeedFieldsSchemaType,
     NeedFieldsSchemaWithVersionType,
+    ResolvedLinkSchemaType,
     SchemasRootType,
     SeverityEnum,
     ValidateSchemaType,
@@ -190,6 +191,8 @@ def validate_type_schema(
         local_network_schema["local"] = schema["validate"]["local"]
     if "network" in schema["validate"]:
         local_network_schema["network"] = schema["validate"]["network"]
+    if "network_back" in schema["validate"]:
+        local_network_schema["network_back"] = schema["validate"]["network_back"]
 
     validator_cache: dict[tuple[str, ...], SchemaValidator] = {}
 
@@ -291,8 +294,19 @@ def recurse_validate_schemas(
         warnings.extend(warnings_local)
         if any_not_of_rule(warnings_local, rule_success):
             success = False
-    if "network" in schema:
-        for link_type, link_schema in schema["network"].items():
+    if "network" in schema or "network_back" in schema:
+        # Flatten outgoing ("network") and incoming ("network_back") link rules
+        # into a single iteration so both directions share the same logic.
+        network_entries: list[tuple[str, str, ResolvedLinkSchemaType]] = [
+            (network_key, link_type, link_schema)
+            for network_key in ("network", "network_back")
+            for link_type, link_schema in schema.get(network_key, {}).items()  # type: ignore[attr-defined]
+        ]
+        for network_key, link_type, link_schema in network_entries:
+            # For incoming links, traverse the computed ``<link_type>_back`` field;
+            # for outgoing links, traverse the link field directly.
+            link_field = link_type if network_key == "network" else f"{link_type}_back"
+            link_desc = "links" if network_key == "network" else "incoming links"
             items_targets_ok: list[str] = []
             """List of target need ids for items validation that passed."""
             items_targets_nok: list[str] = []
@@ -308,18 +322,18 @@ def recurse_validate_schemas(
             schema_path_items = [
                 *schema_path,
                 "validate",
-                "network",
+                network_key,
                 link_type,
                 "items",
             ]
             schema_path_contains = [
                 *schema_path,
                 "validate",
-                "network",
+                network_key,
                 link_type,
                 "contains",
             ]
-            for target_need_id in need[link_type]:
+            for target_need_id in need[link_field]:
                 # collect all downstream warnings for broken links, items and contains
                 # evaluation happens later
                 try:
@@ -327,7 +341,7 @@ def recurse_validate_schemas(
                 except KeyError:
                     # target need does not exist (broken link)
                     rule = MessageRuleEnum.network_missing_target
-                    msg = f"Broken link of type '{link_type}' to '{target_need_id}'"
+                    msg = f"Broken {link_desc[:-1]} of type '{link_type}' to '{target_need_id}'"
                     # report it directly, it's not a minmax warning and the target need is ignored
                     # in the minmax checks
                     warnings.append(
@@ -339,7 +353,7 @@ def recurse_validate_schemas(
                             "schema_path": [
                                 *schema_path,
                                 "validate",
-                                "network",
+                                network_key,
                                 link_type,
                             ],
                             "need_path": [*need_path, link_type],
@@ -408,7 +422,7 @@ def recurse_validate_schemas(
                 ]
                 rule = MessageRuleEnum.network_items_fail
                 msg = (
-                    f"Items validation failed for links of type '{link_type}' "
+                    f"Items validation failed for {link_desc} of type '{link_type}' "
                     f"to {', '.join(items_targets_nok)}"
                 )
                 if items_targets_ok:
@@ -440,7 +454,7 @@ def recurse_validate_schemas(
                     min_contains = link_schema["minContains"]
                 if contains_cnt_ok < min_contains:
                     rule = MessageRuleEnum.network_contains_too_few
-                    msg = f"Too few valid links of type '{link_type}' ({contains_cnt_ok} < {min_contains})"
+                    msg = f"Too few valid {link_desc} of type '{link_type}' ({contains_cnt_ok} < {min_contains})"
                     if contains_cnt_ok > 0:
                         msg += f" / ok: {', '.join(contains_targets_ok)}"
                     if contains_cnt_nok > 0:
@@ -468,7 +482,7 @@ def recurse_validate_schemas(
                     max_contains = link_schema["maxContains"]
                     if contains_cnt_ok > max_contains:
                         rule = MessageRuleEnum.network_contains_too_many
-                        msg = f"Too many valid links of type '{link_type}' ({contains_cnt_ok} > {max_contains})"
+                        msg = f"Too many valid {link_desc} of type '{link_type}' ({contains_cnt_ok} > {max_contains})"
                         if contains_cnt_ok > 0:
                             msg += f" / ok: {', '.join(contains_targets_ok)}"
                         if contains_cnt_nok > 0:

--- a/sphinx_needs/schema/core.py
+++ b/sphinx_needs/schema/core.py
@@ -307,6 +307,14 @@ def recurse_validate_schemas(
             # for outgoing links, traverse the link field directly.
             link_field = link_type if network_key == "network" else f"{link_type}_back"
             link_desc = "links" if network_key == "network" else "incoming links"
+            link_desc_singular = "link" if network_key == "network" else "incoming link"
+            # Label for this hop in ``need_path``. For incoming links the traversed need
+            # is the *source* of the link, so the hop is annotated to make the direction
+            # unambiguous (otherwise ``REQ_1 > links > IMPL_1`` reads as if REQ_1 links to
+            # IMPL_1, when in fact IMPL_1 links to REQ_1).
+            link_path_label = (
+                link_type if network_key == "network" else f"{link_type} (incoming)"
+            )
             items_targets_ok: list[str] = []
             """List of target need ids for items validation that passed."""
             items_targets_nok: list[str] = []
@@ -341,7 +349,7 @@ def recurse_validate_schemas(
                 except KeyError:
                     # target need does not exist (broken link)
                     rule = MessageRuleEnum.network_missing_target
-                    msg = f"Broken {link_desc[:-1]} of type '{link_type}' to '{target_need_id}'"
+                    msg = f"Broken {link_desc_singular} of type '{link_type}' to '{target_need_id}'"
                     # report it directly, it's not a minmax warning and the target need is ignored
                     # in the minmax checks
                     warnings.append(
@@ -356,14 +364,14 @@ def recurse_validate_schemas(
                                 network_key,
                                 link_type,
                             ],
-                            "need_path": [*need_path, link_type],
+                            "need_path": [*need_path, link_path_label],
                         }
                     )
                     if recurse_level == 0 and user_message is not None:
                         warnings[-1]["user_message"] = user_message
                     continue
 
-                need_path_link = [*need_path, link_type, target_need_id]
+                need_path_link = [*need_path, link_path_label, target_need_id]
                 # Handle items validation - all items must pass
                 if link_schema.get("items"):
                     new_success, new_warnings = recurse_validate_schemas(
@@ -435,7 +443,7 @@ def recurse_validate_schemas(
                     "validation_message": msg,
                     "need": need,
                     "schema_path": schema_path_items,
-                    "need_path": [*need_path, link_type],
+                    "need_path": [*need_path, link_path_label],
                     "children": items_nok_warnings,  # user is interested in these
                 }
                 if recurse_level == 0 and user_message is not None:
@@ -471,7 +479,7 @@ def recurse_validate_schemas(
                             "validation_message": msg,
                             "need": need,
                             "schema_path": schema_path_contains,
-                            "need_path": [*need_path, link_type],
+                            "need_path": [*need_path, link_path_label],
                             "children": contains_nok_warnings,  # user is interested in these
                         }
                     )
@@ -494,7 +502,7 @@ def recurse_validate_schemas(
                                 "validation_message": msg,
                                 "need": need,
                                 "schema_path": schema_path_contains,
-                                "need_path": [*need_path, link_type],
+                                "need_path": [*need_path, link_path_label],
                                 # children not passed, no interest in too much success
                             }
                         )

--- a/sphinx_needs/schema/core.py
+++ b/sphinx_needs/schema/core.py
@@ -308,6 +308,9 @@ def recurse_validate_schemas(
             link_field = link_type if network_key == "network" else f"{link_type}_back"
             link_desc = "links" if network_key == "network" else "incoming links"
             link_desc_singular = "link" if network_key == "network" else "incoming link"
+            # Preposition relating the need to the traversed targets: outgoing links go
+            # "to" their targets, incoming links come "from" their sources.
+            link_prep = "to" if network_key == "network" else "from"
             # Label for this hop in ``need_path``. For incoming links the traversed need
             # is the *source* of the link, so the hop is annotated to make the direction
             # unambiguous (otherwise ``REQ_1 > links > IMPL_1`` reads as if REQ_1 links to
@@ -347,7 +350,9 @@ def recurse_validate_schemas(
                 try:
                     target_need = needs[target_need_id]
                 except KeyError:
-                    # target need does not exist (broken link)
+                    # Target need does not exist (broken link). Only reachable for the
+                    # outgoing direction: incoming-link sources come from resolved
+                    # ``<link_type>_back`` fields, so they always resolve to a need.
                     rule = MessageRuleEnum.network_missing_target
                     msg = f"Broken {link_desc_singular} of type '{link_type}' to '{target_need_id}'"
                     # report it directly, it's not a minmax warning and the target need is ignored
@@ -431,7 +436,7 @@ def recurse_validate_schemas(
                 rule = MessageRuleEnum.network_items_fail
                 msg = (
                     f"Items validation failed for {link_desc} of type '{link_type}' "
-                    f"to {', '.join(items_targets_nok)}"
+                    f"{link_prep} {', '.join(items_targets_nok)}"
                 )
                 if items_targets_ok:
                     msg += f" / ok: {', '.join(items_targets_ok)}"

--- a/sphinx_needs/schema/jsons/SchemasRootType.schema.json
+++ b/sphinx_needs/schema/jsons/SchemasRootType.schema.json
@@ -456,6 +456,13 @@
           },
           "title": "Network",
           "type": "object"
+        },
+        "network_back": {
+          "additionalProperties": {
+            "$ref": "#/$defs/ResolvedLinkSchemaType"
+          },
+          "title": "Network Back",
+          "type": "object"
         }
       },
       "title": "ValidateSchemaType",

--- a/tests/schema/__snapshots__/test_schema.ambr
+++ b/tests/schema/__snapshots__/test_schema.ambr
@@ -4979,7 +4979,7 @@
   ERROR: Need 'IMPL_1' has schema violations:
     Severity:       violation
     Field:          type
-    Need path:      REQ_1 > links > IMPL_1
+    Need path:      REQ_1 > links (incoming) > IMPL_1
     Schema path:    req<-[links]-only-tests[0] > validate > network_back > links > items > local > properties > type > const
     Schema message: "test" was expected [sn_schema_violation.network_local_fail]
   
@@ -4995,7 +4995,7 @@
           ]),
           'details': dict({
             'field': 'type',
-            'need_path': 'REQ_1 > links > IMPL_1',
+            'need_path': 'REQ_1 > links (incoming) > IMPL_1',
             'schema_path': 'req<-[links]-only-tests[0] > validate > network_back > links > items > local > properties > type > const',
             'severity': 'violation',
             'validation_msg': '"test" was expected',
@@ -5012,7 +5012,7 @@
   '''
   ERROR: Need 'REQ_1' has schema violations:
     Severity:       violation
-    Need path:      REQ_1 > links
+    Need path:      REQ_1 > links (incoming)
     Schema path:    req<-[links]-test-max-1[0] > validate > network_back > links > contains
     Schema message: Too many valid incoming links of type 'links' (2 > 1) / ok: TEST_1, TEST_2 [sn_schema_violation.network_contains_too_many]
   
@@ -5027,7 +5027,7 @@
           'children': list([
           ]),
           'details': dict({
-            'need_path': 'REQ_1 > links',
+            'need_path': 'REQ_1 > links (incoming)',
             'schema_path': 'req<-[links]-test-max-1[0] > validate > network_back > links > contains',
             'severity': 'violation',
             'validation_msg': "Too many valid incoming links of type 'links' (2 > 1) / ok: TEST_1, TEST_2",
@@ -5044,7 +5044,7 @@
   '''
   ERROR: Need 'REQ_1' has schema violations:
     Severity:       violation
-    Need path:      REQ_1 > links
+    Need path:      REQ_1 > links (incoming)
     Schema path:    req<-[links]-test[0] > validate > network_back > links > contains
     Schema message: Too few valid incoming links of type 'links' (0 < 1) [sn_schema_violation.network_contains_too_few]
   
@@ -5059,7 +5059,7 @@
           'children': list([
           ]),
           'details': dict({
-            'need_path': 'REQ_1 > links',
+            'need_path': 'REQ_1 > links (incoming)',
             'schema_path': 'req<-[links]-test[0] > validate > network_back > links > contains',
             'severity': 'violation',
             'validation_msg': "Too few valid incoming links of type 'links' (0 < 1)",
@@ -5078,6 +5078,98 @@
 # name: test_schemas[schema/fixtures/network-network_back_min_contains_ok].1
   dict({
     'validated_needs_count': 2,
+    'validation_warnings': dict({
+    }),
+  })
+# ---
+# name: test_schemas[schema/fixtures/network-network_back_nested_in_network_error]
+  '''
+  ERROR: Need 'IMPL_1' has schema violations:
+    Severity:       violation
+    Need path:      IMPL_1 > links
+    Schema path:    impl->spec<-test[0] > validate > network > links > contains
+    Schema message: Too few valid links of type 'links' (0 < 1) / nok: SPEC_1
+  
+      Details for SPEC_1
+      Need path:      IMPL_1 > links > SPEC_1 > links (incoming)
+      Schema path:    impl->spec<-test[0] > validate > network > links > contains > validate > network_back > links > contains
+      Schema message: Too few valid incoming links of type 'links' (0 < 1) / nok: IMPL_1
+  
+        Details for IMPL_1
+        Field:          type
+        Need path:      IMPL_1 > links > SPEC_1 > links (incoming) > IMPL_1
+        Schema path:    impl->spec<-test[0] > validate > network > links > contains > validate > network_back > links > contains > local > properties > type > const
+        Schema message: "test" was expected [sn_schema_violation.network_contains_too_few]
+  
+  '''
+# ---
+# name: test_schemas[schema/fixtures/network-network_back_nested_in_network_error].1
+  dict({
+    'validated_needs_count': 2,
+    'validation_warnings': dict({
+      'IMPL_1': list([
+        dict({
+          'children': list([
+            dict({
+              'need_id': 'SPEC_1',
+              'warning': dict({
+                'children': list([
+                ]),
+                'details': dict({
+                  'need_path': 'IMPL_1 > links > SPEC_1',
+                  'schema_path': 'impl->spec<-test[0] > validate > network > links > contains > local',
+                }),
+                'subtype': 'network_local_success',
+              }),
+            }),
+            dict({
+              'need_id': 'SPEC_1',
+              'warning': dict({
+                'children': list([
+                  dict({
+                    'need_id': 'IMPL_1',
+                    'warning': dict({
+                      'children': list([
+                      ]),
+                      'details': dict({
+                        'field': 'type',
+                        'need_path': 'IMPL_1 > links > SPEC_1 > links (incoming) > IMPL_1',
+                        'schema_path': 'impl->spec<-test[0] > validate > network > links > contains > validate > network_back > links > contains > local > properties > type > const',
+                        'validation_msg': '"test" was expected',
+                      }),
+                      'subtype': 'network_local_fail',
+                    }),
+                  }),
+                ]),
+                'details': dict({
+                  'need_path': 'IMPL_1 > links > SPEC_1 > links (incoming)',
+                  'schema_path': 'impl->spec<-test[0] > validate > network > links > contains > validate > network_back > links > contains',
+                  'validation_msg': "Too few valid incoming links of type 'links' (0 < 1) / nok: IMPL_1",
+                }),
+                'subtype': 'network_contains_too_few',
+              }),
+            }),
+          ]),
+          'details': dict({
+            'need_path': 'IMPL_1 > links',
+            'schema_path': 'impl->spec<-test[0] > validate > network > links > contains',
+            'severity': 'violation',
+            'validation_msg': "Too few valid links of type 'links' (0 < 1) / nok: SPEC_1",
+          }),
+          'log_lvl': 'error',
+          'subtype': 'network_contains_too_few',
+          'type': 'sn_schema_violation',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_schemas[schema/fixtures/network-network_back_nested_in_network_ok]
+  ''
+# ---
+# name: test_schemas[schema/fixtures/network-network_back_nested_in_network_ok].1
+  dict({
+    'validated_needs_count': 3,
     'validation_warnings': dict({
     }),
   })

--- a/tests/schema/__snapshots__/test_schema.ambr
+++ b/tests/schema/__snapshots__/test_schema.ambr
@@ -4974,6 +4974,114 @@
     }),
   })
 # ---
+# name: test_schemas[schema/fixtures/network-network_back_items_error]
+  '''
+  ERROR: Need 'IMPL_1' has schema violations:
+    Severity:       violation
+    Field:          type
+    Need path:      REQ_1 > links > IMPL_1
+    Schema path:    req<-[links]-only-tests[0] > validate > network_back > links > items > local > properties > type > const
+    Schema message: "test" was expected [sn_schema_violation.network_local_fail]
+  
+  '''
+# ---
+# name: test_schemas[schema/fixtures/network-network_back_items_error].1
+  dict({
+    'validated_needs_count': 3,
+    'validation_warnings': dict({
+      'REQ_1': list([
+        dict({
+          'children': list([
+          ]),
+          'details': dict({
+            'field': 'type',
+            'need_path': 'REQ_1 > links > IMPL_1',
+            'schema_path': 'req<-[links]-only-tests[0] > validate > network_back > links > items > local > properties > type > const',
+            'severity': 'violation',
+            'validation_msg': '"test" was expected',
+          }),
+          'log_lvl': 'error',
+          'subtype': 'network_local_fail',
+          'type': 'sn_schema_violation',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_schemas[schema/fixtures/network-network_back_max_contains_error]
+  '''
+  ERROR: Need 'REQ_1' has schema violations:
+    Severity:       violation
+    Need path:      REQ_1 > links
+    Schema path:    req<-[links]-test-max-1[0] > validate > network_back > links > contains
+    Schema message: Too many valid incoming links of type 'links' (2 > 1) / ok: TEST_1, TEST_2 [sn_schema_violation.network_contains_too_many]
+  
+  '''
+# ---
+# name: test_schemas[schema/fixtures/network-network_back_max_contains_error].1
+  dict({
+    'validated_needs_count': 3,
+    'validation_warnings': dict({
+      'REQ_1': list([
+        dict({
+          'children': list([
+          ]),
+          'details': dict({
+            'need_path': 'REQ_1 > links',
+            'schema_path': 'req<-[links]-test-max-1[0] > validate > network_back > links > contains',
+            'severity': 'violation',
+            'validation_msg': "Too many valid incoming links of type 'links' (2 > 1) / ok: TEST_1, TEST_2",
+          }),
+          'log_lvl': 'error',
+          'subtype': 'network_contains_too_many',
+          'type': 'sn_schema_violation',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_schemas[schema/fixtures/network-network_back_min_contains_error]
+  '''
+  ERROR: Need 'REQ_1' has schema violations:
+    Severity:       violation
+    Need path:      REQ_1 > links
+    Schema path:    req<-[links]-test[0] > validate > network_back > links > contains
+    Schema message: Too few valid incoming links of type 'links' (0 < 1) [sn_schema_violation.network_contains_too_few]
+  
+  '''
+# ---
+# name: test_schemas[schema/fixtures/network-network_back_min_contains_error].1
+  dict({
+    'validated_needs_count': 1,
+    'validation_warnings': dict({
+      'REQ_1': list([
+        dict({
+          'children': list([
+          ]),
+          'details': dict({
+            'need_path': 'REQ_1 > links',
+            'schema_path': 'req<-[links]-test[0] > validate > network_back > links > contains',
+            'severity': 'violation',
+            'validation_msg': "Too few valid incoming links of type 'links' (0 < 1)",
+          }),
+          'log_lvl': 'error',
+          'subtype': 'network_contains_too_few',
+          'type': 'sn_schema_violation',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_schemas[schema/fixtures/network-network_back_min_contains_ok]
+  ''
+# ---
+# name: test_schemas[schema/fixtures/network-network_back_min_contains_ok].1
+  dict({
+    'validated_needs_count': 2,
+    'validation_warnings': dict({
+    }),
+  })
+# ---
 # name: test_schemas[schema/fixtures/network-no_error_empty_links]
   '''
   ERROR: Need 'IMPL_SAFE' has schema violations:

--- a/tests/schema/fixtures/network.yml
+++ b/tests/schema/fixtures/network.yml
@@ -828,3 +828,102 @@ network_back_items_error:
               items:
                 local:
                   $ref: "#/$defs/type-test"
+
+network_back_nested_in_network_ok:
+  # Mixed/nested: an impl must link to a spec, and that spec must itself have at
+  # least one incoming test link (a forward hop followed by a back hop, sharing the
+  # recursion budget).
+  conf: |
+    extensions = ["sphinx_needs"]
+    needs_from_toml = "ubproject.toml"
+    needs_schema_definitions_from_json = "schemas.json"
+  ubproject: |
+    [needs.fields.asil]
+    nullable = true
+  rst: |
+    .. spec:: a spec
+        :id: SPEC_1
+
+    .. impl:: an impl
+        :id: IMPL_1
+        :links: SPEC_1
+
+    .. test:: a test
+        :id: TEST_1
+        :links: SPEC_1
+  schemas:
+    $defs:
+      type-spec:
+        properties:
+          type:
+            const: spec
+      type-test:
+        properties:
+          type:
+            const: test
+    schemas:
+      - id: "impl->spec<-test"
+        select:
+          properties:
+            type:
+              const: impl
+        validate:
+          network:
+            links:
+              contains:
+                local:
+                  $ref: "#/$defs/type-spec"
+                network_back:
+                  links:
+                    contains:
+                      local:
+                        $ref: "#/$defs/type-test"
+                    minContains: 1
+              minContains: 1
+
+network_back_nested_in_network_error:
+  # Same as above, but SPEC_1 has no incoming test, so the nested network_back fails
+  # and the error surfaces on the impl via the forward link.
+  conf: |
+    extensions = ["sphinx_needs"]
+    needs_from_toml = "ubproject.toml"
+    needs_schema_definitions_from_json = "schemas.json"
+  ubproject: |
+    [needs.fields.asil]
+    nullable = true
+  rst: |
+    .. spec:: a spec
+        :id: SPEC_1
+
+    .. impl:: an impl
+        :id: IMPL_1
+        :links: SPEC_1
+  schemas:
+    $defs:
+      type-spec:
+        properties:
+          type:
+            const: spec
+      type-test:
+        properties:
+          type:
+            const: test
+    schemas:
+      - id: "impl->spec<-test"
+        select:
+          properties:
+            type:
+              const: impl
+        validate:
+          network:
+            links:
+              contains:
+                local:
+                  $ref: "#/$defs/type-spec"
+                network_back:
+                  links:
+                    contains:
+                      local:
+                        $ref: "#/$defs/type-test"
+                    minContains: 1
+              minContains: 1

--- a/tests/schema/fixtures/network.yml
+++ b/tests/schema/fixtures/network.yml
@@ -668,3 +668,163 @@ link_name_contains:
                   "properties":
                     "type":
                       "const": "spec"
+
+# --- network_back: validate incoming links instead of outgoing ones ---
+
+network_back_min_contains_ok:
+  # A req is "covered" when at least one test links to it (incoming 'links').
+  conf: |
+    extensions = ["sphinx_needs"]
+    needs_from_toml = "ubproject.toml"
+    needs_schema_definitions_from_json = "schemas.json"
+  ubproject: |
+    [needs.fields.asil]
+    nullable = true
+  rst: |
+    .. req:: a requirement
+        :id: REQ_1
+
+    .. test:: a test
+        :id: TEST_1
+        :links: REQ_1
+  schemas:
+    $defs:
+      type-req:
+        properties:
+          type:
+            const: req
+      type-test:
+        properties:
+          type:
+            const: test
+    schemas:
+      - id: "req<-[links]-test"
+        message: req must be covered by at least one test
+        select:
+          $ref: "#/$defs/type-req"
+        validate:
+          network_back:
+            links:
+              contains:
+                local:
+                  $ref: "#/$defs/type-test"
+              minContains: 1
+
+network_back_min_contains_error:
+  # REQ_1 has no incoming test link -> too few incoming links.
+  conf: |
+    extensions = ["sphinx_needs"]
+    needs_from_toml = "ubproject.toml"
+    needs_schema_definitions_from_json = "schemas.json"
+  ubproject: |
+    [needs.fields.asil]
+    nullable = true
+  rst: |
+    .. req:: a requirement
+        :id: REQ_1
+  schemas:
+    $defs:
+      type-req:
+        properties:
+          type:
+            const: req
+      type-test:
+        properties:
+          type:
+            const: test
+    schemas:
+      - id: "req<-[links]-test"
+        message: req must be covered by at least one test
+        select:
+          $ref: "#/$defs/type-req"
+        validate:
+          network_back:
+            links:
+              contains:
+                local:
+                  $ref: "#/$defs/type-test"
+              minContains: 1
+
+network_back_max_contains_error:
+  # More incoming test links than allowed -> too many incoming links.
+  conf: |
+    extensions = ["sphinx_needs"]
+    needs_from_toml = "ubproject.toml"
+    needs_schema_definitions_from_json = "schemas.json"
+  ubproject: |
+    [needs.fields.asil]
+    nullable = true
+  rst: |
+    .. req:: a requirement
+        :id: REQ_1
+
+    .. test:: test one
+        :id: TEST_1
+        :links: REQ_1
+
+    .. test:: test two
+        :id: TEST_2
+        :links: REQ_1
+  schemas:
+    $defs:
+      type-req:
+        properties:
+          type:
+            const: req
+      type-test:
+        properties:
+          type:
+            const: test
+    schemas:
+      - id: "req<-[links]-test-max-1"
+        select:
+          $ref: "#/$defs/type-req"
+        validate:
+          network_back:
+            links:
+              contains:
+                local:
+                  $ref: "#/$defs/type-test"
+              minContains: 1
+              maxContains: 1
+
+network_back_items_error:
+  # 'items' requires ALL incoming links to be tests; an incoming impl link fails.
+  conf: |
+    extensions = ["sphinx_needs"]
+    needs_from_toml = "ubproject.toml"
+    needs_schema_definitions_from_json = "schemas.json"
+  ubproject: |
+    [needs.fields.asil]
+    nullable = true
+  rst: |
+    .. req:: a requirement
+        :id: REQ_1
+
+    .. test:: a test
+        :id: TEST_1
+        :links: REQ_1
+
+    .. impl:: an impl
+        :id: IMPL_1
+        :links: REQ_1
+  schemas:
+    $defs:
+      type-req:
+        properties:
+          type:
+            const: req
+      type-test:
+        properties:
+          type:
+            const: test
+    schemas:
+      - id: "req<-[links]-only-tests"
+        select:
+          $ref: "#/$defs/type-req"
+        validate:
+          network_back:
+            links:
+              items:
+                local:
+                  $ref: "#/$defs/type-test"


### PR DESCRIPTION
## Summary

Adds a `network_back` key to schema validation, as a sibling of the existing `network` key, that validates a need's **incoming** links rather than its **outgoing** links.

> **Note:** this feature is being developed **in parallel with ubCode**, so that the two implementations validate identically (same rule codes, same message wording, same semantics).

## Motivation

The existing `network` key validates outgoing links: *"this need's `links` of type X must point to needs matching schema S, with min/max count constraints"*.

There was no way to assert constraints on **incoming** links. The motivating use case:

> *Every `req` must be covered by at least one `test`.*

Previously this could only be expressed as a forward rule on **every** `test`, which is awkward and easy to leave incomplete. With `network_back` it is expressed once, **on the req**:

```yaml
validate:
  network_back:
    links:               # incoming 'links'
      contains:
        local: { $ref: '#/$defs/test' }
      minContains: 1      # >=1 test links to me
```

## Semantics

`network_back` has the **exact same nested shape** as `network` (`items` / `contains` / `minContains` / `maxContains`, recursively containing `local` + `network` + `network_back`). The only difference is direction:

- `network` keys a link type and walks the need's **outgoing** links of that type (`need[link_type]`).
- `network_back` keys a link type and walks the need's **incoming** links of that type — the needs that link *to* this need via that outgoing type (the already-computed `need[link_type + "_back"]` field).

Details:

- `minContains` defaults to 1; `maxContains` unbounded.
- A back hop and a forward hop both consume one level of the shared recursion budget, so `network` and `network_back` can be freely mixed/nested within the same 4-level chain.
- `network_missing_target` (broken link) is **forward-only** — incoming links are resolved from existing needs and always exist.
- The existing message rules are reused (`network_contains_too_few`, `network_contains_too_many`, `network_items_fail`, `network_local_*`); direction is disambiguated by the `schema_path` containing `network_back`, and message text says "incoming links" for the back direction.
- The `select` predicate still selects the *validated* need (the target of the incoming links), not the sources.

## Changes

- `sphinx_needs/schema/config.py`: `network_back` added to `ValidateSchemaType`.
- `sphinx_needs/schema/core.py`: `recurse_validate_schemas` flattens both directions into one loop; incoming links traverse the `<link_type>_back` field.
- `sphinx_needs/schema/config_utils.py`: `$ref` resolution, type-injection, and link-type checks recurse into `network_back`.
- `sphinx_needs/schema/jsons/SchemasRootType.schema.json`: regenerated to allow `network_back`.
- `docs/schema/index.rst`: new "Incoming link validation (`network_back`)" section + coverage example.
- `tests/schema/fixtures/network.yml` + snapshots: cases for back-contains (too few / too many), back-items, and the coverage example.

## Tests

`tests/schema` passes (173 passed, 234 snapshots). `ruff` and `mypy` clean on the changed files.
