### PR TITLE
🧪 Add multi-error network-local parity fixture

### DIFF
--- a/tests/schema/__snapshots__/test_schema.ambr
+++ b/tests/schema/__snapshots__/test_schema.ambr
@@ -5090,6 +5090,60 @@
     }),
   })
 # ---
+# name: test_schemas[schema/fixtures/network-network_local_multi_error]
+  '''
+  ERROR: Need 'SPEC_1' has schema violations:
+    Severity:       violation
+    Field:          asil
+    Need path:      IMPL_1 > links > SPEC_1
+    Schema path:    [0] > validate > network > links > items > local > properties > asil > const
+    Schema message: "A" was expected [sn_schema_violation.network_local_fail]
+  ERROR: Need 'SPEC_1' has schema violations:
+    Severity:       violation
+    Field:          comment
+    Need path:      IMPL_1 > links > SPEC_1
+    Schema path:    [0] > validate > network > links > items > local > properties > comment > const
+    Schema message: "ok" was expected [sn_schema_violation.network_local_fail]
+  
+  '''
+# ---
+# name: test_schemas[schema/fixtures/network-network_local_multi_error].1
+  dict({
+    'validated_needs_count': 2,
+    'validation_warnings': dict({
+      'IMPL_1': list([
+        dict({
+          'children': list([
+          ]),
+          'details': dict({
+            'field': 'asil',
+            'need_path': 'IMPL_1 > links > SPEC_1',
+            'schema_path': '[0] > validate > network > links > items > local > properties > asil > const',
+            'severity': 'violation',
+            'validation_msg': '"A" was expected',
+          }),
+          'log_lvl': 'error',
+          'subtype': 'network_local_fail',
+          'type': 'sn_schema_violation',
+        }),
+        dict({
+          'children': list([
+          ]),
+          'details': dict({
+            'field': 'comment',
+            'need_path': 'IMPL_1 > links > SPEC_1',
+            'schema_path': '[0] > validate > network > links > items > local > properties > comment > const',
+            'severity': 'violation',
+            'validation_msg': '"ok" was expected',
+          }),
+          'log_lvl': 'error',
+          'subtype': 'network_local_fail',
+          'type': 'sn_schema_violation',
+        }),
+      ]),
+    }),
+  })
+# ---
 # name: test_schemas[schema/fixtures/network-network_local_unevaluated_reduced_error]
   '''
   ERROR: Need 'SPEC_1' has schema violations:

--- a/tests/schema/fixtures/network.yml
+++ b/tests/schema/fixtures/network.yml
@@ -697,6 +697,44 @@ network_local_unevaluated_reduced_error:
                     type: {const: spec}
                   unevaluatedProperties: false
 
+network_local_multi_error:
+  # A network-context ``local`` whose target violates *two* property constraints at
+  # once. ``_validate_need_local`` lists ALL of ``iter_errors`` (one warning per error),
+  # so both the ``asil`` and ``comment`` const failures on SPEC_1 are reported — the
+  # oracle for ubcode, whose network-local path historically surfaced only the first.
+  conf: |
+    extensions = ["sphinx_needs"]
+    needs_from_toml = "ubproject.toml"
+    needs_schema_definitions_from_json = "schemas.json"
+  ubproject: |
+    [needs.fields.asil]
+    schema.type = "string"
+    [needs.fields.comment]
+    schema.type = "string"
+  rst: |
+    .. spec:: title
+        :id: SPEC_1
+        :asil: QM
+        :comment: nope
+
+    .. impl:: title
+        :id: IMPL_1
+        :links: SPEC_1
+  schemas:
+    $defs: []
+    schemas:
+      - select:
+          properties:
+            type: {const: "impl"}
+        validate:
+          network:
+            links:
+              items:
+                local:
+                  properties:
+                    asil: {const: "A"}
+                    comment: {const: "ok"}
+
 link_name_contains:
   conf: |
     extensions = ["sphinx_needs"]


### PR DESCRIPTION
Adds `network_local_multi_error` — a network-context `local` whose linked target (`SPEC_1`) violates **two** property `const` constraints at once (`asil` and `comment`).

`_validate_need_local` collects all of `iter_errors` (one `OntologyWarning` per error), so both failures are reported. This pins that behaviour as the parity oracle for the ubcode port, whose network-local path currently surfaces only the first error (the remaining half of the #1461-style "condense network local errors" divergence).

No behaviour change — fixture + snapshot only.
