### PR TITLE
📚 Replace bespoke `need-example` with the shared `syntax-example` directive

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -12,7 +12,8 @@ jobs:
       - name: Set Up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          # the docs extra requires python>=3.11 (sphinx-syntax-example)
+          python-version: "3.12"
       - name: Update pip
         run: python -m pip install --upgrade pip
       - name: Install dependencies

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -132,7 +132,8 @@ jobs:
       - name: Set Up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          # the docs extra requires python>=3.11 (sphinx-syntax-example)
+          python-version: "3.12"
       - name: Update pip
         run: python -m pip install --upgrade pip
       - name: Install Dependencies

--- a/.github/workflows/js_test.yml
+++ b/.github/workflows/js_test.yml
@@ -4,10 +4,11 @@ jobs:
   js_tests:
     runs-on: ubuntu-latest
     steps:
-      - name: Set Up Python 3.10.8
+      - name: Set Up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.10.8
+          # the docs extra requires python>=3.11 (sphinx-syntax-example)
+          python-version: "3.12"
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:

--- a/docs/_static/_css/shared.css
+++ b/docs/_static/_css/shared.css
@@ -135,11 +135,3 @@ table.needs-grid-example {
     background-size: cover;
     background-image: var(--sn-architecture-bg);
 }
-
-.needs-example {
-  padding-left: .6em !important;
-  border-left: .2rem solid var(--sn-color-docs-example, green) !important;
-  border-radius: 3px !important;
-  margin-top: 1.5em !important;
-  margin-bottom: 1.5em !important;
-}

--- a/docs/_static/_css/sphinx_immaterial.css
+++ b/docs/_static/_css/sphinx_immaterial.css
@@ -185,10 +185,3 @@ body {
     width: 100%;
     padding-right: 0.6em !important;  /* note, this line can be removed in sphinx-design v0.6.1 */
 }
-
-.needs-example {
-    border: .05rem solid rgb(72,138,87);
-    padding-left: .5rem;
-    padding-right: .5rem;
-    padding-bottom: .5rem;
-}

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,15 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+- 📚 The documentation now uses the shared
+  `sphinx-syntax-example <https://github.com/sphinx-extensions2/sphinx-syntax-example>`__
+  ``syntax-example`` directive, in place of the bespoke ``need-example`` directive
+  that was defined in ``docs/conf.py``.
+  Consequently, the ``docs`` extra now requires Python >= 3.11.
+
 .. _`release:8.3.0`:
 
 8.3.0

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,9 +37,13 @@ extensions = [
     "sphinx.ext.duration",
     "sphinx.ext.todo",
     "sphinx_ai_index",
+    "sphinx_syntax_example",
 ]
 if DOCS_THEME == "sphinx_immaterial":
     extensions.append("sphinx_immaterial")
+
+# number the `syntax-example` rubrics per document ("Example 1", "Example 2", ...)
+syntax_example_numbering = True
 
 suppress_warnings = ["needs.link_outgoing", "needs.github"]
 
@@ -360,39 +364,6 @@ class NeedsWarningsDirective(SphinxDirective):
         return [parsed]
 
 
-class NeedExampleDirective(SphinxDirective):
-    """Directive to add example content to the documentation.
-
-    It adds a container with a title, a code block, and a parsed content block.
-    """
-
-    optional_arguments = 1
-    final_argument_whitespace = True
-    has_content = True
-
-    def run(self):
-        count = self.env.temp_data.setdefault("needs-example-count", 0)
-        count += 1
-        self.env.temp_data["needs-example-count"] = count
-        root = nodes.container(classes=["needs-example"])
-        self.set_source_info(root)
-        title = f"Example {count}"
-        title_nodes, _ = (
-            self.state.inline_text(f"{title}: {self.arguments[0]}", self.lineno)
-            if self.arguments
-            else ([nodes.Text(title)], [])
-        )
-        root += nodes.rubric("", "", *title_nodes)
-        code = nodes.literal_block(
-            "", "\n".join(self.content), language="rst", classes=["needs-example-raw"]
-        )
-        root += code
-        parsed = nodes.container(classes=["needs-example-raw"])
-        root += parsed
-        self.state.nested_parse(self.content, self.content_offset, parsed)
-        return [root]
-
-
 class NeedCoreFieldsDirective(SphinxDirective):
     """Directive to list all core need fields."""
 
@@ -480,7 +451,6 @@ def suppress_linkcheck_warnings(app: Sphinx):
 
 
 def setup(app: Sphinx):
-    app.add_directive("need-example", NeedExampleDirective)
     app.add_directive("need-warnings", NeedsWarningsDirective)
     app.add_directive("need-core-fields", NeedCoreFieldsDirective)
     app.add_role("need_config_default", NeedConfigDefaultRole())

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -421,7 +421,7 @@ Configuration example:
 
 The above example configuration allows the following usage:
 
-.. need-example::
+.. syntax-example::
 
    .. req:: My requirement
       :id: EXTRA_REQ_001
@@ -780,7 +780,7 @@ These configs can then be selected when using :ref:`needflow`.
 
 This configurations can then be used like this:
 
-.. need-example::
+.. syntax-example::
 
    .. needflow::
       :tags: flow_example
@@ -1030,7 +1030,7 @@ Generates needs ID from title. By default, this setting is set to **False**.
 When no need ID is given by the user, and ``needs_id_from_title`` is set to **True**, then a need ID
 will be calculated based on the current need directive prefix, title, and a hashed value from title.
 
-.. need-example::
+.. syntax-example::
 
    .. req:: Group big short
 
@@ -1101,7 +1101,7 @@ A title can be auto-generated for a requirement by either setting
 The resulting requirement would have the title derived from the first
 sentence of the requirement.
 
-.. need-example::
+.. syntax-example::
 
    .. req::
       :title_from_content:
@@ -1130,7 +1130,7 @@ setting (which is not limited by default).
 If a title is specified for an individual requirement, then that title
 will be used over the generated title.
 
-.. need-example::
+.. syntax-example::
 
    .. req::
       :id: R_ERROR_LOGGING
@@ -1918,7 +1918,7 @@ link name and url.
        }
    }
 
-.. need-example::
+.. syntax-example::
 
    .. spec:: Use needs_string_links
       :id: EXAMPLE_STRING_LINKS
@@ -2311,7 +2311,7 @@ The value can be any data type (string, integer, list, dict, etc.)
 The data passed via needs_render_context will be available as variable(s) when rendering Jinja templates or strings.
 You can use the data passed via needs_render_context as shown below:
 
-.. need-example::
+.. syntax-example::
 
    .. req:: Need with jinja_content enabled
       :id: JINJA1D8913

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -32,6 +32,11 @@ To develop **Sphinx-Needs**  it can be installed, with development extras, into 
 
    pip install sphinx-needs[test,benchmark,docs]
 
+.. note::
+
+   The ``docs`` extra requires Python >= 3.11.
+   On Python 3.10 the extra still installs, but the documentation cannot be built.
+
 or using `uv <https://docs.astral.sh/uv/>`__ to install the dependencies into an isolated environment:
 
 .. code-block:: bash
@@ -63,6 +68,11 @@ To build the **Sphinx-Needs** documentation stored under ``/docs``, run:
    # Build HTML pages with the furo theme,
    # and first remove all old build files
    CLEAN=true tox -e docs-furo
+
+.. note::
+
+   The ``docs-*`` environments pin ``basepython = python3.12``,
+   since building the documentation requires Python >= 3.11.
 
 or to build with a different builder:
 

--- a/docs/directives/need.rst
+++ b/docs/directives/need.rst
@@ -6,7 +6,7 @@ need items
 Creates a **need** object with a specified type.
 You can define the type using the correct directive, like ``.. req::`` or ``.. test::``.
 
-.. need-example::
+.. syntax-example::
 
     .. req:: User needs to login
        :id: ID123
@@ -36,7 +36,7 @@ and stores its PlantUML code under given key from :ref:`needuml` directive under
 
 This diagram data can then be used in other :ref:`needuml` calls to combine and reuse PlantUML elements.
 
-.. need-example::
+.. syntax-example::
 
    .. spec:: Interfaces
       :id: SP_INT
@@ -70,7 +70,7 @@ Filter for diagrams
 The option ``arch`` can be easily used for filtering. For instance to show all need objects, which
 are representing some kind of a diagram.
 
-.. need-example::
+.. syntax-example::
 
    .. needtable::
       :filter: bool(arch)
@@ -114,7 +114,7 @@ All you must specify is the ID for the need.
 
 You can easily set links to multiple needs by using **;** as a separator.
 
-.. need-example::
+.. syntax-example::
 
    .. req:: Link example Target
       :id: REQ_LINK_1
@@ -210,7 +210,7 @@ By using :ref:`needs_links <needs_links>`, you can use the configured link-types
       }
    }
 
-.. need-example::
+.. syntax-example::
 
    .. req:: test me
       :id: test_req
@@ -244,7 +244,7 @@ Default: False
 
    If you delete a need using the :delete: option, the need will not be part of any filter result.
 
-.. need-example::
+.. syntax-example::
 
    .. req:: First Requirement Need
       :id: DELID123
@@ -296,7 +296,7 @@ Allowed values (case-insensitive):
 
 Default: False
 
-.. need-example::
+.. syntax-example::
 
    .. req:: Collapse is set to True
       :tags: collapse; example
@@ -331,7 +331,7 @@ Allowed values (case-insensitive):
 Default: False
 
 
-.. need-example::
+.. syntax-example::
 
     .. req:: First Req Need
        :id: JINJAID123
@@ -385,7 +385,7 @@ elided title if needed.  By default there is no limit to the title length.
 If a title is provided and the flag is present, then the provided title will
 be used and a warning will be issued.
 
-.. need-example::
+.. syntax-example::
 
     .. req::
        :title_from_content:
@@ -402,7 +402,7 @@ layout
 
 ``layout`` can be used to set a specific grid and content mapping.
 
-.. need-example::
+.. syntax-example::
 
    .. req:: My layout requirement 1
       :id: LAYOUT_1
@@ -411,7 +411,7 @@ layout
 
       Some **content** of LAYOUT_1
 
-.. need-example::
+.. syntax-example::
 
    .. req:: My layout requirement 2
       :id: LAYOUT_2
@@ -420,7 +420,7 @@ layout
 
       Some **content** of LAYOUT_2
 
-.. need-example::
+.. syntax-example::
 
    .. req:: My layout requirement 3
       :id: LAYOUT_3
@@ -443,7 +443,7 @@ style
 
 The class-attribute can then be selected with **CSS** to specify the layout of the need.
 
-.. need-example::
+.. syntax-example::
 
    .. req:: My styled requirement
       :id: STYLE_001
@@ -470,7 +470,7 @@ derived from the values of other need options.
 Here ``style`` is set to ``[[copy('status')]]``,
 which leads to the CSS class ``needs_style_open`` if the ``status`` option is set to ``open``.
 
-.. need-example::
+.. syntax-example::
 
    .. req:: My automatically styled requirement
       :id: STYLE_005
@@ -509,7 +509,7 @@ You can have several templates, but can set only one for a need.
 
    .. literalinclude:: /needs_templates/spec_template.need
 
-.. need-example::
+.. syntax-example::
 
    .. spec:: My specification
       :status: open
@@ -539,7 +539,7 @@ For example, you can use it to set a section name before each **need**.
 
    .. literalinclude:: /needs_templates/spec_pre_template.need
 
-.. need-example::
+.. syntax-example::
 
    .. spec:: My specification
       :id: TEMPL_PRE_SPEC
@@ -562,7 +562,7 @@ You can use it to show some need-specific analytics, like dependency diagrams or
 
    .. literalinclude:: /needs_templates/spec_post_template.need
 
-.. need-example::
+.. syntax-example::
 
    .. spec:: My specification
       :id: TEMPL_POST_SPEC

--- a/docs/directives/needarch.rst
+++ b/docs/directives/needarch.rst
@@ -8,7 +8,7 @@ needarch
 ``needarch`` behaves exactly like :ref:`needuml`, but only works inside a need. It provides also additional exclusive
 jinja functions :ref:`needarch_jinja_need` and :ref:`needarch_jinja_import`.
 
-.. need-example::
+.. syntax-example::
 
    .. req:: Requirement arch
       :id: req_arch_001
@@ -35,7 +35,7 @@ need()
 
 The ``need()`` function provides you the need information the :ref:`needarch` is embedded in.
 
-.. need-example::
+.. syntax-example::
 
    .. req:: Req Arch four
       :id: req_arch_004
@@ -64,7 +64,7 @@ This function takes undefined amounts of current need links option names as argu
 
 Then it executes :ref:`needuml_jinja_uml` automatically for all links/need_ids defined from the given arguments.
 
-.. need-example::
+.. syntax-example::
 
    .. req:: Req Arch second
       :id: req_arch_002
@@ -102,7 +102,7 @@ you have, if so please create an issue and mention this chapter. The algorithm
 does detect different parameter sets and does import ``uml()`` calls with different
 :ref:`parameter <needuml_jinja_uml_args>` to the same need.
 
-.. need-example::
+.. syntax-example::
 
    .. comp:: COMP_T_001
       :id: COMP_T_001

--- a/docs/directives/needbar.rst
+++ b/docs/directives/needbar.rst
@@ -7,7 +7,7 @@ needbar
 
 ``needbar`` adds a bar-chart to your documentation:
 
-.. need-example::
+.. syntax-example::
 
    .. needbar::
 
@@ -29,7 +29,7 @@ Options
 
 Example with all options used:
 
-.. need-example::
+.. syntax-example::
 
    .. needbar:: Full bar chart
       :legend:
@@ -60,7 +60,7 @@ title
 
 You can specify the headline of the bar chart using the ``title`` argument.
 
-.. need-example::
+.. syntax-example::
 
    .. needbar:: Title example
 
@@ -71,7 +71,7 @@ You can specify the headline of the bar chart using the ``title`` argument.
 
 It is possible to create bar charts without title.
 
-.. need-example::
+.. syntax-example::
 
    .. needbar::
 
@@ -91,7 +91,7 @@ We get the bar chart's data (values) from the amount of **need** objects found b
 
 Below is a more realistic example with data fetched from filters, together with hardcoded data:
 
-.. need-example::
+.. syntax-example::
 
    .. needbar:: A more real bar chart
       :legend:
@@ -110,7 +110,7 @@ You can place a legend on the barchart by setting the ``:legend:`` flag.
 
 The ``:legend:`` flag does not support any values.
 
-.. need-example::
+.. syntax-example::
 
    .. needbar:: Legend example
       :legend:
@@ -129,7 +129,7 @@ You can enable axis titles on the barchart by setting the ``:x_axis_title:`` or 
    If you use `horizontal`_ or `transpose`_, the meaning of ``:x_axis_title:`` and ``:y_axis_title:`` must be understandable.
    So you have to change the description accordingly.
 
-.. need-example::
+.. syntax-example::
 
    .. needbar:: Axis title example
       :x_axis_title: types
@@ -155,7 +155,7 @@ Also, you can set the ``:xlabels:`` and/or ``:ylabels:`` value to ``FROM_DATA`` 
 
    But if you use `horizontal`_ or `transpose`_, the meaning of ``:x_axis_title:`` and ``:y_axis_title:`` will change automatically.
 
-.. need-example::
+.. syntax-example::
 
    .. needbar:: Labels example 1
       :legend:
@@ -186,7 +186,7 @@ You can render the barchart in a stacked design by setting ``:stacked:`` flag.
 
 The ``:stacked:`` flag does not support any values.
 
-.. need-example::
+.. syntax-example::
 
    .. needbar:: stacked example
       :stacked:
@@ -203,7 +203,7 @@ You can render the barchart with detailed information of the height of each bar 
 
 The ``:show_sum:`` flag does not support any values and it's useful with the ``stacked`` option  enabled.
 
-.. need-example::
+.. syntax-example::
 
    .. needbar:: show_sum example 1
       :show_sum:
@@ -230,7 +230,7 @@ You can render the barchart with detailed information of the height of each bar 
 
 The ``:show_sum:`` flag does not support any values and it's useful with the ``stacked`` option  enabled.
 
-.. need-example::
+.. syntax-example::
 
    .. needbar:: show_top_sum example 1
       :show_top_sum:
@@ -261,7 +261,7 @@ The ``:horizontal:`` flag does not support any values and it's useful with the `
    The meaning of `labels`_ will change automatically with the usage of ``:horizontal:``. We will use the
    ``:x_axis_title:`` as labels for the y-axis and use the ``:y_axis_title:`` as the values in the `legend`_.
 
-.. need-example::
+.. syntax-example::
 
    .. needbar:: horizontal example 1
       :horizontal:
@@ -297,7 +297,7 @@ The ``:transpose:`` flag does not support any values and it's useful with big co
    * Using the ``:transpose:`` flag, transposes the ``:x_axis_title:`` and ``:y_axis_title:`` fetched from the content data or specified with `labels`_ but does not transpose the extra `axis title`_.
    * Remember that with the ``:transpose:`` flag, the length and height of the content data changes, not to think about the width of matching elements, like `colors`_. Please review the impact of ``:transpose:`` before using it.
 
-.. need-example::
+.. syntax-example::
 
    .. needbar:: transpose example 1
       :transpose:
@@ -330,7 +330,7 @@ rotation
 | Use ``:sum_rotation:`` to set rotation of labels for bars on the diagram.
 
 
-.. need-example::
+.. syntax-example::
 
    .. needbar:: rotation example
       :legend:
@@ -355,7 +355,7 @@ This ensures the use of ``,`` (the default separator) in a filter rule. Other op
 
 The ``:separator:`` is a string that supports any symbols.
 
-.. need-example::
+.. syntax-example::
 
    .. needbar:: separator example
       :separator: -
@@ -380,7 +380,7 @@ But besides names, ``:colors:`` options also supports hex-values like ``#ffcc00`
    When you use `horizontal`_ or `transpose`_, the bar's length must be equal to ``:xlabels:`` or ``:ylabels:``.
    If the length does not fit, it will fill the bar with the colors again and you will get a warning.
 
-.. need-example::
+.. syntax-example::
 
    .. needbar:: colors example
       :legend:
@@ -399,7 +399,7 @@ text_color
 
 ``:text_color:`` defines the color for text inside the bar chart and the labels.
 
-.. need-example::
+.. syntax-example::
 
    .. needbar:: text_color example
       :legend:
@@ -428,7 +428,7 @@ Useful styles are for example:
 * dark_background
 * grayscale
 
-.. need-example::
+.. syntax-example::
 
    .. needbar:: style example
       :legend:

--- a/docs/directives/needextend.rst
+++ b/docs/directives/needextend.rst
@@ -30,7 +30,7 @@ The argument of ``needextend`` will be taken as, by order of priority:
 ``needextend`` can modify all string-based and list-based options.
 Also, you can add links or delete tags.
 
-.. need-example::
+.. syntax-example::
 
    .. req:: needextend Example 1
       :id: extend_test_001
@@ -103,14 +103,14 @@ to filter for needs only in the same document as the ``needextend``.
 The following example would set the status of all needs in the current document,
 which do not have the status set explicitly, to ``open``.
 
-.. need-example::
+.. syntax-example::
 
    .. needextend:: c.this_doc() and status is None
       :status: open
 
 To address all needs in the current document, use this syntax:
 
-.. need-example::
+.. syntax-example::
 
    .. needextend:: "c.this_doc()"
       :status: open
@@ -124,7 +124,7 @@ Options containing links get handled in two steps:
 1. Options for the need are set as above.
 2. The referenced need get updated as well and incoming links may get deleted, added or replaced.
 
-.. need-example::
+.. syntax-example::
 
    .. req:: needextend Example 3
       :id: extend_test_003
@@ -182,7 +182,7 @@ To see these values, use ``:layout: debug`` on the need or by :ref:`own_layouts`
 
 Also filtering for these values is supported:
 
-.. need-example::
+.. syntax-example::
 
    We have :need_count:`is_modified` modified needs.
 

--- a/docs/directives/needextract.rst
+++ b/docs/directives/needextract.rst
@@ -10,7 +10,7 @@ needextract
 It supports custom creation of extracts from existing needs.
 For instance, a supplier could get a copy of requirements but would not see all the internal meta-data.
 
-.. need-example::
+.. syntax-example::
 
    .. feature:: A feature
       :id: EXTRACT_FEATURE_1
@@ -36,7 +36,7 @@ It also supports arguments as filter string,
 which works like the option ``filter``, but also
 supports need ID as filter argument.
 
-.. need-example::
+.. syntax-example::
 
    .. needextract:: EXTRACT_FEATURE_1
       :layout: clean
@@ -57,7 +57,7 @@ The original need provides the style information, if not overwritten by :ref:`ne
 
 See :ref:`layouts` for a list of available layouts.
 
-.. need-example::
+.. syntax-example::
 
    .. needextract:: EXTRACT_FEATURE_1
       :layout: focus_r
@@ -72,7 +72,7 @@ The original need provides the layout information , if not overwritten by :ref:`
 
 See :ref:`styles` for a list of available styles.
 
-.. need-example::
+.. syntax-example::
 
    .. needextract:: EXTRACT_FEATURE_1
       :style: blue_border

--- a/docs/directives/needflow.rst
+++ b/docs/directives/needflow.rst
@@ -9,7 +9,7 @@ needflow
 
 If you provide an argument, we use it as caption for the generated image.
 
-.. need-example::
+.. syntax-example::
 
    .. needflow:: My first needflow
       :filter: is_need
@@ -105,7 +105,7 @@ If ``:root_depth:`` is set, only needs with a distance of ``root_depth`` to the 
 
 Other need filters are applied on this initial selection of connected needs.
 
-.. need-example::
+.. syntax-example::
 
    .. needflow::
       :root_id: spec_flow_002
@@ -157,7 +157,7 @@ show_filters
 
 Adds information of used filters below generated flowchart.
 
-.. need-example::
+.. syntax-example::
 
    .. needflow::
       :tags: flow_example
@@ -178,7 +178,7 @@ show_legend
 Adds a legend below generated flowchart. The legends contains all defined need-types and their configured color
 for flowcharts.
 
-.. need-example::
+.. syntax-example::
 
    .. needflow::
       :tags: flow_example
@@ -203,7 +203,7 @@ Adds the link type name beside connections.
 You can configure it globally by setting :ref:`needs_flow_show_links` in **conf.py**.
 Setup data can be found in test case document ``tests/doc_test/doc_links``.
 
-.. need-example::
+.. syntax-example::
 
    .. needflow::
       :tags: flow_example
@@ -245,7 +245,7 @@ You can set this option globally via the configuration option :ref:`needs_flow_l
 
 See also :ref:`needs_links` for more details about specific link types.
 
-.. need-example::
+.. syntax-example::
 
    .. req:: A requirement
       :id: req_flow_001
@@ -302,7 +302,7 @@ when using the ``plantuml`` engine,
 or the :ref:`needs_graphviz_styles` configuration,
 when using the ``graphviz`` engine.
 
-.. need-example::
+.. syntax-example::
 
    .. needflow::
       :filter: is_need
@@ -314,7 +314,7 @@ when using the ``graphviz`` engine.
 
 You can apply multiple configurations together by separating them via ``,`` symbol.
 
-.. need-example::
+.. syntax-example::
 
    .. needflow::
       :filter: is_need
@@ -392,7 +392,7 @@ You can set a scale factor for the final flow chart using the ``scale`` option.
 
 We also support the numbers between ``1`` and ``300``.
 
-.. need-example::
+.. syntax-example::
 
    .. needflow::
       :filter: is_need
@@ -410,7 +410,7 @@ highlight
 The ``:highlight:`` option takes a single :ref:`filter_string` as a value and
 sets the border for each need of the needflow to **red** if the need also passes the filter string.
 
-.. need-example::
+.. syntax-example::
 
    .. needflow::
       :tags: flow_example
@@ -435,7 +435,7 @@ border_color
 The ``:border_color:`` allows for setting per need border colors, based on the need data.
 The value should be written with the :ref:`variant syntax <needs_variant_support>`, and each return value should be a hex (RGB) color.
 
-.. need-example::
+.. syntax-example::
 
    .. needflow:: Engineering plan to develop a car
       :tags: flow_example
@@ -464,7 +464,7 @@ align
 You can set the alignment for the PlantUML image using the ``align`` option.
 Allowed values are: ``left``, ``center``, ``right``
 
-.. need-example::
+.. syntax-example::
 
    .. needflow::
       :filter: is_need and type == 'spec'
@@ -490,7 +490,7 @@ If you set the ``:debug:``, we add a debug-output of the generated PlantUML code
 
 Helpful to identify reasons why a PlantUML build may have thrown errors.
 
-.. need-example::
+.. syntax-example::
 
    .. needflow::
       :filter: is_need

--- a/docs/directives/needgantt.rst
+++ b/docs/directives/needgantt.rst
@@ -7,7 +7,7 @@ needgantt
 
 ``needgantt`` adds a gantt-chart to your documentation.
 
-.. need-example::
+.. syntax-example::
 
     .. needgantt:: Bug handling gantt
        :tags: gantt_example
@@ -113,7 +113,7 @@ List of link names used to define task relationship, ``starts_with``.
 
 Default: None
 
-.. need-example::
+.. syntax-example::
 
    .. needgantt:: Starts_with example
       :tags: gantt_ex_starts_with
@@ -147,7 +147,7 @@ List of link names used to define task relationship, ``starts_after``.
 
 Default: links
 
-.. need-example::
+.. syntax-example::
 
    .. needgantt:: Starts_after example
       :tags: gantt_ex_starts_after
@@ -175,7 +175,7 @@ List of link names used to define task relationship, ``ends_with``.
 
 Default: None
 
-.. need-example::
+.. syntax-example::
 
    .. needgantt:: Ends_with example
       :tags: gantt_ex_ends_with
@@ -204,7 +204,7 @@ We calculate all tasks and milestones dates based on the ``:start_date:`` option
 
 Date format must be ``YYYY-MM-DD``. Example: 2020-03-25
 
-.. need-example::
+.. syntax-example::
 
    .. needgantt:: Bug handling gantt
       :tags: gantt_example
@@ -224,7 +224,7 @@ Default: ``daily``
 
 Works only, if you set :ref:`needgantt_start_date` option.
 
-.. need-example::
+.. syntax-example::
 
    .. needgantt:: Bug handling gantt
       :tags: gantt_example
@@ -257,7 +257,7 @@ You can set the duration option globally by using :ref:`needs_duration_option` i
 
 Default: :ref:`need_duration`
 
-.. need-example::
+.. syntax-example::
 
    .. needgantt:: Duration example
       :tags: gantt_ex_duration
@@ -293,7 +293,7 @@ You can set the completion option globally by using :ref:`needs_completion_optio
 
 Default: :ref:`need_completion`
 
-.. need-example::
+.. syntax-example::
 
    .. needgantt:: Completion example
       :tags: gantt_ex_completion

--- a/docs/directives/needlist.rst
+++ b/docs/directives/needlist.rst
@@ -7,7 +7,7 @@ needlist
 
 **needlist** creates a list of elements based on the result of given filters.
 
-.. need-example::
+.. syntax-example::
 
    .. needlist::
       :tags: main_example
@@ -29,7 +29,7 @@ Flag for adding status information to the needs list results filtered.
 
 If a filtered need has no status information, we write no status output for the need.
 
-.. need-example::
+.. syntax-example::
 
    .. needlist::
       :show_status:
@@ -44,7 +44,7 @@ Flag for adding tag information to the needs list results filtered.
 If a filtered need has no tag information, we write no tag output for the need.
 
 
-.. need-example::
+.. syntax-example::
 
    .. needlist::
       :show_tags:
@@ -58,7 +58,7 @@ show_filters
 If set, we add the used filter below the needlist results:
 
 
-.. need-example::
+.. syntax-example::
 
    .. needlist::
       :show_filters:

--- a/docs/directives/needpie.rst
+++ b/docs/directives/needpie.rst
@@ -7,7 +7,7 @@ needpie
 
 ``needpie`` adds a pie-chart to your documentation.
 
-.. need-example::
+.. syntax-example::
 
    .. needpie:: My pie chart
 
@@ -32,7 +32,7 @@ Options
 
 **Example with all options used:**
 
-.. need-example::
+.. syntax-example::
 
    .. needpie:: Requirement status
       :labels: Open, In progress, Closed
@@ -56,7 +56,7 @@ Use ``:labels:`` to set labels for each value.
 ``:labels:`` must get a comma separated string and the amount of labels must match the amount of
 values/lines from content.
 
-.. need-example::
+.. syntax-example::
 
    .. needpie:: Requirement status
       :labels: Open, In progress, Closed
@@ -73,7 +73,7 @@ You can place a legend on the right side of the pie chart by setting the ``:lege
 
 The ``:legend:`` flag does not support any values.
 
-.. need-example::
+.. syntax-example::
 
    .. needpie:: Requirement status
       :labels: Open, In progress, Closed
@@ -94,7 +94,7 @@ The amount of values for ``:explode:`` must match the amount of values / content
 
 Useful values for ``:explode:`` are between ``0`` and ``0.3``
 
-.. need-example::
+.. syntax-example::
 
    .. needpie:: Requirement status
       :explode: 0,0.2,0
@@ -109,7 +109,7 @@ shadow
 
 ``:shadow:`` activates a shadow in the pie chart. It does not support any further values.
 
-.. need-example::
+.. syntax-example::
 
    .. needpie:: Requirement status
       :explode: 0,0.2,0
@@ -129,7 +129,7 @@ for a complete list of color names.
 
 But besides names, the ``:colors:`` option also supports hex-values like ``#ffcc00``.
 
-.. need-example::
+.. syntax-example::
 
    .. needpie:: Requirement status
       :colors: lightcoral, gold, #555555
@@ -145,7 +145,7 @@ text_color
 
 .. note:: Setting the ``:text_color:`` option does not change the legend and title color.
 
-.. need-example::
+.. syntax-example::
 
    .. needpie:: Requirement status
       :text_color: w
@@ -169,7 +169,7 @@ Useful styles are for example:
 * dark_background
 * grayscale
 
-.. need-example::
+.. syntax-example::
 
    .. needpie:: Requirement status
       :style: Solarize_Light2
@@ -189,7 +189,7 @@ In the past we had overlapping labels. See following diagram.
 
 Now overlapping labels are removed, and we automatically add a legend with removed information.
 
-.. need-example::
+.. syntax-example::
 
    .. needpie:: Requirement status
       :labels: New, Open, In progress, Closed, Outdated, Removed

--- a/docs/directives/needreport.rst
+++ b/docs/directives/needreport.rst
@@ -31,7 +31,7 @@ You can use the template file to customise the content generated  by ``needrepor
          "report_directive": "admonition",
       }
 
-.. need-example::
+.. syntax-example::
 
    .. needreport::
       :types:
@@ -48,7 +48,7 @@ types
 Flag for adding information about the :ref:`needs_types` configuration parameter.
 The flag does not require any values.
 
-.. need-example::
+.. syntax-example::
 
    .. needreport::
       :types:
@@ -62,7 +62,7 @@ links
 Flag for adding information about the :ref:`needs_links` configuration parameter.
 The flag does not require any values.
 
-.. need-example::
+.. syntax-example::
 
    .. needreport::
       :links:
@@ -76,7 +76,7 @@ options
 Flag for adding information about the :ref:`needs_fields` configuration parameter.
 The flag does not require any values.
 
-.. need-example::
+.. syntax-example::
 
    .. needreport::
       :options:
@@ -86,7 +86,7 @@ usage
 Flag for adding information about all the ``need`` objects in the current project.
 The flag does not require any values.
 
-.. need-example::
+.. syntax-example::
 
    .. needreport::
       :usage:

--- a/docs/directives/needsequence.rst
+++ b/docs/directives/needsequence.rst
@@ -7,7 +7,7 @@ needsequence
 
 ``needsequence`` adds a sequence-chart to your documentation.
 
-.. need-example::
+.. syntax-example::
 
     .. needsequence:: My sequence chart
        :start: USER_A, USER_D
@@ -149,7 +149,7 @@ Default: None (no active filtering)
 You can use this function to filter out a specific participant.
 As an example, we use the same ``needsequence`` from the beginning, but without ``USER_C / Expert``:
 
-.. need-example::
+.. syntax-example::
 
     .. needsequence:: My filtered sequence chart
        :start: USER_A, USER_D

--- a/docs/directives/needservice.rst
+++ b/docs/directives/needservice.rst
@@ -72,7 +72,7 @@ their content.
 
 .. tip:: Click the small arrow under the need id to see all meta data.
 
-.. need-example::
+.. syntax-example::
 
     .. needservice:: github-issues
        :query: repo:useblocks/sphinx-needs node latexpdf

--- a/docs/directives/needtable.rst
+++ b/docs/directives/needtable.rst
@@ -7,7 +7,7 @@ needtable
 
 **needtable** generates a table, based on the result of given filters.
 
-.. need-example::
+.. syntax-example::
 
    .. needtable:: Example table
       :tags: main_example
@@ -37,7 +37,7 @@ For instance::
 
 This will show the columns *id*, *title* and *tags* in the order given.
 
-.. need-example::
+.. syntax-example::
 
    .. needtable::
       :columns: id;title;tags
@@ -51,7 +51,7 @@ Tables with a lot of columns will get a horizontal scrollbar in HTML output.
 
 **DataTable style**
 
-.. need-example::
+.. syntax-example::
 
    .. needtable::
       :tags: test
@@ -59,7 +59,7 @@ Tables with a lot of columns will get a horizontal scrollbar in HTML output.
 
 **Normal style**
 
-.. need-example::
+.. syntax-example::
 
    .. needtable::
       :tags: test
@@ -78,7 +78,7 @@ A comma separated list of lengths or percentages used to define the width of eac
 It has the same meaning as the ``width options`` of
 `listtable <https://docutils.sourceforge.io/docs/ref/rst/directives.html#list-table>`_ directive.
 
-.. need-example::
+.. syntax-example::
 
   .. needtable::
      :tags: test
@@ -93,7 +93,7 @@ Custom column titles
 You can customize each column title by following this syntax for its definition: ``OPTION as "My custom title"``.
 The characters ``,`` or ``;`` are not allowed.
 
-.. need-example::
+.. syntax-example::
 
    .. needtable::
       :tags: test
@@ -107,7 +107,7 @@ show_filters
 
 If set, we add the used filter above the table:
 
-.. need-example::
+.. syntax-example::
 
    .. needtable::
       :tags: test
@@ -130,7 +130,7 @@ Overrides config parameter :ref:`needs_table_style` if set.
 
 .. dropdown:: Show example
 
-   .. need-example::
+   .. syntax-example::
 
       .. needtable::
          :style: table
@@ -151,7 +151,7 @@ It adds the part rows directly under the related need’s row, and their id and 
 
 To change the prefix please read :ref:`needs_part_prefix`.
 
-.. need-example::
+.. syntax-example::
 
    .. needtable::
       :tags: test_table
@@ -162,7 +162,7 @@ To change the prefix please read :ref:`needs_part_prefix`.
 
 .. dropdown:: Show above example's configuration
 
-   .. need-example::
+   .. syntax-example::
 
       .. req:: Test need with need parts
          :id: table_001
@@ -192,7 +192,7 @@ You can use the ``style_row`` option to set a specific class-attribute for the t
 
 Also, you can set specific layout for the row.
 
-.. need-example::
+.. syntax-example::
 
   .. needtable::
      :tags: ex_row_color
@@ -205,7 +205,7 @@ Row style based on specific need value
 You can use :ref:`dynamic_functions` to derive the value for ``style_row`` based on a specific value of the
 documented need in the row.
 
-.. need-example::
+.. syntax-example::
 
    .. needtable::
       :tags: ex_row_color
@@ -289,7 +289,7 @@ must have the type ``string``, ``float`` or ``int``.
 
 By default, we use ``id_complete`` if we don't set a sort option.
 
-.. need-example::
+.. syntax-example::
 
    .. needtable::
       :tags: ex_row_color
@@ -297,7 +297,7 @@ By default, we use ``id_complete`` if we don't set a sort option.
 
 In this case, we set the sort option to ``status``. So *EX_ROW_3* is above of *EX_ROW_2*.
 
-.. need-example::
+.. syntax-example::
 
    .. needtable::
       :tags: ex_row_color
@@ -340,7 +340,7 @@ It supports comma separated values and will add classes to the already set class
     }
 
 
-.. need-example::
+.. syntax-example::
 
    .. needtable::
       :tags: test

--- a/docs/directives/needuml.rst
+++ b/docs/directives/needuml.rst
@@ -12,7 +12,7 @@ So it allows to define PlantUML diagrams.
 But gives you access to need object data by supporting `Jinja <https://jinja.palletsprojects.com/>`_ statements,
 which allows you to use loops, if-clauses, and it injects data from need-objects.
 
-.. need-example::
+.. syntax-example::
 
    .. needuml::
 
@@ -53,7 +53,7 @@ extra
 Allows to inject additional key-value pairs into the ``needuml`` rendering.
 ``:extra:`` must be a comma-separated list, containing *key:value* pairs.
 
-.. need-example::
+.. syntax-example::
 
    .. needuml::
       :extra: name:Roberto,work:RocketLab
@@ -90,7 +90,7 @@ If ``:debug:`` is set, a debug-output of the generated PlantUML code gets added 
 
 Helpful to identify reasons why a PlantUML build may have thrown errors.
 
-.. need-example::
+.. syntax-example::
 
    .. needuml::
       :debug:
@@ -108,7 +108,7 @@ Allows to store multiple ``needuml`` inside a need under ``arch`` under the give
 If no option key given, then the first ``needuml`` will be stored in the need under ``arch`` under ``diagram``, ``need["arch"]["diagram"]``.
 Option ``:key:`` value can't be empty, and can't be ``diagram``.
 
-.. need-example::
+.. syntax-example::
 
    .. comp:: Component Y
       :id: COMP_002
@@ -142,7 +142,7 @@ using builder :ref:`needumls_builder` or other builder like ``html`` with config
 
 If given file path already exists, it will be overwritten.
 
-.. need-example::
+.. syntax-example::
 
    .. int:: Test needuml save
       :id: INT_001
@@ -170,7 +170,7 @@ needs
 ~~~~~
 A Python dictionary containing all Needs. The ``need_id`` is used as key.
 
-.. need-example::
+.. syntax-example::
 
    .. needuml::
 
@@ -195,7 +195,7 @@ This functions represents each Need the same way.
    E.g. see even the following example, with text following 
    `{{flow("COMP_001")}}`.
 
-.. need-example::
+.. syntax-example::
 
    .. needuml::
 
@@ -211,7 +211,7 @@ filter(filter_string)
 ~~~~~~~~~~~~~~~~~~~~~
 Finds a list of Sphinx-Need objects that pass the given filter string.
 
-.. need-example::
+.. syntax-example::
 
    .. needuml::
 
@@ -230,7 +230,7 @@ text associated to the hyperlink is either defined by ``option`` (in this case,
 Sphinx-Need picks the text of the field specified by ``option``), or by the free text ``text``.
 
 
-.. need-example::
+.. syntax-example::
 
    .. needuml::
 
@@ -248,7 +248,7 @@ If diagram code is available in the need data under ``arch``, the stored PlantUM
 Please read :ref:`need_diagram` for details.
 
 
-.. need-example::
+.. syntax-example::
 
    .. needuml::
 
@@ -267,7 +267,7 @@ Key argument
 ``key`` value by default is ``diagram``. If no key argument given, then the PlantUML code is loaded from ``diagram`` under ``arch``
 inside the need object.
 
-.. need-example::
+.. syntax-example::
 
    .. comp:: Z
       :id: COMP_Z
@@ -284,7 +284,7 @@ Additional keyword arguments
 
 :ref:`uml() <needuml_jinja_uml>` supports additional keyword parameters which are then available in the loaded PlantUML code.
 
-.. need-example::
+.. syntax-example::
 
    .. comp:: Variant A or B
       :id: COMP_A_B
@@ -307,7 +307,7 @@ Additional keyword arguments
 
 Passing ``variant="A"`` parameter to the :ref:`uml() <needuml_jinja_uml>` function, we get the following:
 
-.. need-example::
+.. syntax-example::
 
    .. needuml::
       :debug:
@@ -316,7 +316,7 @@ Passing ``variant="A"`` parameter to the :ref:`uml() <needuml_jinja_uml>` functi
 
 Passing ``variant="B"`` parameter to the :ref:`uml() <needuml_jinja_uml>` function, we get the following:
 
-.. need-example::
+.. syntax-example::
 
    .. needuml::
       :debug:
@@ -443,7 +443,7 @@ All features are available and ``uml()`` can be used multiple time on different 
 NeedUml Examples
 ----------------
 
-.. need-example::
+.. syntax-example::
 
    .. needuml::
       :scale: 50%
@@ -471,7 +471,7 @@ NeedUml Examples
       card "and much more..." as much #ffcc00
       much -> sn
 
-.. need-example::
+.. syntax-example::
 
     .. comp:: Component X
        :id: COMP_001

--- a/docs/dynamic_functions.rst
+++ b/docs/dynamic_functions.rst
@@ -26,7 +26,7 @@ To refer to a dynamic function, you can use the following syntax:
 - In a need directive option, wrap the function call in double square brackets: ``[[function_name(arg)]]``
 - In a need content, use the :ref:`ndf` role: ``:ndf:`function_name(arg)```
 
-.. need-example:: Dynamic function example
+.. syntax-example:: Dynamic function example
 
    .. req:: my test requirement
       :id: df_1
@@ -278,7 +278,7 @@ If a variant definition is true, then we set the *need option* to the value of t
 
 Below is an implementation of variants for need options:
 
-.. need-example::
+.. syntax-example::
 
    .. req:: Variant options
       :id: VA_004

--- a/docs/filter.rst
+++ b/docs/filter.rst
@@ -40,7 +40,7 @@ You can easily filter for multiple statuses by separating them by ";". Example: 
 
 .. dropdown:: Show example
 
-   .. need-example::
+   .. syntax-example::
 
       .. needlist::
          :status: open
@@ -57,7 +57,7 @@ To search for multiple tags, simply separate them by using ";".
 
 .. dropdown:: Show example
 
-   .. need-example::
+   .. syntax-example::
 
       .. needlist::
          :tags: main_example
@@ -71,7 +71,7 @@ For **:types:** the type itself or the human-readable type-title can be used as 
 
 .. dropdown:: Show example
 
-   .. need-example::
+   .. syntax-example::
 
       .. needtable::
          :types: test
@@ -84,7 +84,7 @@ Sorts the result list. Allowed values are ``status`` or any alphanumerical prope
 
 .. dropdown:: Show example
 
-   .. need-example::
+   .. syntax-example::
 
       .. needtable::
          :sort_by: id
@@ -117,7 +117,7 @@ The usage of a filter string is supported/required by:
 
 The filter string must be a valid Python expression:
 
-.. need-example::
+.. syntax-example::
 
    :need_count:`type=='spec' and status != 'open'`
 
@@ -133,7 +133,7 @@ This allows to perform searches for need_parts, where search options are based o
 
 The following filter will find all need_parts, which are part of a need, which has a tag called *important*.
 
-.. need-example::
+.. syntax-example::
 
    :need_count:`is_part and 'car' in tags`
 
@@ -158,7 +158,7 @@ If it is invalid or returns False, the related need is not taken into account fo
 
 .. dropdown:: Show example
 
-   .. need-example:: ``filter`` option
+   .. syntax-example:: ``filter`` option
 
       needs:
 
@@ -239,7 +239,7 @@ Additionally, to common :ref:`filter_string` variables,
 the ``c.this_doc()`` function is for most directives,
 to filter for needs only in the same document as the directive.
 
-.. need-example::
+.. syntax-example::
 
    .. needtable::
       :filter: c.this_doc()
@@ -260,7 +260,7 @@ The second parameter should be one of the above variables(status, id, content, .
 
    This example uses a regular expressions to find all needs with an e-mail address in title.
 
-   .. need-example::
+   .. syntax-example::
 
       .. req:: Set admin e-mail to admin@mycompany.com
 
@@ -319,7 +319,7 @@ The used code must define a variable ``results``, which must be a list and conta
 
 The code also has access to a variable called ``needs``, which is a :class:`.NeedsAndPartsListView` instance.
 
-.. need-example::
+.. syntax-example::
 
    .. needtable::
       :columns: id, title, type, links, links_back
@@ -462,7 +462,7 @@ More Examples
 
 .. dropdown:: Setup
 
-   .. need-example::
+   .. syntax-example::
 
       .. req:: My first requirement
          :status: open
@@ -493,13 +493,13 @@ More Examples
          Python 2.7 environment.
 
 
-.. need-example:: Filter result as table
+.. syntax-example:: Filter result as table
 
    .. needtable::
       :tags: test
       :status: implemented; open
 
-.. need-example:: Filter result as diagram
+.. syntax-example:: Filter result as diagram
 
    .. needflow::
       :filter: "More Examples" == section_name

--- a/docs/layout_styles.rst
+++ b/docs/layout_styles.rst
@@ -818,7 +818,7 @@ content_footer_side_right
 More Examples
 -------------
 
-.. need-example::
+.. syntax-example::
 
    .. req:: A normal requirement
       :id: EX_REQ_1
@@ -826,7 +826,7 @@ More Examples
 
       This is how a normal requirement looks like
 
-.. need-example::
+.. syntax-example::
 
    .. req:: A more complex and highlighted requirement
       :id: EX_REQ_2
@@ -838,7 +838,7 @@ More Examples
 
       More columns for better data structure and a red border.
 
-.. need-example::
+.. syntax-example::
 
    .. req:: A focused requirement
       :id: EX_REQ_3
@@ -850,7 +850,7 @@ More Examples
       This also a requirement, but we focus on content here.
       All meta-data is hidden, except the need-id.
 
-.. need-example::
+.. syntax-example::
 
    .. req:: A custom requirement with picture
       :author: daniel
@@ -863,7 +863,7 @@ More Examples
       This example uses the value from **author** to reference an image.
       See :ref:`layouts_styles` for the complete explanation.
 
-.. need-example::
+.. syntax-example::
 
    .. req:: A requirement with a permalink
       :id: EX_REQ_5

--- a/docs/roles.rst
+++ b/docs/roles.rst
@@ -19,7 +19,7 @@ With ``[[`` and ``]]`` you can refer to defined and set :ref:`extra fields <need
 
 The possible variables are listed in the configuration documentation for :ref:`needs_role_need_template`.
 
-.. need-example::
+.. syntax-example::
 
    .. req:: Sliced Bread
       :id: roles_req_1
@@ -56,7 +56,7 @@ need_outgoing
 ``:need_outgoing:`` adds a list of all outgoing links of the given need.
 The list contains the need IDs only, no title or any other information is printed.
 
-.. need-example::
+.. syntax-example::
 
    .. req:: Butter on Bread
       :id: roles_req_2
@@ -72,7 +72,7 @@ need_incoming
 
 ``:need_incoming:`` prints a list of IDs of needs which have set outgoing links to the given need.
 
-.. need-example::
+.. syntax-example::
 
    The realisation of **Sliced Bread** is really important because the needs :need_incoming:`roles_req_1` are based on
    it.
@@ -88,7 +88,7 @@ This sub-ids can be linked and referenced in other need functions like links and
 
 The used need_part id can be freely chosen, but should not contain any whitespaces or dots.
 
-.. need-example::
+.. syntax-example::
 
    .. req:: Car must be awesome
       :id: my_car_1
@@ -120,7 +120,7 @@ The used need_part id can be freely chosen, but should not contain any whitespac
 Links to need_parts are shown as dotted line to the upper need inside :ref:`needflow` diagrams.
 They are also getting the part_id as link description.
 
-.. need-example::
+.. syntax-example::
 
    .. needflow::
       :filter: id in ["my_car_1","impl_my_car_1"]
@@ -129,7 +129,7 @@ They are also getting the part_id as link description.
 
 Please see :ref:`needtable_show_parts` of :ref:`needtable` configuration documentation.
 
-.. need-example::
+.. syntax-example::
 
    .. needtable::
       :style: table
@@ -148,7 +148,7 @@ Counts found needs for a given filter and shows the final amount.
 The content of the role must be a valid filter-string as used e.g. by :ref:`needlist` in the ``:filter:`` option.
 See :ref:`filter_string` for more information.
 
-.. need-example::
+.. syntax-example::
 
    | All needs: :need_count:`True`
    | Specification needs: :need_count:`type=='spec'`
@@ -180,7 +180,7 @@ Ratio
 To calculate the ratio of one filter to another filter, you can define two filters separated by ``_?_``
 (question mark surrounded by one space on each side).
 
-.. need-example::
+.. syntax-example::
 
    :need_count:`status == open and type == "spec" ? type == "spec"` % of our specifications are open.
 
@@ -201,7 +201,7 @@ ndf
 
 Executes a :ref:`need dynamic function <dynamic_functions>` and uses the return values as content.
 
-.. need-example::
+.. syntax-example::
 
     A nice :ndf:`echo("first test")` for dynamic functions.
 

--- a/docs/services/github.rst
+++ b/docs/services/github.rst
@@ -267,7 +267,7 @@ Filtering
 +++++++++
 Show all needs, which have ``github`` as part of their ``service`` value.
 
-.. need-example::
+.. syntax-example::
 
     .. needtable::
        :filter: service is not None and 'github' in service

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -49,7 +49,7 @@ A need item is a generic object which can become anything you require for your p
 
 sphinx-needs comes with some default types: ``req``, ``spec``, ``impl``, and ``test``, which can be used as directives:
 
-.. need-example:: A basic need item
+.. syntax-example:: A basic need item
 
     .. req:: Basic need example
         :id: basic_example
@@ -74,7 +74,7 @@ This can be created in the ``conf.py`` file, using the :ref:`needs_types` config
 There are also some optional directive fields 
 that can be used to add additional data to the item or further style its representation:
 
-.. need-example:: A custom need item
+.. syntax-example:: A custom need item
 
     .. tutorial-project:: Our new car
         :id: T_CAR
@@ -116,7 +116,7 @@ By default this will display the title and ID of the need item, but we can also 
 by using an explicit title and using ``[[field]]`` syntax:
 
 
-.. need-example:: Referring to a need item
+.. syntax-example:: Referring to a need item
 
     The project is described in more detail in :need:`T_CAR`.
 
@@ -144,7 +144,7 @@ We can define custom link types in the ``conf.py`` file, using the :ref:`needs_l
 
 We can now uses these links when specifying need items, notice how "back links" are automatically generated when displaying the item:
 
-.. need-example:: Need items with links
+.. syntax-example:: Need items with links
 
    .. tutorial-req:: Safety Features
       :id: T_SAFE
@@ -164,7 +164,7 @@ Lets also add some more need items to our plan:
 
 .. dropdown:: Add Specification items
 
-   .. need-example:: More need items with links
+   .. syntax-example:: More need items with links
 
       .. tutorial-spec:: Implement RADAR system
          :id: T_RADAR
@@ -221,7 +221,7 @@ or generated from external services, using the :ref:`needservice` directive.
 
 Lets import some test cases, we add an additional tag to each, to make them easier to select later on:
 
-.. need-example:: Importing need items
+.. syntax-example:: Importing need items
 
     .. needimport:: _static/tutorial_needs.json
         :tags: tutorial,tutorial_tests
@@ -242,7 +242,7 @@ to add additional fields to them, such as links.
 The ``needextend`` directive expects a :ref:`filter <filter>` argument, which is used to select the need items to extend.
 Here we filter by the tag we set on the imported items above:
 
-.. need-example:: Extending need items
+.. syntax-example:: Extending need items
 
     .. needextend:: "tutorial_tests" in tags
         :+tutorial_tests: T_RADAR
@@ -281,7 +281,7 @@ either by simple options, or by using a more complex expression.
 In the following example we will display a list of all need items with the tag "tutorial",
 sorted by ID, and showing the status of each item:
 
-.. need-example:: Simple list
+.. syntax-example:: Simple list
 
     .. needlist::
         :tags: tutorial
@@ -290,7 +290,7 @@ sorted by ID, and showing the status of each item:
 
 Similarly, we can display the same items in a table format:
 
-.. need-example:: Simple table
+.. syntax-example:: Simple table
 
     .. needtable::
         :tags: tutorial
@@ -301,7 +301,7 @@ Similarly, we can display the same items in a table format:
 There are currently two styles for the table; a simple HTML ``table``, or the default ``datatables`` style to add dynamic pagination, filtering and sorting,
 using the `DataTables <https://datatables.net/>`__ JS package:
 
-.. need-example:: Table with dynamic features
+.. syntax-example:: Table with dynamic features
 
     .. needtable::
         :tags: tutorial
@@ -311,7 +311,7 @@ using the `DataTables <https://datatables.net/>`__ JS package:
 
 Finally, we can display a :ref:`flow diagram <needflow>` of the need items, to also show the relationships between them:
  
-.. need-example:: Flow diagram
+.. syntax-example:: Flow diagram
 
     .. needflow:: Engineering plan to develop a car
         :alt: Engineering plan to develop a car
@@ -327,7 +327,7 @@ Finally, we can display a :ref:`flow diagram <needflow>` of the need items, to a
 
     You can also use the Graphviz engine to render the flow diagram, by setting the ``engine`` option to ``graphviz``:
 
-    .. need-example:: Flow diagram with Graphviz
+    .. syntax-example:: Flow diagram with Graphviz
 
         .. needflow:: Engineering plan to develop a car
             :engine: graphviz
@@ -351,13 +351,13 @@ As well as summarising needs, sphinx-needs provides some built-in roles and dire
 
 In the following examples we will display metrics of the test cases we imported earlier, grouped by status:
 
-.. need-example:: Count of need items
+.. syntax-example:: Count of need items
 
     - Open: :need_count:`'tutorial_tests' in tags and status == 'open'`
     - In Progress: :need_count:`'tutorial_tests' in tags and status == 'in progress'`
     - Closed: :need_count:`'tutorial_tests' in tags and status == 'closed'`
 
-.. need-example:: Pie chart of metric
+.. syntax-example:: Pie chart of metric
 
    .. needpie:: Test Status
       :labels: Open, In progress, Closed
@@ -367,7 +367,7 @@ In the following examples we will display metrics of the test cases we imported 
       'tutorial_tests' in tags and status == 'in progress'
       'tutorial_tests' in tags and status == 'closed'
 
-.. need-example:: Bar chart of metric
+.. syntax-example:: Bar chart of metric
 
    .. needbar:: Test Status
       :horizontal:

--- a/docs/ubproject.toml
+++ b/docs/ubproject.toml
@@ -1,11 +1,11 @@
 "$schema" = "https://ubcode.useblocks.com/ubproject.schema.json"
 
-[parse.extend_directives.need-example]
-argument = true
-options = true
-content = true
-parse_content = true
-content_required = true
+[parse]
+# Enable the built-in extension ports used by these docs:
+# - sphinx_syntax_example: the `.. syntax-example::` directive (also declared in
+#   `extensions` in docs/conf.py), so the engine recognises it by module tag and
+#   renders the same source + rendered-result shape as the Sphinx build.
+extensions = ["sphinx_syntax_example"]
 
 [parse.extend_directives.grid-item-card]
 argument = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,9 @@ docs = [
   "sphinxcontrib-programoutput~=0.17",
   "sphinx-design~=0.6",
   "sphinx-ai-index~=0.1.0",
+  # the `syntax-example` directive; the marker keeps the extra resolvable on
+  # python 3.10 (the directive, and so a docs build, needs python>=3.11)
+  "sphinx-syntax-example~=0.2.0; python_version >= '3.11'",
 ]
 theme-im = ["sphinx-immaterial~=0.11.11"]
 theme-furo = ["furo~=2024.8.6"]
@@ -157,7 +160,8 @@ extras =
 commands =
   pytest --ignore tests/benchmarks {posargs:tests}
 
-[testenv:py{310,311,312,313,314}-benchmark]
+# no py310: the docs extra requires python>=3.11 (sphinx-syntax-example)
+[testenv:py{311,312,313,314}-benchmark]
 extras =
   test
   benchmark
@@ -166,7 +170,9 @@ commands =
   pytest {posargs:tests/benchmarks}
 
 [testenv:docs-{alabaster,furo,im,pds,rtd}]
-extras = 
+# the docs extra requires python>=3.11 (sphinx-syntax-example)
+basepython = python3.12
+extras =
   docs
   furo: theme-furo
   im: theme-im

--- a/sphinx_needs/functions/common.py
+++ b/sphinx_needs/functions/common.py
@@ -40,7 +40,7 @@ def test(
 
     Collects every given args and kwargs and returns a single string, which contains their values/keys.
 
-    .. need-example::
+    .. syntax-example::
 
         .. req:: test requirement
 
@@ -66,7 +66,7 @@ def echo(
     Just returns the given string back.
     Mostly useful for tests.
 
-    .. need-example::
+    .. syntax-example::
 
        A nice :ndf:`echo("first test")` for a dynamic function.
 
@@ -87,7 +87,7 @@ def copy(
     """
     Copies the value of one need option to another
 
-    .. need-example::
+    .. syntax-example::
 
         .. req:: copy-example
            :id: copy_1
@@ -193,7 +193,7 @@ def check_linked_values(
 
     **Needs used as input data**
 
-    .. need-example::
+    .. syntax-example::
 
         .. req:: Input A
            :id: clv_A
@@ -211,7 +211,7 @@ def check_linked_values(
 
     Status gets set to *progress*.
 
-    .. need-example::
+    .. syntax-example::
 
         .. spec:: result 1: Positive check
            :links: clv_A, clv_B
@@ -222,7 +222,7 @@ def check_linked_values(
 
     Status gets not set to *progress*, because status of linked need *clv_C* does not match *"in progress"*.
 
-    .. need-example::
+    .. syntax-example::
 
         .. spec:: result 2: Negative check
            :links: clv_A, clv_B, clv_C
@@ -233,7 +233,7 @@ def check_linked_values(
 
     status gets set to *progress*, because linked need *clv_C* is not part of the filter.
 
-    .. need-example::
+    .. syntax-example::
 
         .. spec:: result 3: Positive check thanks of used filter
            :links: clv_A, clv_B, clv_C
@@ -246,7 +246,7 @@ def check_linked_values(
     That's because ``one_hit`` is used so that only one linked need must have the searched
     value.
 
-    .. need-example::
+    .. syntax-example::
 
         .. spec:: result 4: Positive check thanks of one_hit option
            :links: clv_A, clv_B, clv_C
@@ -256,7 +256,7 @@ def check_linked_values(
     **Result 5: Two checks and a joint status**
     Two checks are performed and both are positive. So their results get joined.
 
-    .. need-example::
+    .. syntax-example::
 
         .. spec:: result 5: Two checks and a joint status
            :links: clv_A, clv_B, clv_C
@@ -335,7 +335,7 @@ def calc_sum(
 
     **Example 2**
 
-    .. need-example::
+    .. syntax-example::
 
        .. req:: Result 1
           :amount: [[calc_sum("hours")]]
@@ -344,7 +344,7 @@ def calc_sum(
 
     **Example 2**
 
-    .. need-example::
+    .. syntax-example::
 
        .. req:: Result 2
           :amount: [[calc_sum("hours", "hours is not None and hours > 10")]]
@@ -352,7 +352,7 @@ def calc_sum(
 
     **Example 3**
 
-    .. need-example::
+    .. syntax-example::
 
        .. req:: Result 3
           :links: sum_input_1; sum_input_3
@@ -361,7 +361,7 @@ def calc_sum(
 
     **Example 4**
 
-    .. need-example::
+    .. syntax-example::
 
        .. req:: Result 4
           :links: sum_input_1; sum_input_3


### PR DESCRIPTION

## Motivation

The docs have long carried their own example directive: `NeedExampleDirective`,
defined inline in `docs/conf.py`, registered as `.. need-example::`. It renders
its content twice — once as a highlighted source block, once as the parsed
result — which is a generic documentation pattern with nothing needs-specific
about it.

That pattern is now published as [`sphinx-syntax-example`][pkg], which provides
the canonical `.. syntax-example::` directive. Adopting it buys two things:

1. **ubCode compatibility.** ubCode's Rust parser has a native implementation of
   `syntax-example`, gated on the `sphinx_syntax_example` extension being
   declared in `ubproject.toml`'s `[parse] extensions`. There is no engine
   support for a `need-example` alias, so as long as the docs used the bespoke
   name they could only be described to ubCode as a generic
   `[parse.extend_directives.*]` stub — parsed, but not rendered like the Sphinx
   build. Using the canonical name means both engines render the same shape from
   the same sources.
2. **Less bespoke code.** ~35 lines of directive implementation and two blocks of
   `.needs-example` CSS leave `docs/`, replaced by one entry in `extensions`.

[pkg]: https://github.com/sphinx-extensions2/sphinx-syntax-example

## Dependency

The docs extra pins `sphinx-syntax-example~=0.2.0`. 0.2.0 is released on PyPI and
adds the opt-in numbering this PR relies on (the `syntax_example_numbering` config
value); everything below was verified against that release, installed from PyPI
into a clean environment. The pin is `~=0.2.0` rather than `~=0.1.1` because 0.1.1
has no numbering — the rubrics would render unnumbered.

## What changed

- **`docs/conf.py`**
  - `NeedExampleDirective` deleted, along with its `app.add_directive("need-example", ...)`
    registration. The sibling local directives (`need-warnings`, `need-core-fields`)
    and the `need_config_default` role are untouched.
  - `"sphinx_syntax_example"` added to `extensions`. The packaged extension
    registers both the directive and its own stylesheet.
  - `syntax_example_numbering = True` — restores the per-document "Example N"
    rubric numbering. The 0.2 format (`"Example {n}"` / `"Example {n}: {title}"`,
    counter reset per document, title inline-parsed) is byte-identical to what the
    bespoke directive produced, so rubric text does not change.
- **187 usages renamed** `.. need-example::` → `.. syntax-example::`: 174 across
  21 files in `docs/`, and 13 in `sphinx_needs/functions/common.py` docstrings
  (rendered into the docs via autodoc). No prose anywhere named the directive, so
  these are the only occurrences.
- **`docs/ubproject.toml`**: the `[parse.extend_directives.need-example]` stub is
  replaced by a `[parse]` table declaring `extensions = ["sphinx_syntax_example"]`
  — the gate ubCode's engine uses to enable its native implementation.
- **CSS**: the now-dead `.needs-example` rules are removed from
  `docs/_static/_css/shared.css` and `docs/_static/_css/sphinx_immaterial.css`.
- **`pyproject.toml`**: `sphinx-syntax-example~=0.2.0; python_version >= '3.11'`
  added to the `docs` extra. **The environment marker is load-bearing** — see below.
- **CI / tox / docs**: six places that install or document the `docs` extra
  assumed Python 3.10 — see below.
- **`docs/changelog.rst`**: an `Unreleased` entry for the migration and the new
  docs-build Python floor.

## Visual change

This is a deliberate restyle of the example blocks. The old look was a green
left-border rule (plus a full green box under `sphinx_immaterial`); the new look
is the packaged stylesheet's framed box, which styles the source and rendered
panes distinctly and is theme-aware. Only the frame and its class names change —
the rubric text and the contents of both panes are byte-identical to before
(see Verification).

## Python floor for docs builds

`sphinx-syntax-example` requires Python >= 3.11, so **building the docs now needs
Python >= 3.11**. The package's own `requires-python` is unchanged (`>=3.10,<4`) —
only the `docs` extra is affected, and `sphinx_needs` itself still runs on 3.10.

### Why the environment marker

The dependency is declared as `sphinx-syntax-example~=0.2.0; python_version >= '3.11'`,
not as a bare pin. Resolution of an extra spans the project's whole
`requires-python` range, so an unmarked entry makes the resolver consider Python
3.10 and fail there — which breaks `uv lock` / `uv sync` (the documented dev path
in `docs/contributing.rst`) and `pip install sphinx-needs[docs]` on 3.10, for
everybody, whether or not they build docs. Reproduced with `uv pip compile`:

```
# unmarked, --python-version 3.10
error: … sphinx-syntax-example==0.1.1 only supports >=3.11 …
# marked, --python-version 3.10
Resolved 43 packages   (sphinx-syntax-example correctly excluded)
```

**Trade-off:** on Python 3.10 the `docs` extra now installs *successfully but
incompletely* — the extension is absent, so a docs build fails at
`extensions = [… "sphinx_syntax_example"]` with an extension-not-found error
rather than at install time. That is a worse error message for the (already
unsupported) case of building docs on 3.10, in exchange for keeping the project
lockable and installable on 3.10 at all. `docs/contributing.rst` states the floor
explicitly so the failure is not a surprise.

### Places that assumed 3.10

Nothing in them was 3.10-specific:

| where | job / env | was | now |
| --- | --- | --- | --- |
| `.github/workflows/js_test.yml` | `js_tests` | 3.10.8 | 3.12 |
| `.github/workflows/benchmark.yaml` | `benchmarks` | 3.10 | 3.12 |
| `.github/workflows/ci.yaml` | `tests-no-mpl` | 3.10 | 3.12 |
| `pyproject.toml` (`[tool.tox]`) | `py{310,…}-benchmark` | py310 factor | py310 factor dropped |
| `pyproject.toml` (`[tool.tox]`) | `docs-{alabaster,furo,…}` | inherited tox's python | `basepython = python3.12` |
| `docs/contributing.rst` | install + build-docs instructions | no floor stated | notes the ≥ 3.11 floor |

3.12 matches `docs.yaml`, which already used it, and `docs-linkcheck`, which
already pinned `basepython = python3.12`. `.readthedocs.yml` already builds on
3.11 and needs no change. The core test matrix in `ci.yaml` and the tox
`py{310,…}` test envs still cover 3.10 — they do not install the `docs` extra.

## Verification

Strict builds (`sphinx-build -nW --keep-going -b html docs …`, furo, `nitpicky = True`)
against an unmodified `origin/master` baseline built the same way:

| build | result |
| --- | --- |
| baseline (`origin/master`) | succeeded, 0 warnings |
| this branch, **released 0.2.0 from PyPI** (clean venv, `pip install -e '.[docs,theme-furo]'`) | succeeded, 0 warnings |
| this branch, released 0.1.1 | succeeded, 0 warnings (rubrics unnumbered, as expected) |

Resolution is clean on the whole `requires-python` range: `uv lock` resolves 115
packages and records `sphinx-syntax-example` at `0.2.0` from `pypi.org/simple`
carrying `marker = "python_full_version >= '3.11'"`; `uv pip compile
--python-version 3.11` pins `sphinx-syntax-example==0.2.0` and `--python-version
3.10` omits it entirely.

Against the release build, all **187 example blocks** (spread over 21 of the 47
built pages) match the baseline exactly in **rubric text, source-pane contents and
rendered-pane contents** — byte-identical after normalising sphinx-needs' own
`SNCB-<uuid4>` container ids, which are randomised on every build and are the only
textual delta found anywhere.

What *does* change is the three wrapper class names: `needs-example` /
`needs-example-raw` (both panes shared one class) become `syntax-example` /
`syntax-example-source` / `syntax-example-render`. That is the intended restyle
hook — the markup *inside* the panes is untouched.

`needs.json` is byte-identical (223 needs), so every need declared inside an
example still exists with the same data, and cross-references such as `T_CAR`
resolve identically. `_static/sphinx-syntax-example.css` is emitted and linked.

## Follow-up

`docs/ubproject.toml` does not yet enable numbering on the ubCode side. The
engine's counterpart is `syntax_example_numbering` under `[parse]` (being added in
the ubcode PR); once that ships, set it there too so both engines agree on rubric
text.
