### PR TITLE
🧪 Add schema config fixtures for invalid $ref value cases

### DIFF
--- a/tests/schema/__snapshots__/test_schema.ambr
+++ b/tests/schema/__snapshots__/test_schema.ambr
@@ -584,8 +584,14 @@
 # name: test_schema_config[ref_mixed_error]
   "Invalid $ref entry, expected a single $ref key: {'$ref': '#/$defs/not-exist', 'required': ['type']}"
 # ---
+# name: test_schema_config[ref_not_defs_prefix]
+  "Invalid $ref value: type-impl, expected to start with '#/$defs/'."
+# ---
 # name: test_schema_config[ref_recursive_error]
   "Circular reference detected for 'type-impl'."
+# ---
+# name: test_schema_config[ref_value_not_string]
+  'Invalid $ref value: 123, expected a string.'
 # ---
 # name: test_schema_config[schemas_select_pattern_unsafe_error]
   '''

--- a/tests/schema/fixtures/config.yml
+++ b/tests/schema/fixtures/config.yml
@@ -321,6 +321,42 @@ ref_recursive_error:
           local:
             $ref: "#/$defs/type-impl"
 
+ref_value_not_string:
+  conf: |
+    extensions = ["sphinx_needs"]
+    needs_schema_definitions_from_json = "schemas.json"
+  rst: |
+    .. impl:: title
+        :id: IMPL_1
+  schemas:
+    $defs:
+      type-impl:
+        properties:
+          type:
+            const: impl
+    schemas:
+      - validate:
+          local:
+            $ref: 123
+
+ref_not_defs_prefix:
+  conf: |
+    extensions = ["sphinx_needs"]
+    needs_schema_definitions_from_json = "schemas.json"
+  rst: |
+    .. impl:: title
+        :id: IMPL_1
+  schemas:
+    $defs:
+      type-impl:
+        properties:
+          type:
+            const: impl
+    schemas:
+      - validate:
+          local:
+            $ref: "type-impl"
+
 extra_option_unknown_keys:
   conf: |
     extensions = ["sphinx_needs"]


### PR DESCRIPTION
Adds two `test_schema_config` fixtures covering the `$ref` config-error branches in `resolve_refs` that previously had no fixture:

- **`ref_value_not_string`** — a `$ref` whose value is not a string (`$ref: 123`) → `Invalid $ref value: 123, expected a string.`
- **`ref_not_defs_prefix`** — a `$ref` that does not start with `#/$defs/` (`$ref: "type-impl"`) → `Invalid $ref value: type-impl, expected to start with '#/$defs/'.`

These complete the fixture coverage of `resolve_refs`' error cases (alongside the existing missing-target / sibling-key / circular fixtures) and serve as the **parity oracle** for the equivalent checks in ubcode's faithful `resolve_refs` port.

Test-only; no behavior change.