### PR TITLE
✨ Add `variant` role for inline variant data references

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -25,6 +25,10 @@ Breaking changes
 Improvements
 ............
 
+- ✨ Add a :ref:`variant role <role_variant>`, resolving ``:variant:`a.b``` at
+  parse time to a text node holding the value looked up from
+  :ref:`needs_variant_data`
+
 - ✨ Add a ``network_back`` schema-validation key, the sibling of ``network``,
   that validates a need's **incoming** links instead of its outgoing ones. It
   reuses the same ``items`` / ``contains`` / ``minContains`` / ``maxContains``

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -25,9 +25,9 @@ Breaking changes
 Improvements
 ............
 
-- ✨ Add a :ref:`variant role <role_variant>`, resolving ``:variant:`a.b``` at
-  parse time to a text node holding the value looked up from
-  :ref:`needs_variant_data`
+- ✨ Add a :ref:`variant role <role_variant>` that resolves a dotted
+  variant-data path inline, at parse time, to a text node holding the value
+  looked up from :ref:`needs_variant_data`
 
 - ✨ Add a ``network_back`` schema-validation key, the sibling of ``network``,
   that validates a need's **incoming** links instead of its outgoing ones. It

--- a/docs/roles.rst
+++ b/docs/roles.rst
@@ -240,3 +240,11 @@ The lookup is a constrained ``var.*`` path resolution (the same as used by
 operators, function calls, or item access are allowed. An invalid reference,
 an unknown key, or a path that resolves to a mapping emits a ``needs.variant``
 warning and produces empty text.
+
+.. note::
+
+    The value is resolved at parse time and baked into the document. Changing
+    :ref:`needs_variant_data` triggers a full rebuild so the resolved values
+    stay current. Editing the *contents* of a :ref:`needs_variant_data_file`
+    without changing its path is not tracked as a build dependency, so run a
+    clean build (``sphinx-build -E``) in that case.

--- a/docs/roles.rst
+++ b/docs/roles.rst
@@ -203,3 +203,36 @@ Executes a :ref:`need dynamic function <dynamic_functions>` and uses the return 
 .. need-example::
 
     A nice :ndf:`echo("first test")` for dynamic functions.
+
+.. _role_variant:
+
+variant
+-------
+.. versionadded:: 8.2.0
+
+Resolves a reference into :ref:`needs_variant_data` and is *immediately*
+replaced during parsing by a text node holding the looked-up value.
+
+The role content is a dotted path into the configured variant data, rooted at
+``var``. The ``var.`` prefix may be given explicitly or omitted, so
+``:variant:`build.opt_level``` and ``:variant:`var.build.opt_level``` are
+equivalent.
+
+Given the configuration:
+
+.. code-block:: python
+
+    needs_variant_data = {
+        "platform": "arm",
+        "build": {"opt_level": 2},
+    }
+
+the reference ``:variant:`platform``` resolves to ``arm`` and
+``:variant:`build.opt_level``` resolves to ``2``. List values are joined with
+``, ``.
+
+The lookup is a constrained ``var.*`` path resolution (the same as used by
+:ref:`needs_variant_data` field references), not an arbitrary expression: no
+operators, function calls, or item access are allowed. An invalid reference,
+an unknown key, or a path that resolves to a mapping emits a ``needs.variant``
+warning and produces empty text.

--- a/docs/roles.rst
+++ b/docs/roles.rst
@@ -232,8 +232,31 @@ then in a document:
     Platform: :variant:`platform`
     Optimisation level: :variant:`build.opt_level`
 
-resolves to ``arm`` and ``2`` respectively. List values are joined into a
-comma-separated string.
+resolves to ``arm`` and ``2`` respectively.
+
+Type handling
+~~~~~~~~~~~~~
+
+The role always produces a single text node. The resolved value is serialised
+to text as follows:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Variant data value
+     - Rendered text
+   * - String (``"arm"``)
+     - The string itself (``arm``).
+   * - Integer / float (``2``, ``1.5``)
+     - Its ``str()`` form (``2``, ``1.5``).
+   * - Boolean (``True``)
+     - ``True`` / ``False`` (Python's ``str(bool)``).
+   * - Array (``["arm", "x86"]``)
+     - The elements joined into a comma-separated string (``arm, x86``).
+   * - Mapping (``{...}``)
+     - Not allowed — emits a warning and renders empty text (reference a leaf
+       value instead).
 
 The lookup is a constrained ``var.*`` path resolution (the same as used by
 :ref:`needs_variant_data` field references), not an arbitrary expression: no

--- a/docs/roles.rst
+++ b/docs/roles.rst
@@ -225,9 +225,15 @@ Given the configuration:
         "build": {"opt_level": 2},
     }
 
-the reference ``:variant:`platform``` resolves to ``arm`` and
-``:variant:`build.opt_level``` resolves to ``2``. List values are joined with
-``, ``.
+then in a document:
+
+.. code-block:: rst
+
+    Platform: :variant:`platform`
+    Optimisation level: :variant:`build.opt_level`
+
+resolves to ``arm`` and ``2`` respectively. List values are joined into a
+comma-separated string.
 
 The lookup is a constrained ``var.*`` path resolution (the same as used by
 :ref:`needs_variant_data` field references), not an arbitrary expression: no

--- a/docs/roles.rst
+++ b/docs/roles.rst
@@ -214,9 +214,7 @@ Resolves a reference into :ref:`needs_variant_data` and is *immediately*
 replaced during parsing by a text node holding the looked-up value.
 
 The role content is a dotted path into the configured variant data, rooted at
-``var``. The ``var.`` prefix may be given explicitly or omitted, so
-``:variant:`build.opt_level``` and ``:variant:`var.build.opt_level``` are
-equivalent.
+``var`` (the ``var`` root is implicit and must not be written).
 
 Given the configuration:
 

--- a/sphinx_needs/config.py
+++ b/sphinx_needs/config.py
@@ -738,7 +738,7 @@ class NeedsSphinxConfig:
         Use :confval:`needs_variant_data` with the ``var.*`` namespace instead.
     """
     variant_data: dict[str, Any] = field(
-        default_factory=dict, metadata={"rebuild": "html", "types": (dict,)}
+        default_factory=dict, metadata={"rebuild": "env", "types": (dict,)}
     )
     """Nested variant data accessible as ``var.*`` in filter expressions.
 
@@ -758,7 +758,7 @@ class NeedsSphinxConfig:
     variant_data_file: str | None = field(
         default=None,
         metadata={
-            "rebuild": "html",
+            "rebuild": "env",
             "types": (str, type(None)),
             "toml_convert": _abs_path,
         },

--- a/sphinx_needs/needs.py
+++ b/sphinx_needs/needs.py
@@ -130,6 +130,7 @@ from sphinx_needs.roles.need_incoming import NeedIncoming, process_need_incoming
 from sphinx_needs.roles.need_outgoing import NeedOutgoing, process_need_outgoing
 from sphinx_needs.roles.need_part import NeedPart, NeedPartRole, process_need_part
 from sphinx_needs.roles.need_ref import NeedRef, process_need_ref
+from sphinx_needs.roles.variant import VariantRole
 from sphinx_needs.schema.config import (
     FieldIntegerSchemaType,
     SchemasFileRootType,
@@ -312,6 +313,9 @@ def setup(app: Sphinx) -> dict[str, Any]:
 
     app.add_role("need_func", NeedFuncRole(with_brackets=True))  # deprecrated
     app.add_role("ndf", NeedFuncRole(with_brackets=False))
+
+    # Resolves :variant:`a.b` immediately to the value from needs_variant_data.
+    app.add_role("variant", VariantRole())
 
     ########################################################################
     # EVENTS

--- a/sphinx_needs/roles/variant.py
+++ b/sphinx_needs/roles/variant.py
@@ -44,8 +44,7 @@ class VariantRole(SphinxRole):
         if not variant_data:
             log_warning(
                 LOGGER,
-                f"'variant' role used but needs_variant_data is not configured: "
-                f"{self.text!r}",
+                f"'variant' role used but no variant data is available: {self.text!r}",
                 "variant",
                 location=self.get_location(),
             )

--- a/sphinx_needs/roles/variant.py
+++ b/sphinx_needs/roles/variant.py
@@ -24,23 +24,19 @@ class VariantRole(SphinxRole):
     """Role that resolves a ``var.*`` reference to its value.
 
     The role text is a dotted path into :confval:`needs_variant_data`,
-    rooted (implicitly or explicitly) at ``var``. For example, given::
+    rooted at ``var`` (the ``var`` root is implicit). For example, given::
 
         needs_variant_data = {"build": {"opt_level": 2}}
 
-    both ``:variant:`build.opt_level``` and ``:variant:`var.build.opt_level```
-    resolve immediately to the text ``2``.
+    ``:variant:`build.opt_level``` resolves immediately to the text ``2``.
     """
 
     def run(self) -> tuple[list[nodes.Node], list[nodes.system_message]]:
         add_doc(self.env, self.env.docname)
 
         expression = self.text.strip()
-        # The lookup is always rooted at ``var``; allow the prefix to be omitted.
-        if expression == "var" or expression.startswith("var."):
-            lookup_expression = expression
-        else:
-            lookup_expression = f"var.{expression}"
+        # The lookup is always rooted at ``var``.
+        lookup_expression = f"var.{expression}"
 
         config = NeedsSphinxConfig(self.env.config)
         variant_data = config.variant_data

--- a/sphinx_needs/roles/variant.py
+++ b/sphinx_needs/roles/variant.py
@@ -1,0 +1,74 @@
+"""Provide a role which resolves a variant data reference inline.
+
+The ``variant`` role takes a dotted path into the configured
+:confval:`needs_variant_data` (e.g. ``:variant:`build.opt_level```) and is
+resolved *immediately* during parsing into a plain text node holding the
+looked-up value. Unlike :class:`~sphinx_needs.roles.need_func.NeedFunc`, no
+placeholder node is left in the doctree for later post-processing.
+"""
+
+from __future__ import annotations
+
+from docutils import nodes
+from sphinx.util.docutils import SphinxRole
+
+from sphinx_needs.config import NeedsSphinxConfig
+from sphinx_needs.logging import get_logger, log_warning
+from sphinx_needs.utils import add_doc
+from sphinx_needs.variant_data import VariantDataError, lookup_variant_data
+
+LOGGER = get_logger(__name__)
+
+
+class VariantRole(SphinxRole):
+    """Role that resolves a ``var.*`` reference to its value.
+
+    The role text is a dotted path into :confval:`needs_variant_data`,
+    rooted (implicitly or explicitly) at ``var``. For example, given::
+
+        needs_variant_data = {"build": {"opt_level": 2}}
+
+    both ``:variant:`build.opt_level``` and ``:variant:`var.build.opt_level```
+    resolve immediately to the text ``2``.
+    """
+
+    def run(self) -> tuple[list[nodes.Node], list[nodes.system_message]]:
+        add_doc(self.env, self.env.docname)
+
+        expression = self.text.strip()
+        # The lookup is always rooted at ``var``; allow the prefix to be omitted.
+        if expression == "var" or expression.startswith("var."):
+            lookup_expression = expression
+        else:
+            lookup_expression = f"var.{expression}"
+
+        config = NeedsSphinxConfig(self.env.config)
+        variant_data = config.variant_data
+
+        if not variant_data:
+            log_warning(
+                LOGGER,
+                f"'variant' role used but needs_variant_data is not configured: "
+                f"{self.text!r}",
+                "variant",
+                location=self.get_location(),
+            )
+            return [nodes.Text("")], []
+
+        try:
+            value = lookup_variant_data(variant_data, lookup_expression)
+        except VariantDataError as exc:
+            log_warning(
+                LOGGER,
+                f"'variant' role could not resolve {self.text!r}: {exc}",
+                "variant",
+                location=self.get_location(),
+            )
+            return [nodes.Text("")], []
+
+        if isinstance(value, list):
+            text = ", ".join(str(item) for item in value)
+        else:
+            text = str(value)
+
+        return [nodes.Text(text)], []

--- a/tests/doc_test/doc_variant_role/conf.py
+++ b/tests/doc_test/doc_variant_role/conf.py
@@ -17,4 +17,5 @@ needs_variant_data = {
         "opt_level": 2,
     },
     "archs": ["arm", "x86"],
+    "ratio": 1.5,
 }

--- a/tests/doc_test/doc_variant_role/conf.py
+++ b/tests/doc_test/doc_variant_role/conf.py
@@ -1,0 +1,20 @@
+extensions = ["sphinx_needs"]
+
+needs_types = [
+    {
+        "directive": "req",
+        "title": "Requirement",
+        "prefix": "REQ_",
+        "color": "#BFD8D2",
+        "style": "node",
+    },
+]
+
+needs_variant_data = {
+    "platform": "arm",
+    "build": {
+        "debug": True,
+        "opt_level": 2,
+    },
+    "archs": ["arm", "x86"],
+}

--- a/tests/doc_test/doc_variant_role/index.rst
+++ b/tests/doc_test/doc_variant_role/index.rst
@@ -1,0 +1,14 @@
+Variant Role Test
+=================
+
+Scalar string: :variant:`platform`
+
+Nested int: :variant:`build.opt_level`
+
+Nested bool: :variant:`build.debug`
+
+Explicit prefix: :variant:`var.platform`
+
+List value: :variant:`archs`
+
+Invalid reference: :variant:`nonexistent`

--- a/tests/doc_test/doc_variant_role/index.rst
+++ b/tests/doc_test/doc_variant_role/index.rst
@@ -7,8 +7,6 @@ Nested int: :variant:`build.opt_level`
 
 Nested bool: :variant:`build.debug`
 
-Explicit prefix: :variant:`var.platform`
-
 List value: :variant:`archs`
 
 Invalid reference: :variant:`nonexistent`

--- a/tests/doc_test/doc_variant_role/index.rst
+++ b/tests/doc_test/doc_variant_role/index.rst
@@ -10,3 +10,5 @@ Nested bool: :variant:`build.debug`
 List value: :variant:`archs`
 
 Invalid reference: :variant:`nonexistent`
+
+Mapping reference: :variant:`build`

--- a/tests/doc_test/doc_variant_role/index.rst
+++ b/tests/doc_test/doc_variant_role/index.rst
@@ -12,3 +12,5 @@ List value: :variant:`archs`
 Invalid reference: :variant:`nonexistent`
 
 Mapping reference: :variant:`build`
+
+Float value: :variant:`ratio`

--- a/tests/doc_test/doc_variant_role_file/conf.py
+++ b/tests/doc_test/doc_variant_role_file/conf.py
@@ -1,0 +1,17 @@
+extensions = ["sphinx_needs"]
+
+needs_types = [
+    {
+        "directive": "req",
+        "title": "Requirement",
+        "prefix": "REQ_",
+        "color": "#BFD8D2",
+        "style": "node",
+    },
+]
+
+# File provides: {"env": "production", "region": "us-east"}
+needs_variant_data_file = "variant_data.json"
+
+# Inline overrides env from "production" to "staging"
+needs_variant_data = {"env": "staging"}

--- a/tests/doc_test/doc_variant_role_file/index.rst
+++ b/tests/doc_test/doc_variant_role_file/index.rst
@@ -1,0 +1,6 @@
+Variant Role File
+=================
+
+From file: :variant:`region`
+
+Overridden inline: :variant:`env`

--- a/tests/doc_test/doc_variant_role_file/variant_data.json
+++ b/tests/doc_test/doc_variant_role_file/variant_data.json
@@ -1,0 +1,4 @@
+{
+  "env": "production",
+  "region": "us-east"
+}

--- a/tests/doc_test/doc_variant_role_no_data/conf.py
+++ b/tests/doc_test/doc_variant_role_no_data/conf.py
@@ -1,0 +1,14 @@
+extensions = ["sphinx_needs"]
+
+needs_types = [
+    {
+        "directive": "req",
+        "title": "Requirement",
+        "prefix": "REQ_",
+        "color": "#BFD8D2",
+        "style": "node",
+    },
+]
+
+# Configured but empty: the role should still warn that no data is available.
+needs_variant_data = {}

--- a/tests/doc_test/doc_variant_role_no_data/index.rst
+++ b/tests/doc_test/doc_variant_role_no_data/index.rst
@@ -1,0 +1,4 @@
+Variant Role No Data
+====================
+
+Reference: :variant:`platform`

--- a/tests/test_variant_role.py
+++ b/tests/test_variant_role.py
@@ -30,7 +30,7 @@ def test_variant_role_html(test_app):
 
     # Only the invalid reference should warn.
     assert warnings == [
-        "srcdir/index.rst:14: WARNING: 'variant' role could not resolve "
+        "srcdir/index.rst:12: WARNING: 'variant' role could not resolve "
         "'nonexistent': Unknown variant data key: 'var.nonexistent' [needs.variant]",
     ]
 
@@ -42,7 +42,5 @@ def test_variant_role_html(test_app):
     assert "Nested int: 2" in index_html
     # Nested bool is stringified.
     assert "Nested bool: True" in index_html
-    # Explicit ``var.`` prefix works too.
-    assert "Explicit prefix: arm" in index_html
     # List values are comma-joined.
     assert "List value: arm, x86" in index_html

--- a/tests/test_variant_role.py
+++ b/tests/test_variant_role.py
@@ -47,6 +47,8 @@ def test_variant_role_html(test_app):
     assert "Nested bool: True" in index_html
     # List values are comma-joined.
     assert "List value: arm, x86" in index_html
+    # Floats are stringified.
+    assert "Float value: 1.5" in index_html
     # A mapping reference produces empty text.
     assert (
         "Mapping reference: </p>" in index_html

--- a/tests/test_variant_role.py
+++ b/tests/test_variant_role.py
@@ -28,10 +28,13 @@ def test_variant_role_html(test_app):
         app._warning.getvalue().replace(str(app.srcdir) + os.sep, "srcdir/")
     ).splitlines()
 
-    # Only the invalid reference should warn.
+    # The invalid reference and the mapping reference should warn.
     assert warnings == [
         "srcdir/index.rst:12: WARNING: 'variant' role could not resolve "
         "'nonexistent': Unknown variant data key: 'var.nonexistent' [needs.variant]",
+        "srcdir/index.rst:14: WARNING: 'variant' role could not resolve "
+        "'build': variant data reference 'var.build' resolves to a mapping "
+        "('var.build'); access a leaf value instead [needs.variant]",
     ]
 
     index_html = Path(app.outdir, "index.html").read_text()
@@ -44,3 +47,65 @@ def test_variant_role_html(test_app):
     assert "Nested bool: True" in index_html
     # List values are comma-joined.
     assert "List value: arm, x86" in index_html
+    # A mapping reference produces empty text.
+    assert (
+        "Mapping reference: </p>" in index_html
+        or "Mapping reference:</p>" in index_html
+    )
+
+
+@pytest.mark.parametrize(
+    "test_app",
+    [
+        {
+            "buildername": "html",
+            "srcdir": "doc_test/doc_variant_role_no_data",
+            "no_plantuml": True,
+        }
+    ],
+    indirect=True,
+)
+def test_variant_role_no_data_html(test_app):
+    """The role warns (and emits empty text) when no variant data is available."""
+    app = test_app
+    app.build()
+
+    warnings = strip_colors(
+        app._warning.getvalue().replace(str(app.srcdir) + os.sep, "srcdir/")
+    ).splitlines()
+
+    assert warnings == [
+        "srcdir/index.rst:4: WARNING: 'variant' role used but no variant data "
+        "is available: 'platform' [needs.variant]",
+    ]
+
+    index_html = Path(app.outdir, "index.html").read_text()
+    assert "Reference: </p>" in index_html or "Reference:</p>" in index_html
+
+
+@pytest.mark.parametrize(
+    "test_app",
+    [
+        {
+            "buildername": "html",
+            "srcdir": "doc_test/doc_variant_role_file",
+            "no_plantuml": True,
+        }
+    ],
+    indirect=True,
+)
+def test_variant_role_file_html(test_app):
+    """The role reads the resolved/merged variant data (file + inline override)."""
+    app = test_app
+    app.build()
+
+    warnings = strip_colors(
+        app._warning.getvalue().replace(str(app.srcdir) + os.sep, "srcdir/")
+    ).splitlines()
+    assert warnings == []
+
+    index_html = Path(app.outdir, "index.html").read_text()
+    # Value from the JSON file.
+    assert "From file: us-east" in index_html
+    # Inline value overrides the file value.
+    assert "Overridden inline: staging" in index_html

--- a/tests/test_variant_role.py
+++ b/tests/test_variant_role.py
@@ -1,0 +1,48 @@
+"""Tests for the ``variant`` role."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+from sphinx.util.console import strip_colors
+
+
+@pytest.mark.parametrize(
+    "test_app",
+    [
+        {
+            "buildername": "html",
+            "srcdir": "doc_test/doc_variant_role",
+            "no_plantuml": True,
+        }
+    ],
+    indirect=True,
+)
+def test_variant_role_html(test_app):
+    app = test_app
+    app.build()
+
+    warnings = strip_colors(
+        app._warning.getvalue().replace(str(app.srcdir) + os.sep, "srcdir/")
+    ).splitlines()
+
+    # Only the invalid reference should warn.
+    assert warnings == [
+        "srcdir/index.rst:14: WARNING: 'variant' role could not resolve "
+        "'nonexistent': Unknown variant data key: 'var.nonexistent' [needs.variant]",
+    ]
+
+    index_html = Path(app.outdir, "index.html").read_text()
+
+    # Scalar string resolves to its value.
+    assert "Scalar string: arm" in index_html
+    # Nested int is stringified.
+    assert "Nested int: 2" in index_html
+    # Nested bool is stringified.
+    assert "Nested bool: True" in index_html
+    # Explicit ``var.`` prefix works too.
+    assert "Explicit prefix: arm" in index_html
+    # List values are comma-joined.
+    assert "List value: arm, x86" in index_html


### PR DESCRIPTION
## Summary

Adds a new `variant` role that resolves a reference into `needs_variant_data` **immediately** during parsing, replacing `` :variant:`a.b` `` with a plain text node holding the looked-up value.

This complements the existing `<{ var.a.b }>` field-value references (from #3ba0da0) by exposing the same lookup as an inline role usable anywhere in body text. Unlike the `ndf`/`need_func` roles — which leave a placeholder node in the doctree for a later post-processing pass — this role resolves in `run()` and returns a `nodes.Text` directly.

## Behaviour

Given:

```python
needs_variant_data = {"platform": "arm", "build": {"opt_level": 2}, "archs": ["arm", "x86"]}
```

- `` :variant:`platform` `` → `arm`
- `` :variant:`build.opt_level` `` → `2`
- `` :variant:`archs` `` → `arm, x86` (lists are comma-joined)

The role content is a dotted path rooted at `var` (the `var` root is implicit). It reuses the existing constrained `lookup_variant_data()` resolution — no operators, function calls, or item access are permitted. A missing config, unknown key, or a path that resolves to a mapping emits a `needs.variant` warning and produces empty text.

## Changes

- `sphinx_needs/roles/variant.py` — new `VariantRole(SphinxRole)`.
- `sphinx_needs/needs.py` — register `app.add_role("variant", VariantRole())`.
- `docs/roles.rst` — document the new role; changelog entry added.
- `tests/test_variant_role.py` + `tests/doc_test/doc_variant_role/` — coverage for scalars, nested values, lists, and the warning path.
