### PR TITLE
🐛 Support additionalProperties in schema validation

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,15 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+Bug fixes
+.........
+
+- 🐛 Support the standard JSON Schema ``additionalProperties`` keyword in
+  ``needs_schema_definitions`` (:issue:`1723`).
+
 .. _`release:8.3.0`:
 
 8.3.0

--- a/docs/schema/index.rst
+++ b/docs/schema/index.rst
@@ -695,7 +695,27 @@ The ``validate`` section contains the actual validation rules:
 
 ``local`` validation also means all link fields are list of need ID strings, not need objects.
 
-**Unevaluated properties control**
+**Additional and unevaluated properties control**
+
+The ``additionalProperties`` property controls whether fields not listed in the
+same schema object's ``properties`` are allowed:
+
+.. code-block:: json
+
+   {
+     "validate": {
+       "local": {
+         "properties": {
+           "status": { "enum": ["open", "closed"] }
+         },
+         "additionalProperties": false
+       }
+     }
+   }
+
+For schemas composed with ``allOf``, prefer ``unevaluatedProperties``. Unlike
+``additionalProperties``, it also recognises properties evaluated by the other
+schemas in the composition.
 
 The ``unevaluatedProperties`` property controls whether properties not explicitly defined in the
 schema are allowed:

--- a/sphinx_needs/schema/config.py
+++ b/sphinx_needs/schema/config.py
@@ -374,6 +374,7 @@ class NeedFieldsSchemaType(AllOfSchemaType):
     properties: NotRequired[dict[str, FieldAndLinkSchemaTypes]]
     required: NotRequired[list[str]]
     """List of required fields in the need."""
+    additionalProperties: NotRequired[bool]
     unevaluatedProperties: NotRequired[bool]
 
 

--- a/sphinx_needs/schema/config_utils.py
+++ b/sphinx_needs/schema/config_utils.py
@@ -417,10 +417,11 @@ def _process_need_fields_schema(
     # Cast to NeedFieldsSchemaType for property access (safe after $ref check)
     need_schema = cast(NeedFieldsSchemaType, schema)
 
-    # Inject 'object' type if properties/required/unevaluatedProperties exist
+    # Inject 'object' type if object-specific keywords exist
     if (
         "properties" in need_schema
         or "required" in need_schema
+        or "additionalProperties" in need_schema
         or "unevaluatedProperties" in need_schema
     ):
         if "type" not in need_schema:

--- a/sphinx_needs/schema/core.py
+++ b/sphinx_needs/schema/core.py
@@ -623,7 +623,13 @@ def validate_object_schema_compiles(schema: Any) -> None:
             "type": "object",
             **{
                 k: schema[k]
-                for k in ("properties", "allOf", "required", "unevaluatedProperties")
+                for k in (
+                    "properties",
+                    "allOf",
+                    "required",
+                    "additionalProperties",
+                    "unevaluatedProperties",
+                )
                 if k in schema
             },
         },
@@ -646,7 +652,13 @@ def compile_validator(schema: NeedFieldsSchemaType) -> SchemaValidator:
         "type": "object",
         **{  # type: ignore[typeddict-item]
             k: schema[k]  # type: ignore[literal-required]
-            for k in ("properties", "allOf", "required", "unevaluatedProperties")
+            for k in (
+                "properties",
+                "allOf",
+                "required",
+                "additionalProperties",
+                "unevaluatedProperties",
+            )
             if k in schema
         },
     }

--- a/sphinx_needs/schema/jsons/SchemasRootType.schema.json
+++ b/sphinx_needs/schema/jsons/SchemasRootType.schema.json
@@ -328,6 +328,10 @@
       "additionalProperties": false,
       "description": "Schema for a set of need fields of all schema types.\n\nThis includes single value fields, multi-value fields,\nand unresolved links.\n\nIntented to validate multiple fields on a need type.",
       "properties": {
+        "additionalProperties": {
+          "title": "Additionalproperties",
+          "type": "boolean"
+        },
         "allOf": {
           "items": {
             "anyOf": [

--- a/tests/schema/test_schema.py
+++ b/tests/schema/test_schema.py
@@ -144,6 +144,57 @@ def test_schema_example(test_app: SphinxTestApp, snapshot) -> None:
                 (
                     "conf.py",
                     """
+extensions = ["sphinx_needs"]
+needs_fields = {"comment": {"schema": {"type": "string"}}}
+needs_schema_definitions = {
+    "schemas": [
+        {
+            "validate": {
+                "local": {
+                    "properties": {"status": {"const": "open"}},
+                    "additionalProperties": False,
+                }
+            }
+        }
+    ]
+}
+""",
+                ),
+                (
+                    "index.rst",
+                    """
+Test
+====
+
+.. req:: Requirement
+   :id: REQ_1
+   :status: open
+   :comment: unexpected
+""",
+                ),
+            ],
+        }
+    ],
+    indirect=True,
+)
+def test_schema_additional_properties(test_app: SphinxTestApp) -> None:
+    """Check that additionalProperties is accepted and applied."""
+    test_app.build()
+    warnings = strip_colors(test_app._warning.getvalue())
+    assert (
+        "Additional properties are not allowed ('comment' was unexpected)" in warnings
+    )
+
+
+@pytest.mark.parametrize(
+    "test_app",
+    [
+        {
+            "buildername": "html",
+            "files": [
+                (
+                    "conf.py",
+                    """
 
 extensions = ["sphinx_needs"]
 needs_schema_validation_enabled = False


### PR DESCRIPTION
## Summary

- I added support for the standard JSON Schema `additionalProperties` keyword in local, selected, and nested schema validation.
- I included the keyword in runtime type validation and the generated configuration schema.
- I documented when to use `additionalProperties` versus `unevaluatedProperties` and added regression coverage.

## Validation

- `pytest -q --ignore=tests/benchmarks -m 'not jstest' tests` (1,026 passed, 5 skipped, 2 deselected)
- `pytest -q tests/schema` (181 passed, 2 skipped)
- `sphinx-build -nW --keep-going -b html docs/ /tmp/sphinx-needs-docs-1723`
- `ruff check .`
- `ruff format --check .`
- targeted mypy check for the changed schema modules
- `git diff --check origin/master...HEAD`

Fixes #1723
