### PR TITLE
🚀 Release v8.3.1

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -16,7 +16,7 @@ on:
     paths: ['docker/**']
 
 env:
-  NEEDS_VERSION: 8.3.0
+  NEEDS_VERSION: 8.3.1
   DEPLOY_IMAGE: ${{ github.event_name != 'pull_request' }}
 
 jobs:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,8 +4,19 @@
 Changelog
 =========
 
-Unreleased
-----------
+.. _`release:8.3.1`:
+
+8.3.1
+-----
+
+:Released: 11.08.2026
+:Full Changelog: `v8.3.0...v8.3.1 <https://github.com/useblocks/sphinx-needs/compare/8.3.0...8.3.1>`__
+
+This is a patch release with a PlantUML bug fix and a documentation
+restructuring.
+
+Bug fixes
+.........
 
 - 🐛 Generated PlantUML diagrams (:ref:`needuml`, :ref:`needarch`,
   :ref:`needflow`, :ref:`needsequence`, :ref:`needgantt`) now derive PlantUML's
@@ -18,6 +29,9 @@ Unreleased
   previously failed with a misleading
   ``WARNING: plantuml command '...' cannot be run``.
   Ordinary documents keep the exact working directory they had before.
+
+Documentation
+.............
 
 - 📚 The documentation now uses the shared
   `sphinx-syntax-example <https://github.com/sphinx-extensions2/sphinx-syntax-example>`__

--- a/sphinx_needs/__init__.py
+++ b/sphinx_needs/__init__.py
@@ -1,6 +1,6 @@
 """Sphinx needs extension for managing needs/requirements and specifications"""
 
-__version__ = "8.3.0"
+__version__ = "8.3.1"
 
 
 def setup(app):  # type: ignore[no-untyped-def]


### PR DESCRIPTION
## Release v8.3.1

Patch release — no new features.

### Changes
- Bump version to `8.3.1` in `sphinx_needs/__init__.py`
- Move changelog entries from "Unreleased" into the `8.3.1` section
  - 🐛 PlantUML: derive working directory from physical source path (#1750)
  - 📚 Docs: shared `syntax-example` directive (#1746)
- Bump `NEEDS_VERSION` to `8.3.1` in the Docker workflow
- Rebased onto current `master`, which includes:
  - 🧪 Fix needuml snapshot for minijinja 2.22 `None` rendering (#1754)
  - 🔧 Stop tracking the generated `docs/_static/tutorial_needs.json` (#1755)

### Release steps after merge
1. Merge this PR
2. Create and push tag `8.3.1` — the [release pipeline](.github/workflows/release.yaml) publishes to PyPI on tag push
