### PR TITLE
🐛 needflow: fix the graphviz label escaper, and stop bad configuration ending the build

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -136,6 +136,19 @@ Improvements
   as a list. A list, tuple, set or frozenset of names is accepted, as is an already-compiled
   ``re.Pattern`` for ``regex`` (a *bytes* pattern is not, as it could never match a field value).
 
+- 👌 :ref:`needflow` ``:debug:`` shows the generated diagram source as a code block under the
+  plantuml engine too **(changed output)**
+
+  The plantuml engine emitted raw HTML, an unnumbered and unstyled ``<pre>`` block,
+  where the graphviz engine emitted a literal block,
+  so the same option gave the source line numbers and the theme's code styling
+  on one engine only.
+  Both now emit a literal block.
+  The plantuml source is shown unhighlighted, because Pygments has no PlantUML lexer.
+
+  This is a deliberate change to the rendered page rather than a fix:
+  a project that styles or scrapes the debug block sees the new markup.
+
 Internal changes
 ................
 
@@ -225,6 +238,44 @@ Bug fixes
 - 🐛 The :ref:`needflow` warning for an unknown ``:link_types:`` value now carries the
   source location of the directive under the graphviz engine, as it already did under
   plantuml.
+
+- 🐛 A wrapped :ref:`needflow` graphviz label no longer breaks an HTML entity in two.
+
+  A need title is wrapped to the label width and escaped for graphviz's HTML-like labels,
+  but the escaping ran first,
+  so the wrapper counted the characters of an entity and could break inside one:
+  a title holding a quote wrapped to ``&quo<br/>t;``,
+  which graphviz refuses to render, ending the build with ``not well-formed (invalid token)``.
+  Wrapping now happens first,
+  which also makes the wrap width count what the reader sees rather than what the escaper wrote.
+
+- 🐛 A :ref:`needs_graphviz_styles` element type holding something other than a mapping of
+  attributes is now reported and ignored.
+
+  Such a value travelled unchecked into the emitter,
+  where ``'str' object has no attribute 'items'`` ended the whole build with a traceback
+  instead of a message.
+  It is now reported as a ``needs.needflow`` warning naming the config,
+  and the diagram is drawn without the offending style.
+
+- 🐛 An unknown :ref:`needs_flow_engine` value is now reported,
+  and the default engine draws the diagram.
+
+  The value was checked with a bare ``assert``,
+  which ends the build with a traceback rather than a message —
+  and which ``python -O`` strips altogether,
+  leaving the unknown name to fail somewhere further downstream.
+  It is now a ``needs.config`` warning, said once for the project.
+
+- 🐛 :ref:`needflow` naming several graphviz ``:config:`` styles no longer leaks the merged
+  style into the diagrams after it.
+
+  The merge took the first style's attributes by reference
+  and then updated that same dictionary with the second style's,
+  rewriting the configured (and built-in) styles in place:
+  every later diagram naming the first style inherited the second one's attributes,
+  for the rest of the build.
+  A page therefore rendered differently depending on which diagrams came before it.
 
 - 🐛 ``c.this_doc()`` now works in :ref:`needpie`, :ref:`needbar` and the
   :ref:`need_count` role (:issue:`1449`)

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -744,6 +744,9 @@ Select between the rendering engines for :ref:`needflow` diagrams,
 * ``plantuml``: Use `PlantUML <https://plantuml.com/>`__ to render the diagrams (default).
 * ``graphviz``: Use `Graphviz <https://graphviz.org>`__ to render the diagrams.
 
+Any other value is reported as a ``needs.config`` warning, once for the project,
+and every diagram is drawn with the default engine.
+
 .. _`needs_flow_show_links`:
 
 needs_flow_show_links
@@ -828,6 +831,11 @@ needs_graphviz_styles
 
 This must be a dictionary which can store multiple `Graphviz configurations <https://graphviz.org>`__.
 These configs can then be selected when using :ref:`needflow` and the engine is set to ``graphviz``.
+
+Each configuration maps an element type -- ``root``, ``graph``, ``node`` or ``edge`` --
+to a mapping of the attributes to set on it.
+An element type holding anything else is reported as a ``needs.needflow`` warning
+and ignored, rather than failing the build.
 
 .. code-block:: python
 

--- a/docs/directives/needflow.rst
+++ b/docs/directives/needflow.rst
@@ -493,9 +493,12 @@ debug
 
 .. versionadded:: 0.5.2
 
-If you set the ``:debug:``, we add a debug-output of the generated PlantUML code after the generated image.
+If you set the ``:debug:``, we add the generated diagram source after the generated image,
+as a line-numbered code block.
+Both engines do this, so the option shows PlantUML or Graphviz source
+according to which engine drew the diagram.
 
-Helpful to identify reasons why a PlantUML build may have thrown errors.
+Helpful to identify reasons why a diagram build may have thrown errors.
 
 .. syntax-example::
 

--- a/sphinx_needs/directives/needflow/_directive.py
+++ b/sphinx_needs/directives/needflow/_directive.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING
 
 from docutils import nodes
@@ -25,6 +25,11 @@ from sphinx_needs.utils import (
 )
 
 LOGGER = get_logger(__name__)
+
+#: The engines a diagram can be drawn with.
+#: The first is the ``needs_flow_engine`` default, and so also the fallback for a
+#: configured value that names no engine at all.
+_ENGINES = ("plantuml", "graphviz")
 
 if TYPE_CHECKING:
     from typing_extensions import Unpack
@@ -86,7 +91,21 @@ class NeedflowDirective(FilterBase):
         )
 
         engine = self.options.get("engine", needs_config.flow_engine)
-        assert engine in ["graphviz", "plantuml"], f"Unknown needflow engine '{engine}'"
+        if engine not in _ENGINES:
+            # the `:engine:` option is validated as it is parsed, so only the
+            # configuration can name an unknown engine here.
+            # This used to be a bare `assert`, which ends the build with a traceback
+            # rather than a message -- and which `python -O` strips altogether, leaving
+            # the unknown name to fail further downstream instead
+            log_warning(
+                LOGGER,
+                f"unknown 'needs_flow_engine' value {engine!r}, "
+                f"so the diagram is drawn with {_ENGINES[0]!r} instead",
+                "config",
+                location=self.get_location(),
+                once=True,
+            )
+            engine = _ENGINES[0]
 
         config_names: str = self.options.get("config", "")
         config = ""
@@ -117,10 +136,29 @@ class NeedflowDirective(FilterBase):
                         for key, value in needs_config.graphviz_styles[
                             config_name
                         ].items():
+                            if not isinstance(value, Mapping):
+                                # a value that is not a mapping of attributes used to
+                                # travel unchecked into the emitter, where
+                                # `'str' object has no attribute 'items'` ended the
+                                # whole build with a traceback instead of a message
+                                log_warning(
+                                    LOGGER,
+                                    f"malformed config {config_name!r} in 'needs_graphviz_styles': "
+                                    f"{key!r} must be a mapping of attributes, "
+                                    f"but is {type(value).__name__}",
+                                    "needflow",
+                                    location=self.get_location(),
+                                )
+                                continue
                             if key in graphviz_style:
                                 graphviz_style[key].update(value)  # type: ignore[literal-required]
                             else:
-                                graphviz_style[key] = value  # type: ignore[literal-required]
+                                # copied, so that merging several configs cannot edit
+                                # the configuration itself: the first config's
+                                # attributes used to be taken by reference and then
+                                # updated with the second's, which leaked one diagram's
+                                # styles into every later one naming the same config
+                                graphviz_style[key] = dict(value)  # type: ignore[literal-required]
                     elif config_name:
                         log_warning(
                             LOGGER,

--- a/sphinx_needs/directives/needflow/_graphviz.py
+++ b/sphinx_needs/directives/needflow/_graphviz.py
@@ -337,12 +337,17 @@ def _label(
     # note this is based on the plantuml template DEFAULT_DIAGRAM_TEMPLATE
 
     br = f'<br align="{align}"/>'
-    # note this text wrapping mimics the jinja wordwrap filter
+    # note this text wrapping mimics the jinja wordwrap filter.
+    # The text is wrapped *before* it is escaped: wrapping escaped text lets the wrapper
+    # count the characters of an entity and break inside one, so a title holding a quote
+    # or an angle bracket produced `&quo<br/>t;` -- invalid markup, which graphviz
+    # refuses to render. It also means the wrap width counts what the reader sees.
     need_title = need["title"] if need["is_need"] else need["content"]
     title = br.join(
         br.join(
-            textwrap.wrap(
-                html.escape(line),
+            html.escape(chunk)
+            for chunk in textwrap.wrap(
+                line,
                 15,
                 expand_tabs=False,
                 replace_whitespace=False,

--- a/sphinx_needs/directives/needflow/_plantuml.py
+++ b/sphinx_needs/directives/needflow/_plantuml.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import html
 from collections.abc import Iterable, Mapping
 
 from docutils import nodes
@@ -377,15 +376,19 @@ def process_needflow_plantuml(
         if current_needflow["debug"] and found_needs:
             # We can only access puml_node if found_needs is set.
             # Otherwise it was not been set, or we get outdated data
-            debug_container = nodes.container()
             if isinstance(puml_node, nodes.figure):
                 data = puml_node.children[0]["uml"]  # type: ignore[index]
             else:
                 data = puml_node["uml"]
-            data = "\n".join([html.escape(line) for line in data.split("\n")])
-            debug_para = nodes.raw("", f"<pre>{data}</pre>", format="html")
-            debug_container += debug_para
-            content.append(debug_container)
+            # the same shape the graphviz engine uses, so that `:debug:` produces the
+            # same kind of block whichever engine drew the diagram; Pygments has no
+            # PlantUML lexer, so the source is shown unhighlighted rather than wrongly
+            code = nodes.literal_block(
+                data, data, language="text", linenos=True, force=True
+            )
+            code.source = env.doc2path(current_needflow["docname"])
+            code.line = current_needflow["lineno"]
+            content.append(code)
 
         node.replace_self(content)
 

--- a/tests/test_github_issues.py
+++ b/tests/test_github_issues.py
@@ -166,7 +166,10 @@ def test_doc_github_1664_legend(test_app):
     debug = _debug_source(Path(app.outdir, "legend.html"))
 
     if app.config.needs_flow_engine == "plantuml":
-        assert "\nlegend\n" in debug
+        # the debug block is line numbered on both engines, so the legend block is
+        # matched without depending on where its lines start
+        assert re.search(r"\d+legend\n", debug)
+        assert re.search(r"\d+endlegend\n", debug)
         # the row is kept, with an empty color swatch cell
         assert "| | Specification |" in debug
     else:

--- a/tests/test_needflow.py
+++ b/tests/test_needflow.py
@@ -756,3 +756,74 @@ def test_graphviz_label_does_not_break_html_entities(test_app):
     assert "&lt;angled&gt;" in debug
     # no entity may be interrupted by a line break element
     assert not re.search(r"&[a-z]*<br[^>]*>[a-z]*;", debug)
+
+
+CLASS_AND_DEBUG = """\
+Class and debug
+===============
+
+.. spec:: A
+   :id: AAAAA
+
+.. needflow::
+   :class: my-flow-class
+   :debug:
+"""
+
+
+@pytest.mark.parametrize(
+    "test_app",
+    [
+        {
+            "buildername": "html",
+            "files": [
+                (Path("conf.py"), CONF_PY),
+                (Path("index.rst"), CLASS_AND_DEBUG),
+            ],
+            "confoverrides": {"needs_flow_engine": "plantuml"},
+        },
+        {
+            "buildername": "html",
+            "files": [
+                (Path("conf.py"), CONF_PY),
+                (Path("index.rst"), CLASS_AND_DEBUG),
+            ],
+            "confoverrides": {
+                "needs_flow_engine": "graphviz",
+                "graphviz_output_format": "svg",
+            },
+        },
+    ],
+    ids=["plantuml", "graphviz"],
+    indirect=True,
+)
+def test_debug_is_a_literal_block_on_both_engines(test_app):
+    """``:debug:`` must produce the same kind of block whichever engine draws.
+
+    It emitted raw HTML on plantuml and a literal block on graphviz, so the same
+    option gave the source line numbers and the theme's code styling on one engine
+    only. Both now emit a literal block.
+
+    ``:class:`` is pinned alongside it, because neither engine sets it deliberately:
+    plantuml gets it only because docutils copies the classes of a replaced node onto
+    the first node replacing it, which happens to be the figure, and graphviz writes
+    it on the image instead. Both honour the option, in different places.
+    """
+    app = test_app
+    app.build()
+
+    warnings = strip_colors(app._warning.getvalue()).strip()
+    assert warnings == ""
+
+    tree = html_parser.parse(Path(app.outdir) / "index.html")
+    if app.config.needs_flow_engine == "plantuml":
+        assert tree.xpath("//figure[contains(@class, 'my-flow-class')]")
+    else:
+        assert tree.xpath("//img[contains(@class, 'my-flow-class')]")
+
+    # a literal block, i.e. inside a highlight container, on either engine
+    blocks = tree.xpath(
+        "//div[contains(concat(' ', normalize-space(@class), ' '), ' highlight ')]//pre"
+    )
+    assert len(blocks) == 1
+    assert "AAAAA" in blocks[0].text_content()

--- a/tests/test_needflow.py
+++ b/tests/test_needflow.py
@@ -827,3 +827,171 @@ def test_debug_is_a_literal_block_on_both_engines(test_app):
     )
     assert len(blocks) == 1
     assert "AAAAA" in blocks[0].text_content()
+
+
+MALFORMED_GRAPHVIZ_STYLE = """\
+Malformed graphviz style
+========================
+
+.. spec:: A
+   :id: AAAAA
+
+.. needflow::
+"""
+
+
+@pytest.mark.parametrize(
+    "test_app",
+    [
+        {
+            "buildername": "html",
+            "files": [
+                (Path("conf.py"), CONF_PY),
+                (Path("index.rst"), MALFORMED_GRAPHVIZ_STYLE),
+            ],
+            "confoverrides": {
+                "needs_flow_engine": "graphviz",
+                "graphviz_output_format": "svg",
+                "needs_graphviz_styles": {"default": "not-a-mapping"},
+            },
+        },
+        {
+            "buildername": "html",
+            "files": [
+                (Path("conf.py"), CONF_PY),
+                (Path("index.rst"), MALFORMED_GRAPHVIZ_STYLE),
+            ],
+            "confoverrides": {
+                "needs_flow_engine": "graphviz",
+                "graphviz_output_format": "svg",
+                "needs_graphviz_styles": {"default": {"node": "not-a-mapping"}},
+            },
+        },
+    ],
+    ids=["entry", "element"],
+    indirect=True,
+)
+def test_malformed_graphviz_style_warns_instead_of_crashing(test_app):
+    """A graphviz style that is not a mapping must not fail the whole build.
+
+    An element type holding something other than a mapping of attributes travelled
+    unchecked from the configuration into the emitter, where
+    ``'str' object has no attribute 'items'`` aborted the build with a traceback
+    instead of a message. Both shapes are now rejected where they are read, and the
+    diagram is drawn without the offending style.
+    """
+    app = test_app
+    app.build()  # must not raise
+
+    warnings = strip_colors(app._warning.getvalue())
+    assert "malformed config 'default' in 'needs_graphviz_styles'" in warnings
+
+    assert "AAAAA" in _get_svg(
+        app.config, Path(app.outdir), "index.html", "needflow-index-0"
+    )
+
+
+INVALID_ENGINE = """\
+Invalid engine
+==============
+
+.. spec:: A
+   :id: AAAAA
+
+.. needflow::
+
+.. needflow::
+"""
+
+
+@pytest.mark.parametrize(
+    "test_app",
+    [
+        {
+            "buildername": "html",
+            "files": [
+                (Path("conf.py"), CONF_PY),
+                (Path("index.rst"), INVALID_ENGINE),
+            ],
+            "confoverrides": {"needs_flow_engine": "nosuchengine"},
+        }
+    ],
+    indirect=True,
+)
+def test_invalid_flow_engine_warns_and_falls_back(test_app):
+    """An unknown ``needs_flow_engine`` must warn, not end the build.
+
+    The value used to trip a bare ``assert``, which reports a traceback rather than a
+    message -- and which ``python -O`` strips altogether, leaving the unknown name to
+    fail somewhere further downstream. The default engine draws the diagram instead.
+    """
+    app = test_app
+    app.build()  # must not raise
+
+    warnings = strip_colors(app._warning.getvalue())
+    assert "unknown 'needs_flow_engine' value 'nosuchengine'" in warnings
+    assert "'plantuml'" in warnings
+    # said once for the project, not once per diagram
+    assert warnings.count("unknown 'needs_flow_engine' value") == 1
+
+    # the fallback engine still drew a diagram, rather than the build ending
+    assert "needflow-index-0" in Path(app.outdir, "index.html").read_text()
+
+
+SHARED_GRAPHVIZ_STYLE = """\
+Shared graphviz style
+=====================
+
+.. spec:: A
+   :id: AAAAA
+
+.. needflow::
+   :config: lefttoright,transparent
+   :debug:
+
+.. needflow::
+   :config: lefttoright
+   :debug:
+"""
+
+
+@pytest.mark.parametrize(
+    "test_app",
+    [
+        {
+            "buildername": "html",
+            "files": [
+                (Path("conf.py"), CONF_PY),
+                (Path("index.rst"), SHARED_GRAPHVIZ_STYLE),
+            ],
+            "confoverrides": {
+                "needs_flow_engine": "graphviz",
+                "graphviz_output_format": "svg",
+            },
+        }
+    ],
+    indirect=True,
+)
+def test_merging_configs_does_not_leak_into_the_next_diagram(test_app):
+    """Naming several ``:config:`` styles must not edit the styles themselves.
+
+    The merge took the first style's attributes by reference and then updated that
+    same dictionary with the second style's, so the configured (and built-in) styles
+    were rewritten in place: every later diagram naming ``lefttoright`` inherited the
+    ``transparent`` background of the diagram before it, for the rest of the build.
+    """
+    app = test_app
+    app.build()
+
+    warnings = strip_colors(app._warning.getvalue()).strip()
+    assert warnings == ""
+
+    outdir = Path(app.outdir)
+    merged = _debug_source(outdir, "index.html", 0)
+    plain = _debug_source(outdir, "index.html", 1)
+
+    assert 'rankdir="LR"' in merged
+    assert 'bgcolor="transparent"' in merged
+
+    assert 'rankdir="LR"' in plain
+    assert 'bgcolor="transparent"' not in plain

--- a/tests/test_needflow.py
+++ b/tests/test_needflow.py
@@ -708,3 +708,51 @@ def test_get_entity_name_unmapped_id_falls_back_with_warning():
     finally:
         module_logger.removeHandler(handler)
         module_logger.setLevel(old_level)
+
+
+ENTITY_IN_TITLE = """\
+Entity in a wrapped title
+=========================
+
+.. spec:: A "quoted" and <angled> title that wraps
+   :id: AAAAA
+
+.. needflow::
+   :debug:
+"""
+
+
+@pytest.mark.parametrize(
+    "test_app",
+    [
+        {
+            "buildername": "html",
+            "files": [(Path("conf.py"), CONF_PY), (Path("index.rst"), ENTITY_IN_TITLE)],
+            "confoverrides": {
+                "needs_flow_engine": "graphviz",
+                "graphviz_output_format": "svg",
+            },
+        }
+    ],
+    indirect=True,
+)
+def test_graphviz_label_does_not_break_html_entities(test_app):
+    """A title holding a quote or a bracket must survive being wrapped.
+
+    The label was escaped and then wrapped, so the wrapper counted the characters of an
+    entity and could break inside one -- producing ``&quo<br/>t;``, which is invalid
+    markup and a visibly broken label. Wrapping first also makes the wrap width count
+    what the reader sees rather than what the escaper wrote.
+    """
+    app = test_app
+    app.build()
+
+    warnings = strip_colors(app._warning.getvalue()).strip()
+    assert warnings == ""
+
+    debug = _debug_source(Path(app.outdir), "index.html")
+
+    assert "&quot;" in debug
+    assert "&lt;angled&gt;" in debug
+    # no entity may be interrupted by a line break element
+    assert not re.search(r"&[a-z]*<br[^>]*>[a-z]*;", debug)


### PR DESCRIPTION
Slice 1 of the #1770 split (see the plan there): the pure fixes, carved out so they can be
reviewed and merged ahead of any vocabulary discussion.

Five independent needflow defects, each with a regression test that fails on `master`, plus
one deliberate output change that is called out separately below. No new directive option,
no new configuration key, no deprecation, and no stored-data version change.

**Fixes**

- **A wrapped graphviz label could break an HTML entity in two.** A need title is wrapped
  to the label width and escaped for graphviz's HTML-like labels, but the escaping ran
  first, so the wrapper counted the characters of an entity and could break inside one. A
  title containing a quote wrapped to `&quo<br/>t;`, and graphviz then refuses the label
  outright: the build reports `not well-formed (invalid token)` and draws no diagram.
  Wrapping now happens first and each piece is escaped after, which also makes the wrap
  width count the characters the reader sees instead of the ones the escaper wrote.

- **A `needs_graphviz_styles` element type holding something other than a mapping of
  attributes ended the build.** The value travelled unchecked into the emitter, where
  `'str' object has no attribute 'items'` surfaced as an `ExtensionError` traceback from
  the `doctree-resolved` handler, naming no configuration key and no file. It is now
  reported where it is read, and the diagram is drawn without the offending style. (An
  *entry* that is not a mapping was already reported; only an element type got through.)

- **An unknown `needs_flow_engine` value failed a bare `assert`.** That ends the build with
  a traceback rather than a message, and `python -O` strips it entirely, leaving the
  unknown name to fail somewhere further downstream instead. It is now a `needs.config`
  warning, said once for the project, and the default engine draws the diagram. The
  `:engine:` option cannot reach this path, because docutils validates it as it is parsed.

- **Naming several graphviz `:config:` styles leaked the merge into later diagrams.** The
  merge took the first style's attribute mapping by reference and then `update()`d that
  same dictionary with the second style's, so the configured — and the built-in — styles
  were rewritten in place. Every later diagram naming the first style inherited the second
  one's attributes for the rest of the build, and in the built-in case for the life of the
  process, so a page rendered differently depending on which diagrams came before it. The
  attributes are now copied before they are merged.

**Deliberate output change (not a fix)**

- **`:debug:` now renders the diagram source as a code block under the plantuml engine
  too.** It emitted raw HTML — an unnumbered, unstyled `<pre>` — where graphviz emitted a
  literal block, so the same option gave the source line numbers and the theme's code
  styling on one engine only. Both now emit a literal block; the plantuml source is shown
  unhighlighted, because Pygments has no PlantUML lexer. A project that styles or scrapes
  the debug block will see the new markup, which is why this is listed as an improvement
  rather than a fix. One existing test assertion that matched the plantuml legend at the
  start of a line is rewritten not to depend on the line numbering, exactly as the
  graphviz half of the same test already does.

**Also pinned, not changed:** `:class:` reaches the plantuml output only because docutils
copies a replaced node's classes onto the first node replacing it, and graphviz writes the
class on the image rather than the figure. Both honour the option, in different places; the
new test records that so the placement cannot drift unnoticed.

**Review notes**

- Four commits, each self-contained: the label escaper, the `:debug:` block, the three
  configuration fixes (one code region), and the changelog.
- Everything is in `sphinx_needs/directives/needflow/` — 70 changed lines of source across
  three files, the rest is tests, changelog and docs.
- The two whole-project `assert warnings == ""` fences in `tests/test_needflow.py` are
  untouched and still green: nothing here warns on a default path, and the two new warnings
  only fire on input that used to end the build.