### PR TITLE
🐛 Fix PyPI release workflow (flit/flit_core version mismatch)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,7 +2,7 @@ name: Release
 on:
   push:
     tags:
-      - '[0-9].[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   publish:
@@ -19,9 +19,13 @@ jobs:
         with:
           python-version: "3.10"
       - name: install flit
-        run: pip install flit
+        # both distributions are pinned together: flit declares an unbounded
+        # flit_core lower bound, so pinning only flit lets the two drift apart
+        run: pip install flit==3.12.0 flit_core==3.12.0
       - name: Build and publish
-        run: flit publish
+        # --use-vcs is the flit 3 default, but flit 4 flipped it: state it
+        # explicitly so tests/ and docs/ stay in the sdist across upgrades
+        run: flit publish --use-vcs
         env:
           FLIT_USERNAME: __token__
           FLIT_PASSWORD: ${{ secrets.PYPI }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
         with:
           python-version: "3.10"
       - name: install flit
-        run: pip install flit~=3.4
+        run: pip install flit
       - name: Build and publish
         run: flit publish
         env:


### PR DESCRIPTION
## Summary

Fixes the failed PyPI release (run [31507560145](https://github.com/useblocks/sphinx-needs/actions/runs/31507560145)) that crashed with:

```
TypeError: SdistBuilder.build() got an unexpected keyword argument 'gen_setup_py'
```

## Root cause

The workflow pinned `flit~=3.4`, which resolved to `flit 3.12.0`. That version declares `flit_core>=3.12.0` with no upper bound, so pip installed the newly released `flit_core 4.0.2`, which removed the deprecated `gen_setup_py` argument from `SdistBuilder.build()`. The `flit 3.12.0` CLI still passes it, crashing during the sdist build step of `flit publish`.

Pinning is not what broke this — half-pinning is. `flit` and `flit_core` are one unit, and bounding only one of them lets the halves move apart.

## Change

- **Pin both distributions**: `pip install flit==3.12.0 flit_core==3.12.0`. That is the pair which built 8.3.0, so the release is unblocked without changing the build backend under the hood.
- **`flit publish --use-vcs`**: the default on flit 3, but flit 4 flipped it to `--no-use-vcs`. Stating it explicitly keeps `tests/` and `docs/` in the sdist across a later flit 4 upgrade.
- **Tag filter** widened to `[0-9]+.[0-9]+.[0-9]+` so major versions >= 10 still match.

Installing an unpinned `flit` was the first attempt and was dropped ([rationale](https://github.com/useblocks/sphinx-needs/pull/1756#issuecomment-5257714965)): flit 4.0.2 declares an equally unbounded `flit_core>=4.0.2`, so the same skew can recur, and moving to flit 4 silently changes the published artifacts — the sdist loses `tests/` and `docs/` (1326 → 703 files, 27.7 MB → 2.5 MB), and the wheel jumps to `Metadata-Version: 2.5` with `AUTHORS` reclassified as a license file.

## Verification

- Reproduced the crash locally with `flit 3.12.0` + `flit_core 4.0.2` in a fresh venv.
- Built this branch in a clean clone with the pinned pair and diffed against the published 8.3.0 artifacts: sdist 1326 entries (the only deltas are real repo changes since 8.3.0), wheel `Metadata-Version: 2.4`, `License-File: LICENSE` only — shape parity with the last good release.
- `twine check` passes on both artifacts.

## Releasing 8.3.1

Merging this does not publish 8.3.1 on its own: `refs/tags/8.3.1` points at the pre-fix commit, and re-running the failed job replays `release.yaml` as of that commit. Nothing was ever published under 8.3.1 (PyPI is still at 8.3.0), so after merge the 8.3.1 release and tag are deleted, the merged commit is re-tagged, and pushing that tag runs the fixed workflow.
