### PR TITLE
♻️ needflow: one graph model, two thin emitters

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -97,6 +97,14 @@ Improvements
   The stored environment version is bumped for the new directive option, so the first build
   after upgrading re-reads every document.
 
+Internal changes
+................
+
+These changes do not affect user-facing behaviour:
+
+- ♻️ :ref:`needflow`'s two engines now share one graph-model pass, with no change to the
+  generated diagram source
+
 Bug fixes
 .........
 

--- a/sphinx_needs/directives/needflow/_directive.py
+++ b/sphinx_needs/directives/needflow/_directive.py
@@ -106,6 +106,9 @@ class NeedflowDirective(FilterBase):
                     )
             config = "\n".join(_configs)
         else:
+            # note a graphviz needflow without a `:config:` silently gets the "default"
+            # style, so it is never unstyled the way a plantuml one is, and naming any
+            # config replaces that default rather than adding to it; it is kept as is
             config_names = config_names if config_names else "default"
             for config_name in config_names.split(","):
                 config_name = config_name.strip()

--- a/sphinx_needs/directives/needflow/_directive.py
+++ b/sphinx_needs/directives/needflow/_directive.py
@@ -141,7 +141,7 @@ class NeedflowDirective(FilterBase):
             "lineno": self.lineno,
             "target_id": targetid,
             "root_id": self.options.get("root_id"),
-            "root_direction": self.options.get("root_direction", "all"),
+            "root_direction": self.options.get("root_direction", "both"),
             "root_depth": self.options.get("root_depth", None),
             "show_legend": "show_legend" in self.options,
             "show_filters": "show_filters" in self.options,

--- a/sphinx_needs/directives/needflow/_graphviz.py
+++ b/sphinx_needs/directives/needflow/_graphviz.py
@@ -90,6 +90,10 @@ def process_needflow_graphviz(
             variant_location=node,
         )
 
+        # this check used to run before the `max_items` cap, which the model now applies;
+        # the verdict is the same either way, because `apply_max_items` either returns the
+        # needs unchanged or truncates them to a limit of at least one, so it can never
+        # turn a non-empty result into an empty one
         if not graph.needs:
             node.replace_self(
                 no_needs_found_paragraph(attributes.get("filter_warning"))
@@ -135,6 +139,9 @@ def process_needflow_graphviz(
         for edge in graph.edges:
             content += _render_edge(edge, graph.show_link_names, cluster_ids)
 
+        # note this lists only the need types that were actually drawn, whereas the
+        # plantuml engine lists every configured type, so the same `:show_legend:` gives
+        # the two engines different legends; it is kept as is
         if attributes["show_legend"]:
             content += _create_legend(
                 [drawn.need for drawn in graph.nodes.values()], needs_config

--- a/sphinx_needs/directives/needflow/_graphviz.py
+++ b/sphinx_needs/directives/needflow/_graphviz.py
@@ -4,7 +4,7 @@ import html
 import textwrap
 from collections.abc import Callable
 from functools import cache
-from typing import Literal, TypedDict
+from typing import Literal
 from urllib.parse import urlparse
 
 from docutils import nodes
@@ -22,24 +22,17 @@ from sphinx_needs.debug import measure_time
 from sphinx_needs.directives.needflow._directive import NeedflowGraphiz
 from sphinx_needs.directives.utils import no_needs_found_paragraph, report_max_items
 from sphinx_needs.errors import NoUri
-from sphinx_needs.filter_common import (
-    apply_max_items,
-    filter_single_need,
-    process_filters,
-)
 from sphinx_needs.logging import log_warning
 from sphinx_needs.need_item import NeedItem, NeedPartItem
-from sphinx_needs.needs_schema import LinkSchema
 from sphinx_needs.utils import remove_node_from_tree
-from sphinx_needs.variants import match_variants
-from sphinx_needs.views import NeedsView
 
-from ._shared import (
-    create_filter_paragraph,
-    filter_by_tree,
-    get_root_needs,
-    resolve_color,
+from ._model import (
+    GraphEdge,
+    GraphNode,
+    build_graph,
+    resolve_link_types,
 )
+from ._shared import create_filter_paragraph
 
 try:
     from sphinx.writers.html5 import HTML5Translator
@@ -58,11 +51,6 @@ def process_needflow_graphviz(
 ) -> None:
     needs_config = NeedsSphinxConfig(app.config)
     needs_schema = SphinxNeedsData(app.env).get_schema()
-    env_data = SphinxNeedsData(app.env)
-    needs_view = env_data.get_needs_view()
-
-    link_type_names = [name.upper() for name in needs_schema.iter_link_field_names()]
-    allowed_link_types_options = [link.upper() for link in needs_config.flow_link_types]
 
     node: NeedflowGraphiz
     for node in found_nodes:  # type: ignore[assignment]
@@ -87,78 +75,36 @@ def process_needflow_graphviz(
             # add the paragraph to after the surrounding figure
             node.parent.parent.insert(node.parent.parent.index(node.parent) + 1, para)
 
-        option_link_types = [link.upper() for link in attributes["link_types"]]
-        for lt in option_link_types:
-            if lt not in link_type_names:
-                log_warning(
-                    LOGGER,
-                    "Unknown link type {link_type} in needflow {flow}. Allowed values: {link_types}".format(
-                        link_type=lt,
-                        flow=attributes["target_id"],
-                        link_types=",".join(link_type_names),
-                    ),
-                    "needflow",
-                    location=node,
-                )
-
-        # compute the allowed link types
-        allowed_link_types: list[LinkSchema] = []
-        for link in needs_schema.iter_link_fields():
-            # Skip link-type handling, if it is not part of a specified list of allowed link_types or
-            # if not part of the overall configuration of needs_flow_link_types
-            if (
-                attributes["link_types"] and link.name.upper() not in option_link_types
-            ) or (
-                not attributes["link_types"]
-                and link.name.upper() not in allowed_link_types_options
-            ):
-                continue
-            # skip creating links from child needs to their own parent need
-            if link.name == "parent_needs":
-                continue
-            allowed_link_types.append(link)
-
-        init_filtered_needs = (
-            filter_by_tree(
-                needs_view,
-                root_id,
-                [lt.name for lt in allowed_link_types],
-                attributes["root_direction"],
-                attributes["root_depth"],
-            )
-            if (root_id := attributes["root_id"])
-            else needs_view
-        )
-        filtered_needs = process_filters(
-            app,
-            init_filtered_needs,
-            node.attributes,
-            origin="needflow",
+        allowed_link_types = resolve_link_types(
+            attributes,
+            schema=needs_schema,
+            config=needs_config,
             location=node,
         )
 
-        if not filtered_needs:
+        graph = build_graph(
+            app,
+            attributes,
+            allowed_link_types,
+            location=node,
+            variant_location=node,
+        )
+
+        if not graph.needs:
             node.replace_self(
                 no_needs_found_paragraph(attributes.get("filter_warning"))
             )
             continue
 
-        # the cap is applied before any of the rendering data is derived,
-        # so that dropped needs cannot be referenced by what is rendered
-        filtered_needs, total_needs = apply_max_items(
-            filtered_needs, attributes.get("max_items"), needs_config
-        )
-        if len(filtered_needs) < total_needs:
+        if len(graph.needs) < graph.total_needs:
             para = report_max_items(
-                len(filtered_needs),
-                total_needs,
+                len(graph.needs),
+                graph.total_needs,
                 origin="needflow",
                 location=node,
             )
             # add the paragraph to after the surrounding figure
             node.parent.parent.insert(node.parent.parent.index(node.parent) + 1, para)
-
-        id_comp_to_need = {need["id_complete"]: need for need in filtered_needs}
 
         content = "digraph needflow {\ncompound=true;\n"
 
@@ -174,31 +120,24 @@ def process_needflow_graphviz(
 
         # calculate node definitions
         content += "\n// node definitions\n"
-        rendered_nodes: dict[str, _RenderedNode] = {}
+        cluster_ids: dict[str, str | None] = {}
         """A mapping of node id_complete to the cluster id if the node is a subgraph, else None."""
-        for root_need in get_root_needs(filtered_needs):
+        for root in graph.roots:
             content += _render_node(
-                root_need,
+                root,
                 node,
-                needs_view,
-                needs_config,
                 lambda n: _get_link_to_need(app, fromdocname, n),
-                id_comp_to_need,
-                rendered_nodes,
+                cluster_ids,
             )
 
         # calculate edge definitions
         content += "\n// edge definitions\n"
-        for need in filtered_needs:
-            for link_type in allowed_link_types:
-                for link in need[link_type.name]:
-                    content += _render_edge(
-                        need, link, link_type, node, needs_config, rendered_nodes
-                    )
+        for edge in graph.edges:
+            content += _render_edge(edge, graph.show_link_names, cluster_ids)
 
         if attributes["show_legend"]:
             content += _create_legend(
-                [r["need"] for r in rendered_nodes.values()], needs_config
+                [drawn.need for drawn in graph.nodes.values()], needs_config
             )
 
         content += "}"
@@ -239,42 +178,34 @@ def _get_link_to_need(
     return None
 
 
-class _RenderedNode(TypedDict):
-    cluster_id: str | None
-    need: NeedItem | NeedPartItem
-
-
 def _quote(text: str) -> str:
     """Quote a string for use in a graphviz file."""
     return '"' + text.replace('"', '\\"') + '"'
 
 
 def _render_node(
-    need: NeedItem | NeedPartItem,
+    drawn: GraphNode,
     node: NeedflowGraphiz,
-    needs_view: NeedsView,
-    config: NeedsSphinxConfig,
     calc_link: Callable[[NeedItem | NeedPartItem], str | None],
-    id_comp_to_need: dict[str, NeedItem | NeedPartItem],
-    rendered_nodes: dict[str, _RenderedNode],
+    cluster_ids: dict[str, str | None],
     subgraph: bool = True,
 ) -> str:
-    """Render a node in the graphviz format."""
+    """Render a node in the graphviz format.
 
-    if subgraph and (
-        (
-            need["is_need"]
-            and any(f"{need['id']}.{i}" in id_comp_to_need for i in need["parts"])
-        )
-        or any(i in id_comp_to_need for i in need["parent_needs_back"])
-    ):
+    :param drawn: The node to render, carrying its resolved presentation.
+    :param node: The needflow node, for the graphviz style of the whole diagram.
+    :param calc_link: How to compute the link target of a need.
+    :param cluster_ids: Collects the cluster id of every node drawn as a subgraph,
+        which the edges need in order to point at the cluster rather than the ghost node.
+    """
+    if subgraph and (drawn.parts or drawn.children):
         # graphviz cannot nest nodes,
         # so we have to create a subgraph to represent a need with parts/children
-        return _render_subgraph(
-            need, node, needs_view, config, calc_link, id_comp_to_need, rendered_nodes
-        )
+        return _render_subgraph(drawn, node, calc_link, cluster_ids)
 
-    rendered_nodes[need["id_complete"]] = {"need": need, "cluster_id": None}
+    need = drawn.need
+    presentation = drawn.presentation
+    cluster_ids[need["id_complete"]] = None
 
     params: list[tuple[str, str]] = []
 
@@ -288,42 +219,31 @@ def _render_node(
 
     # shape
     if need["is_need"]:
-        if need["type_style"] not in _plantuml_shapes:
+        if presentation.type_style not in _plantuml_shapes:
             log_warning(
                 LOGGER,
-                f"Unknown node style {need['type_style']!r} for graphviz engine",
+                f"Unknown node style {presentation.type_style!r} for graphviz engine",
                 "needflow",
                 None,
                 once=True,
             )
-        shape = _plantuml_shapes.get(need["type_style"], need["type_style"])
+        shape = _plantuml_shapes.get(presentation.type_style, presentation.type_style)
         params.append(("shape", _quote(shape)))
     else:
         params.append(("shape", "rectangle"))
 
     # fill color
-    if need["type_color"]:
+    if presentation.type_color:
         style = node.attributes["graphviz_style"].get("node", {}).get("style", "")
         new_style = style + ",filled" if style else "filled"
         params.append(("style", _quote(new_style)))
-        params.append(("fillcolor", _quote(need["type_color"])))
+        params.append(("fillcolor", _quote(presentation.type_color)))
 
     # outline color
-    if node["highlight"] and filter_single_need(
-        need, config, node["highlight"], needs_view.values()
-    ):
+    if presentation.highlight:
         params.append(("color", "red"))
-    elif node["border_color"]:
-        color = resolve_color(
-            match_variants(
-                node["border_color"],
-                need.filter_context(),
-                config.variants,
-                location=node,
-            )
-        )
-        if color:
-            params.append(("color", _quote("#" + color)))
+    elif presentation.border_color:
+        params.append(("color", _quote("#" + presentation.border_color)))
 
     id = _quote(need["id_complete"])
     param_str = ", ".join(f"{key}={value}" for key, value in params)
@@ -331,15 +251,23 @@ def _render_node(
 
 
 def _render_subgraph(
-    need: NeedItem | NeedPartItem,
+    drawn: GraphNode,
     node: NeedflowGraphiz,
-    needs_view: NeedsView,
-    config: NeedsSphinxConfig,
     calc_link: Callable[[NeedItem | NeedPartItem], str | None],
-    id_comp_to_need: dict[str, NeedItem | NeedPartItem],
-    rendered_nodes: dict[str, _RenderedNode],
+    cluster_ids: dict[str, str | None],
 ) -> str:
-    """Render a subgraph in the graphviz format."""
+    """Render a need with parts or child needs, as a graphviz subgraph.
+
+    .. note:: The shape of a need drawn as a subgraph is emitted as configured, without
+       the translation (and the warning) that a plain node gets; it is kept as is.
+
+    :param drawn: The node to render, carrying the nodes nested inside it.
+    :param node: The needflow node, for the graphviz style of the whole diagram.
+    :param calc_link: How to compute the link target of a need.
+    :param cluster_ids: See :func:`_render_node`.
+    """
+    need = drawn.need
+    presentation = drawn.presentation
     params: list[tuple[str, str]] = []
 
     # label
@@ -352,31 +280,20 @@ def _render_subgraph(
 
     # shape
     if need["is_need"]:
-        params.append(("shape", _quote(need["type_style"])))
+        params.append(("shape", _quote(presentation.type_style)))
     else:
         params.append(("shape", "rectangle"))
 
     # fill color
-    if need["type_color"]:
+    if presentation.type_color:
         params.append(("style", "filled"))
-        params.append(("fillcolor", _quote(need["type_color"])))
+        params.append(("fillcolor", _quote(presentation.type_color)))
 
     # outline color
-    if node["highlight"] and filter_single_need(
-        need, config, node["highlight"], needs_view.values()
-    ):
+    if presentation.highlight:
         params.append(("color", "red"))
-    elif node["border_color"]:
-        color = resolve_color(
-            match_variants(
-                node["border_color"],
-                need.filter_context(),
-                config.variants,
-                location=node,
-            )
-        )
-        if color:
-            params.append(("color", _quote("#" + color)))
+    elif presentation.border_color:
+        params.append(("color", _quote("#" + presentation.border_color)))
 
     # we need to create an invisible node to allow links to the subgraph
     id = _quote(need["id_complete"])
@@ -385,46 +302,23 @@ def _render_subgraph(
     cluster_id = _quote("cluster_" + need["id_complete"])
     param_str = "\n".join(f"  {key}={value};" for key, value in params)
 
-    rendered_nodes[need["id_complete"]] = {
-        "need": need,
-        "cluster_id": "cluster_" + need["id_complete"],
-    }
+    cluster_ids[need["id_complete"]] = "cluster_" + need["id_complete"]
 
+    # note the comments are written according to the need itself, not to what is drawn,
+    # so a need whose parts were all filtered out still gets the parts comment
     children = ""
     if need["is_need"] and need["parts"]:
         children += "  // parts:\n"
-        for need_part_id in need["parts"]:
-            need_part_id = need["id"] + "." + need_part_id
-            if need_part_id in id_comp_to_need:
-                children += textwrap.indent(
-                    _render_node(
-                        id_comp_to_need[need_part_id],
-                        node,
-                        needs_view,
-                        config,
-                        calc_link,
-                        id_comp_to_need,
-                        rendered_nodes,
-                        False,
-                    ),
-                    "  ",
-                )
+        for part in drawn.parts:
+            children += textwrap.indent(
+                _render_node(part, node, calc_link, cluster_ids, False), "  "
+            )
     if need["parent_needs_back"]:
         children += "  // child needs:\n"
-        for child_need_id in need["parent_needs_back"]:
-            if child_need_id in id_comp_to_need:
-                children += textwrap.indent(
-                    _render_node(
-                        id_comp_to_need[child_need_id],
-                        node,
-                        needs_view,
-                        config,
-                        calc_link,
-                        id_comp_to_need,
-                        rendered_nodes,
-                    ),
-                    "  ",
-                )
+        for child in drawn.children:
+            children += textwrap.indent(
+                _render_node(child, node, calc_link, cluster_ids), "  "
+            )
 
     return f"subgraph {cluster_id} {{\n{param_str}\n\n  {ghost_node}\n{children}\n}};\n"
 
@@ -462,42 +356,41 @@ def _label(
 
 
 def _render_edge(
-    need: NeedItem | NeedPartItem,
-    link: str,
-    link_type: LinkSchema,
-    node: NeedflowGraphiz,
-    config: NeedsSphinxConfig,
-    rendered_nodes: dict[str, _RenderedNode],
+    edge: GraphEdge,
+    show_links: bool,
+    cluster_ids: dict[str, str | None],
 ) -> str:
-    """Render an edge in the graphviz format."""
-    if need["id_complete"] not in rendered_nodes or link not in rendered_nodes:
+    """Render an edge in the graphviz format.
+
+    :param edge: The edge to render.
+    :param show_links: Whether to label the edge with the link type.
+    :param cluster_ids: The cluster ids collected by :func:`_render_node`.
+    """
+    if not (edge.source_drawn and edge.target_drawn):
         # if the start or end node is not rendered, we should not create a link
         return ""
-
-    show_links = node["show_link_names"] or config.flow_show_links
 
     params: list[tuple[str, str]] = []
 
     if show_links:
-        params.append(("label", _quote(link_type.display.outgoing)))
+        params.append(("label", _quote(edge.link_type.display.outgoing)))
 
-    is_part = "." in link or "." in need["id_complete"]
     params.extend(
         # TODO also use link_type.display.color?
         _style_params_from_link_type(
-            link_type.display.style_part if is_part else link_type.display.style,
-            link_type.display.style_start,
-            link_type.display.style_end,
+            edge.style,
+            edge.link_type.display.style_start,
+            edge.link_type.display.style_end,
         )
     )
 
-    start_id = _quote(need["id_complete"])
-    if (ltail := rendered_nodes[need["id_complete"]]["cluster_id"]) is not None:
+    start_id = _quote(edge.source_id)
+    if (ltail := cluster_ids[edge.source_id]) is not None:
         # the need has been created as a subgraph and so we also need to create a logical link to the cluster
         params.append(("ltail", _quote(ltail)))
 
-    end_id = _quote(link)
-    if (lhead := rendered_nodes[link]["cluster_id"]) is not None:
+    end_id = _quote(edge.target_id)
+    if (lhead := cluster_ids[edge.target_id]) is not None:
         # the end need has been created as a subgraph and so we also need to create a logical link to the cluster
         params.append(("lhead", _quote(lhead)))
 

--- a/sphinx_needs/directives/needflow/_model.py
+++ b/sphinx_needs/directives/needflow/_model.py
@@ -1,0 +1,438 @@
+"""The engine independent graph model behind a ``needflow``.
+
+Both needflow engines draw the same graph and differ only in the syntax they write it
+in.  This module computes that graph exactly once -- which needs are drawn, how they
+nest, how each one is presented, and which edges connect them -- so that
+:mod:`~sphinx_needs.directives.needflow._plantuml` and
+:mod:`~sphinx_needs.directives.needflow._graphviz` are left with nothing but the
+emission of their own syntax.
+
+The model holds resolved values, never syntax: a colour is a colour, not ``#FF0000`` or
+``line:FF0000``, and the nesting of needs is a tree, not braces or a ``subgraph``.
+
+Frozen accidents
+----------------
+
+Several behaviours reproduced here are accidents of the original per-engine
+implementations rather than designed semantics.  They are preserved deliberately --
+this module exists to make the two engines share one implementation, not to change what
+either of them draws -- and are called out at the point where they happen:
+
+- :func:`filter_by_tree` walks depth first, so ``root_depth`` depends on traversal order.
+- ``parent_needs`` is dropped from the allowed link types *before* the root walk, so
+  ``root_id`` never follows the need hierarchy.
+- The root walk runs before the filter, not after it.
+- ``show_link_names`` is OR-ed with ``needs_flow_show_links``, so the configuration can
+  only ever turn labels on.
+- An edge may point at a need that is not drawn as a node (see :class:`GraphEdge`).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+from docutils import nodes
+from sphinx.application import Sphinx
+
+from sphinx_needs.config import NeedsSphinxConfig
+from sphinx_needs.data import NeedsFlowType, SphinxNeedsData
+from sphinx_needs.filter_common import (
+    apply_max_items,
+    filter_single_need,
+    process_filters,
+)
+from sphinx_needs.logging import get_logger, log_warning
+from sphinx_needs.need_item import NeedItem, NeedPartItem
+from sphinx_needs.needs_schema import FieldsSchema, LinkSchema
+from sphinx_needs.variants import match_variants
+from sphinx_needs.views import NeedsView
+
+LOGGER = get_logger(__name__)
+
+#: The location accepted by the warning machinery of the values resolved here.
+LocationType = tuple[str, int | None] | nodes.Element
+
+
+def filter_by_tree(
+    needs_view: NeedsView,
+    root_id: str,
+    link_names: list[str],
+    direction: Literal["both", "incoming", "outgoing"],
+    depth: int | None,
+) -> NeedsView:
+    """Filter all needs by the given ``root_id``,
+    and all needs that are connected to the root need by the given ``link_types``, in the given ``direction``.
+
+    .. note:: The frontier is a dict popped from the end, i.e. the walk is depth first,
+       and the first visit of a need wins.  A need reachable at two different depths can
+       therefore be recorded at the deeper one and have its subtree pruned by ``depth``.
+       This makes ``root_depth`` dependent on traversal order; it is kept as is.
+    """
+    if root_id not in needs_view:
+        return needs_view.filter_ids([])
+    roots = {root_id: (0, needs_view[root_id])}
+    link_prefixes = (
+        ("_back",)
+        if direction == "incoming"
+        else ("",)
+        if direction == "outgoing"
+        else ("", "_back")
+    )
+    links_to_process = [link + d for link in link_names for d in link_prefixes]
+
+    need_ids: list[str] = []
+    while roots:
+        root_id, (root_depth, root) = roots.popitem()
+        if root_id in need_ids:
+            continue
+        if depth is not None and root_depth > depth:
+            continue
+        need_ids.append(root_id)
+        for link_type_name in links_to_process:
+            roots.update(
+                {
+                    i: (root_depth + 1, needs_view[i])
+                    for i in root.get(link_type_name, [])
+                    if i in needs_view
+                }
+            )
+
+    return needs_view.filter_ids(need_ids)
+
+
+def resolve_color(value: None | str | int | float | bool) -> str | None:
+    """Normalise a resolved color option value to an engine neutral form.
+
+    A color may be written with or without a leading ``#``, and each engine adds the
+    prefix that its own syntax requires, so any leading ``#`` characters are stripped here.
+    An unset or empty value means "no color", rather than a color named after the
+    string representation of the value.
+
+    :param value: The resolved value of a color option,
+        e.g. the return value of :func:`~sphinx_needs.variants.match_variants`.
+    :return: The color without a leading ``#``, or ``None`` if no color was given.
+    """
+    if value is None:
+        return None
+    return str(value).strip().lstrip("#") or None
+
+
+def get_root_needs(found_needs: list[NeedItem | NeedPartItem]) -> list[NeedItem]:
+    """Select the needs that start a nesting tree.
+
+    A need is a root if it has no parent need, or if its parent is not part of the
+    result.  Need parts are never roots: they are only ever drawn inside their need.
+
+    :param found_needs: The needs and need parts that passed the filter.
+    :return: The needs to draw at the top level, in the order they were given.
+    """
+    return_list = []
+    for current_need in found_needs:
+        if current_need["is_need"] and isinstance(current_need, NeedItem):
+            if "parent_need" not in current_need or current_need["parent_need"] == "":
+                # need has no parent, we have to add the need to the root needs
+                return_list.append(current_need)
+            else:
+                parent_found: bool = False
+                for elements in found_needs:
+                    if elements["id"] == current_need["parent_need"]:
+                        parent_found = True
+                        break
+                if not parent_found:
+                    return_list.append(current_need)
+    return return_list
+
+
+@dataclass(frozen=True)
+class NodePresentation:
+    """The resolved presentation of a single drawn need, free of any engine syntax."""
+
+    type_style: str
+    """The style name of the need type, or ``rectangle`` for a need part."""
+
+    type_color: str | None
+    """The color of the need type as configured, or ``None`` if it has none.
+
+    This is the raw configured value: it may or may not carry a leading ``#``,
+    which each engine handles in the way its own syntax requires.
+    """
+
+    highlight: bool
+    """Whether the need passed the ``highlight`` filter, and so gets a red outline."""
+
+    border_color: str | None
+    """The resolved ``border_color``, without a leading ``#``.
+
+    ``None`` if the option was not given, resolved to nothing, or if ``highlight``
+    applies -- a highlight always takes precedence over a border color.
+    """
+
+
+@dataclass
+class GraphNode:
+    """A single drawn need or need part, and everything drawn inside it."""
+
+    need: NeedItem | NeedPartItem
+    """The need or need part itself."""
+
+    presentation: NodePresentation
+    """How the need is to be presented."""
+
+    parts: list[GraphNode] = field(default_factory=list)
+    """The parts of the need that are part of the result, in the order of the need.
+
+    Empty for a need part: parts cannot have parts.
+    """
+
+    children: list[GraphNode] = field(default_factory=list)
+    """The child needs that are part of the result, in the order of the parent's back links.
+
+    Empty for a need part, which is never recursed into.
+    """
+
+
+@dataclass(frozen=True)
+class GraphEdge:
+    """A single link between two needs of the result."""
+
+    source_id: str
+    """The complete id of the need the link starts at."""
+
+    target_id: str
+    """The complete id of the need the link points at."""
+
+    link_type: LinkSchema
+    """The link field the link belongs to, carrying its display configuration."""
+
+    is_part: bool
+    """Whether either end of the link is a need part, which is styled differently."""
+
+    source_drawn: bool
+    """Whether the source need is drawn as a node.
+
+    A need that is part of the result is not necessarily drawn: a need part whose need
+    was filtered out has nowhere to be drawn, but its links are still collected here.
+    """
+
+    target_drawn: bool
+    """Whether the target need is drawn as a node (see :attr:`source_drawn`)."""
+
+    @property
+    def style(self) -> str:
+        """The configured line style to use for this link."""
+        return (
+            self.link_type.display.style_part
+            if self.is_part
+            else self.link_type.display.style
+        )
+
+
+@dataclass
+class NeedflowGraph:
+    """The complete graph of one needflow, ready to be emitted by any engine."""
+
+    needs: list[NeedItem | NeedPartItem]
+    """All needs and need parts that passed the filter, after the ``max_items`` cap."""
+
+    total_needs: int
+    """How many needs passed the filter, before the ``max_items`` cap."""
+
+    roots: list[GraphNode]
+    """The top level nodes, each carrying the nodes nested inside it."""
+
+    nodes: dict[str, GraphNode]
+    """Every drawn node, by complete id, in the order the nodes are drawn."""
+
+    edges: list[GraphEdge]
+    """Every link between needs of the result, in the order the engines emit them."""
+
+    show_link_names: bool
+    """Whether edges are to be labelled with the link type."""
+
+
+def resolve_link_types(
+    attributes: NeedsFlowType,
+    /,
+    *,
+    schema: FieldsSchema,
+    config: NeedsSphinxConfig,
+    location: nodes.Element,
+) -> list[LinkSchema]:
+    """Resolve which link fields a needflow may draw.
+
+    Unknown names given to the ``link_types`` option are warned about, but otherwise
+    ignored.
+
+    .. note:: ``parent_needs`` is always removed, so that a child need is not linked to
+       its parent by an edge as well as by nesting.  This happens *before* the list is
+       used for the root walk, so :option:`root_id <needflow:root_id>` cannot follow the
+       need hierarchy either; it is kept as is.
+
+    :param attributes: The needflow's options.
+    :param schema: The schema holding all link fields.
+    :param config: The Sphinx-Needs configuration.
+    :param location: Where to report unknown link type names.
+    :return: The link fields to draw, in schema order.
+    """
+    link_type_names = [link.name.upper() for link in schema.iter_link_fields()]
+    option_link_types = [link.upper() for link in attributes["link_types"]]
+    for lt in option_link_types:
+        if lt not in link_type_names:
+            log_warning(
+                LOGGER,
+                "Unknown link type {link_type} in needflow {flow}. Allowed values: {link_types}".format(
+                    link_type=lt,
+                    flow=attributes["target_id"],
+                    link_types=",".join(link_type_names),
+                ),
+                "needflow",
+                location=location,
+            )
+
+    # note the `needs_flow_link_types` fallback is unreachable, since the directive
+    # always defaults the option to every link type; it is kept as is
+    config_link_types = [link.upper() for link in config.flow_link_types]
+
+    allowed_link_types: list[LinkSchema] = []
+    for link_field in schema.iter_link_fields():
+        # Skip link-type handling, if it is not part of a specified list of allowed link_types or
+        # if not part of the overall configuration of needs_flow_link_types
+        if (
+            attributes["link_types"]
+            and link_field.name.upper() not in option_link_types
+        ) or (
+            not attributes["link_types"]
+            and link_field.name.upper() not in config_link_types
+        ):
+            continue
+        # skip creating links from child needs to their own parent need
+        if link_field.name == "parent_needs":
+            continue
+        allowed_link_types.append(link_field)
+    return allowed_link_types
+
+
+def build_graph(
+    app: Sphinx,
+    attributes: NeedsFlowType,
+    allowed_link_types: list[LinkSchema],
+    /,
+    *,
+    location: nodes.Element,
+    variant_location: LocationType,
+) -> NeedflowGraph:
+    """Compute the whole graph of a single needflow.
+
+    The needs are collected by walking out from ``root_id`` (if given), filtering the
+    result, and capping it to ``max_items``.  They are then arranged into the nesting
+    tree that both engines draw, each drawn need gets its presentation resolved, and the
+    links between all needs of the result are collected.
+
+    :param app: The Sphinx application.
+    :param attributes: The needflow's options.
+    :param allowed_link_types: The link fields to draw, from :func:`resolve_link_types`.
+    :param location: Where to report filter problems.
+    :param variant_location: Where to report ``border_color`` variant problems.
+        The two engines pass different values, which is kept as is.
+    :return: The graph to be emitted.
+    """
+    needs_config = NeedsSphinxConfig(app.config)
+    needs_view = SphinxNeedsData(app.env).get_needs_view()
+
+    # the root walk runs before the filter, so a need excluded by the filter can still
+    # act as a stepping stone to a need that is included; it is kept as is
+    need_values = (
+        filter_by_tree(
+            needs_view,
+            root_id,
+            [lt.name for lt in allowed_link_types],
+            attributes["root_direction"],
+            attributes["root_depth"],
+        )
+        if (root_id := attributes["root_id"])
+        else needs_view
+    )
+    found_needs = process_filters(
+        app,
+        need_values,
+        attributes,
+        origin="needflow",
+        location=location,
+    )
+    # the cap is applied before any of the drawing data is derived,
+    # so that dropped needs cannot be referenced by what is drawn
+    found_needs, total_needs = apply_max_items(
+        found_needs, attributes.get("max_items"), needs_config
+    )
+
+    found_by_id = {need["id_complete"]: need for need in found_needs}
+    drawn: dict[str, GraphNode] = {}
+
+    def _presentation(need: NeedItem | NeedPartItem) -> NodePresentation:
+        highlight = bool(attributes["highlight"]) and filter_single_need(
+            need, needs_config, attributes["highlight"], needs_view.values()
+        )
+        border_color = None
+        if not highlight and attributes["border_color"]:
+            border_color = resolve_color(
+                match_variants(
+                    attributes["border_color"],
+                    need.filter_context(),
+                    needs_config.variants,
+                    location=variant_location,
+                )
+            )
+        return NodePresentation(
+            # need parts have no style of their own
+            type_style=need["type_style"] if need["is_need"] else "rectangle",
+            type_color=need["type_color"] or None,
+            highlight=highlight,
+            border_color=border_color,
+        )
+
+    def _build_node(need: NeedItem | NeedPartItem, *, leaf: bool = False) -> GraphNode:
+        node = GraphNode(need=need, presentation=_presentation(need))
+        drawn[need["id_complete"]] = node
+        if leaf:
+            # a need part is never recursed into, by either engine
+            return node
+        if need["is_need"]:
+            for part_id in need["parts"]:
+                if (part := found_by_id.get(f"{need['id']}.{part_id}")) is not None:
+                    node.parts.append(_build_node(part, leaf=True))
+        for child_id in need["parent_needs_back"]:
+            if (child := found_by_id.get(child_id)) is not None:
+                node.children.append(_build_node(child))
+        return node
+
+    roots = [_build_node(root) for root in get_root_needs(found_needs)]
+
+    edges: list[GraphEdge] = []
+    for need in found_needs:
+        source_id = need["id_complete"]
+        for link_type in allowed_link_types:
+            for link in need[link_type.name]:
+                if link not in found_by_id:
+                    # the link target was filtered out, so there is nothing to point at
+                    continue
+                edges.append(
+                    GraphEdge(
+                        source_id=source_id,
+                        target_id=link,
+                        link_type=link_type,
+                        is_part="." in link or "." in source_id,
+                        source_drawn=source_id in drawn,
+                        target_drawn=link in drawn,
+                    )
+                )
+
+    return NeedflowGraph(
+        needs=found_needs,
+        total_needs=total_needs,
+        roots=roots,
+        nodes=drawn,
+        edges=edges,
+        # the configuration can only ever turn link names on; it is kept as is
+        show_link_names=attributes["show_link_names"] or needs_config.flow_show_links,
+    )

--- a/sphinx_needs/directives/needflow/_model.py
+++ b/sphinx_needs/directives/needflow/_model.py
@@ -29,6 +29,7 @@ either of them draws -- and are called out at the point where they happen:
 
 from __future__ import annotations
 
+from collections.abc import Callable, Container, Iterable
 from dataclasses import dataclass, field
 from typing import Literal
 
@@ -366,33 +367,92 @@ def build_graph(
         found_needs, attributes.get("max_items"), needs_config
     )
 
+    roots, drawn = build_node_tree(
+        found_needs,
+        lambda need: resolve_presentation(
+            need,
+            highlight=attributes["highlight"],
+            border_color=attributes["border_color"],
+            config=needs_config,
+            needs=needs_view.values(),
+            location=variant_location,
+        ),
+    )
+
+    return NeedflowGraph(
+        needs=found_needs,
+        total_needs=total_needs,
+        roots=roots,
+        nodes=drawn,
+        edges=collect_edges(found_needs, allowed_link_types, drawn),
+        # the configuration can only ever turn link names on; it is kept as is
+        show_link_names=attributes["show_link_names"] or needs_config.flow_show_links,
+    )
+
+
+def resolve_presentation(
+    need: NeedItem | NeedPartItem,
+    /,
+    *,
+    highlight: str,
+    border_color: str | None,
+    config: NeedsSphinxConfig,
+    needs: Iterable[NeedItem | NeedPartItem],
+    location: LocationType,
+) -> NodePresentation:
+    """Resolve how a single need is to be presented.
+
+    :param need: The need or need part to be drawn.
+    :param highlight: The ``highlight`` filter, empty if the option was not given.
+    :param border_color: The ``border_color`` option, in variant syntax.
+    :param config: The Sphinx-Needs configuration.
+    :param needs: All needs, for a ``highlight`` filter that consults them.
+    :param location: Where to report ``border_color`` variant problems.
+    :return: The resolved presentation.
+    """
+    is_highlighted = bool(highlight) and filter_single_need(
+        need, config, highlight, needs
+    )
+    resolved_border = None
+    if not is_highlighted and border_color:
+        # a highlight always wins, so the border color is not even resolved
+        resolved_border = resolve_color(
+            match_variants(
+                border_color,
+                need.filter_context(),
+                config.variants,
+                location=location,
+            )
+        )
+    return NodePresentation(
+        # need parts have no style of their own
+        type_style=need["type_style"] if need["is_need"] else "rectangle",
+        type_color=need["type_color"] or None,
+        highlight=is_highlighted,
+        border_color=resolved_border,
+    )
+
+
+def build_node_tree(
+    found_needs: list[NeedItem | NeedPartItem],
+    presentation: Callable[[NeedItem | NeedPartItem], NodePresentation],
+    /,
+) -> tuple[list[GraphNode], dict[str, GraphNode]]:
+    """Arrange the needs of a result into the tree of nodes that the engines draw.
+
+    A need is drawn inside its parent need, and a need part inside its need, so a need
+    whose parent is not part of the result becomes a root, and a need part whose need is
+    not part of the result is not drawn at all.
+
+    :param found_needs: The needs and need parts that passed the filter.
+    :param presentation: How to resolve the presentation of a single need.
+    :return: The root nodes, and every drawn node by complete id.
+    """
     found_by_id = {need["id_complete"]: need for need in found_needs}
     drawn: dict[str, GraphNode] = {}
 
-    def _presentation(need: NeedItem | NeedPartItem) -> NodePresentation:
-        highlight = bool(attributes["highlight"]) and filter_single_need(
-            need, needs_config, attributes["highlight"], needs_view.values()
-        )
-        border_color = None
-        if not highlight and attributes["border_color"]:
-            border_color = resolve_color(
-                match_variants(
-                    attributes["border_color"],
-                    need.filter_context(),
-                    needs_config.variants,
-                    location=variant_location,
-                )
-            )
-        return NodePresentation(
-            # need parts have no style of their own
-            type_style=need["type_style"] if need["is_need"] else "rectangle",
-            type_color=need["type_color"] or None,
-            highlight=highlight,
-            border_color=border_color,
-        )
-
-    def _build_node(need: NeedItem | NeedPartItem, *, leaf: bool = False) -> GraphNode:
-        node = GraphNode(need=need, presentation=_presentation(need))
+    def _build(need: NeedItem | NeedPartItem, *, leaf: bool = False) -> GraphNode:
+        node = GraphNode(need=need, presentation=presentation(need))
         drawn[need["id_complete"]] = node
         if leaf:
             # a need part is never recursed into, by either engine
@@ -400,20 +460,40 @@ def build_graph(
         if need["is_need"]:
             for part_id in need["parts"]:
                 if (part := found_by_id.get(f"{need['id']}.{part_id}")) is not None:
-                    node.parts.append(_build_node(part, leaf=True))
+                    node.parts.append(_build(part, leaf=True))
         for child_id in need["parent_needs_back"]:
             if (child := found_by_id.get(child_id)) is not None:
-                node.children.append(_build_node(child))
+                node.children.append(_build(child))
         return node
 
-    roots = [_build_node(root) for root in get_root_needs(found_needs)]
+    return [_build(root) for root in get_root_needs(found_needs)], drawn
 
+
+def collect_edges(
+    found_needs: list[NeedItem | NeedPartItem],
+    allowed_link_types: list[LinkSchema],
+    drawn: Container[str],
+    /,
+) -> list[GraphEdge]:
+    """Collect every link between the needs of a result.
+
+    A link is collected only if its target is part of the result; whether either of its
+    ends is actually *drawn* is recorded rather than acted on, since the engines differ
+    in what they do with a link that has an undrawn end.
+
+    :param found_needs: The needs and need parts that passed the filter.
+    :param allowed_link_types: The link fields to draw.
+    :param drawn: The complete ids of the drawn nodes, from :func:`build_node_tree`.
+    :return: The edges, in the order the engines emit them.
+    """
+    # a need and a need part are both identified by their complete id
+    found_ids = {need["id_complete"] for need in found_needs}
     edges: list[GraphEdge] = []
     for need in found_needs:
         source_id = need["id_complete"]
         for link_type in allowed_link_types:
             for link in need[link_type.name]:
-                if link not in found_by_id:
+                if link not in found_ids:
                     # the link target was filtered out, so there is nothing to point at
                     continue
                 edges.append(
@@ -426,13 +506,4 @@ def build_graph(
                         target_drawn=link in drawn,
                     )
                 )
-
-    return NeedflowGraph(
-        needs=found_needs,
-        total_needs=total_needs,
-        roots=roots,
-        nodes=drawn,
-        edges=edges,
-        # the configuration can only ever turn link names on; it is kept as is
-        show_link_names=attributes["show_link_names"] or needs_config.flow_show_links,
-    )
+    return edges

--- a/sphinx_needs/directives/needflow/_model.py
+++ b/sphinx_needs/directives/needflow/_model.py
@@ -150,7 +150,11 @@ class NodePresentation:
     """The resolved presentation of a single drawn need, free of any engine syntax."""
 
     type_style: str
-    """The style name of the need type, or ``rectangle`` for a need part."""
+    """The style name of the need type, or ``rectangle`` for a need part.
+
+    A need part has no style of its own, and both engines happen to spell their fallback
+    for one the same way, so the name is shared here rather than left to each engine.
+    """
 
     type_color: str | None
     """The color of the need type as configured, or ``None`` if it has none.

--- a/sphinx_needs/directives/needflow/_plantuml.py
+++ b/sphinx_needs/directives/needflow/_plantuml.py
@@ -17,24 +17,16 @@ from sphinx_needs.diagrams_common import (
 )
 from sphinx_needs.directives.needflow._directive import NeedflowPlantuml
 from sphinx_needs.directives.utils import no_needs_found_paragraph, report_max_items
-from sphinx_needs.filter_common import (
-    apply_max_items,
-    filter_single_need,
-    process_filters,
-)
 from sphinx_needs.logging import get_logger, log_warning
-from sphinx_needs.need_item import NeedItem, NeedPartItem
-from sphinx_needs.needs_schema import LinkSchema
 from sphinx_needs.utils import remove_node_from_tree
-from sphinx_needs.variants import match_variants
-from sphinx_needs.views import NeedsView
 
-from ._shared import (
-    create_filter_paragraph,
-    filter_by_tree,
-    get_root_needs,
-    resolve_color,
+from ._model import (
+    GraphNode,
+    NeedflowGraph,
+    build_graph,
+    resolve_link_types,
 )
+from ._shared import create_filter_paragraph
 
 logger = get_logger(__name__)
 
@@ -102,16 +94,17 @@ def get_entity_name(entity_names: Mapping[str, str], id: str) -> str:
 def get_need_node_rep_for_plantuml(
     app: Sphinx,
     fromdocname: str,
-    current_needflow: NeedsFlowType,
-    needs_view: NeedsView,
-    need_info: NeedItem | NeedPartItem,
+    graph_node: GraphNode,
     entity_names: Mapping[str, str],
 ) -> str:
-    """Calculate need node representation for plantuml.
+    """Emit the plantuml representation of a single need or need part.
 
+    :param graph_node: The node to emit, carrying its resolved presentation.
     :param entity_names: The id to entity name mapping of :func:`make_entity_names`.
     """
     needs_config = NeedsSphinxConfig(app.config)
+    need_info = graph_node.need
+    presentation = graph_node.presentation
 
     node_text = render_template_string(
         needs_config.diagram_template,
@@ -122,30 +115,15 @@ def get_need_node_rep_for_plantuml(
     node_link = calculate_link(app, need_info, fromdocname)
 
     node_colors = []
-    if need_info["type_color"]:
+    if presentation.type_color:
         # We set # later, as the user may not have given a color and the node must get highlighted
-        node_colors.append(need_info["type_color"].replace("#", ""))
+        node_colors.append(presentation.type_color.replace("#", ""))
 
-    if current_needflow["highlight"] and filter_single_need(
-        need_info, needs_config, current_needflow["highlight"], needs_view.values()
-    ):
+    if presentation.highlight:
         node_colors.append("line:FF0000")
-
-    elif current_needflow["border_color"]:
-        color = resolve_color(
-            match_variants(
-                current_needflow["border_color"],
-                need_info.filter_context(),
-                needs_config.variants,
-                location=(current_needflow["docname"], current_needflow["lineno"]),
-            )
-        )
-        if color:
-            # the whole color list is prefixed with a single "#" below
-            node_colors.append(f"line:{color}")
-
-    # need parts style use default "rectangle"
-    node_style = need_info["type_style"] if need_info["is_need"] else "rectangle"
+    elif presentation.border_color:
+        # the whole color list is prefixed with a single "#" below
+        node_colors.append(f"line:{presentation.border_color}")
 
     # node representation for plantuml
     color_suffix = f" #{';'.join(node_colors)}" if node_colors else ""
@@ -154,7 +132,7 @@ def get_need_node_rep_for_plantuml(
         node_text=node_text,
         link=node_link,
         color_suffix=color_suffix,
-        style=node_style,
+        style=presentation.type_style,
     )
     return need_node_code
 
@@ -162,18 +140,20 @@ def get_need_node_rep_for_plantuml(
 def walk_curr_need_tree(
     app: Sphinx,
     fromdocname: str,
-    current_needflow: NeedsFlowType,
-    needs_view: NeedsView,
-    found_needs: list[NeedItem | NeedPartItem],
-    need: NeedItem | NeedPartItem,
+    graph_node: GraphNode,
     entity_names: Mapping[str, str],
 ) -> str:
-    """
-    Walk through each need to find all its child needs and need parts recursively and wrap them together in nested structure.
+    """Emit the need parts and child needs of a need, as a nested plantuml block.
 
+    .. note:: Whether a block is opened, and whether each comment is written, is decided
+       from the need itself rather than from what is drawn.  A need whose parts and
+       children were all filtered out therefore still gets an (empty) block; it is kept
+       as is.
+
+    :param graph_node: The node whose nested nodes are to be emitted.
     :param entity_names: The id to entity name mapping of :func:`make_entity_names`.
     """
-
+    need = graph_node.need
     curr_need_tree = ""
 
     if not need["parts"] and not need["parent_needs_back"]:
@@ -185,55 +165,28 @@ def walk_curr_need_tree(
     if need["is_need"] and need["parts"]:
         # add comment for easy debugging
         curr_need_tree += "'parts:\n"
-        for need_part_id in need["parts"]:
-            # cal need part node
-            need_part_id = need["id"] + "." + need_part_id
-            # get need part from need part id
-            for found_need in found_needs:
-                if need_part_id == found_need["id_complete"]:
-                    curr_need_tree += (
-                        get_need_node_rep_for_plantuml(
-                            app,
-                            fromdocname,
-                            current_needflow,
-                            needs_view,
-                            found_need,
-                            entity_names,
-                        )
-                        + "\n"
-                    )
-                    break
+        for part_node in graph_node.parts:
+            curr_need_tree += (
+                get_need_node_rep_for_plantuml(
+                    app, fromdocname, part_node, entity_names
+                )
+                + "\n"
+            )
 
     # check if curr need has children
     if need["parent_needs_back"]:
         # add comment for easy debugging
         curr_need_tree += "'child needs:\n"
         # walk through all child needs one by one
-        for curr_child_need_id in need["parent_needs_back"]:
-            for curr_child_need in found_needs:
-                if curr_child_need["id_complete"] == curr_child_need_id:
-                    curr_need_tree += get_need_node_rep_for_plantuml(
-                        app,
-                        fromdocname,
-                        current_needflow,
-                        needs_view,
-                        curr_child_need,
-                        entity_names,
-                    )
-                    # check curr need child has children or has parts
-                    if curr_child_need["parent_needs_back"] or curr_child_need["parts"]:
-                        curr_need_tree += walk_curr_need_tree(
-                            app,
-                            fromdocname,
-                            current_needflow,
-                            needs_view,
-                            found_needs,
-                            curr_child_need,
-                            entity_names,
-                        )
-                    # add newline for next element
-                    curr_need_tree += "\n"
-                    break
+        for child_node in graph_node.children:
+            curr_need_tree += get_need_node_rep_for_plantuml(
+                app, fromdocname, child_node, entity_names
+            )
+            curr_need_tree += walk_curr_need_tree(
+                app, fromdocname, child_node, entity_names
+            )
+            # add newline for next element
+            curr_need_tree += "\n"
 
     # We processed embedded needs or need parts, so we will close with "}"
     curr_need_tree += "}"
@@ -244,32 +197,19 @@ def walk_curr_need_tree(
 def cal_needs_node(
     app: Sphinx,
     fromdocname: str,
-    current_needflow: NeedsFlowType,
-    needs_view: NeedsView,
-    found_needs: list[NeedItem | NeedPartItem],
+    graph: NeedflowGraph,
     entity_names: Mapping[str, str],
 ) -> str:
-    """Calculate and get needs node representaion for plantuml including all child needs and need parts.
+    """Emit the plantuml node definitions of a whole diagram.
 
+    :param graph: The graph to emit.
     :param entity_names: The id to entity name mapping of :func:`make_entity_names`.
     """
-    top_needs = get_root_needs(found_needs)
     curr_need_tree = ""
-    for top_need in top_needs:
-        top_need_node = get_need_node_rep_for_plantuml(
-            app, fromdocname, current_needflow, needs_view, top_need, entity_names
-        )
+    for root in graph.roots:
         curr_need_tree += (
-            top_need_node
-            + walk_curr_need_tree(
-                app,
-                fromdocname,
-                current_needflow,
-                needs_view,
-                found_needs,
-                top_need,
-                entity_names,
-            )
+            get_need_node_rep_for_plantuml(app, fromdocname, root, entity_names)
+            + walk_curr_need_tree(app, fromdocname, root, entity_names)
             + "\n"
         )
     return curr_need_tree
@@ -287,11 +227,7 @@ def process_needflow_plantuml(
     env = app.env
     needs_config = NeedsSphinxConfig(app.config)
     env_data = SphinxNeedsData(env)
-    needs_view = env_data.get_needs_view()
     needs_schema = env_data.get_schema()
-
-    link_type_names = [link.name.upper() for link in needs_schema.iter_link_fields()]
-    allowed_link_types_options = [link.upper() for link in needs_config.flow_link_types]
 
     node: NeedflowPlantuml
     for node in found_nodes:  # type: ignore[assignment]
@@ -301,37 +237,12 @@ def process_needflow_plantuml(
 
         current_needflow: NeedsFlowType = node.attributes
 
-        option_link_types = [link.upper() for link in current_needflow["link_types"]]
-        for lt in option_link_types:
-            if lt not in link_type_names:
-                log_warning(
-                    logger,
-                    "Unknown link type {link_type} in needflow {flow}. Allowed values: {link_types}".format(
-                        link_type=lt,
-                        flow=current_needflow["target_id"],
-                        link_types=",".join(link_type_names),
-                    ),
-                    "needflow",
-                    location=node,
-                )
-
-        # compute the allowed link types
-        allowed_link_types: list[LinkSchema] = []
-        for link_field in needs_schema.iter_link_fields():
-            # Skip link-type handling, if it is not part of a specified list of allowed link_types or
-            # if not part of the overall configuration of needs_flow_link_types
-            if (
-                current_needflow["link_types"]
-                and link_field.name.upper() not in option_link_types
-            ) or (
-                not current_needflow["link_types"]
-                and link_field.name.upper() not in allowed_link_types_options
-            ):
-                continue
-            # skip creating links from child needs to their own parent need
-            if link_field.name == "parent_needs":
-                continue
-            allowed_link_types.append(link_field)
+        allowed_link_types = resolve_link_types(
+            current_needflow,
+            schema=needs_schema,
+            config=needs_config,
+            location=node,
+        )
 
         try:
             if "sphinxcontrib.plantuml" not in app.extensions:
@@ -348,28 +259,14 @@ def process_needflow_plantuml(
 
         content: list[nodes.Element] = []
 
-        need_values = (
-            filter_by_tree(
-                needs_view,
-                root_id,
-                [lt.name for lt in allowed_link_types],
-                current_needflow["root_direction"],
-                current_needflow["root_depth"],
-            )
-            if (root_id := current_needflow.get("root_id"))
-            else needs_view
-        )
-
-        found_needs = process_filters(
+        graph = build_graph(
             app,
-            need_values,
             current_needflow,
-            origin="needflow",
+            allowed_link_types,
             location=node,
+            variant_location=(current_needflow["docname"], current_needflow["lineno"]),
         )
-        found_needs, total_needs = apply_max_items(
-            found_needs, current_needflow.get("max_items"), needs_config
-        )
+        found_needs = graph.needs
 
         if found_needs:
             plantuml_block_text = ".. plantuml::\n\n   @startuml   @enduml"
@@ -403,22 +300,10 @@ def process_needflow_plantuml(
             )
 
             puml_node["uml"] += "\n' Nodes definition \n\n"
-            puml_node["uml"] += cal_needs_node(
-                app,
-                fromdocname,
-                current_needflow,
-                needs_view,
-                found_needs,
-                entity_names,
-            )
+            puml_node["uml"] += cal_needs_node(app, fromdocname, graph, entity_names)
 
             puml_node["uml"] += "\n' Connection definition \n\n"
-            puml_node["uml"] += render_connections(
-                found_needs,
-                allowed_link_types,
-                current_needflow["show_link_names"] or needs_config.flow_show_links,
-                entity_names,
-            )
+            puml_node["uml"] += render_connections(graph, entity_names)
 
             # Create a legend
             if current_needflow["show_legend"]:
@@ -470,11 +355,11 @@ def process_needflow_plantuml(
                 no_needs_found_paragraph(current_needflow.get("filter_warning"))
             )
 
-        if len(found_needs) < total_needs:
+        if len(found_needs) < graph.total_needs:
             content.append(
                 report_max_items(
                     len(found_needs),
-                    total_needs,
+                    graph.total_needs,
                     origin="needflow",
                     location=node,
                 )
@@ -502,52 +387,34 @@ def process_needflow_plantuml(
         node.replace_self(content)
 
 
-def render_connections(
-    found_needs: list[NeedItem | NeedPartItem],
-    allowed_link_types: list[LinkSchema],
-    show_links: bool,
-    entity_names: Mapping[str, str],
-) -> str:
-    """
-    Render the connections between the needs.
+def render_connections(graph: NeedflowGraph, entity_names: Mapping[str, str]) -> str:
+    """Emit the plantuml connections between the needs.
 
+    .. note:: An edge is emitted even when one of its ends is not drawn as a node -- a
+       need part whose need was filtered out, say -- in which case plantuml creates a
+       bare node for it; it is kept as is.
+
+    :param graph: The graph to emit the connections of.
     :param entity_names: The id to entity name mapping of :func:`make_entity_names`.
     """
     puml_connections = ""
-    for need_info in found_needs:
-        for link_type in allowed_link_types:
-            for link in need_info[link_type.name]:
-                # Do not create an links, if the link target is not part of the search result.
-                if link not in [
-                    x["id"] for x in found_needs if x["is_need"]
-                ] and link not in [
-                    x["id_complete"] for x in found_needs if x["is_part"]
-                ]:
-                    continue
+    for edge in graph.edges:
+        if graph.show_link_names:
+            desc = edge.link_type.display.outgoing + "\\n"
+            comment = f": {desc}"
+        else:
+            comment = ""
 
-                if show_links:
-                    desc = link_type.display.outgoing + "\\n"
-                    comment = f": {desc}"
-                else:
-                    comment = ""
+        # If source or target of link is a need_part, a specific style is needed
+        link_style = f"[{edge.style}]" if (edge.is_part or edge.style) else ""
 
-                # If source or target of link is a need_part, a specific style is needed
-                if "." in link or "." in need_info["id_complete"]:
-                    link_style = f"[{link_type.display.style_part}]"
-                else:
-                    link_style = (
-                        f"[{link_type.display.style}]"
-                        if link_type.display.style
-                        else ""
-                    )
-
-                # TODO also use link_type.display.color?
-                puml_connections += "{id} {style_start}{link_style}{style_end} {link}{comment}\n".format(
-                    id=get_entity_name(entity_names, need_info["id_complete"]),
-                    link=get_entity_name(entity_names, link),
-                    comment=comment,
-                    link_style=link_style,
-                    style_start=link_type.display.style_start,
-                    style_end=link_type.display.style_end,
-                )
+        source = get_entity_name(entity_names, edge.source_id)
+        target = get_entity_name(entity_names, edge.target_id)
+        arrow = (
+            edge.link_type.display.style_start
+            + link_style
+            + edge.link_type.display.style_end
+        )
+        # TODO also use link_type.display.color?
+        puml_connections += f"{source} {arrow} {target}{comment}\n"
     return puml_connections

--- a/sphinx_needs/directives/needflow/_plantuml.py
+++ b/sphinx_needs/directives/needflow/_plantuml.py
@@ -306,6 +306,9 @@ def process_needflow_plantuml(
             puml_node["uml"] += render_connections(graph, entity_names)
 
             # Create a legend
+            # note this lists every configured need type, whereas the graphviz engine
+            # lists only the types it actually drew, so the same `:show_legend:` gives
+            # the two engines different legends; it is kept as is
             if current_needflow["show_legend"]:
                 puml_node["uml"] += create_legend(needs_config.types)
 

--- a/sphinx_needs/directives/needflow/_shared.py
+++ b/sphinx_needs/directives/needflow/_shared.py
@@ -1,94 +1,23 @@
-from __future__ import annotations
+"""Docutils helpers shared by the needflow engines.
 
-from typing import Literal
+The graph both engines draw lives in :mod:`~sphinx_needs.directives.needflow._model`;
+this module only holds the document content that neither of them writes in its own
+diagram syntax.
+"""
+
+from __future__ import annotations
 
 from docutils import nodes
 
 from sphinx_needs.data import NeedsFlowType
-from sphinx_needs.logging import get_logger
-from sphinx_needs.need_item import NeedItem, NeedPartItem
-from sphinx_needs.views import NeedsView
-
-logger = get_logger(__name__)
-
-
-def filter_by_tree(
-    needs_view: NeedsView,
-    root_id: str,
-    link_names: list[str],
-    direction: Literal["both", "incoming", "outgoing"],
-    depth: int | None,
-) -> NeedsView:
-    """Filter all needs by the given ``root_id``,
-    and all needs that are connected to the root need by the given ``link_types``, in the given ``direction``."""
-    if root_id not in needs_view:
-        return needs_view.filter_ids([])
-    roots = {root_id: (0, needs_view[root_id])}
-    link_prefixes = (
-        ("_back",)
-        if direction == "incoming"
-        else ("",)
-        if direction == "outgoing"
-        else ("", "_back")
-    )
-    links_to_process = [link + d for link in link_names for d in link_prefixes]
-
-    need_ids: list[str] = []
-    while roots:
-        root_id, (root_depth, root) = roots.popitem()
-        if root_id in need_ids:
-            continue
-        if depth is not None and root_depth > depth:
-            continue
-        need_ids.append(root_id)
-        for link_type_name in links_to_process:
-            roots.update(
-                {
-                    i: (root_depth + 1, needs_view[i])
-                    for i in root.get(link_type_name, [])
-                    if i in needs_view
-                }
-            )
-
-    return needs_view.filter_ids(need_ids)
-
-
-def resolve_color(value: None | str | int | float | bool) -> str | None:
-    """Normalise a resolved color option value to an engine neutral form.
-
-    A color may be written with or without a leading ``#``, and each engine adds the
-    prefix that its own syntax requires, so any leading ``#`` characters are stripped here.
-    An unset or empty value means "no color", rather than a color named after the
-    string representation of the value.
-
-    :param value: The resolved value of a color option,
-        e.g. the return value of :func:`~sphinx_needs.variants.match_variants`.
-    :return: The color without a leading ``#``, or ``None`` if no color was given.
-    """
-    if value is None:
-        return None
-    return str(value).strip().lstrip("#") or None
-
-
-def get_root_needs(found_needs: list[NeedItem | NeedPartItem]) -> list[NeedItem]:
-    return_list = []
-    for current_need in found_needs:
-        if current_need["is_need"] and isinstance(current_need, NeedItem):
-            if "parent_need" not in current_need or current_need["parent_need"] == "":
-                # need has no parent, we have to add the need to the root needs
-                return_list.append(current_need)
-            else:
-                parent_found: bool = False
-                for elements in found_needs:
-                    if elements["id"] == current_need["parent_need"]:
-                        parent_found = True
-                        break
-                if not parent_found:
-                    return_list.append(current_need)
-    return return_list
 
 
 def create_filter_paragraph(data: NeedsFlowType) -> nodes.paragraph:
+    """Describe the filters a needflow was created with, as a paragraph.
+
+    :param data: The needflow's options.
+    :return: The paragraph to add to the document.
+    """
     para = nodes.paragraph()
     filter_text = "Used filter:"
     filter_text += (

--- a/tests/test_needflow_model.py
+++ b/tests/test_needflow_model.py
@@ -1,0 +1,496 @@
+"""Unit tests for the engine independent needflow graph model.
+
+The model is what both needflow engines draw from, so the rules tested here -- which
+needs the root walk reaches, which link types may be drawn, how a need is presented, and
+which links become edges -- decide what *every* engine renders.  They are exercised
+directly, without building a documentation project, so that a change in one of them is
+reported as a rule that changed rather than as a diagram that moved.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+from docutils import nodes
+
+from sphinx_needs.config import NeedsSphinxConfig
+from sphinx_needs.data import NeedsFlowType
+from sphinx_needs.directives.needflow._model import (
+    GraphNode,
+    NodePresentation,
+    build_node_tree,
+    collect_edges,
+    filter_by_tree,
+    get_root_needs,
+    resolve_color,
+    resolve_link_types,
+    resolve_presentation,
+)
+from sphinx_needs.need_item import NeedItem, NeedPartData, NeedsContent
+from sphinx_needs.needs_schema import FieldsSchema, LinkDisplayConfig, LinkSchema
+from sphinx_needs.views import NeedsView
+
+CORE_BASE: dict[str, Any] = {
+    "id": "",
+    "type": "story",
+    "type_name": "User Story",
+    "type_prefix": "US_",
+    "type_color": "#BFD8D2",
+    "type_style": "node",
+    "status": None,
+    "tags": [],
+    "constraints": (),
+    "title": "title",
+    "collapse": False,
+    "arch": {},
+    "style": None,
+    "layout": None,
+    "hide": False,
+    "external_css": "external_link",
+    "has_dead_links": False,
+    "has_forbidden_dead_links": False,
+    "sections": (),
+    "signature": None,
+}
+
+
+def need(
+    id: str,
+    *,
+    links: list[str] | None = None,
+    blocks: list[str] | None = None,
+    parent: str | None = None,
+    children: list[str] | None = None,
+    incoming: list[str] | None = None,
+    parts: tuple[str, ...] = (),
+    **core: Any,
+) -> NeedItem:
+    """Create a need item, with only the fields the graph model looks at.
+
+    :param links: The ids the need links to.
+    :param blocks: The ids the need blocks, a second link type.
+    :param parent: The id of the need this one is nested in.
+    :param children: The ids of the needs nested in this one.
+    :param incoming: The ids of the needs linking to this one.
+    :param parts: The ids of the parts of the need.
+    """
+    return NeedItem(
+        core={**CORE_BASE, "id": id, **core},
+        content=NeedsContent(content="content", doctype=".rst"),
+        extras={},
+        links={
+            "links": links or [],
+            "blocks": blocks or [],
+            "parent_needs": [parent] if parent else [],
+        },
+        backlinks={
+            "links": incoming or [],
+            "blocks": [],
+            "parent_needs": children or [],
+        },
+        parts=tuple(NeedPartData(id=part, content=f"part {part}") for part in parts),
+        source=None,
+    )
+
+
+def view(*needs: NeedItem) -> NeedsView:
+    """Create a needs view of the given needs."""
+    return NeedsView._from_needs({n["id"]: n for n in needs})
+
+
+def link_schema(name: str = "links", **display: Any) -> LinkSchema:
+    """Create a link field schema with the given display configuration."""
+    return LinkSchema(
+        name=name,
+        schema={"type": "array", "items": {"type": "string"}},
+        display=LinkDisplayConfig(outgoing=name, incoming=f"{name} back", **display),
+    )
+
+
+def flow(**options: Any) -> NeedsFlowType:
+    """Create the needflow options that the model reads."""
+    return {  # type: ignore[typeddict-item]
+        "target_id": "needflow-index-0",
+        "link_types": [],
+        "highlight": "",
+        "border_color": None,
+        "show_link_names": False,
+        **options,
+    }
+
+
+# --- the root walk -------------------------------------------------------------------
+
+
+def test_walk_returns_only_the_root_when_it_is_unconnected():
+    needs = view(need("A"), need("B"))
+    assert set(filter_by_tree(needs, "A", ["links"], "both", None)) == {"A"}
+
+
+def test_walk_of_an_unknown_root_returns_nothing():
+    """A root that is not a need cannot select anything, rather than everything."""
+    needs = view(need("A"), need("B"))
+    assert set(filter_by_tree(needs, "MISSING", ["links"], "both", None)) == set()
+
+
+@pytest.mark.parametrize(
+    ("direction", "expected"),
+    [
+        ("outgoing", {"B", "C"}),
+        ("incoming", {"B", "A"}),
+        ("both", {"A", "B", "C"}),
+    ],
+)
+def test_walk_follows_the_given_direction(direction, expected):
+    """``outgoing`` follows links, ``incoming`` follows back links, ``both`` follows both."""
+    a = need("A", links=["B"])
+    b = need("B", links=["C"], incoming=["A"])
+    c = need("C", incoming=["B"])
+    assert (
+        set(filter_by_tree(view(a, b, c), "B", ["links"], direction, None)) == expected
+    )
+
+
+@pytest.mark.parametrize(
+    ("depth", "expected"),
+    [(0, {"A"}), (1, {"A", "B"}), (2, {"A", "B", "C"}), (None, {"A", "B", "C", "D"})],
+)
+def test_walk_stops_at_the_given_depth(depth, expected):
+    chain = [
+        need("A", links=["B"]),
+        need("B", links=["C"], incoming=["A"]),
+        need("C", links=["D"], incoming=["B"]),
+        need("D", incoming=["C"]),
+    ]
+    assert (
+        set(filter_by_tree(view(*chain), "A", ["links"], "outgoing", depth)) == expected
+    )
+
+
+def test_walk_terminates_on_a_cycle():
+    """A need already reached is not walked again, so a cycle cannot loop forever."""
+    a = need("A", links=["B"], incoming=["C"])
+    b = need("B", links=["C"], incoming=["A"])
+    c = need("C", links=["A"], incoming=["B"])
+    assert set(filter_by_tree(view(a, b, c), "A", ["links"], "outgoing", None)) == {
+        "A",
+        "B",
+        "C",
+    }
+
+
+def test_walk_ignores_link_types_it_was_not_given():
+    a = need("A", links=["B"], blocks=["C"])
+    assert set(
+        filter_by_tree(view(a, need("B"), need("C")), "A", ["links"], "outgoing", None)
+    ) == {"A", "B"}
+
+
+def test_walk_ignores_links_to_needs_outside_the_view():
+    """A link to a need that no longer exists is a dead link, not a graph node."""
+    a = need("A", links=["GONE"])
+    assert set(filter_by_tree(view(a), "A", ["links"], "outgoing", None)) == {"A"}
+
+
+# --- the allowed link types ----------------------------------------------------------
+
+
+def _schema(*names: str) -> FieldsSchema:
+    schema = FieldsSchema()
+    for name in names:
+        schema.add_link_field(link_schema(name))
+    return schema
+
+
+def _config(**values: Any) -> NeedsSphinxConfig:
+    config = Mock(spec=NeedsSphinxConfig)
+    config.flow_link_types = ["links"]
+    config.filter_data = {}
+    config.variant_data_proxy = None
+    config.variants = {}
+    for key, value in values.items():
+        setattr(config, key, value)
+    return config
+
+
+def test_allowed_link_types_defaults_to_every_type_the_option_lists():
+    allowed = resolve_link_types(
+        flow(link_types=["links", "blocks"]),
+        schema=_schema("links", "blocks", "checks"),
+        config=_config(),
+        location=nodes.paragraph(),
+    )
+    assert [link.name for link in allowed] == ["links", "blocks"]
+
+
+def test_allowed_link_types_matches_names_case_insensitively():
+    allowed = resolve_link_types(
+        flow(link_types=["LINKS"]),
+        schema=_schema("links", "blocks"),
+        config=_config(),
+        location=nodes.paragraph(),
+    )
+    assert [link.name for link in allowed] == ["links"]
+
+
+def test_allowed_link_types_never_includes_parent_needs():
+    """Nesting already shows the hierarchy, so a parent link is never drawn as an edge."""
+    allowed = resolve_link_types(
+        flow(link_types=["links", "parent_needs"]),
+        schema=_schema("links", "parent_needs"),
+        config=_config(),
+        location=nodes.paragraph(),
+    )
+    assert [link.name for link in allowed] == ["links"]
+
+
+def test_allowed_link_types_warns_about_an_unknown_name():
+    records: list[logging.LogRecord] = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record)
+
+    module_logger = logging.getLogger("sphinx.sphinx_needs.directives.needflow._model")
+    handler = _Capture(level=logging.WARNING)
+    module_logger.addHandler(handler)
+    old_level = module_logger.level
+    module_logger.setLevel(logging.WARNING)
+    try:
+        allowed = resolve_link_types(
+            flow(link_types=["links", "BOGUS"]),
+            schema=_schema("links"),
+            config=_config(),
+            location=nodes.paragraph(),
+        )
+    finally:
+        module_logger.removeHandler(handler)
+        module_logger.setLevel(old_level)
+
+    assert [link.name for link in allowed] == ["links"]
+    assert any(
+        "Unknown link type BOGUS in needflow needflow-index-0" in record.getMessage()
+        for record in records
+    )
+
+
+def test_allowed_link_types_falls_back_to_the_configuration():
+    """Without the option, the (unreachable) ``needs_flow_link_types`` fallback applies."""
+    allowed = resolve_link_types(
+        flow(link_types=[]),
+        schema=_schema("links", "blocks"),
+        config=_config(flow_link_types=["blocks"]),
+        location=nodes.paragraph(),
+    )
+    assert [link.name for link in allowed] == ["blocks"]
+
+
+# --- the presentation of a need ------------------------------------------------------
+
+
+def _presentation(item, **options: Any) -> NodePresentation:
+    return resolve_presentation(
+        item,
+        highlight=options.pop("highlight", ""),
+        border_color=options.pop("border_color", None),
+        config=_config(**options),
+        needs=[item],
+        location=nodes.paragraph(),
+    )
+
+
+def test_presentation_takes_the_style_and_color_of_the_need_type():
+    presentation = _presentation(need("A", type_style="card", type_color="#FEDCD2"))
+    assert presentation.type_style == "card"
+    assert presentation.type_color == "#FEDCD2"
+
+
+def test_presentation_of_a_type_without_a_color_has_no_color():
+    """An empty color is no color, not a color named after the empty string."""
+    assert _presentation(need("A", type_color="")).type_color is None
+
+
+def test_presentation_of_a_need_part_is_always_a_rectangle():
+    item = need("A", parts=("p1",)).get_part_item("p1")
+    presentation = _presentation(item)
+    assert presentation.type_style == "rectangle"
+
+
+def test_presentation_highlights_a_need_that_passes_the_filter():
+    presentation = _presentation(need("A", type="story"), highlight="type == 'story'")
+    assert presentation.highlight is True
+
+
+def test_presentation_does_not_highlight_a_need_that_fails_the_filter():
+    presentation = _presentation(need("A", type="story"), highlight="type == 'spec'")
+    assert presentation.highlight is False
+
+
+def test_presentation_resolves_the_border_color():
+    assert _presentation(need("A"), border_color="FF0000").border_color == "FF0000"
+
+
+def test_presentation_strips_a_leading_hash_from_the_border_color():
+    """Each engine adds the prefix its own syntax needs, so the model holds neither."""
+    assert _presentation(need("A"), border_color="#FF0000").border_color == "FF0000"
+
+
+def test_presentation_border_color_of_an_unmatched_variant_is_none():
+    item = need("A", type="story")
+    assert (
+        _presentation(item, border_color="[type == 'spec']:FF0000").border_color is None
+    )
+
+
+def test_presentation_highlight_wins_over_the_border_color():
+    """A highlighted need gets no border color at all, rather than both."""
+    presentation = _presentation(
+        need("A", type="story"), highlight="type == 'story'", border_color="FF0000"
+    )
+    assert presentation.highlight is True
+    assert presentation.border_color is None
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (None, None),
+        ("", None),
+        ("   ", None),
+        ("#", None),
+        ("FF0000", "FF0000"),
+        ("#FF0000", "FF0000"),
+        ("  #FF0000  ", "FF0000"),
+        (False, "False"),
+    ],
+)
+def test_resolve_color(value, expected):
+    assert resolve_color(value) == expected
+
+
+# --- the node tree -------------------------------------------------------------------
+
+
+def _tree(*needs) -> tuple[list[GraphNode], dict[str, GraphNode]]:
+    return build_node_tree(
+        list(needs),
+        lambda n: NodePresentation(
+            type_style="node", type_color=None, highlight=False, border_color=None
+        ),
+    )
+
+
+def test_root_needs_are_the_needs_without_a_parent_in_the_result():
+    parent = need("P", children=["C"])
+    child = need("C", parent="P")
+    assert [n["id"] for n in get_root_needs([parent, child])] == ["P"]
+    assert [n["id"] for n in get_root_needs([child])] == ["C"]
+
+
+def test_root_needs_never_include_a_need_part():
+    parent = need("P", parts=("p1",))
+    part = parent.get_part_item("p1")
+    assert [n["id"] for n in get_root_needs([parent, part])] == ["P"]
+
+
+def test_tree_nests_children_and_parts_of_the_result():
+    parent = need("P", children=["C"], parts=("p1", "p2"))
+    child = need("C", parent="P")
+    roots, drawn = _tree(parent, parent.get_part_item("p1"), child)
+
+    assert [root.need["id"] for root in roots] == ["P"]
+    assert [part.need["id_complete"] for part in roots[0].parts] == ["P.p1"]
+    assert [c.need["id"] for c in roots[0].children] == ["C"]
+    assert set(drawn) == {"P", "P.p1", "C"}
+
+
+def test_tree_omits_children_and_parts_that_were_filtered_out():
+    """What is drawn follows the result, even though the *nesting block* does not."""
+    parent = need("P", children=["C"], parts=("p1",))
+    roots, drawn = _tree(parent)
+    assert roots[0].parts == []
+    assert roots[0].children == []
+    assert set(drawn) == {"P"}
+
+
+def test_tree_does_not_draw_a_part_whose_need_was_filtered_out():
+    parent = need("P", parts=("p1",))
+    roots, drawn = _tree(parent.get_part_item("p1"))
+    assert roots == []
+    assert drawn == {}
+
+
+def test_tree_nests_grandchildren():
+    parent = need("P", children=["C"])
+    child = need("C", parent="P", children=["G"])
+    grandchild = need("G", parent="C")
+    roots, drawn = _tree(parent, child, grandchild)
+    assert [g.need["id"] for g in roots[0].children[0].children] == ["G"]
+    assert set(drawn) == {"P", "C", "G"}
+
+
+# --- the edges -----------------------------------------------------------------------
+
+
+def test_edges_are_collected_per_need_and_link_type():
+    a = need("A", links=["B"], blocks=["B"])
+    b = need("B")
+    edges = collect_edges(
+        [a, b], [link_schema("links"), link_schema("blocks")], {"A", "B"}
+    )
+    assert [(e.source_id, e.target_id, e.link_type.name) for e in edges] == [
+        ("A", "B", "links"),
+        ("A", "B", "blocks"),
+    ]
+
+
+def test_edges_to_a_need_outside_the_result_are_dropped():
+    """A link whose target was filtered out has nothing to point at."""
+    a = need("A", links=["B", "C"])
+    edges = collect_edges([a, need("B")], [link_schema()], {"A", "B"})
+    assert [e.target_id for e in edges] == ["B"]
+
+
+def test_edges_of_a_link_type_that_is_not_allowed_are_not_collected():
+    a = need("A", links=["B"], blocks=["B"])
+    edges = collect_edges([a, need("B")], [link_schema("blocks")], {"A", "B"})
+    assert [e.link_type.name for e in edges] == ["blocks"]
+
+
+def test_edges_record_whether_their_ends_are_drawn():
+    """A need part of a filtered out need is in the result, but is not drawn."""
+    parent = need("P", parts=("p1",))
+    part = parent.get_part_item("p1")
+    a = need("A", links=["P.p1"])
+    edges = collect_edges([a, part], [link_schema()], {"A"})
+    assert len(edges) == 1
+    assert edges[0].source_drawn is True
+    assert edges[0].target_drawn is False
+
+
+def test_edges_of_a_need_part_are_marked_as_part_edges():
+    parent = need("P", parts=("p1",))
+    part = parent.get_part_item("p1")
+    a = need("A", links=["P.p1"])
+    edges = collect_edges([a, part], [link_schema()], {"A", "P.p1"})
+    assert edges[0].is_part is True
+
+
+def test_edges_between_needs_are_not_part_edges():
+    a = need("A", links=["B"])
+    edges = collect_edges([a, need("B")], [link_schema()], {"A", "B"})
+    assert edges[0].is_part is False
+
+
+def test_edge_style_is_the_part_style_for_a_part_edge():
+    """A part edge takes ``style_part``, a need edge takes ``style``."""
+    parent = need("P", parts=("p1",))
+    part = parent.get_part_item("p1")
+    a = need("A", links=["P.p1", "B"])
+    schema = link_schema(style="dashed", style_part="dotted")
+    edges = collect_edges([a, part, need("B")], [schema], {"A", "B", "P.p1"})
+    styles = {e.target_id: e.style for e in edges}
+    assert styles == {"P.p1": "dotted", "B": "dashed"}


### PR DESCRIPTION
#### What moved where

Both needflow engines independently resolved the allowed link types, walked out from
`root_id`, filtered, built the nesting tree, resolved every node's presentation and
collected the edges — in code that had drifted apart (#1768 fixed the divergences that
had already become bugs).

All of that now happens once, in a new `sphinx_needs/directives/needflow/_model.py`, which
hands the engines a graph of dumb dataclasses (`NeedflowGraph`, `GraphNode`, `GraphEdge`,
`NodePresentation`) holding resolved values and no syntax: a colour is a colour, not
`#FF0000` or `line:FF0000`, and nesting is a tree, not braces or a subgraph.

The emitters keep only what is genuinely theirs:

- `_plantuml.py` (553 → 420 lines): source text, the injective entity naming, brace nesting,
  the `' Config` block, legend/debug/caption/align/scale, DOM wiring.
- `_graphviz.py` (739 → 632 lines): source text, `subgraph cluster_*` + the invisible ghost
  node + `ltail`/`lhead`, the plantuml→dot shape and arrow translation tables,
  `graphviz_style`, its own legend/debug, the HTML visitor.
- `_shared.py` (115 → 44 lines): just the "Used filter:" paragraph, the one piece of
  docutils content neither engine writes in diagram syntax.

`resolve_link_types` is deliberately a separate entry point from `build_graph`, so that
plantuml keeps warning about link types BEFORE its `sphinxcontrib.plantuml` import guard.

#### The zero-delta proof

Behaviour is frozen, and the gate is the generated diagram source itself. A harness
captures every `@startuml…@enduml` and every `digraph needflow {…}` at the processor level,
for EVERY `tests/doc_test` project containing a needflow, the whole `docs/` build, and two
purpose-built synthetic projects covering the option paths the fixtures miss — each built
with BOTH engines: 21 projects × 2 engines = 42 builds, 206 diagram sources.

Baseline captured at master, re-run after every commit: zero byte deltas, no exceptions.
The full Sphinx warning stream is compared as a second channel and is also byte-identical,
which is what fences "no new warnings on any default path". The gate itself was
review-verified: deliberate mutations (a one-character emission change; a deleted emitter
call) turn it red in both the content and the missing-diagram direction, and its capture
seam was independently checked against the real renderer boundaries at both the base and
the tip.

#### The one normalisation

The directive defaulted `root_direction` to `"all"`, a value outside the
`Literal["both", "incoming", "outgoing"]` its own `NeedsFlowType` declares;
`filter_by_tree` has always treated it identically to `"both"` via the else-branch. The
default is now `"both"` — the runtime now matches the declared type, and the byte gate
proves the graphs are unchanged. No TypedDict shape change, so no `ENV_DATA_VERSION`
implication.

#### What stayed frozen, and why

This slice exists so the NEXT one (a portable option vocabulary) can be implemented once
instead of twice. Fixing behaviour here would have destroyed the only proof available that
the extraction is faithful. So these are reproduced exactly, and now documented where they
happen rather than being folklore:

- `filter_by_tree` walks depth-first (`dict.popitem`) with first-visit-wins, so
  `root_depth` is traversal-order dependent.
- `parent_needs` is stripped from the allowed link types BEFORE the root walk, so
  `root_id` cannot follow the need hierarchy.
- The root walk runs before the filter.
- `show_link_names` is OR-ed with `needs_flow_show_links`, so config can only turn labels on.
- A plantuml edge is emitted even when an end is not drawn (plantuml then invents a bare
  node); graphviz drops it. The model records `source_drawn`/`target_drawn` and lets each
  engine keep its rule.
- The graphviz engine used to test for an empty result before applying the `max_items`
  cap, and the model now applies the cap first. The verdict is unchanged either way:
  `apply_max_items` returns the needs untouched or truncates them to a limit of at least
  one, so it can never turn a non-empty result into an empty one.
- A need whose parts and children were all filtered out still gets its (empty) plantuml
  nesting block and its `' parts:` comment: those are decided from the need, not from what
  is drawn.
- A need drawn as a graphviz subgraph emits its `type_style` untranslated and unwarned,
  unlike a plain node.
- The per-engine legend content, debug node type, caption/align/scale handling and
  `:config:` namespaces are untouched, in their own emitters.

#### Tests

`tests/test_needflow_model.py` — 47 new unit tests, 0.2s, no documentation project built:
the walk (direction, depth, cycles, links out of the view), allowed-link-type resolution,
presentation (highlight beating border colour, part→rectangle, colour normalisation), the
nesting tree, and the edge membership rule. Purely additive; no existing assertion was
touched. The full suite passes (1337 passed, 11 skipped).

**Changelog**: one bullet under `Unreleased` → `Internal changes`, the section this
repository keeps for changes that do not affect user-facing behaviour: ♻️ needflow's two
engines now share one graph-model pass, with no change to the generated diagram source.