### PR TITLE
✨ needs_card_layouts: the element object form (height, width, label)

### DIFF
--- a/docs/card_layouts.rst
+++ b/docs/card_layouts.rst
@@ -199,6 +199,75 @@ the payload is never itself a literal path or URL.
 
 An element with no value renders nothing, exactly as it does for :ref:`needs_layouts`.
 
+.. _card_layouts_object_form:
+
+The object form
+~~~~~~~~~~~~~~~
+
+Every element string is shorthand for an *object* — a dictionary with a ``type`` key:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
+
+   * - String
+     - Object
+   * - ``"id"``
+     - ``{"type": "id"}``
+   * - ``"field:owner"``
+     - ``{"type": "field", "field": "owner"}``
+   * - ``"image:diagram"``
+     - ``{"type": "image", "field": "diagram"}``
+
+Both spellings are valid wherever elements are accepted, and mix freely in one list.
+An object without options compiles to **exactly** the same layout as its string shorthand —
+the strings stay valid forever and remain the documented default.
+The object form exists to carry options:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 12 12 76
+
+   * - Option
+     - On type
+     - Value
+   * - ``height``
+     - ``image``
+     - The rendered height:
+       a number with an optional ``px``, ``em``, ``rem``, ``%`` or ``pt`` unit,
+       at most 16 characters. A bare number means pixels.
+   * - ``width``
+     - ``image``
+     - The rendered width, with the same value grammar as ``height``.
+   * - ``label``
+     - ``field``
+     - Replaces the field name in the rendered ``name: value`` pair:
+       1–64 characters of letters, digits, spaces and ``_().,/-``,
+       starting and ending alphanumeric.
+
+.. code-block:: python
+
+   needs_card_layouts = {
+       "illustrated": {
+           "footer": [
+               "id",
+               {"type": "field", "field": "owner", "label": "Owned by"},
+           ],
+           "side": {
+               "elements": [{"type": "image", "field": "picture", "height": "40px"}]
+           },
+       }
+   }
+
+``field`` is required for the ``field`` and ``image`` types and forbidden for all others.
+Its value follows the same field-name grammar as the string shorthand,
+and the payload invariant above holds unchanged:
+the value of ``field`` is a **field name**, never a literal path or URL.
+No other type takes any option;
+an option on the wrong type, an unknown key, a missing or extra ``field``,
+or a value outside its grammar makes the specification invalid —
+the card is reported and skipped, exactly like any other invalid specification.
+
 .. _card_layouts_builtins:
 
 Built-in specifications

--- a/docs/card_layouts.rst
+++ b/docs/card_layouts.rst
@@ -243,7 +243,9 @@ The object form exists to carry options:
      - ``field``
      - Replaces the field name in the rendered ``name: value`` pair:
        1–64 characters of letters, digits, spaces and ``_().,/-``,
-       starting and ending alphanumeric.
+       starting and ending alphanumeric,
+       with an underscore only directly between letters or digits
+       (``user_name`` is valid, ``Owned_ by`` and ``a__b`` are not).
 
 .. code-block:: python
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -41,6 +41,7 @@ Improvements
   and its documented limits.
 
 - ✨ :ref:`needs_card_layouts` elements gain an object form
+  (:pr:`1766`)
 
   Every element string is now shorthand for an object with a ``type`` key —
   ``"image:diagram"`` is spelled ``{"type": "image", "field": "diagram"}`` — and the two

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -40,6 +40,35 @@ Improvements
   leaving the rest of the build untouched. See :ref:`card_layouts` for the full vocabulary
   and its documented limits.
 
+- ✨ :ref:`needs_card_layouts` elements gain an object form
+
+  Every element string is now shorthand for an object with a ``type`` key —
+  ``"image:diagram"`` is spelled ``{"type": "image", "field": "diagram"}`` — and the two
+  spellings mix freely in one list. An object without options compiles to exactly the same
+  layout as its string shorthand; the strings stay valid and remain the documented default.
+  The object form exists to carry options: ``height`` and ``width`` on ``image`` elements,
+  and ``label`` on ``field`` elements, replacing the field name in the rendered
+  ``name: value`` pair:
+
+  .. code-block:: python
+
+     needs_card_layouts = {
+         "illustrated": {
+             "footer": [
+                 "id",
+                 {"type": "field", "field": "owner", "label": "Owned by"},
+             ],
+             "side": {
+                 "elements": [{"type": "image", "field": "picture", "height": "40px"}]
+             },
+         }
+     }
+
+  Option values are grammar-bound; an option on the wrong type, an unknown key, or a value
+  outside its grammar is reported as a ``needs.card_layout`` warning and the card is
+  skipped, like any other invalid specification. See
+  :ref:`the object form <card_layouts_object_form>` for the option table and grammars.
+
 - ✨ The ``cypher``, ``width`` and ``height`` directive options are now
   accepted for `ubCode`_ compatibility (:pr:`1760`)
 

--- a/sphinx_needs/card_layouts.py
+++ b/sphinx_needs/card_layouts.py
@@ -125,23 +125,31 @@ _ELEMENT_OPTION_KEYS: Final[dict[str, frozenset[str]]] = {
 }
 """The option keys each element type accepts, beyond ``type`` and ``field``."""
 
-_NAME_PATTERN: Final = re.compile(r"^[A-Za-z_][A-Za-z0-9_-]*$")
+# Every grammar below is enforced with ``fullmatch``: a ``$`` anchor also matches
+# just before a trailing newline, which would let e.g. ``"40px\n"`` through to the
+# emitted layout string and abort the build when the layout call is parsed.
+
+_NAME_PATTERN: Final = re.compile(r"[A-Za-z_][A-Za-z0-9_-]*")
 """Allow-list for a card name and for any field name interpolated into a layout string."""
 
-_DIMENSION_PATTERN: Final = re.compile(r"^[0-9]+(\.[0-9]+)?(px|em|rem|%|pt)?$")
+_DIMENSION_PATTERN: Final = re.compile(r"[0-9]+(\.[0-9]+)?(px|em|rem|%|pt)?")
 """Allow-list for the ``height`` and ``width`` options; a bare number means pixels."""
 
 _DIMENSION_MAX_LENGTH: Final = 16
 """Upper bound on the length of a ``height`` or ``width`` value."""
 
 _LABEL_PATTERN: Final = re.compile(
-    r"^[A-Za-z0-9](?:[A-Za-z0-9 _().,/-]{0,62}[A-Za-z0-9])?$"
+    r"[A-Za-z0-9](?:[A-Za-z0-9 _().,/-]{0,62}[A-Za-z0-9])?"
 )
-"""Allow-list for the ``label`` option: 1-64 characters, alphanumeric at both ends.
+"""Allow-list for the ``label`` option: 1-64 characters, alphanumeric at both ends."""
 
-Deliberately excludes every RST-active character,
-so a label interpolated into a ``prefix=`` argument can never change
-the meaning of the emitted layout string.
+_LABEL_LOOSE_UNDERSCORE: Final = re.compile(r"(?<![A-Za-z0-9])_|_(?![A-Za-z0-9])")
+"""An underscore not sitting directly between two alphanumerics; forbidden in a label.
+
+A word-leading or word-trailing underscore is RST reference syntax
+(``name_``, ``__``), which would crash the HTML writer
+when the label is RST-parsed as a ``prefix`` argument.
+Every other RST-active character is excluded by the label charset itself.
 """
 
 # --- the closed template set ------------------------------------------------
@@ -348,7 +356,7 @@ def _parse_meta(
             warn(f"'meta.{key}' must be a list of strings, got {raw!r}, skipping.")
             return None
         for item in raw:
-            if not _NAME_PATTERN.match(item):
+            if not _NAME_PATTERN.fullmatch(item):
                 warn(f"invalid field name {item!r} in 'meta.{key}', skipping.")
                 return None
         names[key] = tuple(raw)
@@ -438,7 +446,7 @@ def _parse_element_str(
             "'image:<name>'), skipping."
         )
         return None
-    if not _NAME_PATTERN.match(field_name):
+    if not _NAME_PATTERN.fullmatch(field_name):
         warn(
             f"invalid field name {field_name!r} in {region} element "
             f"{element!r}, skipping."
@@ -457,6 +465,10 @@ def _parse_element_dict(
     :param warn: Called with a message for every problem found.
     :return: The normalised element, or ``None`` if it was invalid.
     """
+    # guard before any key set arithmetic: mixed-type keys make ``sorted`` raise
+    if any(not isinstance(key, str) for key in element):
+        warn(f"{region} element keys must be strings, got {element!r}, skipping.")
+        return None
     element_type = element.get("type")
     if element_type not in _ELEMENT_TYPES:
         warn(
@@ -484,7 +496,7 @@ def _parse_element_dict(
                 f"'field' is required in a {element_type!r} {region} element, skipping."
             )
             return None
-        if not isinstance(raw_field, str) or not _NAME_PATTERN.match(raw_field):
+        if not isinstance(raw_field, str) or not _NAME_PATTERN.fullmatch(raw_field):
             warn(f"invalid field name {raw_field!r} in {region} element, skipping.")
             return None
         field_name = raw_field
@@ -495,7 +507,7 @@ def _parse_element_dict(
         if (
             not isinstance(raw, str)
             or len(raw) > _DIMENSION_MAX_LENGTH
-            or not _DIMENSION_PATTERN.match(raw)
+            or not _DIMENSION_PATTERN.fullmatch(raw)
         ):
             warn(
                 f"'{key}' must be a number with an optional px/em/rem/%/pt unit, "
@@ -506,12 +518,14 @@ def _parse_element_dict(
         dimensions[key] = raw
     label = element.get("label")
     if label is not None and (
-        not isinstance(label, str) or not _LABEL_PATTERN.match(label)
+        not isinstance(label, str)
+        or not _LABEL_PATTERN.fullmatch(label)
+        or _LABEL_LOOSE_UNDERSCORE.search(label)
     ):
         warn(
             "'label' must be 1-64 characters from [A-Za-z0-9 _().,/-], "
-            f"starting and ending alphanumeric, got {label!r} in {region} "
-            "element, skipping."
+            "starting and ending alphanumeric, with '_' only directly between "
+            f"alphanumerics, got {label!r} in {region} element, skipping."
         )
         return None
     return ElementSpec(
@@ -894,7 +908,7 @@ def compile_card_layouts(_app: Sphinx, config: Config) -> None:
                 LOGGER, f"needs_card_layouts[{name!r}]: {message}", "card_layout", None
             )
 
-        if not isinstance(name, str) or not _NAME_PATTERN.match(name):
+        if not isinstance(name, str) or not _NAME_PATTERN.fullmatch(name):
             warn(
                 "name must match [A-Za-z_][A-Za-z0-9_-]* to be usable as a layout "
                 "name, skipping."

--- a/sphinx_needs/card_layouts.py
+++ b/sphinx_needs/card_layouts.py
@@ -9,8 +9,9 @@ so that everything downstream of the layout registry
 honours them without any change to the renderer.
 
 The compiler only ever emits from the closed set of templates defined in this module.
-User supplied text never reaches a layout string,
-except for field names which are validated against a strict identifier allow-list first.
+The only user text that ever reaches a layout string is a field name
+or a grammar-bound option value,
+each validated against its strict allow-list first.
 """
 
 from __future__ import annotations
@@ -26,7 +27,7 @@ from sphinx_needs.defaults import LAYOUTS
 from sphinx_needs.logging import get_logger, log_warning
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Container, Iterable, Mapping, Sequence
+    from collections.abc import Callable, Container, Iterable, Mapping
 
     from sphinx.application import Sphinx
     from sphinx.config import Config
@@ -113,9 +114,35 @@ _SIDE_SPANS: Final[tuple[SideSpan, ...]] = ("full", "partial")
 _SIMPLE_ELEMENTS: Final = frozenset(
     {"id", "title", "type", "layout_echo", "style_echo"}
 )
+"""The element types that take neither a field nor any option."""
+
+_ELEMENT_TYPES: Final = _SIMPLE_ELEMENTS | {"field", "image"}
+"""Every value the ``type`` key of an object-form element may take."""
+
+_ELEMENT_OPTION_KEYS: Final[dict[str, frozenset[str]]] = {
+    "field": frozenset({"label"}),
+    "image": frozenset({"height", "width"}),
+}
+"""The option keys each element type accepts, beyond ``type`` and ``field``."""
 
 _NAME_PATTERN: Final = re.compile(r"^[A-Za-z_][A-Za-z0-9_-]*$")
 """Allow-list for a card name and for any field name interpolated into a layout string."""
+
+_DIMENSION_PATTERN: Final = re.compile(r"^[0-9]+(\.[0-9]+)?(px|em|rem|%|pt)?$")
+"""Allow-list for the ``height`` and ``width`` options; a bare number means pixels."""
+
+_DIMENSION_MAX_LENGTH: Final = 16
+"""Upper bound on the length of a ``height`` or ``width`` value."""
+
+_LABEL_PATTERN: Final = re.compile(
+    r"^[A-Za-z0-9](?:[A-Za-z0-9 _().,/-]{0,62}[A-Za-z0-9])?$"
+)
+"""Allow-list for the ``label`` option: 1-64 characters, alphanumeric at both ends.
+
+Deliberately excludes every RST-active character,
+so a label interpolated into a ``prefix=`` argument can never change
+the meaning of the emitted layout string.
+"""
 
 # --- the closed template set ------------------------------------------------
 # Nothing else is ever emitted. No template contains ``{{``, which the layout
@@ -135,7 +162,9 @@ _ELEMENT_TEMPLATES: Final[dict[str, str]] = {
 }
 _FIELD_TEMPLATE: Final = '<<meta("{name}")>>'
 _FIELD_EMPTIES_TEMPLATE: Final = '<<meta("{name}", show_empty=True)>>'
-_IMAGE_TEMPLATE: Final = '<<image("field:{name}", align="center")>>'
+_FIELD_LABEL_TEMPLATE: Final = '<<meta("{name}", prefix="{label}: ")>>'
+_IMAGE_TEMPLATE: Final = '<<image("field:{name}", {options}align="center")>>'
+_IMAGE_OPTION_TEMPLATE: Final = '{key}="{value}", '
 _META_ALL_TEMPLATE: Final = "<<meta_all({args})>>"
 _META_LINKS_ALL: Final = "<<meta_links_all()>>"
 
@@ -173,10 +202,26 @@ class MetaSpec:
 
 
 @dataclass(frozen=True)
+class ElementSpec:
+    """A validated footer or side element.
+
+    The string shorthand ``field:owner`` and the object form
+    ``{"type": "field", "field": "owner"}`` both normalise to this,
+    so the equivalence of the two spellings holds by construction.
+    """
+
+    type: str
+    field: str | None = None
+    height: str | None = None
+    width: str | None = None
+    label: str | None = None
+
+
+@dataclass(frozen=True)
 class SideSpec:
     """The validated ``side`` region of a card specification."""
 
-    elements: tuple[str, ...] = ()
+    elements: tuple[ElementSpec, ...] = ()
     position: SidePosition = "left"
     span: SideSpan = "full"
 
@@ -187,7 +232,7 @@ class CardSpec:
 
     header: bool = True
     meta: MetaSpec | None = MetaSpec()
-    footer: tuple[str, ...] = ()
+    footer: tuple[ElementSpec, ...] = ()
     side: SideSpec | None = None
     collapse: CollapseMode = "honour"
 
@@ -346,10 +391,14 @@ def _parse_side(
         )
         return None
     elements = value.get("elements", [])
-    if not isinstance(elements, (list, tuple)) or not all(
-        isinstance(item, str) for item in elements
-    ):
-        warn(f"'side.elements' must be a list of strings, got {elements!r}, skipping.")
+    if not isinstance(elements, (list, tuple)):
+        warn(
+            f"'side.elements' must be a list of strings or dicts, "
+            f"got {elements!r}, skipping."
+        )
+        return None
+    parsed_elements = _parse_elements(elements, "side", warn)
+    if parsed_elements is None:
         return None
     position = value.get("position", "left")
     if position not in _SIDE_POSITIONS:
@@ -366,53 +415,164 @@ def _parse_side(
             f"got {span!r}, skipping."
         )
         return None
-    return SideSpec(elements=tuple(elements), position=position, span=span)
+    return SideSpec(elements=parsed_elements, position=position, span=span)
 
 
-def _check_elements(
-    elements: Sequence[str],
-    region: str,
-    *,
-    validate_fields: bool,
-    known_fields: Container[str],
-    warn: Callable[[str], None],
-) -> bool:
-    """Validate the elements of a footer or side region.
+def _parse_element_str(
+    element: str, region: str, warn: Callable[[str], None]
+) -> ElementSpec | None:
+    """Validate a string-form element.
 
-    :param elements: The raw element strings.
+    :param element: The raw element string.
     :param region: Name of the region, used in messages.
-    :param validate_fields: Whether referenced need fields must be registered.
-        Elements inherited from a built-in specification are exempt.
-    :param known_fields: The registered need field names.
     :param warn: Called with a message for every problem found.
-    :return: True if every element is valid.
+    :return: The normalised element, or ``None`` if it was invalid.
     """
+    if element in _SIMPLE_ELEMENTS:
+        return ElementSpec(type=element)
+    prefix, _, field_name = element.partition(":")
+    if prefix not in ("field", "image") or not field_name:
+        warn(
+            f"unknown {region} element {element!r} (allowed: "
+            f"{', '.join(sorted(_SIMPLE_ELEMENTS))}, 'field:<name>', "
+            "'image:<name>'), skipping."
+        )
+        return None
+    if not _NAME_PATTERN.match(field_name):
+        warn(
+            f"invalid field name {field_name!r} in {region} element "
+            f"{element!r}, skipping."
+        )
+        return None
+    return ElementSpec(type=prefix, field=field_name)
+
+
+def _parse_element_dict(
+    element: Mapping[str, Any], region: str, warn: Callable[[str], None]
+) -> ElementSpec | None:
+    """Validate an object-form element.
+
+    :param element: The raw element dict.
+    :param region: Name of the region, used in messages.
+    :param warn: Called with a message for every problem found.
+    :return: The normalised element, or ``None`` if it was invalid.
+    """
+    element_type = element.get("type")
+    if element_type not in _ELEMENT_TYPES:
+        warn(
+            f"{region} element 'type' must be one of "
+            f"{', '.join(repr(t) for t in sorted(_ELEMENT_TYPES))}, "
+            f"got {element_type!r}, skipping."
+        )
+        return None
+    takes_field = element_type in ("field", "image")
+    allowed = ({"type", "field"} if takes_field else {"type"}) | (
+        _ELEMENT_OPTION_KEYS.get(element_type, frozenset())
+    )
+    if unknown := sorted(set(element) - allowed):
+        warn(
+            f"key(s) {', '.join(repr(k) for k in unknown)} not allowed in a "
+            f"{element_type!r} {region} element "
+            f"(allowed: {', '.join(sorted(allowed))}), skipping."
+        )
+        return None
+    field_name: str | None = None
+    if takes_field:
+        raw_field = element.get("field")
+        if raw_field is None:
+            warn(
+                f"'field' is required in a {element_type!r} {region} element, skipping."
+            )
+            return None
+        if not isinstance(raw_field, str) or not _NAME_PATTERN.match(raw_field):
+            warn(f"invalid field name {raw_field!r} in {region} element, skipping.")
+            return None
+        field_name = raw_field
+    dimensions: dict[str, str | None] = {"height": None, "width": None}
+    for key in dimensions:
+        if (raw := element.get(key)) is None:
+            continue
+        if (
+            not isinstance(raw, str)
+            or len(raw) > _DIMENSION_MAX_LENGTH
+            or not _DIMENSION_PATTERN.match(raw)
+        ):
+            warn(
+                f"'{key}' must be a number with an optional px/em/rem/%/pt unit, "
+                f"at most {_DIMENSION_MAX_LENGTH} characters, "
+                f"got {raw!r} in {region} element, skipping."
+            )
+            return None
+        dimensions[key] = raw
+    label = element.get("label")
+    if label is not None and (
+        not isinstance(label, str) or not _LABEL_PATTERN.match(label)
+    ):
+        warn(
+            "'label' must be 1-64 characters from [A-Za-z0-9 _().,/-], "
+            f"starting and ending alphanumeric, got {label!r} in {region} "
+            "element, skipping."
+        )
+        return None
+    return ElementSpec(
+        type=element_type,
+        field=field_name,
+        height=dimensions["height"],
+        width=dimensions["width"],
+        label=label,
+    )
+
+
+def _parse_elements(
+    elements: Iterable[Any], region: str, warn: Callable[[str], None]
+) -> tuple[ElementSpec, ...] | None:
+    """Validate and normalise the elements of a footer or side region.
+
+    :param elements: The raw element entries, strings or dicts.
+    :param region: Name of the region, used in messages.
+    :param warn: Called with a message for every problem found.
+    :return: The normalised elements, or ``None`` if any entry was invalid.
+    """
+    parsed: list[ElementSpec] = []
     valid = True
     for element in elements:
-        if element in _SIMPLE_ELEMENTS:
-            continue
-        prefix, _, field_name = element.partition(":")
-        if prefix not in ("field", "image") or not field_name:
+        item: ElementSpec | None
+        if isinstance(element, str):
+            item = _parse_element_str(element, region, warn)
+        elif isinstance(element, dict):
+            item = _parse_element_dict(element, region, warn)
+        else:
             warn(
-                f"unknown {region} element {element!r} (allowed: "
-                f"{', '.join(sorted(_SIMPLE_ELEMENTS))}, 'field:<name>', "
-                "'image:<name>'), skipping."
+                f"{region} element must be a string or a dict, "
+                f"got {element!r}, skipping."
             )
+            item = None
+        if item is None:
             valid = False
-            continue
-        if not _NAME_PATTERN.match(field_name):
+        else:
+            parsed.append(item)
+    return tuple(parsed) if valid else None
+
+
+def _warn_unregistered_fields(
+    elements: Iterable[ElementSpec],
+    region: str,
+    known_fields: Container[str],
+    warn: Callable[[str], None],
+) -> None:
+    """Warn about elements referencing a field nobody registered.
+
+    :param elements: The normalised elements of the region.
+    :param region: Name of the region, used in messages.
+    :param known_fields: The registered need field names.
+    :param warn: Called with a message for every problem found.
+    """
+    for element in elements:
+        if element.field is not None and element.field not in known_fields:
             warn(
-                f"invalid field name {field_name!r} in {region} element "
-                f"{element!r}, skipping."
+                f"{region} element references the need field "
+                f"{element.field!r}, which is not registered; it will render empty."
             )
-            valid = False
-            continue
-        if validate_fields and field_name not in known_fields:
-            warn(
-                f"{region} element {element!r} references the need field "
-                f"{field_name!r}, which is not registered; it will render empty."
-            )
-    return valid
 
 
 def _parse_spec(
@@ -462,11 +622,15 @@ def _parse_spec(
     if meta is None:
         return None
 
-    footer = merged.get("footer", [])
-    if not isinstance(footer, (list, tuple)) or not all(
-        isinstance(item, str) for item in footer
-    ):
-        warn(f"'footer' must be a list of strings, got {footer!r}, skipping.")
+    raw_footer = merged.get("footer", [])
+    if not isinstance(raw_footer, (list, tuple)):
+        warn(
+            f"'footer' must be a list of strings or dicts, got {raw_footer!r}, "
+            "skipping."
+        )
+        return None
+    footer = _parse_elements(raw_footer, "footer", warn)
+    if footer is None:
         return None
 
     side: SideSpec | None = None
@@ -483,23 +647,9 @@ def _parse_spec(
     # their `side` region (upstream's `image` field, which nobody has to register). A footer
     # element is therefore always user-authored and always validated. Overriding an
     # inherited region re-keys its origin to the card, which restores validation there too.
-    valid = _check_elements(
-        footer,
-        "footer",
-        validate_fields=True,
-        known_fields=known_fields,
-        warn=warn,
-    )
-    if side is not None:
-        valid &= _check_elements(
-            side.elements,
-            "side",
-            validate_fields=origins.get("side.elements") not in BUILTIN_CARD_SPECS,
-            known_fields=known_fields,
-            warn=warn,
-        )
-    if not valid:
-        return None
+    _warn_unregistered_fields(footer, "footer", known_fields, warn)
+    if side is not None and origins.get("side.elements") not in BUILTIN_CARD_SPECS:
+        _warn_unregistered_fields(side.elements, "side", known_fields, warn)
 
     title_regions = [
         region
@@ -507,7 +657,7 @@ def _parse_spec(
             ("footer", footer),
             ("side", () if side is None else side.elements),
         )
-        if "title" in elements
+        if any(element.type == "title" for element in elements)
     ]
     if title_regions and header:
         warn(
@@ -522,7 +672,7 @@ def _parse_spec(
     return CardSpec(
         header=header,
         meta=None if meta is False else meta,
-        footer=tuple(footer),
+        footer=footer,
         side=None if side is not None and not side.elements else side,
         collapse=collapse,
     )
@@ -606,23 +756,31 @@ def _build_meta_lines(meta: MetaSpec) -> list[str]:
     return lines
 
 
-def _build_element_lines(elements: Iterable[str]) -> list[str]:
+def _build_element_lines(elements: Iterable[ElementSpec]) -> list[str]:
     """Render footer or side elements.
 
-    :param elements: The validated element strings.
+    :param elements: The validated elements.
     :return: One layout line per element.
     """
     lines: list[str] = []
     for element in elements:
-        if (template := _ELEMENT_TEMPLATES.get(element)) is not None:
+        if (template := _ELEMENT_TEMPLATES.get(element.type)) is not None:
             lines.append(template)
-            continue
-        prefix, _, name = element.partition(":")
-        lines.append(
-            (_IMAGE_TEMPLATE if prefix == "image" else _FIELD_TEMPLATE).format(
-                name=name
+        elif element.type == "field":
+            lines.append(
+                _FIELD_LABEL_TEMPLATE.format(name=element.field, label=element.label)
+                if element.label is not None
+                else _FIELD_TEMPLATE.format(name=element.field)
             )
-        )
+        else:
+            # an optionless image renders the empty options string, so the object
+            # form stays byte-identical to the ``image:<name>`` shorthand
+            options = "".join(
+                _IMAGE_OPTION_TEMPLATE.format(key=key, value=value)
+                for key, value in (("height", element.height), ("width", element.width))
+                if value is not None
+            )
+            lines.append(_IMAGE_TEMPLATE.format(name=element.field, options=options))
     return lines
 
 

--- a/tests/test_card_layouts.py
+++ b/tests/test_card_layouts.py
@@ -802,7 +802,8 @@ def test_spellings_mix_freely_in_one_list() -> None:
     [
         pytest.param("x", id="single-char"),
         pytest.param("Owned by", id="space"),
-        pytest.param("A 0_().,/-9", id="all-allowed-chars"),
+        pytest.param("user_name", id="intra-word-underscore"),
+        pytest.param("Aa_0 ().,/-9", id="all-allowed-chars"),
         pytest.param("a" * 64, id="max-length"),
     ],
 )
@@ -1060,6 +1061,65 @@ def test_dimension_grammar_accepts_its_edges(value: str) -> None:
             {"footer": [{"type": "field", "field": "status", "label": 3}]},
             "'label' must be 1-64 characters",
             id="object-non-string-label",
+        ),
+        # a trailing newline slips past a ``$``-anchored ``match`` and would abort
+        # the build once the emitted layout call is parsed; ``fullmatch`` stops it
+        pytest.param(
+            {"footer": [{"type": "field", "field": "status", "label": "Owned by\n"}]},
+            "'label' must be 1-64 characters",
+            id="object-label-trailing-newline",
+        ),
+        pytest.param(
+            {"footer": [{"type": "image", "field": "badge", "height": "40px\n"}]},
+            "'height' must be a number",
+            id="object-height-trailing-newline",
+        ),
+        pytest.param(
+            {"footer": [{"type": "field", "field": "owner\n"}]},
+            "invalid field name 'owner\\n'",
+            id="object-field-trailing-newline",
+        ),
+        pytest.param(
+            {"footer": ["field:owner\n"]},
+            "invalid field name 'owner\\n'",
+            id="string-field-trailing-newline",
+        ),
+        # a word-leading/-trailing underscore is RST reference syntax (``name_``,
+        # ``__``) and would crash the HTML writer via the RST-parsed ``prefix``
+        pytest.param(
+            {"footer": [{"type": "field", "field": "status", "label": "Owned_ by"}]},
+            "'label' must be 1-64 characters",
+            id="object-label-trailing-underscore",
+        ),
+        pytest.param(
+            {"footer": [{"type": "field", "field": "status", "label": "a__b"}]},
+            "'label' must be 1-64 characters",
+            id="object-label-double-underscore",
+        ),
+        pytest.param(
+            {"footer": [{"type": "field", "field": "status", "label": "anon__ ref"}]},
+            "'label' must be 1-64 characters",
+            id="object-label-anonymous-reference",
+        ),
+        pytest.param(
+            {"footer": [{"type": "field", "field": "status", "label": "Ünicode"}]},
+            "'label' must be 1-64 characters",
+            id="object-label-non-ascii",
+        ),
+        pytest.param(
+            # full-width digits U+FF14 U+FF10: ASCII-only [0-9] must reject them
+            {
+                "footer": [
+                    {"type": "image", "field": "badge", "height": "\uff14\uff10px"}
+                ]
+            },
+            "'height' must be a number",
+            id="object-height-non-ascii-digits",
+        ),
+        pytest.param(
+            {"footer": [{1: "x", "type": "id"}]},
+            "footer element keys must be strings",
+            id="object-non-string-dict-key",
         ),
         pytest.param(
             {"footer": [3]},
@@ -1509,6 +1569,13 @@ Object form
                                         "field": "owner",
                                         "label": "Owned by",
                                     },
+                                    # an intra-word underscore is grammar-legal and
+                                    # must survive the RST parse of the prefix
+                                    {
+                                        "type": "field",
+                                        "field": "owner",
+                                        "label": "user_name",
+                                    },
                                     {"type": "id"},
                                 ]
                             },
@@ -1542,6 +1609,7 @@ def test_object_form_options_render(test_app: Any) -> None:
     labelled = need_table(html, "OBJ_LABEL")
     footer = labelled.split('<td class="need footer"')[1]
     assert "Owned by:" in footer
+    assert "user_name:" in footer
     assert 'class="needs_owner"' in footer
     assert footer.index('class="needs_owner"') < footer.index('class="needs-id"')
 

--- a/tests/test_card_layouts.py
+++ b/tests/test_card_layouts.py
@@ -32,6 +32,7 @@ KNOWN_FIELDS = frozenset(
         "badge",
         "image",
         "layout",
+        "owner",
         "picture",
         "status",
         "style",
@@ -48,7 +49,7 @@ ALLOWED_FUNCTIONS = frozenset(
     {"collapse_button", "image", "meta", "meta_all", "meta_id", "meta_links_all"}
 )
 
-#: The three specifications shared verbatim with the ubCode implementation of the
+#: The four specifications shared verbatim with the ubCode implementation of the
 #: same vocabulary. They are the conformance oracle for both: identical input,
 #: comparable output.
 CONFORMANCE_SPECS: dict[str, dict[str, Any]] = {
@@ -85,12 +86,27 @@ CONFORMANCE_SPECS: dict[str, dict[str, Any]] = {
         "meta": False,
         "footer": ["title", "id"],
     },
+    # the object-form twin: headerless, so side and footer can coexist on a grid
+    "conformance_object": {
+        "header": False,
+        "meta": False,
+        "side": {
+            "elements": [{"type": "image", "field": "image", "height": "40px"}],
+            "position": "left",
+            "span": "full",
+        },
+        "footer": [
+            {"type": "field", "field": "owner", "label": "Owned by"},
+            {"type": "id"},
+        ],
+    },
 }
 
 CONFORMANCE_GRIDS = {
     "conformance_full": "simple_footer",
     "conformance_side": "simple_side_right_partial",
     "conformance_headerless": "content_footer",
+    "conformance_object": "content_footer_side_left",
 }
 
 #: Every valid specification exercised anywhere in this file, so that the
@@ -154,6 +170,35 @@ VALID_SPECS: dict[str, dict[str, Any]] = {
         "meta": {"fields": "all"},
         "collapse": "closed",
     },
+    "object_footer_optionless": {
+        "footer": [
+            {"type": "id"},
+            {"type": "field", "field": "verified_by"},
+            {"type": "image", "field": "badge"},
+        ]
+    },
+    "object_footer_label": {
+        "footer": [{"type": "field", "field": "verified_by", "label": "Verified by"}]
+    },
+    "object_image_options": {
+        "footer": [
+            {"type": "image", "field": "badge", "height": "40px", "width": "3.5em"}
+        ]
+    },
+    "object_side_height": {
+        "side": {
+            "elements": [{"type": "image", "field": "picture", "height": "40"}],
+            "position": "right",
+        }
+    },
+    "object_title_headerless": {
+        "header": False,
+        "meta": False,
+        "footer": [{"type": "title"}],
+    },
+    "object_mixed_spellings": {
+        "footer": ["id", {"type": "field", "field": "status", "label": "State"}]
+    },
 }
 
 
@@ -213,9 +258,35 @@ def test_default_spec_is_clean() -> None:
         ("style_echo", 'style: <<meta("style")>>'),
         ("field:verified_by", '<<meta("verified_by")>>'),
         ("image:badge", '<<image("field:badge", align="center")>>'),
+        ({"type": "id"}, "<<meta_id()>>"),
+        ({"type": "title"}, '<<meta("title")>>'),
+        ({"type": "type"}, '<<meta("type_name")>>'),
+        ({"type": "layout_echo"}, 'layout: <<meta("layout")>>'),
+        ({"type": "style_echo"}, 'style: <<meta("style")>>'),
+        ({"type": "field", "field": "verified_by"}, '<<meta("verified_by")>>'),
+        (
+            {"type": "image", "field": "badge"},
+            '<<image("field:badge", align="center")>>',
+        ),
+        (
+            {"type": "field", "field": "verified_by", "label": "Verified by"},
+            '<<meta("verified_by", prefix="Verified by: ")>>',
+        ),
+        (
+            {"type": "image", "field": "badge", "height": "40px"},
+            '<<image("field:badge", height="40px", align="center")>>',
+        ),
+        (
+            {"type": "image", "field": "badge", "width": "50%"},
+            '<<image("field:badge", width="50%", align="center")>>',
+        ),
+        (
+            {"type": "image", "field": "badge", "height": "40px", "width": "3.5em"},
+            '<<image("field:badge", height="40px", width="3.5em", align="center")>>',
+        ),
     ],
 )
-def test_footer_element_mapping(element: str, expected: str) -> None:
+def test_footer_element_mapping(element: str | dict[str, Any], expected: str) -> None:
     """Every element of the shared vocabulary maps to one layout line."""
     compiled, messages = compile_spec(
         {"header": False, "meta": False, "footer": [element]}
@@ -658,6 +729,119 @@ def test_clean_round_trip_differs_only_in_whitespace() -> None:
 
 
 # --------------------------------------------------------------------------
+# unit tests: the object form
+# --------------------------------------------------------------------------
+
+#: Every string element paired with its object-form spelling.
+OBJECT_TWINS: list[tuple[str, dict[str, Any]]] = [
+    ("id", {"type": "id"}),
+    ("title", {"type": "title"}),
+    ("type", {"type": "type"}),
+    ("layout_echo", {"type": "layout_echo"}),
+    ("style_echo", {"type": "style_echo"}),
+    ("field:verified_by", {"type": "field", "field": "verified_by"}),
+    ("image:badge", {"type": "image", "field": "badge"}),
+]
+
+
+@pytest.mark.parametrize(
+    ("string", "obj"), OBJECT_TWINS, ids=[string for string, _ in OBJECT_TWINS]
+)
+def test_optionless_object_equals_its_string_shorthand(
+    string: str, obj: dict[str, Any]
+) -> None:
+    """An optionless object compiles byte-identically to its string shorthand.
+
+    This is the hard equivalence requirement of the object form:
+    same resolved specification, same compiled layout strings.
+    """
+    compiled_string, string_messages = compile_spec(
+        {"header": False, "meta": False, "footer": [string]}
+    )
+    compiled_object, object_messages = compile_spec(
+        {"header": False, "meta": False, "footer": [obj]}
+    )
+    assert string_messages == object_messages == []
+    assert compiled_string is not None
+    assert compiled_string == compiled_object
+
+
+def test_optionless_object_equivalence_holds_in_the_side_region() -> None:
+    """The equivalence guarantee covers ``side.elements`` as well as ``footer``."""
+    compiled_string, _ = compile_spec(
+        {"side": {"elements": ["image:picture", "id"], "position": "right"}}
+    )
+    compiled_object, messages = compile_spec(
+        {
+            "side": {
+                "elements": [{"type": "image", "field": "picture"}, {"type": "id"}],
+                "position": "right",
+            }
+        }
+    )
+    assert messages == []
+    assert compiled_string is not None
+    assert compiled_string == compiled_object
+
+
+def test_spellings_mix_freely_in_one_list() -> None:
+    """Strings and objects are two spellings of one vocabulary, not two modes."""
+    compiled, messages = compile_spec(
+        {"footer": ["id", {"type": "field", "field": "status", "label": "State"}]}
+    )
+    assert messages == []
+    assert compiled is not None
+    assert compiled["layout"]["footer"] == [
+        "<<meta_id()>>",
+        '<<meta("status", prefix="State: ")>>',
+    ]
+
+
+@pytest.mark.parametrize(
+    "label",
+    [
+        pytest.param("x", id="single-char"),
+        pytest.param("Owned by", id="space"),
+        pytest.param("A 0_().,/-9", id="all-allowed-chars"),
+        pytest.param("a" * 64, id="max-length"),
+    ],
+)
+def test_label_grammar_accepts_its_edges(label: str) -> None:
+    """The label grammar's boundary values are all usable."""
+    compiled, messages = compile_spec(
+        {"footer": [{"type": "field", "field": "status", "label": label}]}
+    )
+    assert messages == []
+    assert compiled is not None
+    assert compiled["layout"]["footer"] == [f'<<meta("status", prefix="{label}: ")>>']
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param("40", id="bare-number-means-px"),
+        pytest.param("40.5", id="decimal"),
+        pytest.param("40px", id="px"),
+        pytest.param("3.5em", id="em"),
+        pytest.param("2rem", id="rem"),
+        pytest.param("100%", id="percent"),
+        pytest.param("12pt", id="pt"),
+        pytest.param("1234567890.123px", id="max-length"),
+    ],
+)
+def test_dimension_grammar_accepts_its_edges(value: str) -> None:
+    """The height/width grammar's boundary values are all usable."""
+    compiled, messages = compile_spec(
+        {"footer": [{"type": "image", "field": "badge", "height": value}]}
+    )
+    assert messages == []
+    assert compiled is not None
+    assert compiled["layout"]["footer"] == [
+        f'<<image("field:badge", height="{value}", align="center")>>'
+    ]
+
+
+# --------------------------------------------------------------------------
 # unit tests: validation
 # --------------------------------------------------------------------------
 
@@ -757,6 +941,141 @@ def test_clean_round_trip_differs_only_in_whitespace() -> None:
             "a card with a meta region but no header is not expressible",
             id="meta-without-header",
         ),
+        # --- object-form elements
+        pytest.param(
+            {"footer": [{"type": "nonsense"}]},
+            "footer element 'type' must be one of",
+            id="object-unknown-type",
+        ),
+        pytest.param(
+            {"footer": [{}]},
+            "footer element 'type' must be one of",
+            id="object-missing-type",
+        ),
+        pytest.param(
+            {"footer": [{"type": "field"}]},
+            "'field' is required in a 'field' footer element",
+            id="object-field-missing-field",
+        ),
+        pytest.param(
+            {"footer": [{"type": "image"}]},
+            "'field' is required in a 'image' footer element",
+            id="object-image-missing-field",
+        ),
+        pytest.param(
+            {"side": {"elements": [{"type": "image"}]}},
+            "'field' is required in a 'image' side element",
+            id="object-side-missing-field",
+        ),
+        pytest.param(
+            {"footer": [{"type": "id", "field": "status"}]},
+            "key(s) 'field' not allowed in a 'id' footer element",
+            id="object-field-on-id",
+        ),
+        pytest.param(
+            {"footer": [{"type": "field", "field": "status", "height": "40px"}]},
+            "key(s) 'height' not allowed in a 'field' footer element",
+            id="object-height-on-field",
+        ),
+        pytest.param(
+            {"footer": [{"type": "image", "field": "badge", "label": "Badge"}]},
+            "key(s) 'label' not allowed in a 'image' footer element",
+            id="object-label-on-image",
+        ),
+        pytest.param(
+            {"footer": [{"type": "id", "label": "ID"}]},
+            "key(s) 'label' not allowed in a 'id' footer element",
+            id="object-label-on-id",
+        ),
+        pytest.param(
+            {"footer": [{"type": "image", "field": "badge", "nope": 1}]},
+            "key(s) 'nope' not allowed in a 'image' footer element",
+            id="object-unknown-key",
+        ),
+        pytest.param(
+            {"footer": [{"type": "field", "field": "bad name"}]},
+            "invalid field name 'bad name'",
+            id="object-bad-field-name",
+        ),
+        pytest.param(
+            {"footer": [{"type": "field", "field": 3}]},
+            "invalid field name 3",
+            id="object-non-string-field",
+        ),
+        pytest.param(
+            {"footer": [{"type": "image", "field": "badge", "height": "40 px"}]},
+            "'height' must be a number",
+            id="object-bad-height",
+        ),
+        pytest.param(
+            {"footer": [{"type": "image", "field": "badge", "width": "-40px"}]},
+            "'width' must be a number",
+            id="object-bad-width",
+        ),
+        pytest.param(
+            {"footer": [{"type": "image", "field": "badge", "height": 40}]},
+            "'height' must be a number",
+            id="object-non-string-height",
+        ),
+        pytest.param(
+            {
+                "footer": [
+                    {"type": "image", "field": "badge", "height": "1234567890.1234px"}
+                ]
+            },
+            "'height' must be a number",
+            id="object-height-too-long",
+        ),
+        pytest.param(
+            {"footer": [{"type": "field", "field": "status", "label": "bad*label"}]},
+            "'label' must be 1-64 characters",
+            id="object-label-rst-char",
+        ),
+        pytest.param(
+            {"footer": [{"type": "field", "field": "status", "label": " padded"}]},
+            "'label' must be 1-64 characters",
+            id="object-label-leading-space",
+        ),
+        pytest.param(
+            {"footer": [{"type": "field", "field": "status", "label": "padded "}]},
+            "'label' must be 1-64 characters",
+            id="object-label-trailing-space",
+        ),
+        pytest.param(
+            {"footer": [{"type": "field", "field": "status", "label": "-dash"}]},
+            "'label' must be 1-64 characters",
+            id="object-label-non-alnum-start",
+        ),
+        pytest.param(
+            {"footer": [{"type": "field", "field": "status", "label": ""}]},
+            "'label' must be 1-64 characters",
+            id="object-empty-label",
+        ),
+        pytest.param(
+            {"footer": [{"type": "field", "field": "status", "label": "a" * 65}]},
+            "'label' must be 1-64 characters",
+            id="object-label-too-long",
+        ),
+        pytest.param(
+            {"footer": [{"type": "field", "field": "status", "label": 3}]},
+            "'label' must be 1-64 characters",
+            id="object-non-string-label",
+        ),
+        pytest.param(
+            {"footer": [3]},
+            "footer element must be a string or a dict",
+            id="object-non-str-non-dict-entry",
+        ),
+        pytest.param(
+            {"side": {"elements": [None]}},
+            "side element must be a string or a dict",
+            id="object-side-bad-entry",
+        ),
+        pytest.param(
+            {"footer": [{"type": "title"}]},
+            "the 'title' element is only allowed when 'header' is false",
+            id="object-title-with-header",
+        ),
     ],
 )
 def test_invalid_specs_are_skipped_with_a_warning(
@@ -826,6 +1145,14 @@ def test_headerless_partial_side_degrades_to_full() -> None:
         pytest.param({"footer": ["field:unknown_field"]}, id="field"),
         pytest.param({"footer": ["image:unknown_field"]}, id="image"),
         pytest.param({"side": {"elements": ["image:unknown_field"]}}, id="side-image"),
+        pytest.param(
+            {"footer": [{"type": "field", "field": "unknown_field"}]},
+            id="object-field",
+        ),
+        pytest.param(
+            {"side": {"elements": [{"type": "image", "field": "unknown_field"}]}},
+            id="object-side-image",
+        ),
     ],
 )
 def test_unregistered_field_warns_but_still_compiles(spec: dict[str, Any]) -> None:
@@ -1044,6 +1371,14 @@ Conformance
    :layout: conformance_headerless
 
    Headerless body.
+
+.. req:: Object card
+   :id: CONF_OBJECT
+   :image: pic.svg
+   :owner: daniel
+   :layout: conformance_object
+
+   Object body.
 """
 
 PIC_SVG = (
@@ -1067,6 +1402,8 @@ PIC_SVG = (
                         "    'verified_by': {'nullable': True},\n"
                         "    'badge': {'nullable': True},\n"
                         "    'picture': {'nullable': True},\n"
+                        "    'image': {'nullable': True},\n"
+                        "    'owner': {'nullable': True},\n"
                         "}\n",
                     ),
                 ),
@@ -1078,7 +1415,7 @@ PIC_SVG = (
     indirect=True,
 )
 def test_conformance_specs_build(test_app: Any) -> None:
-    """The three shared conformance specifications build end to end.
+    """The four shared conformance specifications build end to end.
 
     They are committed identically to the ubCode implementation of the same
     vocabulary, so that both can be compared against one another.
@@ -1107,6 +1444,106 @@ def test_conformance_specs_build(test_app: Any) -> None:
     assert '<tr class="footer row-even"><td class="footer">' in headerless
     footer = headerless.split('<td class="footer">')[1]
     assert footer.index('class="needs_title"') < footer.index('class="needs-id"')
+
+    # conformance_object: the height option reaches the side image, and the
+    # label option renders as the prefix of the footer's name: value pair
+    object_card = need_table(html, "CONF_OBJECT")
+    img = object_card[
+        object_card.index("<img") : object_card.index(">", object_card.index("<img"))
+    ]
+    assert 'src="_images/pic.svg"' in img
+    assert "40px" in img
+    assert "Owned by:" in object_card
+    assert object_card.index('class="needs_owner"') < object_card.index(
+        'class="needs-id"'
+    )
+
+
+OBJECT_INDEX = """\
+Object form
+===========
+
+.. req:: Illustrated requirement
+   :id: OBJ_SIDE
+   :picture: pic.svg
+   :layout: object_side
+
+   Side body.
+
+.. req:: Labelled requirement
+   :id: OBJ_LABEL
+   :owner: daniel
+   :layout: object_label
+
+   Label body.
+"""
+
+
+@pytest.mark.parametrize(
+    "test_app",
+    [
+        {
+            "buildername": "html",
+            "no_plantuml": True,
+            "files": [
+                (
+                    Path("conf.py"),
+                    conf_py(
+                        {
+                            "object_side": {
+                                "side": {
+                                    "elements": [
+                                        {
+                                            "type": "image",
+                                            "field": "picture",
+                                            "height": "40px",
+                                        }
+                                    ],
+                                    "position": "left",
+                                }
+                            },
+                            "object_label": {
+                                "footer": [
+                                    {
+                                        "type": "field",
+                                        "field": "owner",
+                                        "label": "Owned by",
+                                    },
+                                    {"type": "id"},
+                                ]
+                            },
+                        },
+                        "needs_fields = {\n"
+                        "    'picture': {'nullable': True},\n"
+                        "    'owner': {'nullable': True},\n"
+                        "}\n",
+                    ),
+                ),
+                (Path("index.rst"), OBJECT_INDEX),
+                (Path("pic.svg"), PIC_SVG),
+            ],
+        }
+    ],
+    indirect=True,
+)
+def test_object_form_options_render(test_app: Any) -> None:
+    """``height`` reaches the rendered image and ``label`` the rendered pair."""
+    app = test_app
+    app.build()
+    assert app.warning_list == []
+
+    html = scrub((app.outdir / "index.html").read_text())
+
+    side = need_table(html, "OBJ_SIDE")
+    img = side[side.index("<img") : side.index(">", side.index("<img"))]
+    assert 'src="_images/pic.svg"' in img
+    assert "40px" in img
+
+    labelled = need_table(html, "OBJ_LABEL")
+    footer = labelled.split('<td class="need footer"')[1]
+    assert "Owned by:" in footer
+    assert 'class="needs_owner"' in footer
+    assert footer.index('class="needs_owner"') < footer.index('class="needs-id"')
 
 
 # --------------------------------------------------------------------------
@@ -1157,6 +1594,16 @@ Warnings
             {"footer": ["title"]},
             "the 'title' element is only allowed",
             id="title-placement",
+        ),
+        pytest.param(
+            {"footer": [{"type": "image", "field": "badge", "height": "40;px"}]},
+            "'height' must be a number",
+            id="object-bad-height",
+        ),
+        pytest.param(
+            {"footer": [{"type": "field", "field": "status", "label": "**bold**"}]},
+            "'label' must be 1-64 characters",
+            id="object-bad-label",
         ),
     ],
 )


### PR DESCRIPTION
### Summary

The first step named in #1765's Future-vocabulary section: every card-element string
becomes canonical sugar for a dict, and the dict is where per-element options live. The
strings stay valid and remain the documented default.

```python
needs_card_layouts = {
    "spec_card": {
        "footer": [{"type": "field", "field": "owner", "label": "Owned by"}],
        "side": {"elements": [{"type": "image", "field": "diagram", "height": "40px"}]},
    }
}
```

Compilation targets that already exist in the layout DSL, nothing new in the renderer:

| object | emitted |
|---|---|
| `{"type": "image", "field": "x", "height": "40px"}` | `<<image("field:x", height="40px", align="center")>>` (kwargs only when present) |
| `{"type": "field", "field": "owner", "label": "Owned by"}` | `<<meta("owner", prefix="Owned by: ")>>` |
| any optionless object | byte-identical to its string shorthand — one emitter path (`ElementSpec`) for both spellings |

### The closed-template guarantee, extended and then hardened

The compiler's standing guarantee — it cannot emit a layout string that aborts a build —
now covers option values: they are grammar-bound before interpolation, and the guarantee
statement plus the three matrix sweeps were updated accordingly. Adversarial review then
broke the first version of those grammars, twice, both reproduced end to end:

1. **trailing newline** — Python's `$` anchor matches before a final `\n`, so
   `"40px\n"` passed and crashed `ast.parse` at doctree-resolved. All four grammars are
   now `fullmatch`-enforced, with the crash inputs pinned as warn-and-skip tests;
2. **word-trailing underscore** — `"Owned_ by"` is RST reference syntax and killed the
   HTML writer. The label grammar now requires every `_` to sit directly between
   alphanumerics (`user_name` yes, `Owned_ by` no) — adjudicated cross-repo, so the same
   value is valid (or invalid) in ubCode and here alike.

Every rejection — unknown keys, non-string keys, misplaced `field`, options on the wrong
kind, grammar failures, wrong option types — goes through the existing
`needs.card_layout` warning + skip path: the build survives and sibling cards still
compile, matrix-tested like the existing validation failures.

### Conformance

`conformance_object` joins the three committed conformance specifications, verbatim in
both repositories: headerless, a side image with `height="40px"`, a footer field with
`label="Owned by"` — upstream grid `content_footer_side_left` — built end to end with the
attribute and prefix asserted in output.

### Tests and docs

`tests/test_card_layouts.py`: 216 passed (142 at base). Docs: object-form section on the
card-layouts page (equivalence, option table, grammar rules); changelog entry under
Unreleased in #1765's style (`:pr:` number appended now that this PR exists). Pre-commit
(ruff, ruff-format, mypy) clean.

### Refs

Refs #1765 (delivers its Future-vocabulary first step).
