### PR TITLE
🐛 needreport: accurate docs, render failures that warn, and a working default (#899)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -323,8 +323,13 @@ Bug fixes
   so a project with a template of its own gains neither the substitution nor the warning
   unless it was actually rendering a ``dropdown``. A template that never produces one —
   because it writes its own directive, or shadows ``report_directive`` with a
-  ``{% set %}`` — is left exactly as it is, and so is one that writes ``.. dropdown::``
-  as a literal, which re-rendering cannot reach.
+  ``{% set %}`` — is left exactly as it is, and so is one with ``.. dropdown::``
+  hardcoded in it, which re-rendering cannot reach. If the substituted render fails where
+  the default one succeeded, the default is kept and nothing is reported.
+
+  The decision is a textual scan of the rendered report, so a template that merely shows
+  ``.. dropdown::`` as example markup while producing it through ``report_directive`` is
+  treated as though it used it.
 
 Documentation
 .............

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -299,6 +299,26 @@ Documentation
   same-named capture groups, and that the templates are rendered with MiniJinja rather than
   Jinja2.
 
+- 📚 The :ref:`needreport` and :ref:`needs_report_template` pages are corrected against
+  what the directive actually does.
+
+  The "default template" the configuration page printed had drifted so far from the
+  packaged one that copying it — the customisation route both pages recommend — ends the
+  build, because it reads two context variables, ``fields`` and ``json_exclude_fields``,
+  that have never existed. The page now includes the packaged template from the source
+  tree, so the two cannot diverge again, and the context is described as it is: the key is
+  ``options``, ``report_directive`` is listed, and every number in ``usage`` is called out
+  as permanently ``0`` — real counts come from the :ref:`need_count` role that the
+  template emits, and those count need parts and :ref:`needs_external_needs` alike.
+
+  The ``:template:`` option, until now documented nowhere, gains a section of its own and
+  the three-level precedence it takes part in is written down. ``needs_report_template``
+  is described as resolved relative to the source directory rather than "must be an
+  absolute path"; the ``dropdown`` prerequisite and the ``report_directive`` escape hatch
+  now also appear on the configuration page; and an ``.rst`` template kept inside the
+  source directory is noted as being built as a document of its own, with the
+  ``exclude_patterns`` entry that avoids it.
+
 - 📚 ``docs/ubproject.toml``, the `ubCode`_ configuration of this documentation, is brought
   up to date with current ubCode releases
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -292,9 +292,10 @@ Bug fixes
   silently overridable for years, and only ``report_directive`` is meant to be set this
   way. The collision is a property of the configuration rather than of any one directive,
   so it is reported once per build. And when :ref:`needs_report_template` holds a path
-  that is absolute on the file system, the "could not load" warning explains why it names
+  that is absolute in the POSIX sense, the "could not load" warning explains why it names
   a path nobody wrote down: the value is always resolved relative to the source
-  directory, so an absolute one is appended to it rather than read from where it points.
+  directory, so such a path is appended to it rather than read from where it points.
+  A Windows drive-letter path is not relative, so it is used as it stands.
 
   One consequence is worth calling out for ``-W`` builds: a project that overrides one of
   those four reserved names renders exactly as it did before, but now emits a warning

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -295,6 +295,24 @@ Bug fixes
   the value is always resolved relative to the source directory, so an absolute one is
   appended to it rather than read from where it points.
 
+- 🐛 :ref:`needreport` renders without an extension providing ``dropdown``
+  (:issue:`899`)
+
+  Each section of the default template is wrapped in a ``dropdown`` directive, which
+  neither Sphinx nor Sphinx-Needs provides. A project without an extension supplying one
+  got a docutils error per section — at line numbers belonging to the template rather
+  than to the document, so pointing at innocent lines — and, because Sphinx strips
+  ``system_message`` nodes, the report then vanished from the page altogether: an empty
+  section, four errors on the console, and a build that still exited ``0`` unless ``-W``
+  was in use.
+
+  When nothing provides ``dropdown``, the report is now rendered with ``admonition``
+  instead, and one ``needs.needreport`` warning names both remedies. Projects that do
+  load such an extension are unaffected: the directive is looked up in the registry, so
+  a provider is used exactly as before and nothing is warned about. Nor is an explicit
+  choice ever second-guessed — ``needs_render_context = {"report_directive": "dropdown"}``
+  is honoured as written, provider or not.
+
 Documentation
 .............
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -276,6 +276,25 @@ Bug fixes
   had already been rendered into ``_images/``, where it then stayed, referenced by
   nothing.
 
+- 🐛 :ref:`needreport` reports a template it cannot render, instead of ending the build
+
+  A template with a Jinja syntax error — or one that merely applies a filter to a variable
+  that does not exist, which is what the stale example in these docs did — raised out of
+  the directive and took the whole build down with it. That is the failure mode
+  :pr:`1105` set out to remove, and the missing-file case has warned rather than aborted
+  ever since; the render case now does too, as a ``needs.needreport`` warning naming the
+  template and repeating the engine's own explanation. The directive then contributes
+  nothing to the page, exactly as it already did for a template that is missing.
+
+  Two smaller diagnostics come with it. A :ref:`needs_render_context` entry that takes
+  over one of the reserved context names — ``types``, ``links``, ``options`` or ``usage``
+  — is now reported; which value wins is deliberately unchanged, since these have been
+  silently overridable for years, and only ``report_directive`` is meant to be set this
+  way. And when :ref:`needs_report_template` holds a path that is absolute on the file
+  system, the "could not load" warning explains why it names a path nobody wrote down:
+  the value is always resolved relative to the source directory, so an absolute one is
+  appended to it rather than read from where it points.
+
 Documentation
 .............
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -290,10 +290,16 @@ Bug fixes
   over one of the reserved context names — ``types``, ``links``, ``options`` or ``usage``
   — is now reported; which value wins is deliberately unchanged, since these have been
   silently overridable for years, and only ``report_directive`` is meant to be set this
-  way. And when :ref:`needs_report_template` holds a path that is absolute on the file
-  system, the "could not load" warning explains why it names a path nobody wrote down:
-  the value is always resolved relative to the source directory, so an absolute one is
-  appended to it rather than read from where it points.
+  way. The collision is a property of the configuration rather than of any one directive,
+  so it is reported once per build. And when :ref:`needs_report_template` holds a path
+  that is absolute on the file system, the "could not load" warning explains why it names
+  a path nobody wrote down: the value is always resolved relative to the source
+  directory, so an absolute one is appended to it rather than read from where it points.
+
+  One consequence is worth calling out for ``-W`` builds: a project that overrides one of
+  those four reserved names renders exactly as it did before, but now emits a warning
+  where it emitted none, so a green build turns red until the entry is removed or the
+  warning is suppressed.
 
 - 🐛 :ref:`needreport` renders without an extension providing ``dropdown``
   (:issue:`899`)
@@ -312,6 +318,13 @@ Bug fixes
   a provider is used exactly as before and nothing is warned about. Nor is an explicit
   choice ever second-guessed — ``needs_render_context = {"report_directive": "dropdown"}``
   is honoured as written, provider or not.
+
+  The substitution is decided on the rendered report and adopted only when it changes it,
+  so a project with a template of its own gains neither the substitution nor the warning
+  unless it was actually rendering a ``dropdown``. A template that never produces one —
+  because it writes its own directive, or shadows ``report_directive`` with a
+  ``{% set %}`` — is left exactly as it is, and so is one that writes ``.. dropdown::``
+  as a literal, which re-rendering cannot reach.
 
 Documentation
 .............

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -962,9 +962,18 @@ is used:
    The substitution is decided on the **rendered** report, and is made only when it
    changes it. A template of your own that never renders a ``dropdown`` — because it
    writes its own directive, or shadows ``report_directive`` with a ``{% set %}`` — is
-   left alone and warns about nothing. A template that writes ``.. dropdown::`` as a
-   literal is also left alone: re-rendering cannot reach a literal, so nothing would be
-   fixed, and that report keeps the errors it gets today.
+   left alone and warns about nothing. A template with ``.. dropdown::`` hardcoded in it
+   is also left alone: re-rendering cannot reach a name the template does not read from
+   the context, so nothing would be fixed, and that report keeps the errors it gets
+   today. Should the substituted render fail where the default one succeeded, the
+   default is kept and nothing is reported — the fallback can leave a report as it was,
+   never lose it.
+
+   The decision is a textual scan of the rendered report, so it has no notion of
+   reStructuredText block context: a report that merely *shows* ``.. dropdown::`` as
+   example markup — inside a literal block, say — while producing it through
+   ``report_directive`` is treated as though it used it, and the example shown will
+   name ``admonition`` instead.
 
 .. _`needs_report_template_context`:
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -904,10 +904,14 @@ Sphinx reads the documents from, which is also the directory holding ``conf.py``
 ``"/needs_templates/report_template.need"`` and ``"needs_templates/report_template.need"``
 name the same file.
 
-A path that is absolute on the file system is therefore **not** read from where it points.
-It is stripped and joined onto the source directory like any other value, which normally
-ends in a ``Could not load needs report template file ...`` warning naming a path that
-does not exist.
+A POSIX-style absolute path is therefore **not** read from where it points. It is stripped
+and joined onto the source directory like any other value, which normally ends in a
+``Could not load needs report template file ...`` warning naming a path that does not
+exist.
+
+On Windows a drive-letter path such as ``D:\templates\report.need`` is an exception: it
+is not a relative path, so joining it onto the source directory replaces it, and the file
+is read from where it points. The rebase above applies to POSIX-style absolute values.
 
 The first of the following that is set provides the template:
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -944,16 +944,20 @@ is used:
 
    ``dropdown`` is provided neither by Sphinx nor by Sphinx-Needs. It comes from an
    extension that supplies one, for example
-   `sphinx-design <https://sphinx-design.readthedocs.io>`__. With no such extension
-   loaded, the rendered report fails to parse and each of its sections is reported as
-   ``Unknown directive type "dropdown"``. Name a directive you do have through
-   :ref:`needs_render_context` instead:
+   `sphinx-design <https://sphinx-design.readthedocs.io>`__. If no loaded extension
+   provides it, the report is rendered with ``admonition`` instead and a
+   ``needs.needreport`` warning says so. To choose the directive yourself — and to
+   silence that warning — name one through :ref:`needs_render_context`:
 
    .. code-block:: python
 
       needs_render_context = {
           "report_directive": "admonition",
       }
+
+   A value set that way is always used exactly as given, ``"dropdown"`` included: an
+   explicit choice is never substituted, so a project that asks for ``dropdown``
+   without a provider keeps failing as it did before.
 
 .. _`needs_report_template_context`:
 
@@ -981,8 +985,9 @@ any of the other four is reported as a ``needs.needreport`` warning.
    The names of the configured :ref:`needs_fields`, as a list of strings.
 
 ``report_directive``
-   The name of the directive each section of the packaged template is wrapped in;
-   ``dropdown`` unless :ref:`needs_render_context` names another one.
+   The name of the directive each section of the packaged template is wrapped in.
+   ``dropdown``, unless :ref:`needs_render_context` names another one, or nothing
+   provides ``dropdown`` and it falls back to ``admonition`` — see the note above.
 
 ``usage``
    A dictionary with the keys ``needs_amount`` and ``needs_types``, the latter holding one

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -888,105 +888,121 @@ needs_report_template
 
 .. versionadded:: 1.0.1
 
-You can customize the layout of :ref:`needreport` using `Jinja <http://jinja.pocoo.org/>`__.
+You can customise the layout of :ref:`needreport` with a template of your own.
+Set ``needs_report_template`` to the path of the template file:
 
-Set the value of ``needs_report_template`` to the path of the template you want to use.
+.. code-block:: python
+
+   needs_report_template = "/needs_templates/report_template.need"
+
+Finding the template
+++++++++++++++++++++
+
+``needs_report_template`` is resolved relative to the **source directory** — the directory
+Sphinx reads the documents from, which is also the directory holding ``conf.py`` unless
+``sphinx-build -c`` separates the two. A leading ``/`` is stripped before that join, so
+``"/needs_templates/report_template.need"`` and ``"needs_templates/report_template.need"``
+name the same file.
+
+A path that is absolute on the file system is therefore **not** read from where it points.
+It is stripped and joined onto the source directory like any other value, which normally
+ends in a ``Could not load needs report template file ...`` warning naming a path that
+does not exist.
+
+The first of the following that is set provides the template:
+
+#. the ``:template:`` option of an individual :ref:`needreport` directive
+   (see :ref:`template <needreport_template_option>`), resolved relative to the document
+   the directive is written in;
+#. ``needs_report_template``, resolved relative to the source directory as described
+   above;
+#. otherwise the packaged default template shown below.
 
 .. note::
 
-   The path must be an absolute path based on the **conf.py** directory.
-   Example: ``needs_report_template = '/needs_templates/report_template.need'``
+   The file extension is not checked, so any is accepted; ``.rst``, ``.need`` and ``.txt``
+   are the conventional ones. Prefer ``.need`` or ``.txt``: a template named ``.rst`` and
+   placed inside the source directory is also read by Sphinx as a document in its own
+   right, and its unrendered Jinja source then produces a cascade of parse warnings.
+   To keep the ``.rst`` extension, exclude the template from the build:
 
-   The template file should be a plain file with any of the following file extensions: ``.rst``, ``.need``, or ``.txt``.
+   .. code-block:: python
 
-If you do not set ``needs_report_template``, the default template used is:
+      exclude_patterns = ["needs_templates/*.rst"]
 
-.. code-block:: jinja
+The packaged default template
++++++++++++++++++++++++++++++
 
-   {# Output for needs_types #}
-   {% if types|length != 0 %}
-   .. dropdown:: Need Types
-      :class: needs_report_table
+If you do not set ``needs_report_template``, this template, shipped with Sphinx-Needs,
+is used:
 
-      .. list-table::
-        :widths: 40 20 20 20
-        :header-rows: 1
+.. literalinclude:: ../sphinx_needs/directives/needreport_template.rst
+   :language: jinja
+   :caption: sphinx_needs/directives/needreport_template.rst
 
-        * - TITLE
-          - DIRECTIVE
-          - PREFIX
-          - STYLE
-        {% for type in types %}
-        * - {{ type.title }}
-          - {{ type.directive }}
-          - `{{ type.prefix }}`
-          - {{ type.style }}
-        {% endfor %}
-   {% endif %}
-   {# Output for needs_types #}
+.. note::
 
-   {# Output for needs_links #}
-   {% if links|length != 0 %}
-   .. dropdown:: Need Links
-      :class: needs_report_table
+   ``dropdown`` is provided neither by Sphinx nor by Sphinx-Needs. It comes from an
+   extension that supplies one, for example
+   `sphinx-design <https://sphinx-design.readthedocs.io>`__. With no such extension
+   loaded, the rendered report fails to parse and each of its sections is reported as
+   ``Unknown directive type "dropdown"``. Name a directive you do have through
+   :ref:`needs_render_context` instead:
 
-      .. list-table::
-        :widths: 10 30 30 5 20
-        :header-rows: 1
+   .. code-block:: python
 
-        * - OPTION
-          - INCOMING
-          - OUTGOING
-          - COPY
-          - ALLOW DEAD LINKS
-        {% for link in links %}
-        * - {{ link.option | capitalize }}
-          - {{ link.incoming | capitalize }}
-          - {{ link.outgoing | capitalize }}
-          - {{ link.get('copy', None) | capitalize }}
-          - {{ link.get('allow_dead_links', False) | capitalize }}
-        {% endfor %}
-   {% endif %}
-   {# Output for needs_links #}
+      needs_render_context = {
+          "report_directive": "admonition",
+      }
 
-   {# Output for needs_fields #}
-   {% if fields|length != 0 %}
-   .. dropdown:: Need Fields
-      :class: needs_report_table
+.. _`needs_report_template_context`:
 
-      {% for field in fields %}
-      * {{ json_exclude_fields }}
-      {% endfor %}
-   {% endif %}
-   {# Output for needs_fields #}
+Template context
+++++++++++++++++
 
-   {# Output for needs metrics #}
-   {% if usage|length != 0 %}
-   .. dropdown:: Need Metrics
+Templates are rendered with `MiniJinja <https://github.com/mitsuhiko/minijinja>`__, which
+implements a large subset of `Jinja <https://jinja.palletsprojects.com/>`__ but is not
+identical to it, so a template written strictly against the Jinja documentation may still
+fail here.
 
-      .. list-table::
-         :widths: 40 40
-         :header-rows: 1
+The following five names are passed to every template, and are all **reserved**:
+:ref:`needs_render_context` is merged over them, so an entry of the same name replaces the
+value described below. That is the intended way to set ``report_directive``; doing it to
+any of the other four is reported as a ``needs.needreport`` warning.
 
-         * - NEEDS TYPES
-           - NEEDS PER TYPE
-         {% for k, v in usage["needs_types"].items() %}
-         * - {{ k | capitalize }}
-           - {{ v }}
-         {% endfor %}
-         * - **Total Needs Amount**
-           - {{ usage.get("needs_amount") }}
-   {% endif %}
-   {# Output for needs metrics #}
+``types``
+   The :ref:`needs_types` configuration, as a list of dictionaries.
 
-The plugin provides the following variables which you can use in your custom Jinja template:
+``links``
+   The :ref:`needs_links` configuration, as a list of dictionaries carrying the keys
+   ``option``, ``incoming``, ``outgoing``, ``copy`` and ``allow_dead_links``.
 
-* types - list of :ref:`need types <needs_types>`
-* links - list of :ref:`needs_links`
-* fields - list of :ref:`needs_fields`
-* usage - a dictionary object containing information about the following:
-    + needs_amount -> total amount of need objects in the project
-    + needs_types -> number of need objects per needs type
+``options``
+   The names of the configured :ref:`needs_fields`, as a list of strings.
+
+``report_directive``
+   The name of the directive each section of the packaged template is wrapped in;
+   ``dropdown`` unless :ref:`needs_render_context` names another one.
+
+``usage``
+   A dictionary with the keys ``needs_amount`` and ``needs_types``, the latter holding one
+   entry per directive name in :ref:`needs_types`.
+
+   .. warning::
+
+      Only the **keys** of ``usage["needs_types"]`` carry information. Every number in
+      ``usage`` — ``needs_amount`` included — is permanently ``0``, and is kept only for
+      backwards compatibility: the directive runs while the documents are still being
+      read, so no correct count exists yet at that point. A template that prints one of
+      these values reports ``0`` however many needs the project has.
+
+      Real counts come from the :ref:`need_count` role, which is evaluated once every
+      document has been read. That is why the packaged template above reads ``usage`` for
+      its type *names* only, and emits one role per name.
+
+      Such counts cover the whole project: needs from every document, needs pulled in by
+      :ref:`needs_external_needs`, and :ref:`need parts <need_part>`, which each count as
+      a need of their parent's type.
 
 needs_diagram_template
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -2465,6 +2481,14 @@ The value can be any data type (string, integer, list, dict, etc.)
 
    The value can also be a custom defined function,
    however, this will deactivate the caching and incremental build feature of Sphinx.
+
+.. note::
+
+   :ref:`needreport` reserves the five names ``types``, ``links``, ``options``, ``usage``
+   and ``report_directive`` in its own templates, and ``needs_render_context`` is merged
+   **over** them. ``report_directive`` is meant to be set this way; the other four are
+   reported as a ``needs.needreport`` warning. See
+   :ref:`needs_report_template_context`.
 
 The data passed via needs_render_context will be available as variable(s) when rendering Jinja templates or strings.
 You can use the data passed via needs_render_context as shown below:

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -959,6 +959,13 @@ is used:
    explicit choice is never substituted, so a project that asks for ``dropdown``
    without a provider keeps failing as it did before.
 
+   The substitution is decided on the **rendered** report, and is made only when it
+   changes it. A template of your own that never renders a ``dropdown`` — because it
+   writes its own directive, or shadows ``report_directive`` with a ``{% set %}`` — is
+   left alone and warns about nothing. A template that writes ``.. dropdown::`` as a
+   literal is also left alone: re-rendering cannot reach a literal, so nothing would be
+   fixed, and that report keeps the errors it gets today.
+
 .. _`needs_report_template_context`:
 
 Template context
@@ -975,19 +982,22 @@ value described below. That is the intended way to set ``report_directive``; doi
 any of the other four is reported as a ``needs.needreport`` warning.
 
 ``types``
-   The :ref:`needs_types` configuration, as a list of dictionaries.
+   The :ref:`needs_types` configuration, as a list of dictionaries, plus any types
+   registered by a loaded service or extension.
 
 ``links``
    The :ref:`needs_links` configuration, as a list of dictionaries carrying the keys
    ``option``, ``incoming``, ``outgoing``, ``copy`` and ``allow_dead_links``.
 
 ``options``
-   The names of the configured :ref:`needs_fields`, as a list of strings.
+   The names of the configured :ref:`needs_fields`, as a list of strings, plus any
+   fields registered by a loaded service or extension.
 
 ``report_directive``
    The name of the directive each section of the packaged template is wrapped in.
    ``dropdown``, unless :ref:`needs_render_context` names another one, or nothing
-   provides ``dropdown`` and it falls back to ``admonition`` — see the note above.
+   provides ``dropdown`` and substituting ``admonition`` changes what the report
+   renders — see the note above.
 
 ``usage``
    A dictionary with the keys ``needs_amount`` and ``needs_types``, the latter holding one

--- a/docs/directives/needreport.rst
+++ b/docs/directives/needreport.rst
@@ -30,6 +30,8 @@ documented under :ref:`needs_report_template`.
    neither Sphinx nor Sphinx-Needs provides — it needs an extension that supplies one,
    for example `sphinx-design <https://sphinx-design.readthedocs.io>`__.
    If none is loaded, the report is rendered with ``admonition`` instead and warns.
+   A template of your own is only affected if that substitution actually changes what
+   it renders; see :ref:`needs_report_template`.
    To pick the directive yourself, and so render without a warning:
 
    .. code-block:: python

--- a/docs/directives/needreport.rst
+++ b/docs/directives/needreport.rst
@@ -13,17 +13,23 @@ needreport
 
 and it also adds some needs metrics using the `usage`_ option.
 
-To use the ``needreport`` directive, you need to set the :ref:`needs_report_template`
-configuration variable. If you do not set the :ref:`needs_report_template`
-configuration variable, the plugin uses the default needs report template.
+``needreport`` renders a template, and out of the box that is the default template
+packaged with Sphinx-Needs — no configuration is required.
+To render a template of your own instead, either set the :ref:`needs_report_template`
+configuration variable, which applies to every ``needreport`` in the project, or give a
+single directive its own `template`_ option.
 
-The :ref:`needs_report_template` value is a path to the
-`jinja2 <https://jinja.palletsprojects.com/en/2.11.x/templates/>`_ template file.
-You can use the template file to customise the content generated  by ``needreport``.
+Templates are rendered with `MiniJinja <https://github.com/mitsuhiko/minijinja>`__, a
+`Jinja <https://jinja.palletsprojects.com/>`__-compatible engine. The packaged default
+template, how a template path is resolved, and the variables a template can read are all
+documented under :ref:`needs_report_template`.
 
 .. note::
 
-   The default needs report template is set to use ``dropdown`` directives for containing each configuration type, which requires the ``dropdown`` directive to be available in your Sphinx environment. If you do not have the ``dropdown`` directive available, you can use the following configuration to set the default needs report template to use ``admonition`` directives instead:
+   Each section of the default template is wrapped in a ``dropdown`` directive, which
+   neither Sphinx nor Sphinx-Needs provides — it needs an extension that supplies one,
+   for example `sphinx-design <https://sphinx-design.readthedocs.io>`__.
+   If you would rather not load such an extension, name a directive you do have:
 
    .. code-block:: python
 
@@ -90,3 +96,26 @@ The flag does not require any values.
 
    .. needreport::
       :usage:
+
+.. _needreport_template_option:
+
+template
+~~~~~~~~
+
+Path to the template this directive should render, overriding
+:ref:`needs_report_template` for this one directive.
+Unlike the flags above, it takes a value.
+
+The path is resolved relative to the document the directive is written in, and a leading
+``/`` makes it relative to the source directory — the path convention Sphinx uses
+throughout, and *not* the one :ref:`needs_report_template` uses, which is always relative
+to the source directory whether or not it starts with a ``/``.
+
+.. code-block:: rst
+
+   .. needreport::
+      :types:
+      :template: report_templates/types_only.need
+
+If the file does not exist, a ``needs.needreport`` warning is emitted and the directive
+renders nothing.

--- a/docs/directives/needreport.rst
+++ b/docs/directives/needreport.rst
@@ -29,7 +29,8 @@ documented under :ref:`needs_report_template`.
    Each section of the default template is wrapped in a ``dropdown`` directive, which
    neither Sphinx nor Sphinx-Needs provides — it needs an extension that supplies one,
    for example `sphinx-design <https://sphinx-design.readthedocs.io>`__.
-   If you would rather not load such an extension, name a directive you do have:
+   If none is loaded, the report is rendered with ``admonition`` instead and warns.
+   To pick the directive yourself, and so render without a warning:
 
    .. code-block:: python
 

--- a/sphinx_needs/directives/needreport.py
+++ b/sphinx_needs/directives/needreport.py
@@ -36,10 +36,18 @@ FALLBACK_REPORT_DIRECTIVE = "admonition"
 
 #: Recognises :data:`DEFAULT_REPORT_DIRECTIVE` used as a directive in *rendered*
 #: text, the way docutils recognises one: an explicit markup start (``..``) at the
-#: beginning of a possibly indented line, whitespace, the name, and the ``::``
-#: marker -- which docutils lets a single space precede.
+#: beginning of a possibly indented line, whitespace, the name, the ``::`` marker
+#: -- which docutils lets a single space precede -- and then whitespace or the end
+#: of the line.  Without that last part ``.. dropdown::x`` would match, which
+#: docutils reads as a comment rather than as a directive.
+#:
+#: It is a textual scan with no notion of RST block context, so a report that
+#: merely *shows* ``.. dropdown::`` as example markup -- inside a literal block,
+#: say -- while producing it through ``report_directive`` is treated as though it
+#: used it.  Telling those apart needs the parsed document, which is out of all
+#: proportion here; the cost is a substitution inside the displayed example.
 DROPDOWN_MARKER = re.compile(
-    rf"^[ \t]*\.\.[ \t]+{re.escape(DEFAULT_REPORT_DIRECTIVE)}[ \t]?::",
+    rf"^[ \t]*\.\.[ \t]+{re.escape(DEFAULT_REPORT_DIRECTIVE)}[ \t]?::(?=[ \t]|$)",
     re.MULTILINE,
 )
 
@@ -54,7 +62,14 @@ class NeedReportDirective(SphinxDirective):
         "template": directives.unchanged,
     }
 
-    def _render(self, template: str, context: dict[str, Any], path: Path) -> str | None:
+    def _render(
+        self,
+        template: str,
+        context: dict[str, Any],
+        path: Path,
+        *,
+        warn: bool = True,
+    ) -> str | None:
         """Render the report template, or warn and return ``None``.
 
         A template that could not be rendered used to escape ``run()`` and end the
@@ -64,11 +79,18 @@ class NeedReportDirective(SphinxDirective):
         :param template: The template source.
         :param context: The render context.
         :param path: The file the template was read from, named in the warning.
+        :param warn: Whether a failure is reported. The speculative fallback render
+            passes ``False``: that attempt is this directive's own idea rather than
+            anything the author asked for, so its failure must cost nothing and say
+            nothing -- "could not render" would be false of the render the project
+            actually got.
         :returns: The rendered text, or ``None`` if it could not be rendered.
         """
         try:
             return render_template_string(template, context, autoescape=False)
         except Exception as exc:
+            if not warn:
+                return None
             # deliberately broad: MiniJinja raises ``TemplateError`` for a syntax
             # error or for an operation on an undefined value, but the context also
             # carries arbitrary objects from :ref:`needs_render_context`, and a
@@ -226,10 +248,13 @@ class NeedReportDirective(SphinxDirective):
                 needs_report_template_file_content,
                 {**report_info, "report_directive": FALLBACK_REPORT_DIRECTIVE},
                 need_report_template_path,
+                warn=False,
             )
-            if fallback_text is None:
-                return []
-            if not DROPDOWN_MARKER.search(fallback_text):
+            # a template that renders on the ``dropdown`` branch and breaks on the
+            # ``admonition`` one keeps the render it already has: the default text
+            # succeeded above, so the fallback logic can only ever leave the report
+            # as it was, never lose it
+            if fallback_text is not None and not DROPDOWN_MARKER.search(fallback_text):
                 # the substitution reached the output, so it is worth making and
                 # worth reporting.  If the marker survived it, the template wrote
                 # the directive itself, nothing was fixed, and announcing a

--- a/sphinx_needs/directives/needreport.py
+++ b/sphinx_needs/directives/needreport.py
@@ -16,6 +16,12 @@ from sphinx_needs.utils import add_doc
 
 LOGGER = logging.getLogger(__name__)
 
+#: Context names the directive fills in itself.
+#: :ref:`needs_render_context` is merged over the whole context, which is the
+#: documented way to choose ``report_directive`` and a mistake for the rest,
+#: so the rest are warned about.
+RESERVED_CONTEXT_KEYS = ("types", "links", "options", "usage")
+
 
 class NeedReportDirective(SphinxDirective):
     final_argument_whitespace = True
@@ -68,26 +74,58 @@ class NeedReportDirective(SphinxDirective):
             else {},
             "report_directive": "dropdown",
         }
+        if replaced := [
+            key for key in RESERVED_CONTEXT_KEYS if key in needs_config.render_context
+        ]:
+            # warn only; which value wins is long-standing behaviour that projects
+            # may well be relying on, so the swap is made visible rather than undone
+            log_warning(
+                LOGGER,
+                "needs_render_context replaces the needreport context "
+                f"{'keys' if len(replaced) > 1 else 'key'} "
+                f"{', '.join(repr(key) for key in replaced)}; "
+                "only 'report_directive' is meant to be set this way",
+                "needreport",
+                location=self.get_location(),
+            )
         report_info.update(**needs_config.render_context)
 
+        configured_template = ""
         if "template" in self.options:
             need_report_template_path = Path(
                 self.env.relfn2path(self.options["template"], self.env.docname)[1]
             )
         elif needs_config.report_template:
-            # Absolute path starts with /, based on the conf.py directory. The / need to be striped
+            # always relative to the source directory; a leading / is merely stripped
+            configured_template = needs_config.report_template
             need_report_template_path = Path(
                 str(env.app.srcdir)
-            ) / needs_config.report_template.lstrip("/")
+            ) / configured_template.lstrip("/")
         else:
             need_report_template_path = (
                 Path(__file__).parent / "needreport_template.rst"
             )
 
         if not need_report_template_path.is_file():
+            message = (
+                f"Could not load needs report template file {need_report_template_path}"
+            )
+            if (
+                configured_template
+                and (configured := Path(configured_template)).is_absolute()
+                and configured.is_file()
+            ):
+                # the configured value names a real file, just not the one that was
+                # looked for: it was rebased under the source directory like any
+                # other value, and the path above is the nonsense that comes out
+                message += (
+                    "; needs_report_template is resolved relative to the source "
+                    f"directory, so {configured_template!r} was appended to it "
+                    "rather than read from where it points"
+                )
             log_warning(
                 LOGGER,
-                f"Could not load needs report template file {need_report_template_path}",
+                message,
                 "needreport",
                 location=self.get_location(),
             )
@@ -97,9 +135,26 @@ class NeedReportDirective(SphinxDirective):
             encoding="utf8"
         )
 
-        text = render_template_string(
-            needs_report_template_file_content, report_info, autoescape=False
-        )
+        try:
+            text = render_template_string(
+                needs_report_template_file_content, report_info, autoescape=False
+            )
+        except Exception as exc:
+            # deliberately broad: MiniJinja raises ``TemplateError`` for a syntax
+            # error or for an operation on an undefined value, but the context also
+            # carries arbitrary objects from :ref:`needs_render_context`, and a
+            # filter applied to one of those can raise anything at all.  None of it
+            # should end the build; the missing-file path above already warns.
+            detail = getattr(exc, "message", exc)  # MiniJinja's one-line summary
+            log_warning(
+                LOGGER,
+                f"Could not render needs report template file "
+                f"{need_report_template_path}: {detail}",
+                "needreport",
+                location=self.get_location(),
+            )
+            return []
+
         self.state_machine.insert_input(
             text.split("\n"), self.state_machine.document.attributes["source"]
         )

--- a/sphinx_needs/directives/needreport.py
+++ b/sphinx_needs/directives/needreport.py
@@ -22,6 +22,16 @@ LOGGER = logging.getLogger(__name__)
 #: so the rest are warned about.
 RESERVED_CONTEXT_KEYS = ("types", "links", "options", "usage")
 
+#: The directive the packaged template wraps each of its sections in.
+#: Neither Sphinx nor this extension provides it -- it comes from an extension
+#: such as sphinx-design -- so it may not be registered at render time.
+DEFAULT_REPORT_DIRECTIVE = "dropdown"
+
+#: Used in place of :data:`DEFAULT_REPORT_DIRECTIVE` when nothing provides it.
+#: Sphinx always registers ``admonition``, and it is the only always-available
+#: directive that renders as a titled block; core has no collapsible one.
+FALLBACK_REPORT_DIRECTIVE = "admonition"
+
 
 class NeedReportDirective(SphinxDirective):
     final_argument_whitespace = True
@@ -72,7 +82,7 @@ class NeedReportDirective(SphinxDirective):
             }
             if "usage" in self.options
             else {},
-            "report_directive": "dropdown",
+            "report_directive": DEFAULT_REPORT_DIRECTIVE,
         }
         if replaced := [
             key for key in RESERVED_CONTEXT_KEYS if key in needs_config.render_context
@@ -134,6 +144,31 @@ class NeedReportDirective(SphinxDirective):
         needs_report_template_file_content = need_report_template_path.read_text(
             encoding="utf8"
         )
+
+        if (
+            # an explicit choice is never second-guessed, even if it is unavailable
+            "report_directive" not in needs_config.render_context
+            # a template that never reads the name cannot be helped by changing it,
+            # and would only get a warning it can do nothing about
+            and "report_directive" in needs_report_template_file_content
+            and directives.directive(
+                DEFAULT_REPORT_DIRECTIVE,
+                self.state.memo.language,
+                self.state.document,
+            )[0]
+            is None
+        ):
+            report_info["report_directive"] = FALLBACK_REPORT_DIRECTIVE
+            log_warning(
+                LOGGER,
+                f"No loaded extension provides a {DEFAULT_REPORT_DIRECTIVE!r} directive, "
+                f"so the needs report is rendered with "
+                f"{FALLBACK_REPORT_DIRECTIVE!r} instead. Load an extension that provides "
+                "it, for example sphinx-design, or choose the directive yourself with "
+                "needs_render_context = {'report_directive': ...}",
+                "needreport",
+                location=self.get_location(),
+            )
 
         try:
             text = render_template_string(

--- a/sphinx_needs/directives/needreport.py
+++ b/sphinx_needs/directives/needreport.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import re
 from collections.abc import Sequence
 from pathlib import Path
+from typing import Any
 
 from docutils import nodes
 from docutils.parsers.rst import directives
@@ -32,6 +34,15 @@ DEFAULT_REPORT_DIRECTIVE = "dropdown"
 #: directive that renders as a titled block; core has no collapsible one.
 FALLBACK_REPORT_DIRECTIVE = "admonition"
 
+#: Recognises :data:`DEFAULT_REPORT_DIRECTIVE` used as a directive in *rendered*
+#: text, the way docutils recognises one: an explicit markup start (``..``) at the
+#: beginning of a possibly indented line, whitespace, the name, and the ``::``
+#: marker -- which docutils lets a single space precede.
+DROPDOWN_MARKER = re.compile(
+    rf"^[ \t]*\.\.[ \t]+{re.escape(DEFAULT_REPORT_DIRECTIVE)}[ \t]?::",
+    re.MULTILINE,
+)
+
 
 class NeedReportDirective(SphinxDirective):
     final_argument_whitespace = True
@@ -42,6 +53,40 @@ class NeedReportDirective(SphinxDirective):
         "usage": directives.flag,
         "template": directives.unchanged,
     }
+
+    def _render(self, template: str, context: dict[str, Any], path: Path) -> str | None:
+        """Render the report template, or warn and return ``None``.
+
+        A template that could not be rendered used to escape ``run()`` and end the
+        whole build, which is what :pr:`1105` set out to stop for this directive;
+        the missing-file path got that treatment, the render path did not.
+
+        :param template: The template source.
+        :param context: The render context.
+        :param path: The file the template was read from, named in the warning.
+        :returns: The rendered text, or ``None`` if it could not be rendered.
+        """
+        try:
+            return render_template_string(template, context, autoescape=False)
+        except Exception as exc:
+            # deliberately broad: MiniJinja raises ``TemplateError`` for a syntax
+            # error or for an operation on an undefined value, but the context also
+            # carries arbitrary objects from :ref:`needs_render_context`, and a
+            # filter applied to one of those -- or a callable in it -- can raise
+            # anything at all.  None of it should end the build.
+            try:
+                detail = str(getattr(exc, "message", exc))  # MiniJinja's summary
+            except Exception:
+                # asking the exception to describe itself raised in turn, and
+                # letting that escape would be the very failure being handled
+                detail = type(exc).__name__
+            log_warning(
+                LOGGER,
+                f"Could not render needs report template file {path}: {detail}",
+                "needreport",
+                location=self.get_location(),
+            )
+            return None
 
     def run(self) -> Sequence[nodes.raw]:
         env = self.env
@@ -88,7 +133,12 @@ class NeedReportDirective(SphinxDirective):
             key for key in RESERVED_CONTEXT_KEYS if key in needs_config.render_context
         ]:
             # warn only; which value wins is long-standing behaviour that projects
-            # may well be relying on, so the swap is made visible rather than undone
+            # may well be relying on, so the swap is made visible rather than undone.
+            # ``once=True`` because the collision is a property of the configuration
+            # and not of any one directive: a project with a report on every page
+            # would otherwise get the identical line once per directive.  Sphinx
+            # resets that filter per application, so a later build in the same
+            # process still reports.
             log_warning(
                 LOGGER,
                 "needs_render_context replaces the needreport context "
@@ -97,6 +147,7 @@ class NeedReportDirective(SphinxDirective):
                 "only 'report_directive' is meant to be set this way",
                 "needreport",
                 location=self.get_location(),
+                once=True,
             )
         report_info.update(**needs_config.render_context)
 
@@ -145,12 +196,19 @@ class NeedReportDirective(SphinxDirective):
             encoding="utf8"
         )
 
+        text = self._render(
+            needs_report_template_file_content, report_info, need_report_template_path
+        )
+        if text is None:
+            return []
+
         if (
             # an explicit choice is never second-guessed, even if it is unavailable
             "report_directive" not in needs_config.render_context
-            # a template that never reads the name cannot be helped by changing it,
-            # and would only get a warning it can do nothing about
-            and "report_directive" in needs_report_template_file_content
+            # only a report that actually renders the directive can be helped, and
+            # only the rendered text knows that: the name may be shadowed by a
+            # ``{% set %}``, or merely mentioned in a comment or in prose
+            and DROPDOWN_MARKER.search(text)
             and directives.directive(
                 DEFAULT_REPORT_DIRECTIVE,
                 self.state.memo.language,
@@ -158,37 +216,36 @@ class NeedReportDirective(SphinxDirective):
             )[0]
             is None
         ):
-            report_info["report_directive"] = FALLBACK_REPORT_DIRECTIVE
-            log_warning(
-                LOGGER,
-                f"No loaded extension provides a {DEFAULT_REPORT_DIRECTIVE!r} directive, "
-                f"so the needs report is rendered with "
-                f"{FALLBACK_REPORT_DIRECTIVE!r} instead. Load an extension that provides "
-                "it, for example sphinx-design, or choose the directive yourself with "
-                "needs_render_context = {'report_directive': ...}",
-                "needreport",
-                location=self.get_location(),
+            # rendered again rather than patched, because the name reaches the
+            # output through the template's own logic and only the template can
+            # apply it.  Any callable in :ref:`needs_render_context` is therefore
+            # invoked a second time, on this path alone -- the path that produces
+            # an empty report today (:issue:`899`), so the repeat is the cheaper
+            # of the two costs.
+            fallback_text = self._render(
+                needs_report_template_file_content,
+                {**report_info, "report_directive": FALLBACK_REPORT_DIRECTIVE},
+                need_report_template_path,
             )
-
-        try:
-            text = render_template_string(
-                needs_report_template_file_content, report_info, autoescape=False
-            )
-        except Exception as exc:
-            # deliberately broad: MiniJinja raises ``TemplateError`` for a syntax
-            # error or for an operation on an undefined value, but the context also
-            # carries arbitrary objects from :ref:`needs_render_context`, and a
-            # filter applied to one of those can raise anything at all.  None of it
-            # should end the build; the missing-file path above already warns.
-            detail = getattr(exc, "message", exc)  # MiniJinja's one-line summary
-            log_warning(
-                LOGGER,
-                f"Could not render needs report template file "
-                f"{need_report_template_path}: {detail}",
-                "needreport",
-                location=self.get_location(),
-            )
-            return []
+            if fallback_text is None:
+                return []
+            if not DROPDOWN_MARKER.search(fallback_text):
+                # the substitution reached the output, so it is worth making and
+                # worth reporting.  If the marker survived it, the template wrote
+                # the directive itself, nothing was fixed, and announcing a
+                # substitution would be false -- so that report keeps the default
+                # render and the diagnostics it has always had.
+                text = fallback_text
+                log_warning(
+                    LOGGER,
+                    f"No loaded extension provides a {DEFAULT_REPORT_DIRECTIVE!r} "
+                    f"directive, so the needs report is rendered with "
+                    f"{FALLBACK_REPORT_DIRECTIVE!r} instead. Load an extension that "
+                    "provides it, for example sphinx-design, or choose the directive "
+                    "yourself with needs_render_context = {'report_directive': ...}",
+                    "needreport",
+                    location=self.get_location(),
+                )
 
         self.state_machine.insert_input(
             text.split("\n"), self.state_machine.document.attributes["source"]

--- a/tests/doc_test/doc_needreport_no_dropdown/conf.py
+++ b/tests/doc_test/doc_needreport_no_dropdown/conf.py
@@ -1,0 +1,39 @@
+# Deliberately no extension providing a ``dropdown`` directive, and deliberately
+# no ``needs_render_context``: this project renders the packaged default template
+# with the built-in ``report_directive``, which is the configuration issue #899
+# reports and the one the rest of the test suite never exercises.
+extensions = ["sphinx_needs"]
+
+needs_types = [
+    {
+        "directive": "req",
+        "title": "Requirement",
+        "prefix": "R_",
+        "color": "#BFD8D2",
+        "style": "node",
+    },
+    {
+        "directive": "spec",
+        "title": "Specification",
+        "prefix": "S_",
+        "color": "#FEDCD2",
+        "style": "node",
+    },
+]
+
+needs_links = {
+    "blocks": {
+        "incoming": "is blocked by",
+        "outgoing": "blocks",
+    },
+}
+
+needs_fields = {"priority": {"nullable": True}}
+
+needs_external_needs = [
+    {
+        "base_url": "http://my_company.com/docs/v1/",
+        "json_path": "external_reqs.json",
+        "id_prefix": "ext_",
+    },
+]

--- a/tests/doc_test/doc_needreport_no_dropdown/external_reqs.json
+++ b/tests/doc_test/doc_needreport_no_dropdown/external_reqs.json
@@ -1,0 +1,47 @@
+{
+  "created": "2026-01-01T00:00:00.000000",
+  "current_version": "1.0",
+  "project": "needreport external",
+  "versions": {
+    "1.0": {
+      "created": "2026-01-01T00:00:00.000000",
+      "filters": {},
+      "filters_amount": 0,
+      "needs": {
+        "EXT_REQ_1": {
+          "id": "EXT_REQ_1",
+          "type": "req",
+          "title": "External requirement 1",
+          "description": "",
+          "docname": "index",
+          "doctype": ".rst",
+          "external_url": "http://my_company.com/docs/v1/index.html#EXT_REQ_1",
+          "is_external": true,
+          "is_need": true,
+          "is_part": false,
+          "parts": {},
+          "status": null,
+          "tags": [],
+          "links": []
+        },
+        "EXT_REQ_2": {
+          "id": "EXT_REQ_2",
+          "type": "req",
+          "title": "External requirement 2",
+          "description": "",
+          "docname": "index",
+          "doctype": ".rst",
+          "external_url": "http://my_company.com/docs/v1/index.html#EXT_REQ_2",
+          "is_external": true,
+          "is_need": true,
+          "is_part": false,
+          "parts": {},
+          "status": null,
+          "tags": [],
+          "links": []
+        }
+      },
+      "needs_amount": 2
+    }
+  }
+}

--- a/tests/doc_test/doc_needreport_no_dropdown/index.rst
+++ b/tests/doc_test/doc_needreport_no_dropdown/index.rst
@@ -1,0 +1,19 @@
+Needs Report
+============
+
+.. req:: Requirement 1
+   :id: REQ_1
+
+.. req:: Requirement 2
+   :id: REQ_2
+
+   Contains :np:`(PART_1)a need part`, which counts as a need of its own.
+
+.. spec:: Specification 1
+   :id: SPEC_1
+
+.. needreport::
+   :types:
+   :links:
+   :options:
+   :usage:

--- a/tests/test_needreport.py
+++ b/tests/test_needreport.py
@@ -1,10 +1,23 @@
 """Tests for the :ref:`needreport` directive."""
 
+import importlib.util
 import os
+import re
 from pathlib import Path
 
 import pytest
 from sphinx.util.console import strip_colors
+
+SPHINX_DESIGN_INSTALLED = importlib.util.find_spec("sphinx_design") is not None
+
+
+def visible_text(html: str) -> str:
+    """Return the page's text with its tags removed and whitespace collapsed.
+
+    Table cells are wrapped in enough markup that asserting on a rendered
+    number is unreadable otherwise.
+    """
+    return re.sub(r"\s+", " ", re.sub(r"<[^>]+>", " ", html))
 
 
 def build_warnings(app) -> list[str]:
@@ -242,3 +255,243 @@ def test_absolute_report_template_explains_the_rebase(test_app):
         in warnings[0]
     )
     assert warnings[0].endswith("[needs.needreport]")
+
+
+# -- the dropdown prerequisite (issue #899) ---------------------------------
+#
+# The packaged template wraps each section in ``{{ report_directive }}``, which
+# defaults to ``dropdown`` -- a directive neither Sphinx nor this extension
+# provides.  Without a provider every section used to fail to parse, and because
+# Sphinx strips ``system_message`` nodes the report vanished from the page
+# entirely: four ERRORs on the console, an empty section in the HTML, exit 0.
+
+
+@pytest.mark.parametrize(
+    "test_app",
+    [
+        {
+            "buildername": "html",
+            "srcdir": "doc_test/doc_needreport_no_dropdown",
+            "no_plantuml": True,
+        }
+    ],
+    indirect=True,
+)
+def test_no_dropdown_provider_falls_back_to_admonition(test_app):
+    """With nothing providing ``dropdown``, the report renders as admonitions."""
+    app = test_app
+    app.build()
+
+    # one actionable warning naming both remedies, at the directive's own line,
+    # in place of four "Unknown directive type" errors at invented line numbers
+    assert build_warnings(app) == [
+        "<srcdir>/index.rst:15: WARNING: No loaded extension provides a 'dropdown' "
+        "directive, so the needs report is rendered with 'admonition' instead. "
+        "Load an extension that provides it, for example sphinx-design, or choose "
+        "the directive yourself with needs_render_context = "
+        "{'report_directive': ...} [needs.needreport]"
+    ]
+
+    html = Path(app.outdir, "index.html").read_text(encoding="utf8")
+    text = visible_text(html)
+
+    # all four sections are on the page, each as an admonition
+    for section in ("need-types", "need-links", "need-fields", "need-metrics"):
+        assert f'class="admonition-{section} admonition"' in html
+
+    # and they carry their content, not just their titles
+    assert "Requirement req R_ node" in text
+    assert "Specification spec S_ node" in text
+    assert "Blocks Is blocked by Blocks" in text
+    assert "priority" in text
+
+    # the counts come from the :need_count: roles the template emits, so they are
+    # resolved project-wide: 2 local reqs + 1 need part + 2 external reqs
+    assert "Req 5" in text
+    assert "Spec 1" in text
+    assert "Total Needs Amount 6" in text
+
+
+# A stand-in for the ``dropdown`` an extension such as sphinx-design registers.
+# The fallback tests whether the *name* resolves, so any provider will do -- and
+# this one keeps the check covered wherever sphinx-design is not installed.
+STUB_DROPDOWN_CONF = '''\
+from docutils import nodes
+from docutils.parsers.rst import directives
+from sphinx.util.docutils import SphinxDirective
+
+extensions = ["sphinx_needs"]
+
+
+class StubDropdown(SphinxDirective):
+    """Stand in for the dropdown directive that sphinx-design provides."""
+
+    optional_arguments = 1
+    final_argument_whitespace = True
+    has_content = True
+    option_spec = {"class": directives.class_option}
+
+    def run(self):
+        container = nodes.container(classes=["stub-dropdown"])
+        if self.arguments:
+            container += nodes.paragraph(text=self.arguments[0])
+        self.state.nested_parse(self.content, self.content_offset, container)
+        return [container]
+
+
+def setup(app):
+    app.add_directive("dropdown", StubDropdown)
+'''
+
+
+@pytest.mark.parametrize(
+    "test_app",
+    [
+        {
+            "buildername": "html",
+            "no_plantuml": True,
+            "files": [
+                (Path("conf.py"), STUB_DROPDOWN_CONF),
+                (Path("index.rst"), REPORT_INDEX),
+            ],
+        }
+    ],
+    indirect=True,
+)
+def test_dropdown_provider_is_left_alone(test_app):
+    """A registered ``dropdown`` is used as before, with nothing warned about."""
+    app = test_app
+    app.build()
+
+    assert build_warnings(app) == []
+
+    html = Path(app.outdir, "index.html").read_text(encoding="utf8")
+    # the dropdown path was taken: the provider rendered the section, and no
+    # admonition was substituted for it
+    assert '<div class="stub-dropdown' in html
+    assert "Need Types" in visible_text(html)
+    assert "admonition-need-types" not in html
+
+
+@pytest.mark.skipif(
+    not SPHINX_DESIGN_INSTALLED, reason="sphinx-design is not installed"
+)
+@pytest.mark.parametrize(
+    "test_app",
+    [
+        {
+            "buildername": "html",
+            "no_plantuml": True,
+            "files": [
+                (
+                    Path("conf.py"),
+                    'extensions = ["sphinx_needs", "sphinx_design"]\n',
+                ),
+                (Path("index.rst"), REPORT_INDEX),
+            ],
+        }
+    ],
+    indirect=True,
+)
+def test_sphinx_design_dropdown_output_is_unchanged(test_app):
+    """The real provider still produces its own markup, and warns about nothing."""
+    app = test_app
+    app.build()
+
+    assert build_warnings(app) == []
+
+    html = Path(app.outdir, "index.html").read_text(encoding="utf8")
+    assert "sd-dropdown" in html
+    assert "<details" in html
+    assert "admonition-need-types" not in html
+
+
+EXPLICIT_DROPDOWN_CONF = """\
+extensions = ["sphinx_needs"]
+needs_render_context = {"report_directive": "dropdown"}
+"""
+
+
+@pytest.mark.parametrize(
+    "test_app",
+    [
+        {
+            "buildername": "html",
+            "no_plantuml": True,
+            "files": [
+                (Path("conf.py"), EXPLICIT_DROPDOWN_CONF),
+                (Path("index.rst"), REPORT_INDEX),
+            ],
+        }
+    ],
+    indirect=True,
+)
+def test_explicitly_configured_dropdown_is_never_substituted(test_app):
+    """An explicit ``report_directive`` is honoured, unavailable or not.
+
+    Asking for ``dropdown`` by name and getting an admonition would be a worse
+    surprise than the error, so this configuration keeps failing exactly as it
+    always has.
+    """
+    app = test_app
+    app.build()
+
+    # docutils quotes the whole offending block back, so this spans many lines
+    reported = "\n".join(build_warnings(app))
+    assert 'ERROR: Unknown directive type "dropdown".' in reported
+    assert "No loaded extension provides" not in reported
+
+    # and the section is dropped from the page, exactly as it is today
+    html = Path(app.outdir, "index.html").read_text(encoding="utf8")
+    assert "admonition-need-types" not in html
+    assert "Need Types" not in html
+
+
+# -- needs_report_template, the success path --------------------------------
+
+CUSTOM_TEMPLATE_CONF = """\
+extensions = ["sphinx_needs"]
+needs_report_template = "/report_templates/types.need"
+"""
+
+CUSTOM_TEMPLATE = """\
+The project defines {{ types|length }} need types:
+
+{% for type in types %}
+* {{ type.title }} (``{{ type.directive }}``)
+{% endfor %}
+"""
+
+
+@pytest.mark.parametrize(
+    "test_app",
+    [
+        {
+            "buildername": "html",
+            "no_plantuml": True,
+            "files": [
+                (Path("conf.py"), CUSTOM_TEMPLATE_CONF),
+                (Path("index.rst"), REPORT_INDEX),
+                (Path("report_templates/types.need"), CUSTOM_TEMPLATE),
+            ],
+        }
+    ],
+    indirect=True,
+)
+def test_needs_report_template_renders(test_app):
+    """A configured template is found under the source directory and rendered.
+
+    ``needs_report_template`` had no passing test at all: it was only ever
+    exercised through the ``:template:`` option, and only in its failing form.
+    """
+    app = test_app
+    app.build()
+
+    assert build_warnings(app) == []
+
+    text = visible_text(Path(app.outdir, "index.html").read_text(encoding="utf8"))
+    # the leading "/" of the configured path is stripped, not treated as the
+    # file system root, so the template is found relative to the source directory
+    assert "The project defines 8 need types:" in text
+    assert "Requirement" in text
+    assert "Specification" in text

--- a/tests/test_needreport.py
+++ b/tests/test_needreport.py
@@ -8,6 +8,8 @@ from pathlib import Path
 import pytest
 from sphinx.util.console import strip_colors
 
+from sphinx_needs.directives.needreport import DROPDOWN_MARKER
+
 SPHINX_DESIGN_INSTALLED = importlib.util.find_spec("sphinx_design") is not None
 
 
@@ -495,3 +497,316 @@ def test_needs_report_template_renders(test_app):
     assert "The project defines 8 need types:" in text
     assert "Requirement" in text
     assert "Specification" in text
+
+
+# -- the fallback only fires when it changes the report ----------------------
+#
+# Deciding on the raw template text -- "does the file mention report_directive?"
+# -- warned three shapes that build correctly today and cannot be helped by the
+# substitution: a Jinja comment naming the variable, a ``{% set %}`` shadowing
+# it, and the name appearing in rendered prose.  All three kept their output but
+# gained a warning, which under ``sphinx-build -W`` is a red CI.  The decision is
+# therefore made on the *rendered* text, and the substitution is adopted only
+# when re-rendering actually removes the dropdown usage.
+
+NO_PROVIDER_CONF = """\
+extensions = ["sphinx_needs"]
+needs_report_template = "/report_template.need"
+"""
+
+# Mentions the name in a Jinja comment, and hardcodes the directive it wants.
+COMMENT_MENTION_TEMPLATE = """\
+{# report_directive is deliberately not used here #}
+.. admonition:: Need Types
+
+   {% for type in types %}
+   * {{ type.title }}
+   {% endfor %}
+"""
+
+# Overrides the directive inside the template rather than in conf.py, which is
+# the docs' "choose the directive yourself" advice taken by a different route.
+SET_SHADOW_TEMPLATE = """\
+{% set report_directive = "admonition" %}
+.. {{ report_directive }}:: Need Types
+
+   {% for type in types %}
+   * {{ type.title }}
+   {% endfor %}
+"""
+
+# The name survives only into rendered prose, never into a directive.
+PROSE_MENTION_TEMPLATE = """\
+.. admonition:: Need Types
+
+   Set report_directive to choose how this block is rendered.
+
+   {% for type in types %}
+   * {{ type.title }}
+   {% endfor %}
+"""
+
+
+@pytest.mark.parametrize(
+    "test_app",
+    [
+        pytest.param(
+            {
+                "buildername": "html",
+                "no_plantuml": True,
+                "files": [
+                    (Path("conf.py"), NO_PROVIDER_CONF),
+                    (Path("index.rst"), REPORT_INDEX),
+                    (Path("report_template.need"), template),
+                ],
+            },
+            id=name,
+        )
+        for name, template in (
+            ("comment-mention", COMMENT_MENTION_TEMPLATE),
+            ("set-shadow", SET_SHADOW_TEMPLATE),
+            ("prose-mention", PROSE_MENTION_TEMPLATE),
+        )
+    ],
+    indirect=True,
+)
+def test_template_that_renders_no_dropdown_is_left_alone(test_app):
+    """A report that never renders a ``dropdown`` is not warned about.
+
+    Each of these projects builds cleanly today with no ``dropdown`` provider
+    loaded, so each must keep building cleanly: a new warning here would fail a
+    ``-W`` build that has nothing to fix.
+    """
+    app = test_app
+    app.build()
+
+    assert build_warnings(app) == []
+
+    html = Path(app.outdir, "index.html").read_text(encoding="utf8")
+    # the report is on the page, rendered by the template's own choice
+    assert 'class="admonition-need-types admonition"' in html
+    assert "Requirement" in visible_text(html)
+
+
+HARDCODED_DROPDOWN_TEMPLATE = """\
+.. dropdown:: Need Types
+
+   {% for type in types %}
+   * {{ type.title }}
+   {% endfor %}
+"""
+
+
+@pytest.mark.parametrize(
+    "test_app",
+    [
+        {
+            "buildername": "html",
+            "no_plantuml": True,
+            "files": [
+                (Path("conf.py"), NO_PROVIDER_CONF),
+                (Path("index.rst"), REPORT_INDEX),
+                (Path("report_template.need"), HARDCODED_DROPDOWN_TEMPLATE),
+            ],
+        }
+    ],
+    indirect=True,
+)
+def test_hardcoded_dropdown_template_keeps_todays_errors(test_app):
+    """A template that writes ``.. dropdown::`` itself is not claimed to be fixed.
+
+    Substituting the context variable cannot reach a literal in the template, so
+    re-rendering changes nothing.  Announcing "rendered with admonition instead"
+    would be false, and the warning would name no remedy the author could apply,
+    so this configuration keeps exactly the diagnostics it has today.
+    """
+    app = test_app
+    app.build()
+
+    reported = "\n".join(build_warnings(app))
+    assert 'ERROR: Unknown directive type "dropdown".' in reported
+    assert "No loaded extension provides" not in reported
+
+    html = Path(app.outdir, "index.html").read_text(encoding="utf8")
+    assert "admonition-need-types" not in html
+
+
+# Mentions the name, and cannot be rendered: the fallback decision must not run
+# ahead of the render and announce a substitution that never happened.
+UNRENDERABLE_MENTION_TEMPLATE = """\
+{# report_directive #}
+{% if no_such_variable|length != 0 %}
+Never rendered.
+{% endif %}
+"""
+
+
+@pytest.mark.parametrize(
+    "test_app",
+    [
+        {
+            "buildername": "html",
+            "no_plantuml": True,
+            "files": [
+                (Path("conf.py"), NO_PROVIDER_CONF),
+                (Path("index.rst"), REPORT_INDEX),
+                (Path("report_template.need"), UNRENDERABLE_MENTION_TEMPLATE),
+            ],
+        }
+    ],
+    indirect=True,
+)
+def test_unrenderable_template_warns_only_about_the_render(test_app):
+    """A template that cannot render gets one warning, about the render.
+
+    The fallback decision is made on rendered text, so there is nothing for it
+    to decide here -- and the author is not told the report was "rendered with
+    admonition instead" when nothing was rendered at all.
+    """
+    app = test_app
+    app.build()
+
+    warnings = build_warnings(app)
+    assert len(warnings) == 1, warnings
+    assert "Could not render needs report template file" in warnings[0]
+    assert "No loaded extension provides" not in warnings[0]
+
+
+# -- the render-failure report cannot itself end the build -------------------
+
+# ``getattr(exc, "message", exc)`` only swallows ``AttributeError``; an exception
+# whose own reporting raises would escape the handler and end the build -- the
+# very failure the handler exists to prevent.
+NASTY_DETAIL_CONF = '''\
+extensions = ["sphinx_needs"]
+needs_report_template = "/report_template.need"
+
+
+class NastyError(RuntimeError):
+    """An exception that cannot be asked to describe itself."""
+
+    @property
+    def message(self):
+        raise RuntimeError("message property exploded")
+
+
+def explode():
+    raise NastyError("boom")
+
+
+needs_render_context = {"explode": explode}
+'''
+
+NASTY_DETAIL_TEMPLATE = "{{ explode() }}\n"
+
+
+@pytest.mark.parametrize(
+    "test_app",
+    [
+        {
+            "buildername": "html",
+            "no_plantuml": True,
+            "files": [
+                (Path("conf.py"), NASTY_DETAIL_CONF),
+                (Path("index.rst"), REPORT_INDEX),
+                (Path("report_template.need"), NASTY_DETAIL_TEMPLATE),
+            ],
+        }
+    ],
+    indirect=True,
+)
+def test_render_failure_detail_that_raises_cannot_end_the_build(test_app):
+    """Reporting the failure falls back to the exception's type name."""
+    app = test_app
+    app.build()
+
+    warnings = build_warnings(app)
+    # Sphinx separately notes that ``needs_render_context`` cannot be cached
+    # because it holds a function, which has nothing to do with the directive
+    reported = [warning for warning in warnings if "needs.needreport" in warning]
+    assert len(reported) == 1, warnings
+    assert "Could not render needs report template file" in reported[0]
+    # the one thing that can still be said about it
+    assert reported[0].endswith(": NastyError [needs.needreport]"), reported[0]
+
+    # and the page is still there
+    assert "<h1>Report" in Path(app.outdir, "index.html").read_text(encoding="utf8")
+
+
+# -- the marker used to recognise a rendered dropdown ------------------------
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        (".. dropdown:: Title", True),
+        ("   .. dropdown:: Title", True),
+        ("\t.. dropdown::", True),
+        (".. dropdown::", True),
+        # docutils allows a single space before the ``::`` marker
+        (".. dropdown ::", True),
+        ("Intro\n\n.. dropdown:: Title\n", True),
+        # not explicit markup: docutils needs whitespace after the ``..``
+        ("..dropdown:: Title", False),
+        # a different directive whose name merely starts the same way
+        (".. dropdowns:: Title", False),
+        # not at the start of a line
+        ("see the .. dropdown:: directive", False),
+        # the name in prose, and in a Jinja comment, are not directives
+        ("Set report_directive to dropdown.", False),
+        ("{# report_directive #}\n.. admonition:: Title", False),
+        ("", False),
+    ],
+)
+def test_dropdown_marker_matches_docutils_recognition(text, expected):
+    """The marker recognises a directive the way docutils does, and nothing else."""
+    assert bool(DROPDOWN_MARKER.search(text)) is expected
+
+
+# -- one configuration mistake, one warning ----------------------------------
+
+MANY_REPORTS_INDEX = """\
+Report
+======
+
+.. needreport::
+   :types:
+
+.. needreport::
+   :links:
+
+.. needreport::
+   :usage:
+"""
+
+
+@pytest.mark.parametrize(
+    "test_app",
+    [
+        {
+            "buildername": "html",
+            "no_plantuml": True,
+            "files": [
+                (Path("conf.py"), RESERVED_KEY_CONF),
+                (Path("index.rst"), MANY_REPORTS_INDEX),
+            ],
+        }
+    ],
+    indirect=True,
+)
+def test_reserved_context_key_warns_once_per_build(test_app):
+    """The reserved-key warning is a fact about ``conf.py``, so it is said once.
+
+    It does not depend on the directive that happened to notice it, and a
+    project with a report on every page would otherwise get the same line once
+    per directive.
+    """
+    app = test_app
+    app.build()
+
+    warnings = build_warnings(app)
+    assert len(warnings) == 1, warnings
+    assert (
+        "needs_render_context replaces the needreport context key 'types'"
+        in (warnings[0])
+    )

--- a/tests/test_needreport.py
+++ b/tests/test_needreport.py
@@ -22,6 +22,17 @@ def visible_text(html: str) -> str:
     return re.sub(r"\s+", " ", re.sub(r"<[^>]+>", " ", html))
 
 
+def highlighted_block(html: str) -> str:
+    """Return the page's first syntax-highlighted literal block.
+
+    Its content is one ``<span>`` per token, so asserting on the page text does
+    not work: the tags collapse to spaces and split the directive marker up.
+    """
+    match = re.search(r'<div class="highlight[^"]*">.*?</div>', html, re.S)
+    assert match is not None, "no highlighted block on the page"
+    return match.group(0)
+
+
 def build_warnings(app) -> list[str]:
     """Return the warnings of a finished build, one per line.
 
@@ -750,6 +761,9 @@ def test_render_failure_detail_that_raises_cannot_end_the_build(test_app):
         ("..dropdown:: Title", False),
         # a different directive whose name merely starts the same way
         (".. dropdowns:: Title", False),
+        # docutils requires whitespace or end-of-line after ``::``; without it the
+        # line is a comment, so this must not count as a usage
+        (".. dropdown::x", False),
         # not at the start of a line
         ("see the .. dropdown:: directive", False),
         # the name in prose, and in a Jinja comment, are not directives
@@ -759,7 +773,14 @@ def test_render_failure_detail_that_raises_cannot_end_the_build(test_app):
     ],
 )
 def test_dropdown_marker_matches_docutils_recognition(text, expected):
-    """The marker recognises a directive the way docutils does, and nothing else."""
+    """The marker follows docutils' own recognition of a directive.
+
+    Tabs are tolerated where docutils writes a space, because docutils expands
+    them before the line is ever matched.  What the marker cannot know is RST
+    block context: example markup inside a literal block matches too, which is
+    the documented limitation recorded on ``DROPDOWN_MARKER`` and pinned by
+    ``test_example_markup_in_a_literal_block_is_substituted`` below.
+    """
     assert bool(DROPDOWN_MARKER.search(text)) is expected
 
 
@@ -810,3 +831,142 @@ def test_reserved_context_key_warns_once_per_build(test_app):
         "needs_render_context replaces the needreport context key 'types'"
         in (warnings[0])
     )
+
+
+# -- the heuristic's known edge, and its safety net ---------------------------
+#
+# The decision is a textual scan of the rendered report, so it cannot tell a
+# directive from example markup showing one.  A template that prints
+# ``{{ report_directive }}`` inside a literal block -- to document the report's
+# own markup, say -- therefore looks like a live usage.  These two tests pin what
+# that costs: the displayed example changes, and nothing else does.
+
+LITERAL_BLOCK_TEMPLATE = """\
+.. code-block:: rst
+
+   .. {{ report_directive }}:: Need Types
+"""
+
+# The same, plus a branch that only breaks when the fallback is being tried.
+LITERAL_BLOCK_SECOND_RENDER_FAILS_TEMPLATE = """\
+.. code-block:: rst
+
+   .. {{ report_directive }}:: Need Types
+{% if report_directive == "admonition" %}{{ no_such_variable|length }}{% endif %}
+"""
+
+
+@pytest.mark.parametrize(
+    "test_app",
+    [
+        {
+            "buildername": "html",
+            "no_plantuml": True,
+            "files": [
+                (Path("conf.py"), NO_PROVIDER_CONF),
+                (Path("index.rst"), REPORT_INDEX),
+                (Path("report_template.need"), LITERAL_BLOCK_TEMPLATE),
+            ],
+        }
+    ],
+    indirect=True,
+)
+def test_example_markup_in_a_literal_block_is_substituted(test_app):
+    """Example markup showing the directive is treated as though it used it.
+
+    Distinguishing the two needs the parsed document rather than the rendered
+    text, which is out of proportion to the problem, so this is pinned as the
+    documented cost of the heuristic rather than left to be discovered.
+    """
+    app = test_app
+    app.build()
+
+    assert len(build_warnings(app)) == 1
+    assert "No loaded extension provides" in build_warnings(app)[0]
+
+    # the substitution reached the displayed example, which is the whole cost
+    block = highlighted_block(Path(app.outdir, "index.html").read_text(encoding="utf8"))
+    assert ">admonition<" in block
+    assert ">dropdown<" not in block
+
+
+@pytest.mark.parametrize(
+    "test_app",
+    [
+        {
+            "buildername": "html",
+            "no_plantuml": True,
+            "files": [
+                (Path("conf.py"), NO_PROVIDER_CONF),
+                (Path("index.rst"), REPORT_INDEX),
+                (
+                    Path("report_template.need"),
+                    LITERAL_BLOCK_SECOND_RENDER_FAILS_TEMPLATE,
+                ),
+            ],
+        }
+    ],
+    indirect=True,
+)
+def test_a_failed_fallback_render_keeps_the_report(test_app):
+    """A fallback render that fails costs the project nothing.
+
+    The default render has already succeeded by then, so the report it produced
+    is kept.  The failed attempt is this directive's own idea rather than
+    anything the author wrote, so it is not reported either: "could not render"
+    would be false of the render the page actually got.  The fallback logic can
+    therefore leave a report as it was, but never lose it.
+    """
+    app = test_app
+    app.build()
+
+    assert build_warnings(app) == []
+
+    # the default render is on the page, untouched
+    block = highlighted_block(Path(app.outdir, "index.html").read_text(encoding="utf8"))
+    assert ">dropdown<" in block
+    assert ">admonition<" not in block
+
+
+# The same safety net on a project that is genuinely broken today: the report
+# really does use the directive, and the fallback render really does fail.
+REAL_USE_SECOND_RENDER_FAILS_TEMPLATE = """\
+.. {{ report_directive }}:: Need Types
+
+   {% for type in types %}
+   * {{ type.title }}
+   {% endfor %}
+
+{% if report_directive == "admonition" %}{{ no_such_variable|length }}{% endif %}
+"""
+
+
+@pytest.mark.parametrize(
+    "test_app",
+    [
+        {
+            "buildername": "html",
+            "no_plantuml": True,
+            "files": [
+                (Path("conf.py"), NO_PROVIDER_CONF),
+                (Path("index.rst"), REPORT_INDEX),
+                (Path("report_template.need"), REAL_USE_SECOND_RENDER_FAILS_TEMPLATE),
+            ],
+        }
+    ],
+    indirect=True,
+)
+def test_failed_fallback_on_a_real_usage_keeps_todays_behaviour(test_app):
+    """When the substitution cannot be rendered, today's diagnostics stand.
+
+    Nothing is claimed to have been fixed, and no "could not render" is reported
+    for a render that succeeded; the project keeps exactly the docutils error it
+    has always had for an unprovided ``dropdown``.
+    """
+    app = test_app
+    app.build()
+
+    reported = "\n".join(build_warnings(app))
+    assert 'ERROR: Unknown directive type "dropdown".' in reported
+    assert "No loaded extension provides" not in reported
+    assert "Could not render" not in reported

--- a/tests/test_needreport.py
+++ b/tests/test_needreport.py
@@ -3,7 +3,7 @@
 import importlib.util
 import os
 import re
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 
 import pytest
 from sphinx.util.console import strip_colors
@@ -229,6 +229,8 @@ import pathlib
 
 extensions = ["sphinx_needs"]
 needs_report_template = str(pathlib.Path(__file__).parent / "report_template.need")
+# pin the wrapper, so the template loader is the only thing that can warn here
+needs_render_context = {"report_directive": "admonition"}
 """
 
 TYPES_TEMPLATE = """\
@@ -256,18 +258,63 @@ TYPES_TEMPLATE = """\
     indirect=True,
 )
 def test_absolute_report_template_explains_the_rebase(test_app):
-    """The nonsense path in the warning is explained rather than left bare."""
+    """What an absolute ``needs_report_template`` does, on each platform.
+
+    The value is joined onto the source directory, and ``pathlib`` gives that
+    join two different meanings.  A POSIX-style absolute value has its leading
+    ``/`` stripped first, so it is appended and the file is looked for at a path
+    nobody wrote down.  A drive-letter absolute value is not relative at all, so
+    the join *replaces* the source directory with it and the file is read from
+    where it points -- ``lstrip("/")`` never touches a ``D:\\...`` value either.
+
+    So the rebase this warning explains is POSIX-only, and the two halves are
+    asserted rather than one of them skipped.
+    """
     app = test_app
     app.build()
 
     warnings = build_warnings(app)
-    assert len(warnings) == 1, warnings
-    assert "Could not load needs report template file" in warnings[0]
-    assert (
-        "needs_report_template is resolved relative to the source directory"
-        in warnings[0]
-    )
-    assert warnings[0].endswith("[needs.needreport]")
+
+    if os.name == "nt":
+        # the configured path is used as it stands: the template is found, and
+        # there is nothing to warn about
+        assert warnings == []
+        text = visible_text(Path(app.outdir, "index.html").read_text(encoding="utf8"))
+        assert "Need Types" in text
+        assert "Requirement" in text
+    else:
+        assert len(warnings) == 1, warnings
+        assert "Could not load needs report template file" in warnings[0]
+        assert (
+            "needs_report_template is resolved relative to the source directory"
+            in warnings[0]
+        )
+        assert warnings[0].endswith("[needs.needreport]")
+
+
+@pytest.mark.parametrize(
+    ("srcdir", "configured", "expected"),
+    [
+        # POSIX: the leading "/" is stripped, so the value is appended and the
+        # file is looked for somewhere nobody wrote down
+        ("/srcdir", "/templates/t.need", "/srcdir/templates/t.need"),
+        ("/srcdir", "templates/t.need", "/srcdir/templates/t.need"),
+        # Windows: a drive-letter value is not relative, so the join replaces the
+        # source directory with it -- and lstrip("/") never touches it
+        (r"D:\srcdir", r"D:\elsewhere\t.need", r"D:\elsewhere\t.need"),
+        (r"D:\srcdir", r"templates\t.need", r"D:\srcdir\templates\t.need"),
+    ],
+)
+def test_report_template_join_semantics(srcdir, configured, expected):
+    """Pin the ``pathlib`` behaviour the resolution of the config key rests on.
+
+    ``needreport.py`` resolves it as ``Path(srcdir) / value.lstrip("/")``, and
+    what that means differs by platform: appended on POSIX, replaced on Windows.
+    The test above asserts the consequence for a whole build on whichever
+    platform it runs; this asserts the cause on both, everywhere.
+    """
+    pure = PureWindowsPath if "\\" in srcdir else PurePosixPath
+    assert pure(srcdir) / configured.lstrip("/") == pure(expected)
 
 
 # -- the dropdown prerequisite (issue #899) ---------------------------------

--- a/tests/test_needreport.py
+++ b/tests/test_needreport.py
@@ -1,3 +1,5 @@
+"""Tests for the :ref:`needreport` directive."""
+
 import os
 from pathlib import Path
 
@@ -5,20 +7,29 @@ import pytest
 from sphinx.util.console import strip_colors
 
 
+def build_warnings(app) -> list[str]:
+    """Return the warnings of a finished build, one per line.
+
+    The source directory is randomised per test run, so it is collapsed to
+    ``<srcdir>/`` to keep the expected strings readable and stable.
+    """
+    return (
+        strip_colors(app._warning.getvalue())
+        .replace(str(app.srcdir) + os.path.sep, "<srcdir>/")
+        .strip()
+    ).splitlines()
+
+
 @pytest.mark.parametrize(
     "test_app",
     [{"buildername": "html", "srcdir": "doc_test/doc_needreport", "no_plantuml": True}],
     indirect=True,
 )
-def test_doc_needarch(test_app):
+def test_doc_needreport(test_app):
     app = test_app
     app.build()
     # check for warning about missing options
-    warnings = (
-        strip_colors(test_app._warning.getvalue())
-        .replace(str(test_app.srcdir) + os.path.sep, "<srcdir>/")
-        .strip()
-    ).splitlines()
+    warnings = build_warnings(app)
     assert warnings == [
         "<srcdir>/index.rst:6: WARNING: No options specified to generate need report [needs.needreport]",
         "<srcdir>/index.rst:8: WARNING: Could not load needs report template file <srcdir>/unknown.rst [needs.needreport]",
@@ -29,3 +40,205 @@ def test_doc_needarch(test_app):
     assert "Need Links" in html
     assert "Need Fields" in html
     assert "Need Metrics" in html
+
+
+# -- render failures --------------------------------------------------------
+#
+# A template that cannot be rendered used to escape ``run()`` as a
+# ``minijinja.TemplateError`` and end the whole build, which is precisely what
+# :pr:`1105` set out to stop ("Change errors in the directive to emit warnings,
+# rather than excepting the whole build").  The missing-file path got that
+# treatment; the render path did not.
+
+REPORT_INDEX = """\
+Report
+======
+
+.. needreport::
+   :types:
+"""
+
+RENDER_FAIL_CONF = """\
+extensions = ["sphinx_needs"]
+needs_report_template = "/report_template.need"
+"""
+
+# ``{% for %}`` is never closed
+SYNTAX_ERROR_TEMPLATE = """\
+{% for type in types %}
+* {{ type.title }}
+"""
+
+# MiniJinja tolerates an undefined value printed on its own, but not one passed
+# through a filter -- and this is exactly what the stale template in the docs
+# did with its non-existent ``fields`` variable.
+UNDEFINED_FILTER_TEMPLATE = """\
+{% if no_such_variable|length != 0 %}
+Never rendered.
+{% endif %}
+"""
+
+
+@pytest.mark.parametrize(
+    ("test_app", "expected_detail"),
+    [
+        pytest.param(
+            {
+                "buildername": "html",
+                "no_plantuml": True,
+                "files": [
+                    (Path("conf.py"), RENDER_FAIL_CONF),
+                    (Path("index.rst"), REPORT_INDEX),
+                    (Path("report_template.need"), SYNTAX_ERROR_TEMPLATE),
+                ],
+            },
+            "syntax error: unexpected end of input",
+            id="syntax-error",
+        ),
+        pytest.param(
+            {
+                "buildername": "html",
+                "no_plantuml": True,
+                "files": [
+                    (Path("conf.py"), RENDER_FAIL_CONF),
+                    (Path("index.rst"), REPORT_INDEX),
+                    (Path("report_template.need"), UNDEFINED_FILTER_TEMPLATE),
+                ],
+            },
+            "cannot calculate length of value of type undefined",
+            id="undefined-through-filter",
+        ),
+    ],
+    indirect=["test_app"],
+)
+def test_render_failure_warns_and_build_survives(test_app, expected_detail):
+    """A template that cannot be rendered warns, like a template that is missing."""
+    app = test_app
+    app.build()
+
+    warnings = build_warnings(app)
+    assert len(warnings) == 1, warnings
+    assert warnings[0].startswith(
+        "<srcdir>/index.rst:4: WARNING: Could not render needs report template file "
+        "<srcdir>/report_template.need: "
+    ), warnings[0]
+    # the engine's own explanation is carried through, so the author can act on it
+    assert expected_detail in warnings[0]
+    assert warnings[0].endswith("[needs.needreport]")
+
+    # the build still produced its page, and the directive contributed nothing to it
+    html = Path(app.outdir, "index.html").read_text(encoding="utf8")
+    assert "<h1>Report" in html
+    assert "Never rendered." not in html
+
+
+# -- reserved context keys --------------------------------------------------
+
+RESERVED_KEY_CONF = """\
+extensions = ["sphinx_needs"]
+needs_render_context = {
+    "report_directive": "admonition",
+    "types": [
+        {
+            "directive": "injected",
+            "title": "Injected By Context",
+            "prefix": "I_",
+            "style": "node",
+        }
+    ],
+}
+"""
+
+
+@pytest.mark.parametrize(
+    "test_app",
+    [
+        {
+            "buildername": "html",
+            "no_plantuml": True,
+            "files": [
+                (Path("conf.py"), RESERVED_KEY_CONF),
+                (Path("index.rst"), REPORT_INDEX),
+            ],
+        }
+    ],
+    indirect=True,
+)
+def test_reserved_context_key_warns_but_still_overrides(test_app):
+    """A reserved key taken over by ``needs_render_context`` warns, and still wins.
+
+    The warning is new; the override is not.  Silently replacing ``types`` with
+    whatever the configuration happens to hold has produced convincing nonsense
+    for years, but changing who wins would break the projects relying on it, so
+    this only makes the swap visible.
+    """
+    app = test_app
+    app.build()
+
+    warnings = build_warnings(app)
+    assert warnings == [
+        "<srcdir>/index.rst:4: WARNING: needs_render_context replaces the needreport "
+        "context key 'types'; only 'report_directive' is meant to be set this way "
+        "[needs.needreport]"
+    ]
+
+    # today's behaviour, unchanged: the configured value is what gets rendered
+    html = Path(app.outdir, "index.html").read_text(encoding="utf8")
+    assert "Injected By Context" in html
+    assert "Requirement" not in html
+
+
+# ``report_directive`` is the documented override and must stay silent.  That is
+# asserted by ``test_doc_needreport`` above: its project sets exactly that key,
+# and its warning list is compared for equality, so a warning here would fail it.
+
+
+# -- an absolute needs_report_template --------------------------------------
+
+# ``needs_report_template`` is always resolved against the source directory, so
+# a path that is absolute on the file system is stripped and rebased under it,
+# and the resulting "not found" names a path the author never wrote down.
+ABS_TEMPLATE_CONF = """\
+import pathlib
+
+extensions = ["sphinx_needs"]
+needs_report_template = str(pathlib.Path(__file__).parent / "report_template.need")
+"""
+
+TYPES_TEMPLATE = """\
+.. {{ report_directive }}:: Need Types
+
+   {% for type in types %}
+   * {{ type.title }}
+   {% endfor %}
+"""
+
+
+@pytest.mark.parametrize(
+    "test_app",
+    [
+        {
+            "buildername": "html",
+            "no_plantuml": True,
+            "files": [
+                (Path("conf.py"), ABS_TEMPLATE_CONF),
+                (Path("index.rst"), REPORT_INDEX),
+                (Path("report_template.need"), TYPES_TEMPLATE),
+            ],
+        }
+    ],
+    indirect=True,
+)
+def test_absolute_report_template_explains_the_rebase(test_app):
+    """The nonsense path in the warning is explained rather than left bare."""
+    app = test_app
+    app.build()
+
+    warnings = build_warnings(app)
+    assert len(warnings) == 1, warnings
+    assert "Could not load needs report template file" in warnings[0]
+    assert (
+        "needs_report_template is resolved relative to the source directory"
+        in warnings[0]
+    )
+    assert warnings[0].endswith("[needs.needreport]")


### PR DESCRIPTION
Six commits, one directive. Each is self-contained and reviewable on its own; the
first changes no behaviour at all. The sections below describe the end state.

Closes #899.

## 📚 `needreport` documentation matches the code

The "default template" printed under `needs_report_template` had drifted about four
years from the packaged one. Copying it — the customisation route both pages recommend —
**ends the build**, because it reads two context variables that have never existed:
`fields` (the key is `options`) and `json_exclude_fields` (never in the context at all).
It also hardcodes `.. dropdown::` where the real template writes
`{{ report_directive }}`, so a copy silently loses the one escape hatch that makes the
report render without a dropdown provider — the very workaround #899 reporters are given.

It is now a `literalinclude` of `sphinx_needs/directives/needreport_template.rst`, so the
page and the template cannot diverge again. (`docs/installation.rst` already includes a
packaged file the same way.)

The rest of the page is corrected against measured behaviour rather than rewritten:

- **`usage` holds no numbers.** Every value in it is permanently `0` and is kept only for
  backwards compatibility; only the *keys* of `usage["needs_types"]` carry information.
  The counts in a rendered report come from the `:need_count:` roles the template emits,
  which are resolved after every document is read — and are therefore whole-project,
  need-part-inclusive and external-need-inclusive. The docs previously described these as
  "the total amount of need objects", which is both the wrong source and the wrong count.
- **The `:template:` option was documented nowhere**, including that its path is
  *document*-relative while `needs_report_template` is *source-directory*-relative. It now
  has a section, and the three-level precedence between the two and the packaged default
  is written down.
- **"The path must be an absolute path based on the conf.py directory"** was wrong twice:
  a relative value works fine, and a POSIX-style absolute one is stripped and rebased under
  the source directory, producing a "not found" naming a path nobody wrote. (On Windows a
  drive-letter path replaces the join base and is read from where it points — the CI matrix
  caught this, and the docs scope the rebase accordingly.) Also, the code uses `srcdir`,
  not `confdir`.
- The `dropdown` prerequisite and the `report_directive` override now also appear on the
  configuration page — the page reporters get pointed at, and the one whose template
  hardcoded `.. dropdown::`.
- The five reserved context names are listed, and `needs_render_context` is documented as
  merging over them.
- An `.rst` template inside the source directory is also built as a document of its own,
  spraying parse errors; `.need`/`.txt` is recommended, with the `exclude_patterns` snippet
  for anyone keeping `.rst`.
- The extension allow-list is advisory, not enforced; templates render with **MiniJinja**,
  which is Jinja-compatible but not identical (the page linked the Jinja2 2.11 docs).
- `needreport.rst` no longer opens by saying you "need to set" `needs_report_template`,
  which its own next sentence contradicts.

## 🐛 Render failures warn instead of ending the build

PR #1105 set out to "change errors in the directive to emit warnings, rather than
excepting the whole build". The missing-file path got that; the render call two statements
later did not, so any `minijinja.TemplateError` escaped `run()` and killed the build —
dumping the whole template context to the console with it.

Both ways in are easy to hit: a syntax error in the template, and any operation on an
undefined value (`{% if fields|length != 0 %}` — i.e. **following the stale documentation
above was one of them**). The render is now wrapped, emitting one `needreport` warning
carrying the template path and the engine's own one-line explanation, then contributing
nothing to the page: the same shape as the missing-file path above it.

Two smaller diagnostics ride along, both warn-only and both leaving behaviour alone:

- `needs_render_context` silently replaces the directive's own context keys — a string
  given for `types` renders as one table row per character. That is now reported. **Which
  value wins is deliberately unchanged**: only `report_directive` is meant to be set this
  way, but the rest have been overridable for years.
- When `needs_report_template` is absolute in the POSIX sense, the "could not load"
  warning now explains why it names a path nobody wrote down. (A Windows drive-letter
  path is not relative, so it is used as it stands and needs no explaining.)

The reserved-key collision is a property of `conf.py` rather than of any one directive, so
it is reported with `once=True` — one line per build, not one per `needreport`. Worth
calling out for `-W` builds: such a project renders exactly as before but now emits a
warning where it emitted none.

Reporting the failure cannot itself fail: `getattr(exc, "message", exc)` only swallows
`AttributeError`, so an exception whose own `.message` raises would have escaped the
handler and ended the build — precisely the failure being handled. It falls back to the
exception's type name.

## 🐛 The default renders without an extension providing `dropdown` (#899)

`dropdown` comes from an extension such as sphinx-design, which is not a runtime
dependency — it appears only in the `docs` extra. Without one, each enabled section
produced `ERROR: Unknown directive type "dropdown"` at template line numbers projected
onto the user's document (a 19-line `index.rst` blamed at lines 46, 82 and 121), and then
Sphinx stripped the `system_message` nodes and the report **vanished from the page
entirely**. Empty section, four console errors, exit 0 — or a failed build under `-W`.
Open since March 2023.

The report is now rendered first, and the directive looked up in the docutils registry; if
the rendered report uses `dropdown` and nothing provides it, `admonition` is used instead
and one warning names both remedies.

**Nothing changes for a project that renders today**, which the implementation enforces
rather than assumes:

- an explicit `needs_render_context = {"report_directive": ...}` is never overridden,
  `"dropdown"` included — asking for a directive by name and quietly getting another
  would be worse than the error, so that project keeps failing exactly as before;
- otherwise the decision is made on the **rendered** report, not on the template source.
  The template is rendered normally first; only if the result actually contains a
  `.. dropdown::` directive, and nothing provides one, is it re-rendered with
  `admonition` — and the substitution is adopted, and the warning emitted, only if that
  second render removes the usage.

That second rule is what makes the claim true rather than merely stated. Deciding on the
template *text* ("does the file mention `report_directive`?") warns three shapes that
build correctly today and cannot be helped: a Jinja comment naming the variable, a
`{% set report_directive = "admonition" %}` shadowing it, and the name reaching only
rendered prose. Each keeps its output byte-for-byte and gains a warning — which under
`-W` is a red CI with nothing to fix. A template with `.. dropdown::` hardcoded in it is
left alone for the mirror-image reason: re-rendering cannot reach a name the template
never reads from the context, so nothing is fixed and announcing a substitution would be
false. All four shapes have tests.

Two properties keep the heuristic from costing anything it should not. If the substituted
render fails where the default one succeeded, the default render is kept and nothing is
reported — the fallback can leave a report as it was, but never lose it. And the marker
follows docutils' own recognition, including the whitespace-or-end-of-line after `::`
without which docutils reads the line as a comment.

One limitation is documented rather than fixed: the decision is a textual scan of the
rendered report, so a report that merely *shows* `.. dropdown::` as example markup — in a
literal block, say — while producing it through `report_directive` is treated as though
it used it, and the displayed example will name `admonition`. Distinguishing the two
needs the parsed document rather than the rendered text, which is out of proportion to
the problem; there is a test pinning the current behaviour so it stays a known edge.

Verified on this repository's own documentation: the five rendered dropdown blocks in
`directives/needreport.html` are **byte-identical** before and after — sha256
`7c5c6aec5e05b1e9`, the same on both sides — with no `needreport` warning anywhere in the
build.

## Tests

`tests/test_needreport.py` was one test — a warnings-list equality and four substring
assertions — and its fixture pinned `report_directive = "admonition"`, which is precisely
why the suite could never see #899. It is now 37 tests:

- a new fixture project with the **default** `report_directive` and no provider, asserting
  the fallback and the rendered **content**, not just the four section titles;
- the first assertions on real numbers this module has had: `Req 5` / `Total Needs Amount
  6` over 2 local needs + 1 need part + 2 external needs, which pins the parts-inclusive
  and external-inclusive counting of the `:need_count:` roles;
- a registered-provider case (a stub `dropdown`, so it runs everywhere) and the real
  sphinx-design case, both asserting no substitution and no warning;
- the explicit-`dropdown`-without-provider case, pinning that it is never second-guessed;
- a Jinja syntax error and an undefined-through-filter template, each asserting a warning
  and a surviving build;
- a reserved-key collision, asserting the warning *and* that the override still wins;
- the first passing test of `needs_report_template`, which was previously exercised only
  in its failing form;
- the four "leave it alone" shapes above, each asserting zero warnings and the output the
  project gets today, plus a unit test pinning that the dropdown marker is recognised the
  way docutils recognises a directive (indented, tab-indented, `.. dropdown ::`, and not
  `..dropdown::`, `.. dropdowns::`, or the name in prose);
- an unrenderable template that mentions the name, asserting **one** warning — about the
  render — rather than also being told it was "rendered with admonition instead";
- a context callable raising an exception whose `.message` property raises, asserting the
  build survives with one warning;
- three `needreport` directives against one colliding key, asserting one warning;
- a template whose substituted render fails keeping the default render it already had —
  the fallback can leave a report as it was, never lose it — and the literal-block
  example edge pinned as the documented limitation (the marker unit test also covers
  `.. dropdown::x`, which docutils reads as a comment);
- the absolute-path test asserts both platforms (POSIX: rebased and explained; Windows:
  a drive-letter path is used as it stands), backed by a join-semantics unit test that
  pins the `pathlib` behaviour the branch's premise rests on — on every platform, so a
  future `pathlib` change fails loudly rather than only on one OS's CI leg.

## Deliberately not done

Several findings from the same audit were left alone on purpose, and are worth stating so
they are not read as oversights. **`usage` is not re-populated with real numbers**: at
directive-run time the need set is still incomplete — that is why #1110 moved counting to
post-processing — so any value written there would be wrong-but-plausible instead of
wrong-and-obvious, and it would establish a second, half-populated data path that #1487
would then have to unpick; the docs now explain the zeros instead. **The default
`report_directive` is not changed to `admonition`**, and the packaged template is not
rewritten around a core-only construct: either would silently take collapsible dropdowns
away from every project that has a provider today. **No dependency is added** —
depending on sphinx-design for one directive's default styling would inject its CSS and JS
into every page of every project, and would still not fix the repro, since installing the
package does not register the directive. Also dropped: filtering the GitHub service's
`issue`/`pr`/`commit` types out of the report (service-registration behaviour, far wider
than needreport, and changing it would alter working output), and sandboxing `:template:`
against `..` escapes (standard `relfn2path` semantics, no evidence of harm).

Two items are flagged for you rather than fixed here:

- **Diagnostic locations (#1776).** Errors inside template-rendered RST are reported at
  template line numbers projected onto the user's document — the single biggest reason
  #899 reads as confusing, since the reporter's own paste points at an innocent line. The
  honest fix is to pass a synthetic source name to `insert_input`, which changes **every**
  existing diagnostic string for template-generated content and would break any downstream
  `-W` suppression regex or warning allowlist. That needs your call, so it is out of scope
  here and left to #1776.
- Two smaller observations, neither touched: `needreport.py` uses `env.app.srcdir`, which
  now emits `RemovedInSphinx11Warning`; and the new `:template:` docs carry no
  `.. versionadded::`, because the release that introduced the option could not be
  established from the history available here — happy to add one if you know it.

Unrelated to this PR but adjacent: landing the documentation commit means #1487 would
extend an accurate page rather than a stale one, and the `literalinclude` keeps whatever
template it ships in sync automatically.