### PR TITLE
Feature/external sources in needsjson

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,28 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+External sources provenance in needs.json
+.........................................
+
+When external needs are included in the ``needs.json`` output (by relaxing
+:ref:`needs_builder_filter`), the JSON now contains an ``external_sources``
+section in each version block that records the full provenance chain.
+
+Each external need also receives an ``external_source`` field linking it to
+the ``base_url`` of its source configuration. When a downstream project
+consumes this ``needs.json`` and re-exports, the inherited sources are
+propagated with an ``origin`` field indicating the intermediate project.
+
+This enables full traceability across multi-project documentation chains
+(e.g. Project X |rarr| Project A |rarr| Project B).
+
+.. |rarr| unicode:: U+2192
+
+See :ref:`needs_external_needs` for configuration details.
+
 .. _`release:8.2.0`:
 
 8.2.0

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1853,8 +1853,7 @@ Need objects imported via :ref:`needs_external_needs` get sorted out.
 
 .. _`needs_builder_filter_provenance`:
 
-External sources provenance in needs.json
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+**External sources provenance in needs.json**
 
 .. versionadded:: 8.3.0
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1851,6 +1851,54 @@ Need objects imported via :ref:`needs_external_needs` get sorted out.
 
    needs_builder_filter = 'status=="open"'
 
+.. _`needs_builder_filter_provenance`:
+
+External sources provenance in needs.json
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. versionadded:: 8.3.0
+
+When ``needs_builder_filter`` is set to include external needs (e.g. ``""`` or
+``"True"``), the generated ``needs.json`` will also include an
+``external_sources`` section in each version block. This records the
+:ref:`needs_external_needs` configuration entries that produced the external
+needs, enabling downstream consumers to reconstruct the full provenance chain.
+
+Each external need in the JSON output also receives an ``external_source``
+field containing the ``base_url`` of its source.
+
+**Example output:**
+
+.. code-block:: json
+
+   {
+     "versions": {
+       "1.0": {
+         "external_sources": [
+           {
+             "base_url": "https://upstream.io/en/latest",
+             "id_prefix": "UP_",
+             "json_path": "upstream_needs.json",
+             "origin": null
+           }
+         ],
+         "needs": {
+           "UP_REQ_01": {
+             "is_external": true,
+             "external_source": "https://upstream.io/en/latest",
+             "external_url": "https://upstream.io/en/latest/index.html#REQ_01"
+           }
+         }
+       }
+     }
+   }
+
+**Transitive provenance:** When a downstream project consumes a ``needs.json``
+that already contains ``external_sources``, those entries are inherited and
+re-exported with an ``origin`` field set to the intermediate project's
+``base_url``. This allows any consumer to trace the full chain of provenance
+back to the original source.
+
 .. _`needs_string_links`:
 
 needs_string_links

--- a/sphinx_needs/data.py
+++ b/sphinx_needs/data.py
@@ -1059,16 +1059,16 @@ class SphinxNeedsData:
             self.env._needs_inherited_external_sources = []
         return self.env._needs_inherited_external_sources
 
-    def add_inherited_external_sources(
-        self, sources: list[ExternalSourceInfo]
-    ) -> None:
+    def add_inherited_external_sources(self, sources: list[ExternalSourceInfo]) -> None:
         """Add inherited external source entries (from a consumed needs.json).
 
         Deduplicates by ``base_url``.
 
         :param sources: The ``external_sources`` list from a consumed JSON file.
         """
-        existing = {s["base_url"] for s in self.inherited_external_sources if "base_url" in s}
+        existing = {
+            s["base_url"] for s in self.inherited_external_sources if "base_url" in s
+        }
         for source in sources:
             if source.get("base_url") and source["base_url"] not in existing:
                 self.inherited_external_sources.append(source)

--- a/sphinx_needs/data.py
+++ b/sphinx_needs/data.py
@@ -540,6 +540,41 @@ class NeedsInfoComputedType(TypedDict):
     """True if all constraints passed, False if any failed, None if not yet checked."""
 
 
+class ExternalSourceInfo(TypedDict, total=False):
+    """Metadata about an external source that contributed needs to this project.
+
+    Stored in the ``external_sources`` section of the needs.json output so that
+    downstream consumers can reconstruct the full provenance chain.
+    """
+
+    base_url: str
+    """The base URL of the external source (required)."""
+
+    target_url: str
+    """Jinja template for constructing per-need URLs (optional)."""
+
+    id_prefix: str
+    """Prefix applied to all IDs from this source (optional)."""
+
+    css_class: str
+    """CSS class applied to needs from this source (optional)."""
+
+    json_url: str
+    """Remote URL the JSON was fetched from (optional)."""
+
+    json_path: str
+    """Local path the JSON was loaded from (optional)."""
+
+    version: str
+    """Version used when loading from this source (optional)."""
+
+    origin: str | None
+    """base_url of the intermediate project that re-exported this source.
+
+    ``None`` means the source was directly consumed by this project.
+    """
+
+
 class NeedsBaseDataType(TypedDict):
     """A base type for data items collected from directives."""
 
@@ -989,6 +1024,56 @@ class SphinxNeedsData:
             return self._needs_all_nodes[need_id].deepcopy()
         return None
 
+    # --- External source provenance tracking ---
+
+    @property
+    def external_source_map(self) -> dict[str, str]:
+        """Mapping of need_id to the base_url of the external source that provided it.
+
+        Populated during :func:`~sphinx_needs.external_needs.load_external_needs`.
+        """
+        try:
+            return self.env._needs_external_source_map
+        except AttributeError:
+            self.env._needs_external_source_map = {}
+        return self.env._needs_external_source_map
+
+    def register_external_source(self, need_id: str, base_url: str) -> None:
+        """Register which external source a need came from.
+
+        :param need_id: The ID of the external need (after prefix applied).
+        :param base_url: The ``base_url`` of the ExternalSource config entry.
+        """
+        self.external_source_map[need_id] = base_url
+
+    @property
+    def inherited_external_sources(self) -> list[ExternalSourceInfo]:
+        """External source entries inherited from consumed needs.json files.
+
+        These are propagated into the output ``needs.json`` so downstream
+        consumers can reconstruct the full provenance chain.
+        """
+        try:
+            return self.env._needs_inherited_external_sources
+        except AttributeError:
+            self.env._needs_inherited_external_sources = []
+        return self.env._needs_inherited_external_sources
+
+    def add_inherited_external_sources(
+        self, sources: list[ExternalSourceInfo]
+    ) -> None:
+        """Add inherited external source entries (from a consumed needs.json).
+
+        Deduplicates by ``base_url``.
+
+        :param sources: The ``external_sources`` list from a consumed JSON file.
+        """
+        existing = {s["base_url"] for s in self.inherited_external_sources if "base_url" in s}
+        for source in sources:
+            if source.get("base_url") and source["base_url"] not in existing:
+                self.inherited_external_sources.append(source)
+                existing.add(source["base_url"])
+
 
 def merge_data(
     _app: Sphinx, env: BuildEnvironment, docnames: list[str], other: BuildEnvironment
@@ -1056,3 +1141,7 @@ def merge_data(
     _merge("_needs_all_nodes")
     _merge("_need_all_needextend")
     _merge("_needs_all_needumls")
+
+    # Merge external source provenance data
+    _merge("_needs_external_source_map")
+    this_data.add_inherited_external_sources(other_data.inherited_external_sources)

--- a/sphinx_needs/external_needs.py
+++ b/sphinx_needs/external_needs.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+from typing import Any
 
 import requests
 from requests_file import FileAdapter
@@ -10,8 +11,8 @@ from sphinx.environment import BuildEnvironment
 
 from sphinx_needs._jinja import compile_template
 from sphinx_needs.api import InvalidNeedException, add_external_need, del_need
-from sphinx_needs.config import NeedsSphinxConfig
-from sphinx_needs.data import NeedsCoreFields, SphinxNeedsData
+from sphinx_needs.config import ExternalSource, NeedsSphinxConfig
+from sphinx_needs.data import ExternalSourceInfo, NeedsCoreFields, SphinxNeedsData
 from sphinx_needs.logging import get_logger, log_warning
 from sphinx_needs.need_item import NeedItemSourceExternal
 from sphinx_needs.utils import clean_log, import_prefix_link_edit
@@ -25,6 +26,7 @@ def load_external_needs(
     """Load needs from configured external sources."""
     needs_config = NeedsSphinxConfig(app.config)
     needs_schema = SphinxNeedsData(env).get_schema()
+    data_accessor = SphinxNeedsData(env)
 
     for idx, source in enumerate(needs_config.external_needs):
         if "base_url" not in source:
@@ -106,6 +108,10 @@ def load_external_needs(
                     )
                 )
 
+        # Inherit external_sources from the consumed JSON for provenance chain
+        if "external_sources" in data:
+            _inherit_external_sources(data_accessor, data["external_sources"], source)
+
         log.debug(f"Loading {len(needs)} needs.")
 
         defaults = (
@@ -124,6 +130,7 @@ def load_external_needs(
         # all known need fields in the project
         known_keys = {
             "full_title",  # legacy
+            "external_source",  # provenance metadata from needs.json
             *NeedsCoreFields,
             *(x for x in needs_schema.iter_link_field_names()),
             *(f"{x}_back" for x in needs_schema.iter_link_field_names()),
@@ -132,6 +139,7 @@ def load_external_needs(
         # all keys that should not be imported from external needs
         omitted_keys = {
             "full_title",  # legacy
+            "external_source",  # provenance metadata, not a need field
             *(k for k, v in NeedsCoreFields.items() if v.get("exclude_external")),
             *(f"{x}_back" for x in needs_schema.iter_link_field_names()),
         }
@@ -195,6 +203,8 @@ def load_external_needs(
                     allow_type_coercion=source.get("allow_type_coercion", True),
                     **need_params,
                 )
+                # Register provenance: which source produced this need
+                data_accessor.register_external_source(ext_need_id, source["base_url"])
             except InvalidNeedException as err:
                 location = source.get("json_url", "") or source.get("json_path", "")
                 log_warning(
@@ -220,3 +230,33 @@ def load_external_needs(
 
 class NeedsExternalException(BaseException):
     pass
+
+
+def _inherit_external_sources(
+    data_accessor: SphinxNeedsData,
+    sources_from_json: list[dict[str, Any]],
+    consuming_source: ExternalSource,
+) -> None:
+    """Inherit ``external_sources`` entries from a consumed needs.json.
+
+    For each entry in the consumed JSON's ``external_sources``, we re-record it
+    with ``origin`` set to the ``base_url`` of the source we are consuming from
+    (unless it already has an origin, meaning it was already a transitive entry).
+
+    :param data_accessor: The SphinxNeedsData instance.
+    :param sources_from_json: The ``external_sources`` list from the consumed JSON.
+    :param consuming_source: The ExternalSource config entry we are currently loading.
+    """
+    inherited: list[ExternalSourceInfo] = []
+    consumer_base_url = consuming_source["base_url"]
+    for entry in sources_from_json:
+        info = ExternalSourceInfo(
+            base_url=entry["base_url"],
+            origin=entry.get("origin") or consumer_base_url,
+        )
+        # Carry over optional fields if present
+        for key in ("target_url", "id_prefix", "css_class", "json_url", "json_path", "version"):
+            if key in entry:
+                info[key] = entry[key]
+        inherited.append(info)
+    data_accessor.add_inherited_external_sources(inherited)

--- a/sphinx_needs/external_needs.py
+++ b/sphinx_needs/external_needs.py
@@ -255,7 +255,14 @@ def _inherit_external_sources(
             origin=entry.get("origin") or consumer_base_url,
         )
         # Carry over optional fields if present
-        for key in ("target_url", "id_prefix", "css_class", "json_url", "json_path", "version"):
+        for key in (
+            "target_url",
+            "id_prefix",
+            "css_class",
+            "json_url",
+            "json_path",
+            "version",
+        ):
             if key in entry:
                 info[key] = entry[key]
         inherited.append(info)

--- a/sphinx_needs/needsfile.py
+++ b/sphinx_needs/needsfile.py
@@ -19,7 +19,7 @@ from jsonschema_rs import Draft7Validator, ValidationError
 from sphinx.environment import BuildEnvironment
 
 from sphinx_needs.config import NeedsSphinxConfig
-from sphinx_needs.data import NeedsCoreFields, SphinxNeedsData
+from sphinx_needs.data import ExternalSourceInfo, NeedsCoreFields, SphinxNeedsData
 from sphinx_needs.logging import get_logger, log_warning
 from sphinx_needs.need_item import NeedItem
 from sphinx_needs.needs_schema import FieldLiteralValue, FieldsSchema
@@ -111,6 +111,7 @@ class NeedsList:
             self.needs_list["created"] = ""
         self.log = log
 
+        self._data_accessor = SphinxNeedsData(env)
         self._exclude_need_keys = set(self.needs_config.json_exclude_fields)
 
         schema = SphinxNeedsData(env).get_schema()
@@ -174,6 +175,11 @@ class NeedsList:
                     key in self._need_defaults and value == self._need_defaults[key]
                 )
             }
+        # Inject external_source provenance for external needs
+        if need_info.get("is_external"):
+            source_map = self._data_accessor.external_source_map
+            if need_info["id"] in source_map:
+                writable_needs["external_source"] = source_map[need_info["id"]]
         self.needs_list["versions"][version]["needs"][need_info["id"]] = writable_needs
         self.needs_list["versions"][version]["needs_amount"] = len(
             self.needs_list["versions"][version]["needs"]
@@ -192,6 +198,54 @@ class NeedsList:
             self.needs_list.pop("created", None)
         self.needs_list["current_version"] = self.current_version
         self.needs_list["project"] = self.project
+
+        # Build external_sources provenance metadata
+        external_sources = self._build_external_sources()
+        if external_sources:
+            self.needs_list["versions"][self.current_version]["external_sources"] = (
+                external_sources
+            )
+
+    def _build_external_sources(self) -> list[ExternalSourceInfo]:
+        """Build the ``external_sources`` list for the current version.
+
+        Combines:
+        - Direct sources from this project's ``needs_external_needs`` config
+        - Inherited sources from consumed needs.json files (transitive)
+        """
+        sources: list[ExternalSourceInfo] = []
+        seen_base_urls: set[str] = set()
+
+        # Direct sources from config
+        for ext_source in self.needs_config.external_needs:
+            base_url = ext_source.get("base_url", "")
+            if not base_url or base_url in seen_base_urls:
+                continue
+            info = ExternalSourceInfo(base_url=base_url, origin=None)
+            if "target_url" in ext_source:
+                info["target_url"] = ext_source["target_url"]
+            if "id_prefix" in ext_source:
+                info["id_prefix"] = ext_source["id_prefix"]
+            if "css_class" in ext_source:
+                info["css_class"] = ext_source["css_class"]
+            if "json_url" in ext_source:
+                info["json_url"] = ext_source["json_url"]
+            if "json_path" in ext_source:
+                info["json_path"] = ext_source["json_path"]
+            if "version" in ext_source:
+                info["version"] = ext_source["version"]
+            sources.append(info)
+            seen_base_urls.add(base_url)
+
+        # Inherited (transitive) sources
+        for inherited in self._data_accessor.inherited_external_sources:
+            base_url = inherited.get("base_url", "")
+            if not base_url or base_url in seen_base_urls:
+                continue
+            sources.append(inherited)
+            seen_base_urls.add(base_url)
+
+        return sources
 
     def write_json(self, needs_file: str = "needs.json", needs_path: str = "") -> None:
         self._finalise()

--- a/tests/__snapshots__/test_external.ambr
+++ b/tests/__snapshots__/test_external.ambr
@@ -4,9 +4,19 @@
     'current_version': '1.3',
     'versions': dict({
       '1.3': dict({
+        'external_sources': list([
+          dict({
+            'base_url': 'http://my_company.com/docs/v1',
+            'id_prefix': 'EXT_',
+            'json_path': 'exported_needs.json',
+            'origin': None,
+            'version': '1.3',
+          }),
+        ]),
         'needs': dict({
           'EXT_REQ_01': dict({
             'external_css': 'external_link',
+            'external_source': 'http://my_company.com/docs/v1',
             'external_url': 'http://my_company.com/docs/v1/index.html#REQ_01',
             'id': 'EXT_REQ_01',
             'is_external': True,
@@ -505,6 +515,14 @@
     'current_version': '1.0',
     'versions': dict({
       '1.0': dict({
+        'external_sources': list([
+          dict({
+            'base_url': 'http://my_company.com/docs/v1',
+            'id_prefix': 'EXT_',
+            'json_path': 'needs_test_small.json',
+            'origin': None,
+          }),
+        ]),
         'needs': dict({
           'EXT_TEST_02': dict({
             'avatar': '',
@@ -515,6 +533,7 @@
             'doctype': '',
             'duration': 0,
             'external_css': 'external_link',
+            'external_source': 'http://my_company.com/docs/v1',
             'external_url': 'http://my_company.com/docs/v1/index.html#TEST_02',
             'has_dead_links': True,
             'has_forbidden_dead_links': True,

--- a/tests/__snapshots__/test_link_conditions.ambr
+++ b/tests/__snapshots__/test_link_conditions.ambr
@@ -4,6 +4,14 @@
     'current_version': '',
     'versions': dict({
       '': dict({
+        'external_sources': list([
+          dict({
+            'base_url': 'http://my_company.com/docs/v1',
+            'id_prefix': 'EXT_',
+            'json_path': 'needs_test_external.json',
+            'origin': None,
+          }),
+        ]),
         'needs': dict({
           'IMP_COND_FAIL': dict({
             'docname': 'index',
@@ -748,6 +756,14 @@
     'current_version': '',
     'versions': dict({
       '': dict({
+        'external_sources': list([
+          dict({
+            'base_url': 'http://my_company.com/docs/v1',
+            'id_prefix': 'EXT_',
+            'json_path': 'needs_test_external.json',
+            'origin': None,
+          }),
+        ]),
         'needs': dict({
           'IMP_COND_FAIL': dict({
             'docname': 'index',

--- a/tests/__snapshots__/test_need_constraints.ambr
+++ b/tests/__snapshots__/test_need_constraints.ambr
@@ -4,6 +4,14 @@
     'current_version': '',
     'versions': dict({
       '': dict({
+        'external_sources': list([
+          dict({
+            'base_url': 'http://my_company.com/docs/v1',
+            'id_prefix': 'ext_',
+            'json_path': 'needs_test_small.json',
+            'origin': None,
+          }),
+        ]),
         'needs': dict({
           'SECURITY_REQ': dict({
             'arch': dict({

--- a/tests/__snapshots__/test_needs_from_toml.ambr
+++ b/tests/__snapshots__/test_needs_from_toml.ambr
@@ -4,11 +4,19 @@
     'current_version': '0.1.0',
     'versions': dict({
       '0.1.0': dict({
+        'external_sources': list([
+          dict({
+            'base_url': 'http://example.com/docs',
+            'json_path': '/private/var/folders/vb/__zyv72j1wj2sp6k_bllyg480000gn/T/sn_test_build_data/KGCcJQNC1G/needs_from_toml/folder/external_needs.json',
+            'origin': None,
+          }),
+        ]),
         'needs': dict({
           'NEED_1': dict({
             'content': 'This is the first need.',
             'doctype': '',
             'external_css': 'external_link',
+            'external_source': 'http://example.com/docs',
             'external_url': 'http://example.com/docs/__error__.html#NEED_1',
             'id': 'NEED_1',
             'is_external': True,

--- a/tests/__snapshots__/test_needs_from_toml.ambr
+++ b/tests/__snapshots__/test_needs_from_toml.ambr
@@ -7,7 +7,6 @@
         'external_sources': list([
           dict({
             'base_url': 'http://example.com/docs',
-            'json_path': '/private/var/folders/vb/__zyv72j1wj2sp6k_bllyg480000gn/T/sn_test_build_data/KGCcJQNC1G/needs_from_toml/folder/external_needs.json',
             'origin': None,
           }),
         ]),

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -310,3 +310,168 @@ def test_external_empty_versions(test_app):
     needs = json.loads(needs_json)
     # the empty external needs should just be ignored without crashing.
     assert "TEST_01" not in needs["versions"][""]["needs"]
+
+
+def test_external_sources_provenance_chain(tmp_path: Path):
+    """Test that external_sources metadata is written to needs.json and inherited transitively.
+
+    Chain: Project X (origin) -> Project A (consumes X) -> Project B (consumes A)
+    Project B should see both A and X in its external_sources.
+    """
+    if version_info < (7, 2):
+        pytest.skip("Requires Sphinx >= 7.2")
+
+    # --- Project X: origin project that just has some needs ---
+    project_x = tmp_path / "project_x"
+    project_x.mkdir()
+    project_x.joinpath("conf.py").write_text(
+        dedent("""\
+        version = "1.0"
+        extensions = ["sphinx_needs"]
+        needs_json_remove_defaults = True
+        """),
+        "utf8",
+    )
+    project_x.joinpath("index.rst").write_text(
+        dedent("""\
+        Project X
+        =========
+
+        .. req:: Requirement from X
+           :id: X_REQ_01
+        """),
+        "utf8",
+    )
+    app_x = SphinxTestApp(
+        buildername="needs", srcdir=project_x, builddir=project_x / "_build"
+    )
+    try:
+        app_x.build()
+    finally:
+        app_x.cleanup()
+    assert app_x._warning.getvalue() == ""
+    x_needs_json = Path(str(app_x.outdir), "needs.json").read_bytes()
+
+    # --- Project A: consumes X, exports including external needs ---
+    project_a = tmp_path / "project_a"
+    project_a.mkdir()
+    project_a.joinpath("x_needs.json").write_bytes(x_needs_json)
+    project_a.joinpath("conf.py").write_text(
+        dedent("""\
+        version = "2.0"
+        extensions = ["sphinx_needs"]
+        needs_id_regex = "^[A-Za-z0-9_]*"
+        needs_external_needs = [{
+            'json_path': 'x_needs.json',
+            'base_url': 'https://project-x.io/en/latest',
+            'version': '1.0',
+            'id_prefix': 'PX_',
+        }]
+        needs_builder_filter = ""
+        needs_json_remove_defaults = True
+        """),
+        "utf8",
+    )
+    project_a.joinpath("index.rst").write_text(
+        dedent("""\
+        Project A
+        =========
+
+        .. req:: Requirement from A
+           :id: A_REQ_01
+        """),
+        "utf8",
+    )
+    app_a = SphinxTestApp(
+        buildername="needs", srcdir=project_a, builddir=project_a / "_build"
+    )
+    try:
+        app_a.build()
+    finally:
+        app_a.cleanup()
+    assert app_a._warning.getvalue() == ""
+
+    a_json_path = Path(str(app_a.outdir), "needs.json")
+    a_needs_data = json.loads(a_json_path.read_text("utf8"))
+
+    # Verify Project A's needs.json has external_sources
+    a_version_data = a_needs_data["versions"]["2.0"]
+    assert "external_sources" in a_version_data
+    a_sources = a_version_data["external_sources"]
+    assert len(a_sources) == 1
+    assert a_sources[0]["base_url"] == "https://project-x.io/en/latest"
+    assert a_sources[0]["origin"] is None  # direct source
+    assert a_sources[0]["id_prefix"] == "PX_"
+
+    # Verify the external need has external_source field
+    px_req = a_version_data["needs"]["PX_X_REQ_01"]
+    assert px_req["is_external"] is True
+    assert px_req["external_source"] == "https://project-x.io/en/latest"
+
+    # --- Project B: consumes A, should inherit X's provenance ---
+    project_b = tmp_path / "project_b"
+    project_b.mkdir()
+    project_b.joinpath("a_needs.json").write_bytes(a_json_path.read_bytes())
+    project_b.joinpath("conf.py").write_text(
+        dedent("""\
+        version = "3.0"
+        extensions = ["sphinx_needs"]
+        needs_id_regex = "^[A-Za-z0-9_]*"
+        needs_external_needs = [{
+            'json_path': 'a_needs.json',
+            'base_url': 'https://project-a.io/en/latest',
+            'version': '2.0',
+            'id_prefix': 'PA_',
+        }]
+        needs_builder_filter = ""
+        needs_json_remove_defaults = True
+        """),
+        "utf8",
+    )
+    project_b.joinpath("index.rst").write_text(
+        dedent("""\
+        Project B
+        =========
+
+        .. req:: Requirement from B
+           :id: B_REQ_01
+        """),
+        "utf8",
+    )
+    app_b = SphinxTestApp(
+        buildername="needs", srcdir=project_b, builddir=project_b / "_build"
+    )
+    try:
+        app_b.build()
+    finally:
+        app_b.cleanup()
+    assert app_b._warning.getvalue() == ""
+
+    b_json_path = Path(str(app_b.outdir), "needs.json")
+    b_needs_data = json.loads(b_json_path.read_text("utf8"))
+
+    # Verify Project B's needs.json has both direct and inherited sources
+    b_version_data = b_needs_data["versions"]["3.0"]
+    assert "external_sources" in b_version_data
+    b_sources = b_version_data["external_sources"]
+    b_sources_by_url = {s["base_url"]: s for s in b_sources}
+
+    # Direct source: Project A
+    assert "https://project-a.io/en/latest" in b_sources_by_url
+    assert b_sources_by_url["https://project-a.io/en/latest"]["origin"] is None
+
+    # Inherited source: Project X (via A)
+    assert "https://project-x.io/en/latest" in b_sources_by_url
+    assert (
+        b_sources_by_url["https://project-x.io/en/latest"]["origin"]
+        == "https://project-a.io/en/latest"
+    )
+
+    # Verify external needs from A have external_source pointing to A
+    pa_a_req = b_version_data["needs"]["PA_A_REQ_01"]
+    assert pa_a_req["is_external"] is True
+    assert pa_a_req["external_source"] == "https://project-a.io/en/latest"
+
+    pa_px_req = b_version_data["needs"]["PA_PX_X_REQ_01"]
+    assert pa_px_req["is_external"] is True
+    assert pa_px_req["external_source"] == "https://project-a.io/en/latest"

--- a/tests/test_needs_from_toml.py
+++ b/tests/test_needs_from_toml.py
@@ -5,6 +5,20 @@ import pytest
 from syrupy.filters import props
 
 
+def _remove_json_paths(data):
+    """Remove json_path from external_sources to avoid platform-specific path differences."""
+    if isinstance(data, dict):
+        if "versions" in data:
+            for version_data in data["versions"].values():
+                if "external_sources" in version_data:
+                    for source in version_data["external_sources"]:
+                        source.pop("json_path", None)
+        return {k: _remove_json_paths(v) for k, v in data.items()}
+    elif isinstance(data, list):
+        return [_remove_json_paths(item) for item in data]
+    return data
+
+
 @pytest.mark.parametrize(
     "test_app",
     [
@@ -21,6 +35,8 @@ def test_needs_from_toml(test_app, snapshot):
     app.build()
     assert not app._warning.getvalue()
     data = json.loads(Path(app.outdir, "needs.json").read_text("utf8"))
+    # Remove json_path from external_sources as it contains platform-specific absolute paths
+    data = _remove_json_paths(data)
     assert data == snapshot(
         exclude=props("created", "project", "creator", "needs_schema")
     )


### PR DESCRIPTION
## Problem

When needs_builder_filter is relaxed to include external needs in needs.json, downstream consumers lose the provenance metadata. (information on the configured external needs in a producer -> links can for consumers not be generated anymore).

This probably is not an easy thing to merge - i would guess other tooling handling external needs would need to adapt first or follow?

The extended example is:

1.) I have a sphinx-needs "Project A" consuming external needs and publishing them to needs.json
2.) "Project B" consumes  "Project A" needs.json -> the links from project A cannot be rebuild because the external needs configuration of "Project A" is not known. 

## Solution

- external_sources list in the version block
- (and/or) external_source field on each external need
- Transitive inheritance from consumed JSON files

## Testing

tox -e py312 -- tests/test_external.py tests/test_needs_external_needs_build.py