### PR TITLE
🐛 Use the physical source directory for generated PlantUML diagrams

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,18 @@ Changelog
 Unreleased
 ----------
 
+- 🐛 Generated PlantUML diagrams (:ref:`needuml`, :ref:`needarch`,
+  :ref:`needflow`, :ref:`needsequence`, :ref:`needgantt`) now derive PlantUML's
+  working directory from the *physical* path of the source document instead of
+  its logical docname (:issue:`1749`).
+
+  Relative ``!include`` paths therefore also resolve for documents whose source
+  file does not live under ``srcdir`` — e.g. documents contributed by
+  `sphinx-mounts <https://github.com/useblocks/sphinx-mounts>`__ — which
+  previously failed with a misleading
+  ``WARNING: plantuml command '...' cannot be run``.
+  Ordinary documents keep the exact working directory they had before.
+
 - 📚 The documentation now uses the shared
   `sphinx-syntax-example <https://github.com/sphinx-extensions2/sphinx-syntax-example>`__
   ``syntax-example`` directive, in place of the bespoke ``need-example`` directive

--- a/sphinx_needs/diagrams_common.py
+++ b/sphinx_needs/diagrams_common.py
@@ -14,6 +14,7 @@ from urllib.parse import urlparse
 from docutils import nodes
 from docutils.parsers.rst import directives
 from sphinx.application import Sphinx
+from sphinx.environment import BuildEnvironment
 from sphinx.util.docutils import SphinxDirective
 
 from sphinx_needs.config import NeedsSphinxConfig, NeedType
@@ -108,6 +109,30 @@ def no_plantuml(node: nodes.Element) -> None:
     para += text
     content.append(para)
     node.replace_self(content)
+
+
+def set_plantuml_paths(
+    puml_node: nodes.Element, env: BuildEnvironment, docname: str
+) -> None:
+    """Point a generated PlantUML node at the physical location of ``docname``.
+
+    ``sphinxcontrib-plantuml`` runs the PlantUML process with
+    ``cwd = os.path.join(srcdir, node["incdir"])``, so ``incdir`` decides where
+    relative ``!include`` paths are resolved. Deriving it from the *logical*
+    docname breaks as soon as the document does not physically live under
+    ``srcdir`` -- e.g. a document contributed by ``sphinx-mounts``, whose source
+    file stays in an external tree. PlantUML then gets a non-existent ``cwd``,
+    which surfaces as the misleading "plantuml command cannot be run".
+
+    ``env.doc2path(docname, base=False)`` returns a srcdir-relative path for an
+    ordinary document and the absolute external path for a mounted one. Since
+    ``os.path.join`` discards its left operand when the right one is absolute,
+    both cases resolve correctly -- and ordinary documents keep the exact
+    ``incdir`` value they had before, so PlantUML's content-addressed cache
+    stays valid (and machine-independent) for them.
+    """
+    puml_node["incdir"] = os.path.dirname(env.doc2path(docname, base=False))
+    puml_node["filename"] = os.path.split(docname)[1]  # Needed for plantuml >= 0.9
 
 
 def add_config(config: str) -> str:

--- a/sphinx_needs/directives/needflow/_plantuml.py
+++ b/sphinx_needs/directives/needflow/_plantuml.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import html
-import os
 
 from docutils import nodes
 from sphinx.application import Sphinx
@@ -10,7 +9,11 @@ from sphinx_needs._jinja import render_template_string
 from sphinx_needs.config import NeedsSphinxConfig
 from sphinx_needs.data import NeedsFlowType, SphinxNeedsData
 from sphinx_needs.debug import measure_time
-from sphinx_needs.diagrams_common import calculate_link, create_legend
+from sphinx_needs.diagrams_common import (
+    calculate_link,
+    create_legend,
+    set_plantuml_paths,
+)
 from sphinx_needs.directives.needflow._directive import NeedflowPlantuml
 from sphinx_needs.directives.utils import no_needs_found_paragraph
 from sphinx_needs.filter_common import filter_single_need, process_filters
@@ -319,10 +322,7 @@ def process_needflow_plantuml(
                 puml_node["uml"] += create_legend(needs_config.types)
 
             puml_node["uml"] += "\n@enduml"
-            puml_node["incdir"] = os.path.dirname(current_needflow["docname"])
-            puml_node["filename"] = os.path.split(current_needflow["docname"])[
-                1
-            ]  # Needed for plantuml >= 0.9
+            set_plantuml_paths(puml_node, env, current_needflow["docname"])
 
             scale = int(current_needflow["scale"])
             # if scale != 100:

--- a/sphinx_needs/directives/needgantt.py
+++ b/sphinx_needs/directives/needgantt.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 import re
 from collections.abc import Sequence
 from datetime import datetime
@@ -18,6 +17,7 @@ from sphinx_needs.diagrams_common import (
     get_debug_container,
     get_filter_para,
     no_plantuml,
+    set_plantuml_paths,
 )
 from sphinx_needs.directives.utils import (
     SphinxNeedsLinkTypeException,
@@ -351,10 +351,7 @@ def process_needgantt(
             puml_node["uml"] += create_legend(needs_config.types)
 
         puml_node["uml"] += "\n@endgantt"
-        puml_node["incdir"] = os.path.dirname(current_needgantt["docname"])
-        puml_node["filename"] = os.path.split(current_needgantt["docname"])[
-            1
-        ]  # Needed for plantuml >= 0.9
+        set_plantuml_paths(puml_node, env, current_needgantt["docname"])
 
         scale = int(current_needgantt["scale"])
         # if scale != 100:

--- a/sphinx_needs/directives/needsequence.py
+++ b/sphinx_needs/directives/needsequence.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 import re
 from collections.abc import Sequence
 from typing import Any
@@ -18,6 +17,7 @@ from sphinx_needs.diagrams_common import (
     get_debug_container,
     get_filter_para,
     no_plantuml,
+    set_plantuml_paths,
 )
 from sphinx_needs.directives.utils import no_needs_found_paragraph
 from sphinx_needs.filter_common import FilterBase
@@ -191,10 +191,7 @@ def process_needsequence(
             puml_node["uml"] += create_legend(needs_types)
 
         puml_node["uml"] += "\n@enduml"
-        puml_node["incdir"] = os.path.dirname(current_needsequence["docname"])
-        puml_node["filename"] = os.path.split(current_needsequence["docname"])[
-            1
-        ]  # Needed for plantuml >= 0.9
+        set_plantuml_paths(puml_node, env, current_needsequence["docname"])
 
         scale = int(current_needsequence["scale"])
         # if scale != 100:

--- a/sphinx_needs/directives/needuml.py
+++ b/sphinx_needs/directives/needuml.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import html
-import os
 import time
 from collections.abc import Sequence
 from pathlib import PurePosixPath
@@ -16,7 +15,7 @@ from sphinx_needs._jinja import render_template_string
 from sphinx_needs.config import NeedsSphinxConfig
 from sphinx_needs.data import SphinxNeedsData
 from sphinx_needs.debug import measure_time
-from sphinx_needs.diagrams_common import calculate_link
+from sphinx_needs.diagrams_common import calculate_link, set_plantuml_paths
 from sphinx_needs.directives.needflow._plantuml import make_entity_name
 from sphinx_needs.filter_common import filter_needs_view
 from sphinx_needs.logging import log_warning
@@ -646,10 +645,7 @@ def process_needuml(
         else:
             puml_node["align"] = "center"
 
-        puml_node["incdir"] = os.path.dirname(current_needuml["docname"])
-        puml_node["filename"] = os.path.split(current_needuml["docname"])[
-            1
-        ]  # Needed for plantuml >= 0.9
+        set_plantuml_paths(puml_node, env, current_needuml["docname"])
 
         content.append(puml_node)
 

--- a/tests/test_plantuml_incdir.py
+++ b/tests/test_plantuml_incdir.py
@@ -52,6 +52,13 @@ class MountAwareProject(Project):
         for src in sorted(self.bundle.glob("*.rst")):
             docname = f"mounted/{src.stem}"
             self.docnames.add(docname)
+            # ``str``, deliberately -- do not "modernise" this to ``Path``.
+            # Sphinx stores ``_StrPath`` here, a ``Path`` subclass that still
+            # supports string slicing, because its own HTML builder does
+            # ``env.doc2path(docname, False)[len(docname):]`` to recover the
+            # source suffix. A plain ``pathlib.Path`` raises ``TypeError:
+            # 'PosixPath' object is not subscriptable`` there on Sphinx 7.4.
+            # ``str`` is the one type that works across sphinx>=7.4,<10.
             self._docname_to_path[docname] = str(src)
             self._path_to_docname[str(src)] = docname
             docs.add(docname)
@@ -84,8 +91,8 @@ def mount_stub_setup(app: Sphinx) -> dict[str, Any]:
     """``setup()`` body for the fixture project's ``conf.py``.
 
     ``_collect_incdirs`` runs at priority 900, i.e. *after* sphinx-needs' own
-    ``doctree-resolved`` handlers (default 500) have replaced the needuml and
-    needflow nodes with generated PlantUML ones.
+    ``doctree-resolved`` handlers (default 500) have replaced the needuml,
+    needflow, needsequence and needgantt nodes with generated PlantUML ones.
     """
     app.collected_incdirs = {}  # type: ignore[attr-defined]
     app.connect("builder-inited", _install_project)
@@ -126,14 +133,31 @@ Host subdirectory page
    class HostLocal
 """
 
-# The mounted document. Two generated-PlantUML directives are exercised, and the
-# ``!include`` resolves only when ``incdir`` points at the bundle on disk.
+# The mounted document. It exercises all four directives that route through
+# ``set_plantuml_paths()``, so a site-specific mistake in any of them is caught.
+# The ``!include`` resolves only when ``incdir`` points at the bundle on disk.
+#
+# The three needs form a sender -> message -> receiver chain, because
+# needsequence throws its PlantUML node away and emits "no needs found" unless
+# it can draw at least one connection (see ``process_needsequence``). Every need
+# also carries ``:duration:``, without which needgantt warns.
 BUNDLE_INDEX = """
 Mounted bundle
 ==============
 
-.. req:: A mounted requirement
+.. req:: A mounted sender
    :id: MOUNTED_REQ
+   :duration: 3
+   :links: MOUNTED_MSG
+
+.. req:: A mounted message
+   :id: MOUNTED_MSG
+   :duration: 2
+   :links: MOUNTED_RCV
+
+.. req:: A mounted receiver
+   :id: MOUNTED_RCV
+   :duration: 1
 
 .. needuml::
 
@@ -142,7 +166,12 @@ Mounted bundle
    MountedIncludeWorked -> MountedLocal
 
 .. needflow::
-   :filter: id == "MOUNTED_REQ"
+
+.. needsequence::
+   :start: MOUNTED_REQ
+   :link_types: links
+
+.. needgantt::
 """
 
 BUNDLE_LIB_PUML = """
@@ -187,8 +216,10 @@ def test_incdir_uses_physical_source_dir(
 
     # Mounted document -- the bundle's physical directory, not the logical
     # docname dir ``mounted``, which does not exist under srcdir at all.
-    # Two entries: one for the needuml, one for the needflow.
-    assert incdirs["mounted/index"] == [str(bundle), str(bundle)]
+    # One entry per generated-PlantUML directive, in document order: needuml,
+    # needflow, needsequence, needgantt -- i.e. every ``set_plantuml_paths()``
+    # call site except needarch, which shares needuml's.
+    assert incdirs["mounted/index"] == [str(bundle)] * 4
 
     # End-to-end proof that PlantUML ran and resolved the bundle-relative
     # ``!include``. Before the fix this failed with "plantuml command cannot be

--- a/tests/test_plantuml_incdir.py
+++ b/tests/test_plantuml_incdir.py
@@ -1,0 +1,201 @@
+"""``incdir`` on generated PlantUML nodes must name the *physical* source dir.
+
+``sphinxcontrib-plantuml`` starts the PlantUML process with
+``cwd = os.path.join(srcdir, node["incdir"])``, so ``incdir`` decides where
+relative ``!include`` paths are resolved. Deriving it from the *logical* docname
+breaks for any document whose source file does not physically live under
+``srcdir`` -- e.g. a document contributed by ``sphinx-mounts``, which registers
+an absolute external path for its docname. PlantUML then gets a non-existent
+``cwd`` and fails with the misleading "plantuml command cannot be run".
+
+See https://github.com/useblocks/sphinx-needs/issues/1749.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from collections.abc import Callable
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from sphinx.project import Project
+
+if TYPE_CHECKING:
+    from docutils import nodes
+    from sphinx.application import Sphinx
+    from sphinx.testing.util import SphinxTestApp
+
+
+class MountAwareProject(Project):
+    """A stand-in for ``sphinx-mounts``, reduced to the essential trick.
+
+    A mount registers a docname whose source file lives *outside* ``srcdir`` by
+    storing an **absolute** path in the project's docname->path mapping. Sphinx
+    joins that onto ``srcdir`` and an absolute right-hand operand wins, so the
+    external file is read transparently. Reproducing it here keeps the test free
+    of a ``sphinx-mounts`` dependency.
+
+    Defined at module level (rather than inside the fixture's ``conf.py``) so
+    that Sphinx can pickle the environment holding it.
+    """
+
+    #: Directory whose ``*.rst`` files are mounted under the ``mounted/`` prefix.
+    bundle: Path
+
+    def discover(
+        self,
+        exclude_paths: Any = (),
+        include_paths: Any = ("**",),
+    ) -> set[str]:
+        docs = super().discover(exclude_paths, include_paths)
+        for src in sorted(self.bundle.glob("*.rst")):
+            docname = f"mounted/{src.stem}"
+            self.docnames.add(docname)
+            self._docname_to_path[docname] = str(src)
+            self._path_to_docname[str(src)] = docname
+            docs.add(docname)
+        return docs
+
+
+def _install_project(app: Sphinx) -> None:
+    """Swap in the mount-aware project, mirroring what sphinx-mounts does on
+    ``builder-inited`` -- before ``env.find_files`` calls ``discover()``."""
+    if not isinstance(app.project, MountAwareProject):
+        mounted = MountAwareProject(app.project.srcdir, app.project.source_suffix)
+        mounted.bundle = Path(app.confdir).parent / "bundle"
+        mounted.docnames = set(app.project.docnames)
+        mounted._docname_to_path = dict(app.project._docname_to_path)
+        mounted._path_to_docname = dict(app.project._path_to_docname)
+        app.project = mounted
+    if app.env is not None:
+        app.env.project = app.project
+
+
+def _collect_incdirs(app: Sphinx, doctree: nodes.document, docname: str) -> None:
+    """Record the ``incdir`` of every PlantUML node, keyed by docname."""
+    from sphinxcontrib.plantuml import plantuml
+
+    for node in doctree.findall(plantuml):
+        app.collected_incdirs.setdefault(docname, []).append(node["incdir"])  # type: ignore[attr-defined]
+
+
+def mount_stub_setup(app: Sphinx) -> dict[str, Any]:
+    """``setup()`` body for the fixture project's ``conf.py``.
+
+    ``_collect_incdirs`` runs at priority 900, i.e. *after* sphinx-needs' own
+    ``doctree-resolved`` handlers (default 500) have replaced the needuml and
+    needflow nodes with generated PlantUML ones.
+    """
+    app.collected_incdirs = {}  # type: ignore[attr-defined]
+    app.connect("builder-inited", _install_project)
+    app.connect("doctree-resolved", _collect_incdirs, priority=900)
+    return {"version": "0.1"}
+
+
+CONF_PY = """
+from tests.test_plantuml_incdir import mount_stub_setup
+
+extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
+plantuml_output_format = "svg_img"
+
+
+def setup(app):
+    return mount_stub_setup(app)
+"""
+
+HOST_INDEX = """
+Host project
+============
+
+.. toctree::
+
+   sub/host
+   mounted/index
+"""
+
+# A needuml in a *nested* host document: ``incdir`` must stay the plain
+# srcdir-relative directory it has always been, so PlantUML's content-addressed
+# cache keeps working -- and stays machine-independent -- for ordinary projects.
+HOST_SUB = """
+Host subdirectory page
+======================
+
+.. needuml::
+
+   class HostLocal
+"""
+
+# The mounted document. Two generated-PlantUML directives are exercised, and the
+# ``!include`` resolves only when ``incdir`` points at the bundle on disk.
+BUNDLE_INDEX = """
+Mounted bundle
+==============
+
+.. req:: A mounted requirement
+   :id: MOUNTED_REQ
+
+.. needuml::
+
+   !include lib.puml
+
+   MountedIncludeWorked -> MountedLocal
+
+.. needflow::
+   :filter: id == "MOUNTED_REQ"
+"""
+
+BUNDLE_LIB_PUML = """
+class MountedIncludeWorked
+class MountedLocal
+"""
+
+
+@pytest.fixture
+def mounted_project(tmp_path: Path) -> tuple[Path, Path]:
+    """Write a host project plus a sibling bundle mounted into it."""
+    host = tmp_path / "host"
+    bundle = tmp_path / "bundle"
+    (host / "sub").mkdir(parents=True)
+    bundle.mkdir()
+
+    (host / "conf.py").write_text(textwrap.dedent(CONF_PY), encoding="utf-8")
+    (host / "index.rst").write_text(textwrap.dedent(HOST_INDEX), encoding="utf-8")
+    (host / "sub" / "host.rst").write_text(textwrap.dedent(HOST_SUB), encoding="utf-8")
+    (bundle / "index.rst").write_text(textwrap.dedent(BUNDLE_INDEX), encoding="utf-8")
+    (bundle / "lib.puml").write_text(textwrap.dedent(BUNDLE_LIB_PUML), encoding="utf-8")
+    return host, bundle
+
+
+def test_incdir_uses_physical_source_dir(
+    mounted_project: tuple[Path, Path],
+    sphinx_test_tempdir: Path,
+    make_app: Callable[..., SphinxTestApp],
+    get_warnings_list: Callable[[SphinxTestApp], list[str]],
+) -> None:
+    host, bundle = mounted_project
+    plantuml = "java -Djava.awt.headless=true -jar {}".format(
+        sphinx_test_tempdir / "utils" / "plantuml.jar"
+    )
+    app = make_app(srcdir=host, freshenv=True, confoverrides={"plantuml": plantuml})
+    app.build()
+
+    incdirs: dict[str, list[str]] = app.collected_incdirs  # type: ignore[attr-defined]
+
+    # Ordinary nested host document -- unchanged, srcdir-relative.
+    assert incdirs["sub/host"] == ["sub"]
+
+    # Mounted document -- the bundle's physical directory, not the logical
+    # docname dir ``mounted``, which does not exist under srcdir at all.
+    # Two entries: one for the needuml, one for the needflow.
+    assert incdirs["mounted/index"] == [str(bundle), str(bundle)]
+
+    # End-to-end proof that PlantUML ran and resolved the bundle-relative
+    # ``!include``. Before the fix this failed with "plantuml command cannot be
+    # run", because the non-existent cwd surfaced as ENOENT from ``subprocess``.
+    assert get_warnings_list(app) == []
+    rendered = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in (Path(app.outdir) / "_images").glob("*.svg")
+    )
+    assert "MountedIncludeWorked" in rendered


### PR DESCRIPTION
Closes #1749

## Problem

`sphinxcontrib-plantuml` starts the PlantUML process with
`cwd = os.path.join(srcdir, node["incdir"])`, so `incdir` decides where relative
`!include` paths are resolved.

Sphinx-Needs derived `incdir` from the **logical docname**:

```python
puml_node["incdir"] = os.path.dirname(current_needuml["docname"])
```

For a document whose source file does not physically live under `srcdir` — e.g.
one contributed by [sphinx-mounts](https://github.com/useblocks/sphinx-mounts),
which registers an absolute external path for its docname — that yields a
directory that does not exist. `subprocess.Popen` fails with `ENOENT`, which
`sphinxcontrib-plantuml` reports as:

```
WARNING: plantuml command '…/plantuml' cannot be run [plantuml]
```

The message is misleading: the PlantUML executable is fine, the `cwd` is not.

## Fix

Derive `incdir` from `env.doc2path(docname, base=False)` instead — the same
thing `sphinxcontrib-plantuml`'s own `uml` directive does — through a new shared
`set_plantuml_paths()` helper in `diagrams_common.py`.

The bug was present at **four** sites, all now routed through the helper:

| directive | file |
| --- | --- |
| `needuml` / `needarch` | `directives/needuml.py` |
| `needflow` (plantuml engine) | `directives/needflow/_plantuml.py` |
| `needsequence` | `directives/needsequence.py` |
| `needgantt` | `directives/needgantt.py` |

### Why `base=False` and not an absolute path

`doc2path(..., base=False)` returns a **srcdir-relative** path for an ordinary
document and the **absolute external** path for a mounted one. Since
`os.path.join` discards its left operand when the right one is absolute, PlantUML
ends up with the correct `cwd` in both cases.

Picking the relative form matters beyond taste:

- Ordinary documents get a **byte-identical** `incdir` to before
  (`dirname("a/b/c")` == `dirname("a/b/c.rst")`), so nothing changes for existing
  projects.
- `incdir` feeds `hash_plantuml_node()`, i.e. PlantUML's content-addressed cache
  key. Always emitting an absolute path would invalidate every cached diagram and
  make the cache non-portable across machines and checkout locations. This way
  only genuinely-mounted documents get an absolute key.

## Test

`tests/test_plantuml_incdir.py` builds a host project plus a sibling bundle
mounted via a ~20-line stand-in for sphinx-mounts (it reproduces the one trick
that matters — an absolute path in `Project._docname_to_path` — so the test
carries no new dependency), and asserts:

- an ordinary nested host document keeps `incdir == "sub"`;
- the mounted document gets the bundle's physical directory, not `"mounted"`;
- PlantUML actually runs and resolves a bundle-relative `!include`, with zero
  build warnings.

Verified failing before the fix (`['mounted', 'mounted'] != [<bundle>, <bundle>]`)
and passing after.

Full suite: 1018 passed. The two `tests/test_sn_collapse_button.py` failures on
this branch reproduce identically on `master` and are unrelated.
