### PR TITLE
🧪 Fix needuml snapshot for minijinja 2.22 `None` rendering

### DIFF
--- a/tests/__snapshots__/test_needuml.ambr
+++ b/tests/__snapshots__/test_needuml.ambr
@@ -862,7 +862,7 @@
         
         class "Test story" as test {
           implement
-          none
+          None
         }
         
         node "<size:12>System</size>\n**Test System**\n<size:10>SYS_001</size>" as SYS_001 [[../index.html#SYS_001]] #FF68D2
@@ -907,7 +907,7 @@
         
         class "Test story" as test {
            implement
-           none
+           None
         }
         
         node "<size:12>System</size>\n**Test System**\n<size:10>SYS_001</size>" as SYS_001 [[../index.html#SYS_001]] #FF68D2
@@ -984,7 +984,7 @@
         
         class "Test story" as test {
            implement
-           none
+           None
         }
         
         Alice -> Bob: Hi Bob
@@ -1053,7 +1053,7 @@
         
         class "Test story" as test {
            implement
-           none
+           None
         }
         
         node "<size:12>System</size>\n**Test System**\n<size:10>SYS_001</size>" as SYS_001 [[../index.html#SYS_001]] #FF68D2


### PR DESCRIPTION
## Fix failing `test_needuml` snapshot

The core test suite fails on `tests/test_needuml.py::test_doc_build_html`:

```
-         none
+         None
```

### Root cause

**Dependency drift, unrelated to any pending PR.** `sphinx_needs/_jinja.py` renders Jinja templates with **minijinja**. minijinja **2.22.0** (released ~Aug 2026) changed how Python `None` is rendered inside `{{ }}` expressions: it now prints `None` (Jinja2-compatible), whereas all earlier 2.x versions printed `none`.

The `doc_test/doc_needuml` project renders `{{needs['ST_001'].status}}` where `ST_001` has no status → the value is `None`. The committed snapshot (`tests/__snapshots__/test_needuml.ambr`) was generated with an older minijinja and contains `none`. CI installs `minijinja~=2.15`, which resolves to the latest 2.x — so any run after the 2.22.0 release fails.

Verified locally:
- minijinja `2.17.1` … `2.21.0`: `render_str("{{ v }}", v=None)` → `'none'`
- minijinja `2.22.0`: `render_str("{{ v }}", v=None)` → `'None'`

### Fix

Update the 4 occurrences in the needuml snapshot (`none` → `None`). The new behavior is the intended one (the whole point of the minijinja adapter is Jinja2 compatibility). `tests/test_needuml.py` passes locally with minijinja 2.22.0 + sphinx 9.1.

### Notes
- The `Docs-Linkcheck` failure on release PRs (compare link 404 until the tag exists) is unrelated and pre-existing — see release PR #1742.