### PR TITLE
🐛 needflow: fix legend crash, id collisions, border_color handling and highlight/warning divergences

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -70,37 +70,38 @@ Improvements
 Bug fixes
 .........
 
-- 🐛 :ref:`needflow` no longer fails the build when a need type has no ``color`` and the
-  diagram shows a legend (:issue:`1664`)
+- 🐛 :ref:`needflow` no longer fails the build when a need type has no ``color`` (or an
+  empty one) and the diagram shows a legend (:issue:`1664`).
 
   ``color`` is optional in :ref:`needs_types`, but both engines read it unguarded while
   building the legend, so ``:show_legend:`` ended the build with ``KeyError: 'color'``.
-  Such a type keeps its legend row, with an empty color swatch.
+  Such a type keeps its legend row, with an empty color swatch; a type whose ``color`` is
+  set to an empty string no longer emits an empty swatch value either.
 
 - 🐛 :ref:`needflow` needs whose ids differ only in punctuation are no longer drawn as a
-  single node by the plantuml engine
+  single node by the plantuml engine.
 
   PlantUML entity names cannot contain punctuation, so ids such as ``R-1`` and ``R=1`` both
   became ``R_1`` and silently collapsed into one node, taking their edges with them.
   Entity names are now assigned per diagram, so that they stay unique; the names shown by
   ``:debug:`` therefore change for such ids. :ref:`needuml` entity names are unchanged.
 
-- 🐛 :ref:`needflow` ``:border_color:`` accepts a value written with a leading ``#``
+- 🐛 :ref:`needflow` ``:border_color:`` accepts a value written with a leading ``#``.
 
   ``#00FF00`` previously reached graphviz as ``##00FF00`` and PlantUML as ``line:#00FF00``,
   which PlantUML rejects outright. Both engines now normalise the value and add the prefix
-  their own syntax needs. Relatedly, a variant expression that matches nothing again means
+  their own syntax needs. Relatedly, a variant expression that matches nothing now means
   "no border color" under graphviz, instead of the literal color ``#None``.
 
 - 🐛 :ref:`needflow` ``:highlight:`` filters that consult ``needs`` now also work for a
-  need with parts or child needs
+  need with parts or child needs.
 
   The graphviz engine draws such a need as a subgraph, and that path evaluated the filter
   without the needs list, so the same expression could behave differently -- or fail the
   build -- depending on whether a need happened to have children.
 
 - 🐛 A graphviz :ref:`needflow` image without an ``:alt:`` option now gets
-  ``alt="needflow graphviz diagram"``
+  ``alt="needflow graphviz diagram"``.
 
   The intended default was unreachable, so every such image was published with an empty
   ``alt`` attribute. Writing ``:alt:`` with no value still gives an empty ``alt``, for a

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -105,6 +105,8 @@ Bug fixes
   The intended default was unreachable, so every such image was published with an empty
   ``alt`` attribute. Writing ``:alt:`` with no value still gives an empty ``alt``, for a
   diagram that is purely decorative.
+  The stored environment version is bumped, because the option is recorded differently
+  when it is not given, so the first build after upgrading re-reads every document.
 
 - 🐛 The :ref:`needflow` warning for an unknown ``:config:`` name now names
   :ref:`needs_flow_configs`, which was misspelled as ``need_flows_configs``.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -67,6 +67,52 @@ Improvements
   The stored environment version is bumped for the new directive option, so the first build
   after upgrading re-reads every document.
 
+Bug fixes
+.........
+
+- 🐛 :ref:`needflow` no longer fails the build when a need type has no ``color`` and the
+  diagram shows a legend (:issue:`1664`)
+
+  ``color`` is optional in :ref:`needs_types`, but both engines read it unguarded while
+  building the legend, so ``:show_legend:`` ended the build with ``KeyError: 'color'``.
+  Such a type keeps its legend row, with an empty color swatch.
+
+- 🐛 :ref:`needflow` needs whose ids differ only in punctuation are no longer drawn as a
+  single node by the plantuml engine
+
+  PlantUML entity names cannot contain punctuation, so ids such as ``R-1`` and ``R=1`` both
+  became ``R_1`` and silently collapsed into one node, taking their edges with them.
+  Entity names are now assigned per diagram, so that they stay unique; the names shown by
+  ``:debug:`` therefore change for such ids. :ref:`needuml` entity names are unchanged.
+
+- 🐛 :ref:`needflow` ``:border_color:`` accepts a value written with a leading ``#``
+
+  ``#00FF00`` previously reached graphviz as ``##00FF00`` and PlantUML as ``line:#00FF00``,
+  which PlantUML rejects outright. Both engines now normalise the value and add the prefix
+  their own syntax needs. Relatedly, a variant expression that matches nothing again means
+  "no border color" under graphviz, instead of the literal color ``#None``.
+
+- 🐛 :ref:`needflow` ``:highlight:`` filters that consult ``needs`` now also work for a
+  need with parts or child needs
+
+  The graphviz engine draws such a need as a subgraph, and that path evaluated the filter
+  without the needs list, so the same expression could behave differently -- or fail the
+  build -- depending on whether a need happened to have children.
+
+- 🐛 A graphviz :ref:`needflow` image without an ``:alt:`` option now gets
+  ``alt="needflow graphviz diagram"``
+
+  The intended default was unreachable, so every such image was published with an empty
+  ``alt`` attribute. Writing ``:alt:`` with no value still gives an empty ``alt``, for a
+  diagram that is purely decorative.
+
+- 🐛 The :ref:`needflow` warning for an unknown ``:config:`` name now names
+  :ref:`needs_flow_configs`, which was misspelled as ``need_flows_configs``.
+
+- 🐛 The :ref:`needflow` warning for an unknown ``:link_types:`` value now carries the
+  source location of the directive under the graphviz engine, as it already did under
+  plantuml.
+
 Documentation
 .............
 

--- a/docs/directives/needflow.rst
+++ b/docs/directives/needflow.rst
@@ -90,6 +90,11 @@ alt
 
 Set the ``alt`` option to a string to add an alternative text to the generated image.
 
+If the option is not set, the graphviz engine describes the image as
+``needflow graphviz diagram``.
+Set the option to an empty value to publish an empty alternative text instead,
+for a diagram that is purely decorative.
+
 root_id
 ~~~~~~~
 

--- a/sphinx_needs/data.py
+++ b/sphinx_needs/data.py
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
 
 LOGGER = getLogger(__name__)
 
-ENV_DATA_VERSION: Final = 5
+ENV_DATA_VERSION: Final = 6
 """Version of the data stored in the environment.
 
 See https://www.sphinx-doc.org/en/master/extdev/index.html#extension-metadata

--- a/sphinx_needs/data.py
+++ b/sphinx_needs/data.py
@@ -664,8 +664,9 @@ class NeedsFlowType(NeedsFilteredDiagramBaseType):
     classes: list[str]
     """List of CSS classes."""
 
-    alt: str
-    """Alternative text for the diagram in HTML output."""
+    alt: str | None
+    """Alternative text for the diagram in HTML output,
+    ``None`` if the option was not given."""
 
     root_id: str | None
     """need ID to use as a root node."""

--- a/sphinx_needs/diagrams_common.py
+++ b/sphinx_needs/diagrams_common.py
@@ -241,10 +241,18 @@ def calculate_link(
 
 
 def create_legend(need_types: list[NeedType]) -> str:
+    """Create the PlantUML legend for the given need types.
+
+    :param need_types: The need types to document, in the order they are shown.
+    :return: The PlantUML ``legend`` block.
+    """
+
     def create_row(need_type: NeedType) -> str:
-        return "\n|<back:{color}> {color} </back>| {name} |".format(
-            color=need_type["color"], name=need_type["title"]
-        )
+        # 'color' is optional, and a type without one keeps its row,
+        # with an empty swatch cell, rather than being dropped from the legend
+        color = need_type.get("color") or ""
+        swatch = f"<back:{color}> {color} </back>" if color else " "
+        return f"\n|{swatch}| {need_type['title']} |"
 
     rows = map(create_row, need_types)
     table = "|= Color |= Type |" + "".join(rows)

--- a/sphinx_needs/directives/needflow/_directive.py
+++ b/sphinx_needs/directives/needflow/_directive.py
@@ -157,7 +157,9 @@ class NeedflowDirective(FilterBase):
             "debug": "debug" in self.options,
             "caption": self.arguments[0] if self.arguments else None,
             "classes": self.options.get("class", []),
-            "alt": self.options.get("alt", ""),
+            # None means the option was not given, so that an engine can tell it apart
+            # from an explicitly empty value, i.e. a deliberately undescribed diagram
+            "alt": self.options.get("alt"),
             "max_items": self.options.get("max_items"),
             **self.collect_filter_attributes(),
         }

--- a/sphinx_needs/directives/needflow/_directive.py
+++ b/sphinx_needs/directives/needflow/_directive.py
@@ -100,7 +100,7 @@ class NeedflowDirective(FilterBase):
                 elif config_name:
                     log_warning(
                         LOGGER,
-                        f"config key {config_name!r} not in 'need_flows_configs'",
+                        f"config key {config_name!r} not in 'needs_flow_configs'",
                         "needflow",
                         location=self.get_location(),
                     )

--- a/sphinx_needs/directives/needflow/_graphviz.py
+++ b/sphinx_needs/directives/needflow/_graphviz.py
@@ -34,7 +34,12 @@ from sphinx_needs.utils import remove_node_from_tree
 from sphinx_needs.variants import match_variants
 from sphinx_needs.views import NeedsView
 
-from ._shared import create_filter_paragraph, filter_by_tree, get_root_needs
+from ._shared import (
+    create_filter_paragraph,
+    filter_by_tree,
+    get_root_needs,
+    resolve_color,
+)
 
 try:
     from sphinx.writers.html5 import HTML5Translator
@@ -309,7 +314,7 @@ def _render_node(
     ):
         params.append(("color", "red"))
     elif node["border_color"]:
-        color = str(
+        color = resolve_color(
             match_variants(
                 node["border_color"],
                 need.filter_context(),
@@ -360,7 +365,7 @@ def _render_subgraph(
     if node["highlight"] and filter_single_need(need, config, node["highlight"]):
         params.append(("color", "red"))
     elif node["border_color"]:
-        color = str(
+        color = resolve_color(
             match_variants(
                 node["border_color"],
                 need.filter_context(),

--- a/sphinx_needs/directives/needflow/_graphviz.py
+++ b/sphinx_needs/directives/needflow/_graphviz.py
@@ -98,7 +98,7 @@ def process_needflow_graphviz(
                         link_types=",".join(link_type_names),
                     ),
                     "needflow",
-                    None,
+                    location=node,
                 )
 
         # compute the allowed link types

--- a/sphinx_needs/directives/needflow/_graphviz.py
+++ b/sphinx_needs/directives/needflow/_graphviz.py
@@ -362,7 +362,9 @@ def _render_subgraph(
         params.append(("fillcolor", _quote(need["type_color"])))
 
     # outline color
-    if node["highlight"] and filter_single_need(need, config, node["highlight"]):
+    if node["highlight"] and filter_single_need(
+        need, config, node["highlight"], needs_view.values()
+    ):
         params.append(("color", "red"))
     elif node["border_color"]:
         color = resolve_color(

--- a/sphinx_needs/directives/needflow/_graphviz.py
+++ b/sphinx_needs/directives/needflow/_graphviz.py
@@ -625,8 +625,12 @@ def _create_legend(
 
     for need_type in need_types:
         title = html.escape(need_type["title"])
-        color = _quote(need_type["color"])
-        label += f'\n<TR><TD align="left" bgcolor={color}>{title}</TD></TR>'
+        # 'color' is optional, and a type without one keeps its row,
+        # without a background color, rather than being dropped from the legend
+        if color := need_type.get("color"):
+            label += f'\n<TR><TD align="left" bgcolor={_quote(color)}>{title}</TD></TR>'
+        else:
+            label += f'\n<TR><TD align="left">{title}</TD></TR>'
 
     label += "\n</TABLE>>"
 

--- a/sphinx_needs/directives/needflow/_graphviz.py
+++ b/sphinx_needs/directives/needflow/_graphviz.py
@@ -696,7 +696,10 @@ def html_visit_needflow_graphviz(self: HTML5Translator, node: NeedflowGraphiz) -
     if fname is None:
         self.body.append(self.encode(code))
     else:
-        alt = attrributes.get("alt", "needflow graphviz diagram")
+        alt = attrributes["alt"]
+        if alt is None:
+            # the author did not describe the diagram, so give it a generic description
+            alt = "needflow graphviz diagram"
         if "align" in attrributes:
             self.body.append(
                 f'<div align="{attrributes["align"]}" class="align-{attrributes["align"]}">'

--- a/sphinx_needs/directives/needflow/_plantuml.py
+++ b/sphinx_needs/directives/needflow/_plantuml.py
@@ -77,11 +77,26 @@ def make_entity_names(ids: Iterable[str]) -> dict[str, str]:
 def get_entity_name(entity_names: Mapping[str, str], id: str) -> str:
     """Look up the PlantUML entity name of a need id.
 
+    Every id that is rendered is mapped up front, so an unmapped id means an emission
+    site was not given the mapping of the diagram it is drawing. That would silently
+    reintroduce the collisions :func:`make_entity_names` exists to prevent, so it is
+    reported; a diagram with plainer names is still better than a failed build, hence
+    the direct conversion is returned rather than raising.
+
     :param entity_names: The mapping created by :func:`make_entity_names`.
     :param id: The complete id of the need.
     :return: The mapped entity name, or a direct conversion for an unmapped id.
     """
-    return entity_names.get(id) or make_entity_name(id)
+    if (name := entity_names.get(id)) is not None:
+        return name
+    log_warning(
+        logger,
+        f"Need id {id!r} was not mapped to a plantuml entity name, "
+        "so it may collide with another need in the diagram",
+        "needflow",
+        location=None,
+    )
+    return make_entity_name(id)
 
 
 def get_need_node_rep_for_plantuml(

--- a/sphinx_needs/directives/needflow/_plantuml.py
+++ b/sphinx_needs/directives/needflow/_plantuml.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import html
+from collections.abc import Iterable, Mapping
 
 from docutils import nodes
 from sphinx.application import Sphinx
@@ -41,14 +42,55 @@ def make_entity_name(name: str) -> str:
     return name
 
 
+def make_entity_names(ids: Iterable[str]) -> dict[str, str]:
+    """Create a stable, injective mapping of need ids to PlantUML entity names.
+
+    :func:`make_entity_name` folds every character PlantUML forbids in an entity name
+    to ``_``, so distinct need ids can sanitise to the same name -- ``R-1`` and ``R=1``
+    both become ``R_1`` -- and would then be drawn as a single node.
+    Any id that would reuse an already taken name is therefore given a numeric suffix.
+
+    The ids are processed in sorted order, so the mapping depends only on the set of
+    ids and not on the order in which they happen to be filtered.
+
+    :param ids: The complete ids of all needs to be rendered.
+    :return: A mapping of each id to a unique PlantUML entity name.
+    """
+    entity_names: dict[str, str] = {}
+    taken: set[str] = set()
+    for id in sorted(set(ids)):
+        name = base = make_entity_name(id)
+        suffix = 1
+        while name in taken:
+            suffix += 1
+            name = f"{base}_{suffix}"
+        taken.add(name)
+        entity_names[id] = name
+    return entity_names
+
+
+def get_entity_name(entity_names: Mapping[str, str], id: str) -> str:
+    """Look up the PlantUML entity name of a need id.
+
+    :param entity_names: The mapping created by :func:`make_entity_names`.
+    :param id: The complete id of the need.
+    :return: The mapped entity name, or a direct conversion for an unmapped id.
+    """
+    return entity_names.get(id) or make_entity_name(id)
+
+
 def get_need_node_rep_for_plantuml(
     app: Sphinx,
     fromdocname: str,
     current_needflow: NeedsFlowType,
     needs_view: NeedsView,
     need_info: NeedItem | NeedPartItem,
+    entity_names: Mapping[str, str],
 ) -> str:
-    """Calculate need node representation for plantuml."""
+    """Calculate need node representation for plantuml.
+
+    :param entity_names: The id to entity name mapping of :func:`make_entity_names`.
+    """
     needs_config = NeedsSphinxConfig(app.config)
 
     node_text = render_template_string(
@@ -85,7 +127,7 @@ def get_need_node_rep_for_plantuml(
     # node representation for plantuml
     color_suffix = f" #{';'.join(node_colors)}" if node_colors else ""
     need_node_code = '{style} "{node_text}" as {id} [[{link}]]{color_suffix}'.format(
-        id=make_entity_name(need_info["id_complete"]),
+        id=get_entity_name(entity_names, need_info["id_complete"]),
         node_text=node_text,
         link=node_link,
         color_suffix=color_suffix,
@@ -101,9 +143,12 @@ def walk_curr_need_tree(
     needs_view: NeedsView,
     found_needs: list[NeedItem | NeedPartItem],
     need: NeedItem | NeedPartItem,
+    entity_names: Mapping[str, str],
 ) -> str:
     """
     Walk through each need to find all its child needs and need parts recursively and wrap them together in nested structure.
+
+    :param entity_names: The id to entity name mapping of :func:`make_entity_names`.
     """
 
     curr_need_tree = ""
@@ -125,7 +170,12 @@ def walk_curr_need_tree(
                 if need_part_id == found_need["id_complete"]:
                     curr_need_tree += (
                         get_need_node_rep_for_plantuml(
-                            app, fromdocname, current_needflow, needs_view, found_need
+                            app,
+                            fromdocname,
+                            current_needflow,
+                            needs_view,
+                            found_need,
+                            entity_names,
                         )
                         + "\n"
                     )
@@ -140,7 +190,12 @@ def walk_curr_need_tree(
             for curr_child_need in found_needs:
                 if curr_child_need["id_complete"] == curr_child_need_id:
                     curr_need_tree += get_need_node_rep_for_plantuml(
-                        app, fromdocname, current_needflow, needs_view, curr_child_need
+                        app,
+                        fromdocname,
+                        current_needflow,
+                        needs_view,
+                        curr_child_need,
+                        entity_names,
                     )
                     # check curr need child has children or has parts
                     if curr_child_need["parent_needs_back"] or curr_child_need["parts"]:
@@ -151,6 +206,7 @@ def walk_curr_need_tree(
                             needs_view,
                             found_needs,
                             curr_child_need,
+                            entity_names,
                         )
                     # add newline for next element
                     curr_need_tree += "\n"
@@ -168,13 +224,17 @@ def cal_needs_node(
     current_needflow: NeedsFlowType,
     needs_view: NeedsView,
     found_needs: list[NeedItem | NeedPartItem],
+    entity_names: Mapping[str, str],
 ) -> str:
-    """Calculate and get needs node representaion for plantuml including all child needs and need parts."""
+    """Calculate and get needs node representaion for plantuml including all child needs and need parts.
+
+    :param entity_names: The id to entity name mapping of :func:`make_entity_names`.
+    """
     top_needs = get_root_needs(found_needs)
     curr_need_tree = ""
     for top_need in top_needs:
         top_need_node = get_need_node_rep_for_plantuml(
-            app, fromdocname, current_needflow, needs_view, top_need
+            app, fromdocname, current_needflow, needs_view, top_need, entity_names
         )
         curr_need_tree += (
             top_need_node
@@ -185,6 +245,7 @@ def cal_needs_node(
                 needs_view,
                 found_needs,
                 top_need,
+                entity_names,
             )
             + "\n"
         )
@@ -312,9 +373,20 @@ def process_needflow_plantuml(
                 puml_node["uml"] += config
                 puml_node["uml"] += "\n\n"
 
+            # the entity names must be assigned for the whole diagram at once,
+            # so that ids sanitising to the same name stay distinct nodes
+            entity_names = make_entity_names(
+                need["id_complete"] for need in found_needs
+            )
+
             puml_node["uml"] += "\n' Nodes definition \n\n"
             puml_node["uml"] += cal_needs_node(
-                app, fromdocname, current_needflow, needs_view, found_needs
+                app,
+                fromdocname,
+                current_needflow,
+                needs_view,
+                found_needs,
+                entity_names,
             )
 
             puml_node["uml"] += "\n' Connection definition \n\n"
@@ -322,6 +394,7 @@ def process_needflow_plantuml(
                 found_needs,
                 allowed_link_types,
                 current_needflow["show_link_names"] or needs_config.flow_show_links,
+                entity_names,
             )
 
             # Create a legend
@@ -410,9 +483,12 @@ def render_connections(
     found_needs: list[NeedItem | NeedPartItem],
     allowed_link_types: list[LinkSchema],
     show_links: bool,
+    entity_names: Mapping[str, str],
 ) -> str:
     """
     Render the connections between the needs.
+
+    :param entity_names: The id to entity name mapping of :func:`make_entity_names`.
     """
     puml_connections = ""
     for need_info in found_needs:
@@ -444,8 +520,8 @@ def render_connections(
 
                 # TODO also use link_type.display.color?
                 puml_connections += "{id} {style_start}{link_style}{style_end} {link}{comment}\n".format(
-                    id=make_entity_name(need_info["id_complete"]),
-                    link=make_entity_name(link),
+                    id=get_entity_name(entity_names, need_info["id_complete"]),
+                    link=get_entity_name(entity_names, link),
                     comment=comment,
                     link_style=link_style,
                     style_start=link_type.display.style_start,

--- a/sphinx_needs/directives/needflow/_plantuml.py
+++ b/sphinx_needs/directives/needflow/_plantuml.py
@@ -29,7 +29,12 @@ from sphinx_needs.utils import remove_node_from_tree
 from sphinx_needs.variants import match_variants
 from sphinx_needs.views import NeedsView
 
-from ._shared import create_filter_paragraph, filter_by_tree, get_root_needs
+from ._shared import (
+    create_filter_paragraph,
+    filter_by_tree,
+    get_root_needs,
+    resolve_color,
+)
 
 logger = get_logger(__name__)
 
@@ -112,13 +117,16 @@ def get_need_node_rep_for_plantuml(
         node_colors.append("line:FF0000")
 
     elif current_needflow["border_color"]:
-        color = match_variants(
-            current_needflow["border_color"],
-            need_info.filter_context(),
-            needs_config.variants,
-            location=(current_needflow["docname"], current_needflow["lineno"]),
+        color = resolve_color(
+            match_variants(
+                current_needflow["border_color"],
+                need_info.filter_context(),
+                needs_config.variants,
+                location=(current_needflow["docname"], current_needflow["lineno"]),
+            )
         )
         if color:
+            # the whole color list is prefixed with a single "#" below
             node_colors.append(f"line:{color}")
 
     # need parts style use default "rectangle"

--- a/sphinx_needs/directives/needflow/_shared.py
+++ b/sphinx_needs/directives/needflow/_shared.py
@@ -53,6 +53,23 @@ def filter_by_tree(
     return needs_view.filter_ids(need_ids)
 
 
+def resolve_color(value: None | str | int | float | bool) -> str | None:
+    """Normalise a resolved color option value to an engine neutral form.
+
+    A color may be written with or without a leading ``#``, and each engine adds the
+    prefix that its own syntax requires, so any given one is stripped here.
+    An unset or empty value means "no color", rather than a color named after the
+    string representation of the value.
+
+    :param value: The resolved value of a color option,
+        e.g. the return value of :func:`~sphinx_needs.variants.match_variants`.
+    :return: The color without a leading ``#``, or ``None`` if no color was given.
+    """
+    if value is None:
+        return None
+    return str(value).strip().lstrip("#") or None
+
+
 def get_root_needs(found_needs: list[NeedItem | NeedPartItem]) -> list[NeedItem]:
     return_list = []
     for current_need in found_needs:

--- a/sphinx_needs/directives/needflow/_shared.py
+++ b/sphinx_needs/directives/needflow/_shared.py
@@ -57,7 +57,7 @@ def resolve_color(value: None | str | int | float | bool) -> str | None:
     """Normalise a resolved color option value to an engine neutral form.
 
     A color may be written with or without a leading ``#``, and each engine adds the
-    prefix that its own syntax requires, so any given one is stripped here.
+    prefix that its own syntax requires, so any leading ``#`` characters are stripped here.
     An unset or empty value means "no color", rather than a color named after the
     string representation of the value.
 

--- a/tests/doc_test/doc_github_issue_1664/index.rst
+++ b/tests/doc_test/doc_github_issue_1664/index.rst
@@ -1,6 +1,10 @@
 Github Issue 1664 test
 ======================
 
+.. toctree::
+
+   legend
+
 .. spec:: Test
     :id: ID_SPC_1001
     :status: open

--- a/tests/doc_test/doc_github_issue_1664/legend.rst
+++ b/tests/doc_test/doc_github_issue_1664/legend.rst
@@ -1,0 +1,12 @@
+Legend for a need type without a color
+======================================
+
+.. spec:: Legend test
+    :id: ID_SPC_1002
+    :status: open
+    :tags: legend
+
+.. needflow::
+    :tags: legend
+    :show_legend:
+    :debug:

--- a/tests/test_github_issues.py
+++ b/tests/test_github_issues.py
@@ -3,6 +3,7 @@ import subprocess
 from pathlib import Path
 
 import pytest
+from lxml import html as html_parser
 from sphinx.util.console import strip_colors
 
 
@@ -122,3 +123,66 @@ def test_doc_github_1664(test_app):
     assert "#000000" not in html
     for graphviz_file in Path(app.outdir, "_images").glob("graphviz-*.svg"):
         assert "#000000" not in graphviz_file.read_text()
+
+
+@pytest.mark.parametrize(
+    "test_app",
+    [
+        {
+            "buildername": "html",
+            "srcdir": "doc_test/doc_github_issue_1664",
+            "confoverrides": {"needs_flow_engine": "plantuml"},
+        },
+        {
+            "buildername": "html",
+            "srcdir": "doc_test/doc_github_issue_1664",
+            "confoverrides": {
+                "needs_flow_engine": "graphviz",
+                "graphviz_output_format": "svg",
+            },
+        },
+    ],
+    ids=["plantuml", "graphviz"],
+    indirect=True,
+)
+def test_doc_github_1664_legend(test_app):
+    """
+    https://github.com/useblocks/sphinx-needs/issues/1664
+
+    The other half of the issue: ``color`` is optional in ``needs_types``, but both
+    legend builders subscripted it unguarded, so ``:show_legend:`` turned a
+    colorless need type into a hard build failure (``KeyError: 'color'``).
+
+    The type must keep its legend row -- only the color swatch is left blank --
+    so the legend still documents every type it is asked about.
+    """
+    app = test_app
+    app.build()  # must not raise
+
+    # a legend the engine cannot parse would be reported as a render warning
+    warnings = strip_colors(app._warning.getvalue()).strip()
+    assert warnings == ""
+
+    debug = _debug_source(Path(app.outdir, "legend.html"))
+
+    if app.config.needs_flow_engine == "plantuml":
+        assert "\nlegend\n" in debug
+        # the row is kept, with an empty color swatch cell
+        assert "| | Specification |" in debug
+    else:
+        assert "<B>Legend</B>" in debug
+        # the row is kept, without a bgcolor attribute
+        assert '<TR><TD align="left">Specification</TD></TR>' in debug
+
+
+def _debug_source(html_file: Path) -> str:
+    """Return the diagram source emitted by the needflow ``:debug:`` option.
+
+    Both engines render it inside a ``<pre>``, but only graphviz syntax highlights
+    it, so the text content is taken rather than the markup.
+
+    :param html_file: The built HTML page holding the needflow.
+    :return: The concatenated text of every ``<pre>`` block on the page.
+    """
+    tree = html_parser.fromstring(html_file.read_text(encoding="utf8"))
+    return "\n".join(pre.text_content() for pre in tree.xpath("//pre"))

--- a/tests/test_needflow.py
+++ b/tests/test_needflow.py
@@ -511,3 +511,53 @@ def test_highlight_can_consult_other_needs(test_app):
         # the parent is a subgraph and the child a plain node
         assert "  color=red;" in debug
         assert ", color=red]" in debug
+
+
+UNKNOWN_CONFIG = """\
+Unknown config
+==============
+
+.. spec:: A
+   :id: AAAAA
+
+.. needflow::
+   :config: nonexistent_cfg
+"""
+
+
+@pytest.mark.parametrize(
+    "test_app",
+    [
+        {
+            "buildername": "html",
+            "files": [(Path("conf.py"), CONF_PY), (Path("index.rst"), UNKNOWN_CONFIG)],
+            "confoverrides": {"needs_flow_engine": "plantuml"},
+        },
+        {
+            "buildername": "html",
+            "files": [(Path("conf.py"), CONF_PY), (Path("index.rst"), UNKNOWN_CONFIG)],
+            "confoverrides": {
+                "needs_flow_engine": "graphviz",
+                "graphviz_output_format": "svg",
+            },
+        },
+    ],
+    ids=["plantuml", "graphviz"],
+    indirect=True,
+)
+def test_unknown_config_names_its_config_value(test_app):
+    """An unknown ``:config:`` name must point at the config value that holds them.
+
+    Each engine reads its own config value, and the plantuml message used to
+    misspell it as ``need_flows_configs``, which does not exist.
+    """
+    app = test_app
+    app.build()
+
+    warnings = strip_colors(app._warning.getvalue())
+
+    if app.config.needs_flow_engine == "plantuml":
+        assert "config key 'nonexistent_cfg' not in 'needs_flow_configs'" in warnings
+    else:
+        assert "config key 'nonexistent_cfg' not in 'needs_graphviz_styles'" in warnings
+    assert "need_flows_configs" not in warnings

--- a/tests/test_needflow.py
+++ b/tests/test_needflow.py
@@ -445,3 +445,69 @@ def test_border_color_handling(test_app):
         assert "##00FF00" not in prefixed
         assert _outline_colors(unmatched) == []
         assert "#None" not in unmatched
+
+
+HIGHLIGHT_WITH_NEEDS = """\
+Highlight consulting other needs
+================================
+
+.. spec:: Parent
+   :id: PARENT
+
+   .. spec:: Child
+      :id: CHILD
+
+.. needflow::
+   :highlight: len(needs) > 1
+   :debug:
+"""
+
+
+@pytest.mark.parametrize(
+    "test_app",
+    [
+        {
+            "buildername": "html",
+            "files": [
+                (Path("conf.py"), CONF_PY),
+                (Path("index.rst"), HIGHLIGHT_WITH_NEEDS),
+            ],
+            "confoverrides": {"needs_flow_engine": "plantuml"},
+        },
+        {
+            "buildername": "html",
+            "files": [
+                (Path("conf.py"), CONF_PY),
+                (Path("index.rst"), HIGHLIGHT_WITH_NEEDS),
+            ],
+            "confoverrides": {
+                "needs_flow_engine": "graphviz",
+                "graphviz_output_format": "svg",
+            },
+        },
+    ],
+    ids=["plantuml", "graphviz"],
+    indirect=True,
+)
+def test_highlight_can_consult_other_needs(test_app):
+    """A ``:highlight:`` filter sees all needs, whether or not a need has children.
+
+    The graphviz subgraph path (taken by a need with parts or children) used to
+    evaluate the filter without the needs list, so an expression referencing
+    ``needs`` behaved differently -- here it would fail the whole build -- for a
+    parent need than for a leaf one.
+    """
+    app = test_app
+    app.build()
+
+    warnings = strip_colors(app._warning.getvalue()).strip()
+    assert warnings == ""
+
+    debug = _debug_source(Path(app.outdir), "index.html")
+
+    if app.config.needs_flow_engine == "plantuml":
+        assert debug.count("line:FF0000") == 2
+    else:
+        # the parent is a subgraph and the child a plain node
+        assert "  color=red;" in debug
+        assert ", color=red]" in debug

--- a/tests/test_needflow.py
+++ b/tests/test_needflow.py
@@ -666,3 +666,45 @@ def test_graphviz_alt_text(test_app):
     alts = [img.attrib["alt"] for img in tree.xpath("//img[@class='graphviz']")]
 
     assert alts == ["needflow graphviz diagram", "my alt text", ""]
+
+
+def test_get_entity_name_unmapped_id_falls_back_with_warning():
+    """An unmapped id must degrade to a direct conversion, loudly, never crash.
+
+    Every rendered need is mapped up front, so an unmapped id means an emission site
+    bypassed the diagram's injective mapping; the lookup falls back to the (possibly
+    colliding) direct conversion and warns. The two ``warnings == ""`` build tests
+    above prove the fallback is unreachable today; this pins its contract directly.
+
+    The capture handler is attached to the module's own logger rather than relying on
+    propagation, which Sphinx disables once an application has configured logging.
+    """
+    import logging
+
+    from sphinx_needs.directives.needflow._plantuml import get_entity_name
+
+    records: list[logging.LogRecord] = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record)
+
+    module_logger = logging.getLogger(
+        "sphinx.sphinx_needs.directives.needflow._plantuml"
+    )
+    handler = _Capture(level=logging.WARNING)
+    module_logger.addHandler(handler)
+    old_level = module_logger.level
+    module_logger.setLevel(logging.WARNING)
+    try:
+        assert get_entity_name({"R-1": "R_1", "R=1": "R_1_2"}, "R=1") == "R_1_2"
+        assert records == []
+
+        assert get_entity_name({}, "R=1") == "R_1"
+        assert any(
+            "'R=1' was not mapped to a plantuml entity name" in record.getMessage()
+            for record in records
+        )
+    finally:
+        module_logger.removeHandler(handler)
+        module_logger.setLevel(old_level)

--- a/tests/test_needflow.py
+++ b/tests/test_needflow.py
@@ -8,7 +8,6 @@ from sphinx import version_info
 from sphinx.config import Config
 from sphinx.util.console import strip_colors
 
-
 #: A ``conf.py`` for the inline source projects below.
 #: The id regex is relaxed, so that ids exercising the entity name sanitisation
 #: (see :func:`~sphinx_needs.directives.needflow._plantuml.make_entity_names`) are allowed.

--- a/tests/test_needflow.py
+++ b/tests/test_needflow.py
@@ -1,4 +1,5 @@
 import os
+import re
 from pathlib import Path, PurePosixPath
 
 import pytest
@@ -27,7 +28,20 @@ needs_types = [
 """
 
 
-def _debug_source(outdir: Path, file: str) -> str:
+#: The graphviz outline color attribute, i.e. ``color`` but not ``fillcolor``.
+_OUTLINE_COLOR = re.compile(r'(?<!fill)color="([^"]*)"')
+
+
+def _outline_colors(source: str) -> list[str]:
+    """Return every graphviz outline color in a diagram source.
+
+    :param source: The generated graphviz source.
+    :return: The value of each ``color`` attribute, in order of appearance.
+    """
+    return _OUTLINE_COLOR.findall(source)
+
+
+def _debug_source(outdir: Path, file: str, index: int = 0) -> str:
     """Return the diagram source emitted by the needflow ``:debug:`` option.
 
     Both engines render it inside a ``<pre>``, but only graphviz syntax highlights
@@ -35,10 +49,11 @@ def _debug_source(outdir: Path, file: str) -> str:
 
     :param outdir: The build output directory.
     :param file: The name of the built HTML page holding the needflow.
-    :return: The concatenated text of every ``<pre>`` block on the page.
+    :param index: The position of the needflow on the page.
+    :return: The text of the requested ``<pre>`` block.
     """
     tree = html_parser.parse(outdir / file)
-    return "\n".join(pre.text_content() for pre in tree.xpath("//pre"))
+    return tree.xpath("//pre")[index].text_content()
 
 
 def _get_svg(config: Config, outdir: Path, file: str, id: str) -> str:
@@ -348,3 +363,85 @@ def test_node_ids_are_injective(test_app):
         assert debug.count('"R-1" [label=') == 1
         assert debug.count('"R=1" [label=') == 1
         assert '"R=1" -> "R-1" [' in debug
+
+
+BORDER_COLORS = """\
+Border colors
+=============
+
+.. spec:: Parent
+   :id: PARENT
+
+   .. spec:: Child
+      :id: CHILD
+
+.. needflow::
+   :border_color: FF0000
+   :debug:
+
+.. needflow::
+   :border_color: #00FF00
+   :debug:
+
+.. needflow::
+   :border_color: [status == 'nonexistent']:0000FF
+   :debug:
+"""
+
+
+@pytest.mark.parametrize(
+    "test_app",
+    [
+        {
+            "buildername": "html",
+            "files": [(Path("conf.py"), CONF_PY), (Path("index.rst"), BORDER_COLORS)],
+            "confoverrides": {"needs_flow_engine": "plantuml"},
+        },
+        {
+            "buildername": "html",
+            "files": [(Path("conf.py"), CONF_PY), (Path("index.rst"), BORDER_COLORS)],
+            "confoverrides": {
+                "needs_flow_engine": "graphviz",
+                "graphviz_output_format": "svg",
+            },
+        },
+    ],
+    ids=["plantuml", "graphviz"],
+    indirect=True,
+)
+def test_border_color_handling(test_app):
+    """``:border_color:`` accepts an optional leading ``#`` and may resolve to nothing.
+
+    Each engine has its own syntax for an outline color, so the option value is
+    normalised before either adds its own prefix -- previously a value written with
+    a ``#`` produced ``##RRGGBB`` (graphviz) or ``line:#RRGGBB`` (plantuml), and a
+    variant expression matching nothing produced the literal color ``#None``
+    (graphviz only).
+
+    The project deliberately holds a need with a child, so that both graphviz node
+    paths -- the plain node and the subgraph -- are covered and must agree.
+    """
+    app = test_app
+    app.build()
+
+    warnings = strip_colors(app._warning.getvalue()).strip()
+    assert warnings == ""
+
+    outdir = Path(app.outdir)
+    bare = _debug_source(outdir, "index.html", 0)
+    prefixed = _debug_source(outdir, "index.html", 1)
+    unmatched = _debug_source(outdir, "index.html", 2)
+
+    if app.config.needs_flow_engine == "plantuml":
+        assert bare.count("line:FF0000") == 2
+        assert prefixed.count("line:00FF00") == 2
+        assert "line:#00FF00" not in prefixed
+        assert "line:" not in unmatched
+    else:
+        # once for the subgraph (the parent) and once for the plain node (the child),
+        # so the two graphviz node paths are pinned to the same handling
+        assert _outline_colors(bare) == ["#FF0000", "#FF0000"]
+        assert _outline_colors(prefixed) == ["#00FF00", "#00FF00"]
+        assert "##00FF00" not in prefixed
+        assert _outline_colors(unmatched) == []
+        assert "#None" not in unmatched

--- a/tests/test_needflow.py
+++ b/tests/test_needflow.py
@@ -617,3 +617,53 @@ def test_unknown_link_type_warning_has_a_location(test_app):
     assert re.search(
         r"<srcdir>/index\.rst:\d+: WARNING: Unknown link type BOGUS_LT", warnings
     )
+
+
+ALT_TEXTS = """\
+Alt texts
+=========
+
+.. spec:: A
+   :id: AAAAA
+
+.. needflow::
+
+.. needflow::
+   :alt: my alt text
+
+.. needflow::
+   :alt:
+"""
+
+
+@pytest.mark.parametrize(
+    "test_app",
+    [
+        {
+            "buildername": "html",
+            "files": [(Path("conf.py"), CONF_PY), (Path("index.rst"), ALT_TEXTS)],
+            "confoverrides": {
+                "needs_flow_engine": "graphviz",
+                "graphviz_output_format": "svg",
+            },
+        }
+    ],
+    indirect=True,
+)
+def test_graphviz_alt_text(test_app):
+    """A graphviz needflow gets a placeholder ``alt``, unless the author sets one.
+
+    The directive always stored an ``alt``, so the intended placeholder default was
+    unreachable and every image was published with an empty ``alt``. An explicitly
+    empty ``:alt:`` still means "no alternative text", for a decorative diagram.
+    """
+    app = test_app
+    app.build()
+
+    warnings = strip_colors(app._warning.getvalue()).strip()
+    assert warnings == ""
+
+    tree = html_parser.parse(Path(app.outdir) / "index.html")
+    alts = [img.attrib["alt"] for img in tree.xpath("//img[@class='graphviz']")]
+
+    assert alts == ["needflow graphviz diagram", "my alt text", ""]

--- a/tests/test_needflow.py
+++ b/tests/test_needflow.py
@@ -8,6 +8,39 @@ from sphinx.config import Config
 from sphinx.util.console import strip_colors
 
 
+#: A ``conf.py`` for the inline source projects below.
+#: The id regex is relaxed, so that ids exercising the entity name sanitisation
+#: (see :func:`~sphinx_needs.directives.needflow._plantuml.make_entity_names`) are allowed.
+CONF_PY = """\
+extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
+plantuml_output_format = "svg"
+needs_id_regex = "^[A-Z0-9_=-]+$"
+needs_types = [
+    {
+        "directive": "spec",
+        "title": "Specification",
+        "prefix": "SP_",
+        "color": "#FEDCD2",
+        "style": "node",
+    },
+]
+"""
+
+
+def _debug_source(outdir: Path, file: str) -> str:
+    """Return the diagram source emitted by the needflow ``:debug:`` option.
+
+    Both engines render it inside a ``<pre>``, but only graphviz syntax highlights
+    it, so the text content is taken rather than the markup.
+
+    :param outdir: The build output directory.
+    :param file: The name of the built HTML page holding the needflow.
+    :return: The concatenated text of every ``<pre>`` block on the page.
+    """
+    tree = html_parser.parse(outdir / file)
+    return "\n".join(pre.text_content() for pre in tree.xpath("//pre"))
+
+
 def _get_svg(config: Config, outdir: Path, file: str, id: str) -> str:
     root_tree = html_parser.parse(outdir / file)
     if config.needs_flow_engine == "plantuml":
@@ -251,3 +284,67 @@ def test_doc_build_needflow_incl_child_needs(test_app):
             '"../index.html#SPEC_5"',
         ):
             assert link not in svg
+
+
+COLLIDING_IDS = """\
+Colliding need ids
+==================
+
+.. spec:: First
+   :id: R-1
+
+.. spec:: Second
+   :id: R=1
+   :links: R-1
+
+.. needflow::
+   :debug:
+"""
+
+
+@pytest.mark.parametrize(
+    "test_app",
+    [
+        {
+            "buildername": "html",
+            "files": [(Path("conf.py"), CONF_PY), (Path("index.rst"), COLLIDING_IDS)],
+            "confoverrides": {"needs_flow_engine": "plantuml"},
+        },
+        {
+            "buildername": "html",
+            "files": [(Path("conf.py"), CONF_PY), (Path("index.rst"), COLLIDING_IDS)],
+            "confoverrides": {
+                "needs_flow_engine": "graphviz",
+                "graphviz_output_format": "svg",
+            },
+        },
+    ],
+    ids=["plantuml", "graphviz"],
+    indirect=True,
+)
+def test_node_ids_are_injective(test_app):
+    """Needs whose ids sanitise alike must still be drawn as two nodes.
+
+    PlantUML entity names cannot contain punctuation, so ``R-1`` and ``R=1`` both
+    fold to ``R_1`` and used to collapse into a single node, silently losing a need
+    and its edge. Graphviz quotes its ids and is immune, which is asserted here too,
+    so both engines are pinned to the same "ids are stable and injective" policy.
+    """
+    app = test_app
+    app.build()
+
+    warnings = strip_colors(app._warning.getvalue()).strip()
+    assert warnings == ""
+
+    debug = _debug_source(Path(app.outdir), "index.html")
+
+    if app.config.needs_flow_engine == "plantuml":
+        # the ids are mapped in sorted order, so "R-1" keeps the plain name
+        # and "R=1" is disambiguated with a numeric suffix
+        assert debug.count("as R_1 ") == 1
+        assert debug.count("as R_1_2 ") == 1
+        assert "R_1_2 --> R_1" in debug
+    else:
+        assert debug.count('"R-1" [label=') == 1
+        assert debug.count('"R=1" [label=') == 1
+        assert '"R=1" -> "R-1" [' in debug

--- a/tests/test_needflow.py
+++ b/tests/test_needflow.py
@@ -561,3 +561,59 @@ def test_unknown_config_names_its_config_value(test_app):
     else:
         assert "config key 'nonexistent_cfg' not in 'needs_graphviz_styles'" in warnings
     assert "need_flows_configs" not in warnings
+
+
+UNKNOWN_LINK_TYPE = """\
+Unknown link type
+=================
+
+.. spec:: A
+   :id: AAAAA
+
+.. needflow::
+   :link_types: bogus_lt
+"""
+
+
+@pytest.mark.parametrize(
+    "test_app",
+    [
+        {
+            "buildername": "html",
+            "files": [
+                (Path("conf.py"), CONF_PY),
+                (Path("index.rst"), UNKNOWN_LINK_TYPE),
+            ],
+            "confoverrides": {"needs_flow_engine": "plantuml"},
+        },
+        {
+            "buildername": "html",
+            "files": [
+                (Path("conf.py"), CONF_PY),
+                (Path("index.rst"), UNKNOWN_LINK_TYPE),
+            ],
+            "confoverrides": {
+                "needs_flow_engine": "graphviz",
+                "graphviz_output_format": "svg",
+            },
+        },
+    ],
+    ids=["plantuml", "graphviz"],
+    indirect=True,
+)
+def test_unknown_link_type_warning_has_a_location(test_app):
+    """The unknown link type warning must say which needflow it came from.
+
+    The graphviz engine passed no location, so the warning arrived without the
+    ``file:line`` of the directive that caused it.
+    """
+    app = test_app
+    app.build()
+
+    warnings = strip_colors(app._warning.getvalue()).replace(
+        str(app.srcdir) + os.path.sep, "<srcdir>/"
+    )
+
+    assert re.search(
+        r"<srcdir>/index\.rst:\d+: WARNING: Unknown link type BOGUS_LT", warnings
+    )


### PR DESCRIPTION
Seven independently evidenced `needflow` defects, each with a regression test. No new
options, no deprecations, no refactor — the two engines keep their current behaviour
everywhere else. (First slice of the needflow portable-options work; the option
abstraction itself comes separately.)

## Fixes

- **`:show_legend:` crashed the build for a need type without a `color`** (#1664).
  `color` is optional in `needs_types`, but `diagrams_common.create_legend`
  (plantuml) and `_graphviz._create_legend` both subscripted it, so the build ended with
  `KeyError: 'color'` on either engine. The type now keeps its legend row with a blank
  swatch instead of being dropped, and a type whose `color` is an empty string no longer
  emits an empty swatch value. This is the other half of #1664, whose fix covered the node
  colour only — its fixture had no `:show_legend:`, so the legend path was never covered.
- **PlantUML drew two needs as one node when their ids differed only in punctuation.**
  PlantUML entity names cannot contain punctuation, so `R-1` and `R=1` both became `R_1`,
  and the second need plus its edges silently disappeared (the edge became the self-loop
  `R_1 --> R_1`). Entity names are now assigned per diagram from a stable, injective
  mapping. The shared `make_entity_name` is deliberately unchanged, because `needuml`
  imports it and its entity names are user-visible references there.
- **`:border_color:` mishandled a leading `#`, and a variant matching nothing.**
  `#00FF00` reached graphviz as `##00FF00` and PlantUML as `line:#00FF00`, which PlantUML
  rejects outright (the diagram failed to render). Separately, graphviz wrapped
  `match_variants` in `str(...)`, so an unmatched variant expression became the literal
  colour `#None`. Both engines now normalise the value through one helper and add their own
  prefix, and an unset result means "no border colour" on both. The two graphviz code paths
  — plain node and subgraph — are covered by the same test and must agree.
- **`:highlight:` filters that consult `needs` failed for a need with parts or children.**
  Graphviz draws such a need as a subgraph, and that path called `filter_single_need`
  without the needs list, while the plain-node path passed it. An expression like
  `len(needs) > 1` therefore raised `NeedsInvalidFilter: name 'needs' is not defined` and
  failed the whole build, purely because a need happened to have a child.
- **A graphviz needflow image had no alternative text.** The directive always stored an
  `alt`, so the intended `alt="needflow graphviz diagram"` default was unreachable and
  every image was published with `alt=""`. The placeholder now applies when `:alt:` is
  absent; writing `:alt:` with no value still gives `alt=""` for a diagram that is purely
  decorative. This is the one user-visible rendering change in the PR.
- **Two warning defects.** The unknown-`:config:` warning named `need_flows_configs`,
  which does not exist (it is `needs_flow_configs`), and the graphviz unknown-`:link_types:`
  warning was emitted without a location, so it arrived with no `file:line` — unlike the
  plantuml one.

## Environment version

`ENV_DATA_VERSION` goes 5 → 6, because the `alt` fix changes how the option is recorded
when it is not given (`""` → `None`) and that value is persisted in doctrees. Without the
bump the two halves can disagree within one version: an older reader over a newer doctree
publishes the literal `alt="None"`, and a newer reader over an older doctree leaves the fix
silently inert. The first build after upgrading re-reads every document.

## Tests

- `tests/test_github_issues.py::test_doc_github_1664_legend` (both engines), on the
  existing `doc_test/doc_github_issue_1664` project extended with a `:show_legend:` page.
- Seven new tests in `tests/test_needflow.py`, parameterised over both engines where the
  behaviour is shared, asserting on the `:debug:` diagram source (and, for `alt`, on the
  built `<img>`): node-id injectivity, `border_color` normalisation, `highlight` with
  `needs`, both `:config:` warning texts, the link-type warning location, the three
  `alt` cases, and the entity-name fallback contract (value + warning) covered directly.
- Each behavioural fix's test was recorded failing against the unfixed code before its
  fix landed; the commits are ordered test-then-fix per defect.
- The plantuml entity-name lookup warns if an id reaches it unmapped, which cannot happen
  today — the two `assert warnings == ""` tests in `tests/test_needflow.py` are what keeps
  it that way, and they stay green.
- The full suite passes (1214 passed, 11 skipped) with no snapshot changes.

## Documentation

`docs/changelog.rst` gains a `Bug fixes` section under `Unreleased`, and the `alt` section
of `docs/directives/needflow.rst` now documents the graphviz default and the
explicitly-empty case. The `border_color` reference needs no change: accepting a leading
`#` is a tolerance, not a contradiction of what it documents.