### PR TITLE
🐛 needgantt: address tasks by id and fix the start_date month

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -333,6 +333,7 @@ Bug fixes
   treated as though it used it.
 
 - 🐛 :ref:`needgantt` draws each task once, in its type color **(changed output)**
+  (:pr:`1778`)
 
   Tasks are declared as ``[<title>] as [<id>]``, which binds every later ``[...]``
   reference to the *id*, but the completion and color lines addressed tasks by their
@@ -346,7 +347,7 @@ Bug fixes
   colored and shaded as configured.
 
 - 🐛 :ref:`needgantt_start_date` names the month it was given, and a December date no
-  longer ends the build **(changed output)**
+  longer ends the build **(changed output)** (:pr:`1778`)
 
   The date was reformatted through a month name table indexed with the 1-based month
   number, so the chart started one month later than asked for — ``2020-03-25`` became
@@ -360,7 +361,7 @@ Documentation
 .............
 
 - 📚 :ref:`needgantt` no longer claims that task elements are linked to their related
-  need when PlantUML's output format is ``svg``.
+  need when PlantUML's output format is ``svg`` (:pr:`1778`)
 
   No such link has ever been generated; the only link a chart produces is its caption,
   which points at the generated image file.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -332,8 +332,38 @@ Bug fixes
   ``.. dropdown::`` as example markup while producing it through ``report_directive`` is
   treated as though it used it.
 
+- 🐛 :ref:`needgantt` draws each task once, in its type color **(changed output)**
+
+  Tasks are declared as ``[<title>] as [<id>]``, which binds every later ``[...]``
+  reference to the *id*, but the completion and color lines addressed tasks by their
+  *title*. PlantUML does not reject an unbound reference — it silently declares a second,
+  zero length task of that name — so every need carrying a type color or a completion
+  value was drawn twice, which, since :ref:`needs_types` entries carry a color by default,
+  is every need in almost every chart. The color and the completion landed on the phantom
+  bar, too, leaving the real one in PlantUML's default grey: a three need chart rendered
+  as six bars, three of them grey and full length, three of them zero length and correctly
+  colored. Both lines now address the task by its id, so a chart of N needs draws N bars,
+  colored and shaded as configured.
+
+- 🐛 :ref:`needgantt_start_date` names the month it was given, and a December date no
+  longer ends the build **(changed output)**
+
+  The date was reformatted through a month name table indexed with the 1-based month
+  number, so the chart started one month later than asked for — ``2020-03-25`` became
+  ``the 25th of April 2020`` — and any December date raised
+  ``IndexError: list index out of range``, aborting the build. The generated statement is
+  now the ISO date, which PlantUML also accepts (``Project starts 2020-03-25``) and which
+  renders the identical chart, and which cannot mis-suffix a date either: ``2020-01-01``
+  used to be written ``the 01th of February 2020``.
+
 Documentation
 .............
+
+- 📚 :ref:`needgantt` no longer claims that task elements are linked to their related
+  need when PlantUML's output format is ``svg``.
+
+  No such link has ever been generated; the only link a chart produces is its caption,
+  which points at the generated image file.
 
 - 📚 The :ref:`needpie` and :ref:`needbar` pages are corrected against what the two
   directives actually do.

--- a/docs/directives/needgantt.rst
+++ b/docs/directives/needgantt.rst
@@ -74,8 +74,6 @@ needgantt
    So if you get any syntax errors during the build, please download the
    `latest PlantUML <http://sourceforge.net/projects/plantuml/files/plantuml.jar/download>`__ version.
 
-If ``svg`` is set as output format for PlantUML, we link the tasks elements to their related need.
-
 We take the colors for the chart from the :ref:`needs_types` configuration.
 You can deactivate this behavior by setting :ref:`needgantt_no_color`.
 

--- a/sphinx_needs/directives/needgantt.py
+++ b/sphinx_needs/directives/needgantt.py
@@ -25,7 +25,7 @@ from sphinx_needs.directives.utils import (
 )
 from sphinx_needs.filter_common import FilterBase, filter_single_need, process_filters
 from sphinx_needs.logging import get_logger, log_warning
-from sphinx_needs.utils import MONTH_NAMES, add_doc, remove_node_from_tree
+from sphinx_needs.utils import add_doc, remove_node_from_tree
 
 logger = get_logger(__name__)
 
@@ -221,7 +221,6 @@ def process_needgantt(
 
         # Project start date handling
         start_date_string = current_needgantt["start_date"]
-        start_date_plantuml = None
         if start_date_string:
             try:
                 start_date = datetime.strptime(start_date_string, "%Y-%m-%d")
@@ -234,10 +233,10 @@ def process_needgantt(
                     )
                 )
 
-            month = MONTH_NAMES[int(start_date.strftime("%m"))]
-            start_date_plantuml = start_date.strftime(f"%dth of {month} %Y")
-        if start_date_plantuml:
-            puml_node["uml"] += f"Project starts the {start_date_plantuml}\n"
+            # PlantUML also understands the ISO date, so it is passed through as given
+            puml_node["uml"] += "Project starts {}\n".format(
+                start_date.strftime("%Y-%m-%d")
+            )
 
         # Element handling
         puml_node["uml"] += "\n' Elements definition \n\n"
@@ -287,14 +286,17 @@ def process_needgantt(
                     need["title"], need["id"], duration
                 )
 
+            # tasks are declared as "[<title>] as [<id>]", which binds every later
+            # "[...]" reference to the id; a reference to the title would not raise,
+            # it would silently declare a second, zero length task of that name
             if complete:
                 el_completion_string += "[{}] is {}% completed\n".format(
-                    need["title"], complete
+                    need["id"], complete
                 )
 
             if need["type_color"]:
                 el_color_string += "[{}] is colored in {}\n".format(
-                    need["title"], need["type_color"]
+                    need["id"], need["type_color"]
                 )
 
             puml_node["uml"] += gantt_element

--- a/sphinx_needs/utils.py
+++ b/sphinx_needs/utils.py
@@ -38,22 +38,6 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
-MONTH_NAMES = [
-    "January",
-    "February",
-    "March",
-    "April",
-    "May",
-    "June",
-    "July",
-    "August",
-    "September",
-    "October",
-    "November",
-    "December",
-]
-
-
 class DummyOptionSpec(dict[str, Callable[[str], str]]):
     """An option_spec allows any options."""
 

--- a/tests/test_needgantt.py
+++ b/tests/test_needgantt.py
@@ -1,0 +1,184 @@
+"""Tests for the ``needgantt`` directive."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+from sphinx.util.console import strip_colors
+from sphinxcontrib.plantuml import plantuml
+
+#: A ``conf.py`` for the inline source projects below.
+#: ``needgantt`` requires both of its value options to be numeric fields.
+CONF_PY = """\
+extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
+needs_types = [
+    {
+        "directive": "story",
+        "title": "User Story",
+        "prefix": "US_",
+        "color": "#BFD8D2",
+        "style": "node",
+    },
+]
+needs_fields = {
+    "duration": {"schema": {"type": "integer"}, "nullable": True},
+    "completion": {"schema": {"type": "integer"}, "nullable": True},
+}
+"""
+
+#: A chart exercising every statement kind the directive emits:
+#: a declaration, a completion value, a type colour, a milestone and a constraint.
+CHART = """\
+Gantt chart
+===========
+
+.. story:: Find and report bug
+   :id: TASK_A
+   :duration: 3
+   :completion: 80
+
+.. story:: Analyse bug
+   :id: TASK_B
+   :duration: 2
+   :links: TASK_A
+
+.. story:: Solution ticket closed
+   :id: TASK_C
+   :duration: 1
+   :links: TASK_B
+
+.. needgantt:: Chart
+   :starts_after_links: links
+   :milestone_filter: id == "TASK_C"
+   :start_date: 2020-03-25
+"""
+
+#: A declaration, i.e. ``[<title>] as [<id>] lasts <n> days``.
+_DECLARATION = re.compile(r"^\[(?P<title>.*)\] as \[(?P<id>[^\]]*)\] lasts ")
+
+#: Any bracketed task reference.
+_REFERENCE = re.compile(r"\[([^\]]*)\]")
+
+
+def _capture_diagrams(app) -> list[str]:
+    """Collect the PlantUML source of every diagram the build generates.
+
+    The generated source is asserted on rather than the rendered image, so that the
+    assertions describe what the directive decided to draw and do not depend on the
+    PlantUML binary being able to draw it.
+
+    :param app: The (not yet built) Sphinx application.
+    :return: A list that is filled with one source per diagram, as the build runs.
+    """
+    sources: list[str] = []
+
+    def collect(app_, doctree, docname):
+        for node in doctree.findall(plantuml):
+            sources.append(node["uml"])
+
+    app.connect("doctree-resolved", collect, priority=900)
+    return sources
+
+
+def _statements(uml: str) -> list[str]:
+    """The meaningful statements of a generated chart, i.e. without comments."""
+    return [
+        stripped
+        for line in uml.splitlines()
+        if (stripped := line.strip()) and not stripped.startswith("'")
+    ]
+
+
+def _declarations(uml: str) -> dict[str, str]:
+    """The tasks a generated chart declares, as ``{alias: title}``."""
+    return {
+        match["id"]: match["title"]
+        for line in _statements(uml)
+        if (match := _DECLARATION.match(line))
+    }
+
+
+@pytest.mark.parametrize(
+    "test_app",
+    [
+        {
+            "buildername": "html",
+            "files": [(Path("conf.py"), CONF_PY), (Path("index.rst"), CHART)],
+        }
+    ],
+    indirect=True,
+)
+def test_tasks_are_addressed_by_id(test_app):
+    """Every statement must address a task that was actually declared.
+
+    Tasks are declared as ``[<title>] as [<id>]``, which binds later ``[...]``
+    references to the *alias*. PlantUML does not reject an unbound reference: it
+    silently declares a new, zero length task of that name. So a completion or colour
+    line addressing a task by its title used to draw a second, phantom bar for every
+    need that had a type colour or a completion value -- which, since types carry a
+    colour by default, is every need in almost every chart.
+    """
+    app = test_app
+    sources = _capture_diagrams(app)
+    app.build()
+
+    assert strip_colors(app._warning.getvalue()).strip() == ""
+
+    assert len(sources) == 1
+    uml = sources[0]
+
+    declared = _declarations(uml)
+    assert declared == {
+        "TASK_A": "Find and report bug",
+        "TASK_B": "Analyse bug",
+        "TASK_C": "Solution ticket closed",
+    }
+
+    # no statement may reference a task that is not one of the declared aliases,
+    # as any such reference silently becomes an extra bar in the rendered chart
+    for statement in _statements(uml):
+        if _DECLARATION.match(statement):
+            continue
+        for reference in _REFERENCE.findall(statement):
+            assert reference in declared, (
+                f"undeclared task {reference!r} referenced by {statement!r}"
+            )
+
+    # and, explicitly, the two accumulators that used to address tasks by title
+    assert "[TASK_A] is 80% completed" in uml
+    assert "[TASK_A] is colored in #BFD8D2" in uml
+
+
+@pytest.mark.parametrize(
+    "test_app,date",
+    [
+        (
+            {
+                "buildername": "html",
+                "files": [
+                    (Path("conf.py"), CONF_PY),
+                    (Path("index.rst"), CHART.replace("2020-03-25", date)),
+                ],
+            },
+            date,
+        )
+        for date in ("2020-01-01", "2020-03-25", "2020-12-31")
+    ],
+    ids=["january", "march", "december"],
+    indirect=["test_app"],
+)
+def test_start_date_is_the_given_date(test_app, date):
+    """The project must start on the date the option gives, in every month.
+
+    The date used to be re-formatted through a month name table that was indexed
+    with the 1-based month number, so the chart started one month later than asked
+    for, and a December date raised an ``IndexError`` that aborted the whole build.
+    """
+    app = test_app
+    sources = _capture_diagrams(app)
+    app.build()
+
+    assert strip_colors(app._warning.getvalue()).strip() == ""
+    assert f"Project starts {date}" in sources[0]


### PR DESCRIPTION
Two defects in the PlantUML source that `process_needgantt` generates. Both were found
while implementing needgantt rendering in [ubCode](https://ubcode.useblocks.com/), by
rendering the byte-exact text this function emits and comparing it against what the
directive's documentation says it draws.

Both defects have the same shape: the generated source is wrong, but PlantUML does not
say so — one is silently accepted and mis-drawn, the other blows up in Python before
PlantUML ever sees it.

## 1. Every coloured or completed task is drawn twice — and the real bar gets neither the colour nor the completion

Tasks are declared as `[<title>] as [<id>]`, which binds every later `[...]` reference to
the **id**. The constraint lines already used the id. The completion and colour
accumulators used the **title**.

PlantUML does not reject an unbound reference — it silently declares a **new, zero length
task** of that name. Minimal reproduction:

```
@startgantt
[Title One] as [ID1] lasts 3 days
[Title One] is 80% completed
@endgantt
```

→ **2 task rows.** Addressing the same statement by `[ID1]` → **1 row.**

Since `needs_types` entries carry a colour by default, this fired for essentially every
need in every chart. A three-need chart with one completion value rendered as **six**
bars, and the damage was not merely cosmetic: the colour and the completion attached to
the *phantom* bar, leaving the real one in PlantUML's default grey.

<details>
<summary>Before / after, from the generated SVG (3 needs, 2 types, one <code>:completion: 80</code>)</summary>

```
before                                    after
──────────────────────────────────────    ──────────────────────────────────────
6 task rows for 3 needs                   3 task rows for 3 needs
  Find and report bug   ← declared          Find and report bug
  Analyse bug           ← declared          Analyse bug
  Test release          ← declared          Test release
  Find and report bug   ← PHANTOM
  Analyse bug           ← PHANTOM
  Test release          ← PHANTOM

<rect fill="#E2E2F0" width="44"  …/>      <rect fill="#BFD8D2" width="35.2" …/>
   the real TASK_A bar, DEFAULT GREY         the real TASK_A bar, 80% of 44
<rect fill="#BFD8D2" width="9.6" …/>      <rect fill="#FFFFFF" width="8.8"  …/>
   the phantom, coloured, 80% of 12          the 20% remainder
```

</details>

Both accumulators now emit the id, like the constraint lines always did.

## 2. `:start_date:` names the wrong month, and December ends the build

`utils.py` defined a 0-based `MONTH_NAMES` starting `"January"`; `needgantt.py` indexed it
with the **1-based** `int(start_date.strftime("%m"))`.

- `:start_date: 2020-03-25` → `Project starts the 25th of April 2020` — one month late.
- `:start_date: 2020-12-25` → `IndexError: list index out of range`, surfacing as
  `ExtensionError: Handler … for event 'doctree-resolved' threw an exception`. **The
  build dies**; there is no way to put a December date on a gantt chart.

The generated statement is now the ISO date, which PlantUML also accepts:

```
Project starts 2020-03-25
```

I went for the ISO form rather than `MONTH_NAMES[start_date.month - 1]` because:

- it removes the bug class instead of repairing one instance of it — there is no longer
  an index to get wrong, and `MONTH_NAMES` had exactly one definition and one use, no
  `__all__` entry and no mention in the docs, so it is deleted;
- it renders the **identical** chart. The two forms produce byte-identical SVG apart from
  the `<?plantuml-src …?>` processing instruction, on PlantUML 1.2026.6 and 1.2022.5
  alike, so this does not raise the effective PlantUML floor;
- it is what the user wrote — `:start_date:` is already validated as `%Y-%m-%d`, so
  echoing it through is the smallest possible transformation, and it is locale
  independent (unlike `%B`);
- it drops the bogus ordinal suffix as a side effect, without adding any suffix logic:
  the old code appended a literal `th`, so `2020-01-01` was written
  `the 01th of February 2020`.

## Why the test suite never caught defect 1

`tests/doc_test/utils/plantuml.jar` is **PlantUML 1.2022.5**, and every test app is
pointed at it (`tests/conftest.py:288`). The phantom-task behaviour is newer than that:

| source | 1.2022.5 | 1.2026.6 |
|---|---|---|
| current `master` (title-addressed) | 3 rows, colours and 80% shading correct | 6 rows, real bars grey |
| this PR (id-addressed) | 3 rows, colours and 80% shading correct | 3 rows, correct |

1.2022.5 still resolved a `[title]` reference back to the aliased task; a current PlantUML
creates a second task instead. The `<rect>` lists for the two sources at 1.2022.5 are
byte-identical, so **the fix is safe in both directions**: users on an old PlantUML see no
change at all, users on a current one get the chart they always should have had.

## Changed output

This changes the generated PlantUML for any chart with a type colour, a completion value
or a `:start_date:` — i.e. almost all of them. The rendered result is either identical
(old PlantUML) or strictly more correct (current PlantUML); nothing that rendered
correctly before renders differently now. Both changelog entries are marked
**(changed output)**.

## Tests

`tests/test_needgantt.py` is new — there was no needgantt test module. It follows the two
patterns already in the suite: inline `files` source projects (`tests/test_needflow.py`)
and a `doctree-resolved` collector for the generated PlantUML
(`tests/test_filter.py::_capture_diagrams`, whose docstring makes the case for asserting
on the generated source rather than the rendered image).

- `test_tasks_are_addressed_by_id` asserts the general invariant — **no statement may
  reference a task that is not a declared alias** — which is precisely the property whose
  violation PlantUML answers with a phantom bar. It covers the milestone path and the
  already-correct constraint lines too.
- `test_start_date_is_the_given_date` is parametrised over January, March and December,
  the last being the crash boundary.

Both fixes were mutated back out individually to confirm each test fails for its own fix
and no other (`1 failed, 3 passed` and `3 failed, 1 passed` respectively).

## Docs

The page claimed:

> If `svg` is set as output format for PlantUML, we link the tasks elements to their
> related need.

There is no `calculate_link` call and no `[[…]]` emission anywhere in `needgantt.py`
(unlike `needflow/_plantuml.py`, which does link). Task bars have never been hyperlinked;
the only link a chart produces is its caption, pointing at the generated image file. The
sentence is removed rather than implemented, as adding task links would be a feature
rather than a fix.

## A third defect, left alone — float completion values

Not fixed here, to keep this PR to the two defects above, but worth recording since it is
the same class and it is currently visible in this repo's own documentation.

`completion` is never rounded, while `duration` three lines above it is, under the comment
*"float durations not supported by plantuml"*. A `number`-typed completion field therefore
emits `[…] is 90.0% completed`, which **PlantUML 1.2026.6 rejects** (`Syntax Error?
(Assumed diagram type: gantt)`) though 1.2022.5 accepted it — the same version gate as
defect 1.

This is not hypothetical: `docs/directives/needgantt.rst`'s `completion_option` example
uses `:completion_option: amount`, and `docs/ubproject.toml:104` declares `amount` as
`schema.type = "number"`. A docs build on a current PlantUML consequently emits
`docs/directives/needgantt.rst:296: WARNING: error while running plantuml` — on `master`
as well as on this branch (same warning, two lines further down), so this PR neither
causes nor fixes it. Happy to add the `round()` here or in a follow-up, whichever you
prefer.

## Verification

- New module: 4 tests, red before the fixes with the exact expected failures, green after.
- Full suite (`-m "not jstest and not benchmark"`): identical `FAILED` set on this branch
  and on `master` content in the same tree — 20 pre-existing local failures either way,
  unrelated to needgantt (needuml, report_dead_links, needarch, …), and all passing when
  run in isolation. The delta is exactly the 4 new tests.
- `ruff check`, `ruff format`, `mypy` clean.
- Docs build (`-nW --keep-going`): 1 warning on this branch, the same 1 warning on
  `master` — the pre-existing float-completion one above.
- Render checks used PlantUML 1.2026.6 and this repo's bundled 1.2022.5.
