### PR TITLE
🧪 Add network-local reduction parity fixtures

### DIFF
--- a/tests/schema/__snapshots__/test_schema.ambr
+++ b/tests/schema/__snapshots__/test_schema.ambr
@@ -5090,6 +5090,48 @@
     }),
   })
 # ---
+# name: test_schemas[schema/fixtures/network-network_local_unevaluated_reduced_error]
+  '''
+  ERROR: Need 'SPEC_1' has schema violations:
+    Severity:       violation
+    Need path:      IMPL_1 > links > SPEC_1
+    Schema path:    [0] > validate > network > links > items > local > unevaluatedProperties
+    Schema message: Unevaluated properties are not allowed ('asil' was unexpected) [sn_schema_violation.network_local_fail]
+  
+  '''
+# ---
+# name: test_schemas[schema/fixtures/network-network_local_unevaluated_reduced_error].1
+  dict({
+    'validated_needs_count': 2,
+    'validation_warnings': dict({
+      'IMPL_1': list([
+        dict({
+          'children': list([
+          ]),
+          'details': dict({
+            'need_path': 'IMPL_1 > links > SPEC_1',
+            'schema_path': '[0] > validate > network > links > items > local > unevaluatedProperties',
+            'severity': 'violation',
+            'validation_msg': "Unevaluated properties are not allowed ('asil' was unexpected)",
+          }),
+          'log_lvl': 'error',
+          'subtype': 'network_local_fail',
+          'type': 'sn_schema_violation',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_schemas[schema/fixtures/network-network_local_unevaluated_reduced_ok]
+  ''
+# ---
+# name: test_schemas[schema/fixtures/network-network_local_unevaluated_reduced_ok].1
+  dict({
+    'validated_needs_count': 2,
+    'validation_warnings': dict({
+    }),
+  })
+# ---
 # name: test_schemas[schema/fixtures/network-no_error_empty_links]
   '''
   ERROR: Need 'IMPL_SAFE' has schema violations:

--- a/tests/schema/fixtures/network.yml
+++ b/tests/schema/fixtures/network.yml
@@ -627,6 +627,76 @@ max_network_levels:
                                                   type:
                                                     const: spec
 
+network_local_unevaluated_reduced_ok:
+  # The network-local schema uses ``unevaluatedProperties``, whose semantics are only
+  # meaningful after ``reduce_need()`` strips the fields the schema does not reference.
+  # SN applies that same reduction inside the network path (``_validate_need_local``)
+  # as for top-level local validation, so the linked spec — reduced to just
+  # ``{type: spec}`` — validates cleanly and ``items`` passes with no warning.
+  conf: |
+    extensions = ["sphinx_needs"]
+    needs_from_toml = "ubproject.toml"
+    needs_schema_definitions_from_json = "schemas.json"
+  ubproject: |
+    [needs.fields.asil]
+    nullable = true
+  rst: |
+    .. spec:: title
+        :id: SPEC_1
+
+    .. impl:: title
+        :id: IMPL_1
+        :links: SPEC_1
+  schemas:
+    $defs: []
+    schemas:
+      - select:
+          properties:
+            type: {const: "impl"}
+        validate:
+          network:
+            links:
+              items:
+                local:
+                  properties:
+                    type: {const: spec}
+                  unevaluatedProperties: false
+
+network_local_unevaluated_reduced_error:
+  # Same as ``network_local_unevaluated_reduced_ok`` but the linked spec sets an extra
+  # field (``asil``) that the network-local schema does not reference. ``reduce_need()``
+  # keeps actively-set extra fields, so ``unevaluatedProperties: false`` still fails on
+  # it — confirming reduction matches the top-level path without masking real violations.
+  conf: |
+    extensions = ["sphinx_needs"]
+    needs_from_toml = "ubproject.toml"
+    needs_schema_definitions_from_json = "schemas.json"
+  ubproject: |
+    [needs.fields.asil]
+    nullable = true
+  rst: |
+    .. spec:: title
+        :id: SPEC_1
+        :asil: QM
+
+    .. impl:: title
+        :id: IMPL_1
+        :links: SPEC_1
+  schemas:
+    $defs: []
+    schemas:
+      - select:
+          properties:
+            type: {const: "impl"}
+        validate:
+          network:
+            links:
+              items:
+                local:
+                  properties:
+                    type: {const: spec}
+                  unevaluatedProperties: false
+
 link_name_contains:
   conf: |
     extensions = ["sphinx_needs"]


### PR DESCRIPTION
Adds two schema-validation fixtures that pin sphinx-needs' behaviour for a network-context `local` schema using `unevaluatedProperties`, to serve as the parity oracle for the ubcode port.

- **`network_local_unevaluated_reduced_ok`** — a linked spec with no extra fields, reduced to just `{type: spec}`, validates cleanly. Confirms `_validate_need_local` applies `reduce_need` inside the network path exactly as for top-level local validation.
- **`network_local_unevaluated_reduced_error`** — the linked spec sets an extra `asil` field the schema does not reference; reduction keeps actively-set extra fields, so `unevaluatedProperties: false` still fails. Confirms reduction does not mask real violations.

No behaviour change — fixtures + snapshots only.