### PR TITLE
🔧 ubproject.toml: furo source triple for ubc build html view/edit buttons

### DIFF
--- a/docs/ubproject.toml
+++ b/docs/ubproject.toml
@@ -20,6 +20,12 @@ hide_title = true
 favicon = "_static/sphinx-needs-logo-square-dark.svg"
 # conf.py computes `2017-{now.year}`; TOML is static, so the year is written out.
 copyright = "2017-2026, team useblocks"
+# The furo triple from conf.py's `html_theme_options` (source_repository /
+# source_branch / source_directory), so the built site's view/edit buttons
+# point at the same files the Sphinx build's do.
+source_repository = "https://github.com/useblocks/sphinx-needs"
+source_branch = "master"
+source_directory = "docs/"
 
 [parse]
 # Enable the built-in extension ports used by these docs:


### PR DESCRIPTION
`ubc build html` now renders furo-parity "view this page" / "edit this page" buttons in the content-icon row, driven by the same three values `conf.py` already passes to furo (`html_theme_options`: `source_repository` / `source_branch` / `source_directory`). This adds the triple to `docs/ubproject.toml` so the ubc-built docs link to the same source files the Sphinx/furo build's buttons do.

The values mirror `conf.py` exactly, and the resulting URLs were verified byte-identical against the live furo build of these docs (e.g. `filter.rst` → `blob/master/docs/filter.rst?plain=true` / `edit/master/docs/filter.rst`) during development of the feature (useblocks/ubcode#2916, useblocks/ubcode#2919).

Two sequencing notes:

- Released `ubc` versions that predate the keys simply ignore them — nothing breaks.
- Schema-aware editors may flag the three lines as unknown properties until the next ubCode release publishes the updated config schema; opening as draft so it can be merged whenever that lands (or earlier, if the editor hint is acceptable).