### PR TITLE
✨ needflow: portable direction, link-label and legend options

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,59 @@ Unreleased
 Improvements
 ............
 
+- ✨ New :ref:`needflow` ``:direction:`` option and :ref:`needs_flow_direction`
+  configuration (:pr:`1782`)
+
+  A diagram says which way it flows as an intent — ``down`` (the default), ``up``,
+  ``right`` or ``left`` — and each engine spells that in its own language, so the same
+  document renders the same way on either engine.
+  The tokens ``TB``, ``TD``, ``BT``, ``LR`` and ``RL`` are accepted as aliases, so a
+  habit picked up from Graphviz or Mermaid does not have to be unlearned.
+
+  .. code-block:: rst
+
+     .. needflow::
+        :direction: right
+
+  PlantUML has no bottom-up or right-to-left layout, so ``up`` is drawn ``down`` and
+  ``left`` is drawn ``right``, with one ``needs.needflow`` warning per project;
+  Graphviz draws all four.
+  A diagram is never refused for asking: a plainer diagram is better than a failed build.
+
+  An explicit ``:direction:`` also wins over a layout that the ``:config:`` it is written
+  beside happens to set, on both engines, and the disagreement is reported.
+  A diagram that does not use the option keeps byte-identical diagram source.
+
+- ✨ :ref:`needflow` ``:show_legend:`` takes the name of a legend configuration
+  (:pr:`1782`)
+
+  Written bare it draws exactly the legend it always drew, so no existing diagram
+  changes — including the long-standing difference that ``plantuml`` lists every
+  configured need type while ``graphviz`` lists only the ones it drew.
+  Written with a value it names an entry of the new :ref:`needs_flow_legends`:
+
+  .. code-block:: python
+
+     needs_flow_legends = {
+         "beside": {"parts": ["types", "links"], "placement": "external"},
+     }
+
+  A legend with ``placement = "external"`` is rendered as a document table beside the
+  diagram, so it looks the same on both engines, its text is selectable and searchable,
+  and it can describe **link types** — which no in-diagram legend ever could.
+  It lists only what the diagram actually drew.
+  ``parts`` is an ordered list, and the order is contract: ``["links", "types"]`` puts
+  the link table first and keeps it there.
+
+  The new :ref:`needs_flow_show_legend` says *which* legend a diagram gets when it asks
+  for one without naming it — never *whether*: asking stays with the directive.
+  Resolution is a chain — the option's name, then the project default, then the engine's
+  own legend — and a name that is not defined warns and hands on to the next step, so a
+  typo in one diagram does not cost the project the legend it configured.
+
+  A ``needs_flow_legends`` entry that cannot be used is reported as a ``needs.config``
+  warning and skipped, rather than failing the build.
+
 - 🔧 The undocumented ``needtable`` ``:style_col:`` option is deprecated —
   it was declared but never read, so it has never had any effect.
   A document that sets it still builds and now gets a ``deprecated`` warning;
@@ -148,6 +201,40 @@ Improvements
 
   This is a deliberate change to the rendered page rather than a fix:
   a project that styles or scrapes the debug block sees the new markup.
+
+Breaking changes
+................
+
+- ‼️ :ref:`needflow` ``:show_link_names:`` takes an optional value, and now wins over
+  :ref:`needs_flow_show_links` (:pr:`1782`)
+
+  The option chooses what each connection is labelled with: ``none``, ``outgoing``,
+  ``incoming`` or ``type``.
+  Written bare it still means ``outgoing``, which is what the flag has always drawn, so
+  no existing document changes; the other three values are new.
+
+  ``needs_flow_show_links`` takes the same four values, and ``True``/``False`` keep
+  meaning ``outgoing``/``none``.
+  Any other non-string value is read for its truth, because that is what a value declared
+  a boolean for years actually did — ``1`` still draws labels.
+
+  **A string that is not one of the four values now warns and falls back to** ``none``,
+  where it used to be truthy and draw labels.
+  That is the one input whose behaviour changes.
+  If you build with ``-W``, note that the warning fails the build; silence it with
+  ``suppress_warnings = ["needs.config"]`` or, better, write one of the four values.
+
+  The option now overrides the configuration instead of being combined with it.
+  A project that turned labels on previously left no way of drawing a single unlabelled
+  diagram; ``:show_link_names: none`` is that way.
+
+  Enumerated ``needs_flow_*`` configuration values — ``needs_flow_show_links``,
+  :ref:`needs_flow_direction` and :ref:`needs_flow_engine` — are now matched without
+  regard to case or surrounding whitespace, exactly as the matching directive options
+  always have been.
+  A project whose value only differed in capitalisation stops warning and starts being
+  honoured.
+
 
 Internal changes
 ................

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -747,6 +747,114 @@ Select between the rendering engines for :ref:`needflow` diagrams,
 Any other value is reported as a ``needs.config`` warning, once for the project,
 and every diagram is drawn with the default engine.
 
+.. _`needs_flow_direction`:
+
+needs_flow_direction
+~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 8.4.0
+
+The direction :ref:`needflow` diagrams flow in by default:
+``down`` (the default), ``up``, ``right`` or ``left``.
+
+.. code-block:: python
+
+   needs_flow_direction = "right"
+
+A diagram overrides it with :ref:`needflow_direction`;
+only a diagram that does not set the option consults this value.
+
+.. _`needs_flow_legends`:
+
+needs_flow_legends
+~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 8.4.0
+
+Named legend configurations that a diagram selects by name with
+:ref:`show_legend <needflow_show_legend>`.
+
+.. code-block:: python
+
+   needs_flow_legends = {
+       "beside": {"parts": ["types", "links"], "placement": "external"},
+   }
+
+Default value: ``{}``.
+
+``parts`` is a **list** of the sections to describe -- ``types``, ``links`` or both --
+**in the order they are shown**; it defaults to ``["types"]``.
+
+Order is contract, not an artefact of how the list happens to be written:
+``["links", "types"]`` puts the link table first and keeps it there on every engine,
+so a reader scanning two diagrams finds the same section in the same place.
+
+Only a list is accepted.
+A bare string such as ``"both"`` is reported and ignored --
+a single name cannot express an order,
+and a second accepted spelling would have to keep meaning the same thing
+in every tool that reads this configuration.
+
+``placement`` is a *preference*, not a demand:
+
+``internal``
+   Draw the legend inside the picture where the engine can,
+   and beside it where the engine cannot.
+``external``
+   Draw the legend beside the picture, as a document table.
+   The table looks the same on every engine, its text is selectable and searchable,
+   and it can describe link types -- which no in-diagram legend ever could.
+
+Unset, ``placement`` takes **the engine's own default placement**.
+There is no single right answer to write down here:
+both engines in Sphinx-Needs can draw a legend of need types inside the picture and
+always have, so unset means ``internal`` for them,
+while an engine with no legend construct at all has only the external table to fall
+back on and unset means ``external`` for it.
+Naming the engine's default, rather than a fixed value, is what keeps one contract
+across the tools that read this key.
+
+An engine that cannot draw the legend asked for inside the picture substitutes the
+external one without warning.
+Both engines here draw an in-image legend of need types, and neither can describe link
+types that way, so a legend whose ``parts`` include ``links`` is always drawn beside the
+diagram however it was placed.
+
+That substitution is silent by design.
+The two legends carry identical information and differ only in where they sit,
+so it is a cosmetic one,
+and a warning about it would be unactionable on a project whose other engine can never
+satisfy the preference.
+
+An entry that cannot be used is reported as a ``needs.config`` warning, once for the
+project, and the rest of the configuration is still read.
+
+.. _`needs_flow_show_legend`:
+
+needs_flow_show_legend
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 8.4.0
+
+Which entry of :ref:`needs_flow_legends` a diagram gets
+when it asks for a legend without naming one.
+
+.. code-block:: python
+
+   needs_flow_show_legend = "beside"
+
+Default value: ``""``.
+
+This selects *which* legend, never *whether* one is drawn:
+a diagram still has to ask, with :ref:`show_legend <needflow_show_legend>`.
+There is deliberately no project-wide way of putting a legend on every diagram --
+a legend describes one picture, and the decision belongs with that picture.
+
+A diagram that names its own legend overrides this;
+a diagram whose name is not defined falls back to it, having said so.
+If this value names nothing either,
+that is reported once for the build and the engine's own legend is drawn.
+
 .. _`needs_flow_show_links`:
 
 needs_flow_show_links
@@ -754,15 +862,34 @@ needs_flow_show_links
 
 .. versionadded:: 0.3.11
 
-Used to de/activate the output of link type names beside the connection in the :ref:`needflow` directive:
+.. versionchanged:: 8.4.0
+   Accepts a value as well as a boolean.
+
+What :ref:`needflow` diagrams label their connections with by default:
+``none`` (the default), ``outgoing``, ``incoming`` or ``type``.
 
 .. code-block:: python
 
-   needs_flow_show_links = True
+   needs_flow_show_links = "outgoing"
 
-Default value: ``False``
+Default value: ``False``, i.e. ``none``.
 
-Can be configured also for each :ref:`needflow` directive via :ref:`needflow_show_link_names`.
+``True`` and ``False`` are also accepted, and mean ``outgoing`` and ``none``, which is
+what they have always meant.
+The same goes for any other non-string value: this option was declared a boolean for
+years, so a truthy one such as ``1`` still draws labels.
+A *string* that is not one of the four values is a mistake rather than a truth value, so
+it warns and falls back to ``none`` -- which is the one input whose behaviour changes,
+since it used to draw labels.
+
+A diagram overrides it with :ref:`show_link_names <needflow_show_link_names>`,
+including turning labels off again with ``none``.
+
+.. note::
+
+   Every enumerated ``needs_flow_*`` value -- this one, :ref:`needs_flow_direction`
+   and :ref:`needs_flow_engine` -- is matched without regard to case or surrounding
+   whitespace, exactly as the matching directive option is.
 
 .. _`needs_flow_link_types`:
 

--- a/docs/directives/needflow.rst
+++ b/docs/directives/needflow.rst
@@ -182,8 +182,25 @@ Adds information of used filters below generated flowchart.
 show_legend
 ~~~~~~~~~~~
 
-Adds a legend below generated flowchart. The legends contains all defined need-types and their configured color
-for flowcharts.
+.. versionchanged:: 8.4.0
+   Takes the *name* of a legend configuration.
+   Written bare it still draws the legend it always drew, so no existing diagram changes.
+
+Describes the diagram: its need types, its link types, or both.
+
+Written without a value, the engine chooses:
+
+.. code-block:: rst
+
+   .. needflow::
+      :show_legend:
+
+Both engines draw their own in-image legend for that, exactly as they always have --
+including the long-standing difference that ``plantuml`` lists every configured need type
+while ``graphviz`` lists only the ones it drew.
+That difference is deliberately left alone, so no existing diagram changes;
+a named legend is how a project gets the same legend on both.
+A project can also change what "bare" means, with :ref:`needs_flow_show_legend`.
 
 .. syntax-example::
 
@@ -197,6 +214,48 @@ for flowcharts.
       :engine: graphviz
       :tags: flow_example
       :show_legend:
+
+Written with a value, it names an entry of :ref:`needs_flow_legends`:
+
+.. code-block:: python
+
+   needs_flow_legends = {
+       "beside": {"parts": ["types", "links"], "placement": "external"},
+   }
+
+A legend placed beside the diagram lists only what the diagram actually drew,
+whichever engine drew it,
+and shows its sections in the order ``parts`` gives them.
+
+.. syntax-example::
+
+   .. needflow::
+      :tags: flow_example
+      :show_legend: beside
+
+.. dropdown:: Using Graphviz engine
+
+   .. needflow::
+      :engine: graphviz
+      :tags: flow_example
+      :show_legend: beside
+
+The option takes a name and never the sections inline.
+A project names its legends whatever it likes,
+so a legend called ``types`` would collide with the section called ``types``
+and need a precedence rule nobody should have to learn.
+One namespace, no reserved words.
+
+Which legend a diagram gets is resolved in order:
+the name this option gives,
+then :ref:`needs_flow_show_legend`,
+then the engine's own legend.
+
+Naming a legend that :ref:`needs_flow_legends` does not define is a warning on that
+diagram, listing the names that are available.
+The name is then treated as though it had not been written,
+so the project default still applies --
+a typo in one diagram does not cost the project the legend it configured.
 
 .. _needflow_show_link_names:
 
@@ -205,23 +264,47 @@ show_link_names
 
 .. versionadded:: 0.3.11
 
-Adds the link type name beside connections.
+.. versionchanged:: 8.4.0
+   Takes an optional value.
+   Written bare it still means ``outgoing``, which is what the flag has always drawn,
+   so no existing document changes.
 
-You can configure it globally by setting :ref:`needs_flow_show_links` in **conf.py**.
-Setup data can be found in test case document ``tests/doc_test/doc_links``.
+Chooses what each connection is labelled with:
+
+``none``
+   Nothing (the default).
+``outgoing``
+   The outgoing title of the link type, e.g. ``links outgoing``.
+``incoming``
+   The incoming title of the link type, e.g. ``links incoming``.
+``type``
+   The bare link field name, e.g. ``links``,
+   for a diagram that wants the data model rather than prose.
+
+Written without a value, ``:show_link_names:`` means ``outgoing``:
+
+.. code-block:: rst
+
+   .. needflow::
+      :show_link_names:
+
+You can set the project default with :ref:`needs_flow_show_links` in **conf.py**.
+Because the option now takes a value rather than only being present or absent,
+a single diagram can turn labels off again with ``none``,
+which the bare flag could not express.
 
 .. syntax-example::
 
    .. needflow::
       :tags: flow_example
-      :show_link_names:
+      :show_link_names: incoming
 
 .. dropdown:: Using Graphviz engine
 
    .. needflow::
       :engine: graphviz
       :tags: flow_example
-      :show_link_names:
+      :show_link_names: incoming
 
 .. _needflow_link_types:
 
@@ -295,6 +378,49 @@ See also :ref:`needs_links` for more details about specific link types.
       :tags: flow_example
       :link_types: tests, blocks
       :show_link_names:
+
+.. _needflow_direction:
+
+direction
+~~~~~~~~~
+
+.. versionadded:: 8.4.0
+
+Sets the direction the diagram flows in:
+``down`` (the default), ``up``, ``right`` or ``left``.
+The tokens ``TB``, ``TD``, ``BT``, ``LR`` and ``RL`` are accepted as aliases,
+so a habit picked up from Graphviz or Mermaid does not have to be unlearned.
+
+You can set the project default with :ref:`needs_flow_direction` in **conf.py**.
+
+Not every engine can draw every direction.
+PlantUML has no bottom-up or right-left layout at all,
+so ``up`` is drawn ``down`` and ``left`` is drawn ``right``,
+with one warning per project;
+Graphviz draws all four.
+A diagram is never refused for asking:
+a plainer diagram is better than a failed build.
+
+An explicit ``:direction:`` also wins over a layout that the ``:config:`` it is written
+beside happens to set.
+The config is a preamble of defaults and the option a per-element value,
+which is the precedence both engines already give them;
+where the two disagree the option is used and the disagreement is reported.
+
+.. syntax-example::
+
+   .. needflow::
+      :tags: flow_example
+      :link_types: tests, blocks
+      :direction: right
+
+.. dropdown:: Using Graphviz engine
+
+   .. needflow::
+      :engine: graphviz
+      :tags: flow_example
+      :link_types: tests, blocks
+      :direction: right
 
 .. _needflow_config:
 

--- a/docs/ubproject.toml
+++ b/docs/ubproject.toml
@@ -348,6 +348,10 @@ on_fail = []
 style = ["yellow_bar"]
 force_style = false
 
+[needs.flow_legends.beside]
+parts = ["types", "links"]
+placement = "external"
+
 [needs.flow_configs]
 my_config = """
 skinparam monochrome true

--- a/sphinx_needs/config.py
+++ b/sphinx_needs/config.py
@@ -833,6 +833,22 @@ class NeedsSphinxConfig:
 
     .. versionadded:: 8.4.0
     """
+    flow_legends: dict[str, dict[str, Any]] = field(
+        default_factory=dict, metadata={"rebuild": "html", "types": ()}
+    )
+    """Named legend configurations that the needflow ``:show_legend:`` option selects.
+
+    .. versionadded:: 8.4.0
+    """
+    flow_show_legend: str = field(
+        default="", metadata={"rebuild": "html", "types": (str,)}
+    )
+    """Which legend a needflow shows when it asks for one without naming it.
+
+    This selects *which* legend, never *whether*: asking for one stays per directive.
+
+    .. versionadded:: 8.4.0
+    """
     flow_link_types: list[str] = field(
         default_factory=lambda: ["links"], metadata={"rebuild": "html", "types": ()}
     )

--- a/sphinx_needs/config.py
+++ b/sphinx_needs/config.py
@@ -815,10 +815,17 @@ class NeedsSphinxConfig:
         default="plantuml", metadata={"rebuild": "env", "types": (str,)}
     )
     """The rendering engine to use for needflow diagrams."""
-    flow_show_links: bool = field(
-        default=False, metadata={"rebuild": "html", "types": (bool,)}
+    flow_show_links: bool | str = field(
+        default=False, metadata={"rebuild": "html", "types": (bool, str)}
     )
-    """If True, show links in needflow diagrams by default."""
+    """What needflow diagrams label their edges with, by default.
+
+    One of ``none``, ``outgoing``, ``incoming`` or ``type``.
+    ``True`` and ``False`` are also accepted, and mean ``outgoing`` and ``none``.
+
+    .. versionchanged:: 8.4.0
+       Accepts a value as well as a boolean.
+    """
     flow_direction: Literal["down", "up", "right", "left"] = field(
         default="down", metadata={"rebuild": "html", "types": (str,)}
     )

--- a/sphinx_needs/config.py
+++ b/sphinx_needs/config.py
@@ -819,6 +819,13 @@ class NeedsSphinxConfig:
         default=False, metadata={"rebuild": "html", "types": (bool,)}
     )
     """If True, show links in needflow diagrams by default."""
+    flow_direction: Literal["down", "up", "right", "left"] = field(
+        default="down", metadata={"rebuild": "html", "types": (str,)}
+    )
+    """The default direction needflow diagrams are drawn in.
+
+    .. versionadded:: 8.4.0
+    """
     flow_link_types: list[str] = field(
         default_factory=lambda: ["links"], metadata={"rebuild": "html", "types": ()}
     )

--- a/sphinx_needs/data.py
+++ b/sphinx_needs/data.py
@@ -634,6 +634,13 @@ class NeedsFilteredDiagramBaseType(NeedsFilteredBaseType):
     show_legend: bool
     show_filters: bool
     show_link_names: bool
+    """Whether to label edges with the link type.
+
+    .. versionchanged:: 8.4.0
+       For :class:`NeedsFlowType` this records only that the option was *given*; what it
+       was given is in ``show_link_names_value``, since needflow's widened option cannot
+       narrow a key the other diagram directives share.
+    """
     link_types: list[str]
     config: str
     config_names: str
@@ -703,6 +710,13 @@ class NeedsFlowType(NeedsFilteredDiagramBaseType):
 
     Detected when the engine configuration is resolved, i.e. while the engine is still
     known, so that the model can honour it without knowing which engine it is for."""
+
+    show_link_names_value: Literal["none", "outgoing", "incoming", "type"] | None
+    """What to label edges with, ``None`` if ``show_link_names`` was not given.
+
+    The bare ``show_link_names`` flag of :class:`NeedsFilteredDiagramBaseType` is shared
+    with the other diagram directives, which still take it as a flag, so needflow's
+    widened value lands beside it rather than changing its type."""
 
 
 class NeedsGanttType(NeedsFilteredDiagramBaseType):

--- a/sphinx_needs/data.py
+++ b/sphinx_needs/data.py
@@ -40,8 +40,16 @@ if TYPE_CHECKING:
 
 LOGGER = getLogger(__name__)
 
-ENV_DATA_VERSION: Final = 6
+ENV_DATA_VERSION: Final = 7
 """Version of the data stored in the environment.
+
+Bumped whenever the shape of that data changes, so that Sphinx re-reads instead of
+handing a pickled doctree to code that no longer understands it.
+
+Version 7 adds the resolved needflow presentation options to :class:`NeedsFlowType`.
+They are read while the diagram is rendered, i.e. from the doctree, so an unbumped
+rebuild over an existing ``_build`` keeps the old doctrees and ends with a ``KeyError``
+rather than re-reading the document.
 
 See https://www.sphinx-doc.org/en/master/extdev/index.html#extension-metadata
 """
@@ -685,6 +693,16 @@ class NeedsFlowType(NeedsFilteredDiagramBaseType):
 
     max_items: int | None
     """Maximum number of needs to show, ``None`` if the option was not given."""
+
+    direction: Literal["down", "up", "right", "left"] | None
+    """The direction to draw the diagram in,
+    ``None`` if the option was not given, in which case the configuration is consulted."""
+
+    config_direction: Literal["down", "up", "right", "left"] | None
+    """The direction the selected engine configuration sets, if any.
+
+    Detected when the engine configuration is resolved, i.e. while the engine is still
+    known, so that the model can honour it without knowing which engine it is for."""
 
 
 class NeedsGanttType(NeedsFilteredDiagramBaseType):

--- a/sphinx_needs/data.py
+++ b/sphinx_needs/data.py
@@ -718,6 +718,12 @@ class NeedsFlowType(NeedsFilteredDiagramBaseType):
     with the other diagram directives, which still take it as a flag, so needflow's
     widened value lands beside it rather than changing its type."""
 
+    show_legend_key: str
+    """The legend configuration ``show_legend`` named, empty when written bare.
+
+    Whether a legend is shown at all is the ``show_legend`` flag of
+    :class:`NeedsFilteredDiagramBaseType`; this only says which one."""
+
 
 class NeedsGanttType(NeedsFilteredDiagramBaseType):
     """Data for a single (filtered) gantt chart."""

--- a/sphinx_needs/directives/needflow/_directive.py
+++ b/sphinx_needs/directives/needflow/_directive.py
@@ -29,6 +29,7 @@ from ._options import (
     direction_option,
     graphviz_config_direction,
     plantuml_config_direction,
+    show_legend_option,
     show_link_names_option,
 )
 
@@ -71,7 +72,7 @@ class NeedflowDirective(FilterBase):
         "direction": direction_option,
         "highlight": directives.unchanged_required,
         "border_color": directives.unchanged_required,
-        "show_legend": directives.flag,
+        "show_legend": show_legend_option,
         "show_filters": directives.flag,
         "show_link_names": show_link_names_option,
         "config": directives.unchanged_required,
@@ -208,6 +209,7 @@ class NeedflowDirective(FilterBase):
             "root_direction": self.options.get("root_direction", "both"),
             "root_depth": self.options.get("root_depth", None),
             "show_legend": "show_legend" in self.options,
+            "show_legend_key": self.options.get("show_legend", ""),
             "show_filters": "show_filters" in self.options,
             # the flag records only that the option was *given*; what it was given goes
             # into the value beside it, because the flag is shared with the other diagram

--- a/sphinx_needs/directives/needflow/_directive.py
+++ b/sphinx_needs/directives/needflow/_directive.py
@@ -29,6 +29,7 @@ from ._options import (
     direction_option,
     graphviz_config_direction,
     plantuml_config_direction,
+    show_link_names_option,
 )
 
 LOGGER = get_logger(__name__)
@@ -72,7 +73,7 @@ class NeedflowDirective(FilterBase):
         "border_color": directives.unchanged_required,
         "show_legend": directives.flag,
         "show_filters": directives.flag,
-        "show_link_names": directives.flag,
+        "show_link_names": show_link_names_option,
         "config": directives.unchanged_required,
         "max_items": directives.nonnegative_int,
         # ubCode compatibility: accepted and ignored by Sphinx-Needs.
@@ -208,7 +209,11 @@ class NeedflowDirective(FilterBase):
             "root_depth": self.options.get("root_depth", None),
             "show_legend": "show_legend" in self.options,
             "show_filters": "show_filters" in self.options,
+            # the flag records only that the option was *given*; what it was given goes
+            # into the value beside it, because the flag is shared with the other diagram
+            # directives, which still take it as a bare flag
             "show_link_names": "show_link_names" in self.options,
+            "show_link_names_value": self.options.get("show_link_names"),
             "link_types": link_types,
             "config_names": config_names,
             "config": config,

--- a/sphinx_needs/directives/needflow/_directive.py
+++ b/sphinx_needs/directives/needflow/_directive.py
@@ -24,6 +24,13 @@ from sphinx_needs.utils import (
     split_link_types,
 )
 
+from ._options import (
+    FlowDirection,
+    direction_option,
+    graphviz_config_direction,
+    plantuml_config_direction,
+)
+
 LOGGER = get_logger(__name__)
 
 #: The engines a diagram can be drawn with.
@@ -60,6 +67,7 @@ class NeedflowDirective(FilterBase):
         # debug; render the graph code in the document
         "debug": directives.flag,
         # formatting
+        "direction": direction_option,
         "highlight": directives.unchanged_required,
         "border_color": directives.unchanged_required,
         "show_legend": directives.flag,
@@ -90,16 +98,22 @@ class NeedflowDirective(FilterBase):
             self.options.get("link_types", all_link_types), location
         )
 
-        engine = self.options.get("engine", needs_config.flow_engine)
+        # normalised the same way the option is: docutils' `choice` lowercases and strips
+        # before matching, so `:engine: PlantUML` has always been accepted while the same
+        # word in `conf.py` warned and fell back -- an asymmetry with nothing to suggest
+        # that capitalisation was the cause
+        raw_engine = self.options.get("engine", needs_config.flow_engine)
+        engine = str(raw_engine).strip().lower()
         if engine not in _ENGINES:
             # the `:engine:` option is validated as it is parsed, so only the
             # configuration can name an unknown engine here.
             # This used to be a bare `assert`, which ends the build with a traceback
             # rather than a message -- and which `python -O` strips altogether, leaving
-            # the unknown name to fail further downstream instead
+            # the unknown name to fail further downstream instead.
+            # The value is quoted as it was *written*, so it can be found in `conf.py`
             log_warning(
                 LOGGER,
-                f"unknown 'needs_flow_engine' value {engine!r}, "
+                f"unknown 'needs_flow_engine' value {raw_engine!r}, "
                 f"so the diagram is drawn with {_ENGINES[0]!r} instead",
                 "config",
                 location=self.get_location(),
@@ -175,6 +189,14 @@ class NeedflowDirective(FilterBase):
                             location=self.get_location(),
                         )
 
+        # detected while the engine is still known, so that the model can honour an
+        # engine config's own layout without knowing which engine wrote it
+        config_direction: FlowDirection | None = (
+            plantuml_config_direction(config)
+            if engine == "plantuml"
+            else graphviz_config_direction(graphviz_style)
+        )
+
         add_doc(self.env, self.env.docname)
 
         attributes: NeedsFlowType = {
@@ -192,6 +214,10 @@ class NeedflowDirective(FilterBase):
             "config": config,
             "graphviz_style": graphviz_style,
             "scale": get_scale(self.options, self.get_location()),
+            # None means the option was not given, so that the configured project
+            # default is consulted rather than silently overridden by it
+            "direction": self.options.get("direction"),
+            "config_direction": config_direction,
             "highlight": self.options.get("highlight", ""),
             "border_color": self.options.get("border_color", None),
             "align": self.options.get("align", "center"),

--- a/sphinx_needs/directives/needflow/_graphviz.py
+++ b/sphinx_needs/directives/needflow/_graphviz.py
@@ -33,7 +33,7 @@ from ._model import (
     resolve_link_types,
 )
 from ._options import LinkLabels, graphviz_rankdir
-from ._shared import create_filter_paragraph
+from ._shared import create_filter_paragraph, create_legend_nodes
 
 try:
     from sphinx.writers.html5 import HTML5Translator
@@ -151,9 +151,9 @@ def process_needflow_graphviz(
             content += _render_edge(edge, graph.link_labels, cluster_ids)
 
         # note this lists only the need types that were actually drawn, whereas the
-        # plantuml engine lists every configured type, so the same `:show_legend:` gives
-        # the two engines different legends; it is kept as is
-        if attributes["show_legend"]:
+        # plantuml engine lists every configured type, so the same bare `:show_legend:`
+        # gives the two engines different legends; it is kept as is
+        if graph.legend is not None and graph.legend.internal:
             content += _create_legend(
                 [drawn.need for drawn in graph.nodes.values()], needs_config
             )
@@ -169,6 +169,16 @@ def process_needflow_graphviz(
             code.source, code.line = node.source, node.line
             # add the debug code to after the surrounding figure
             node.parent.parent.insert(node.parent.parent.index(node.parent) + 1, code)
+
+        # ...and beside it otherwise, as a document table identical on every engine;
+        # inserted last so that it ends up directly below the figure it describes
+        if graph.legend is not None and not graph.legend.internal:
+            for legend in create_legend_nodes(
+                graph.legend.parts, graph.drawn_types, graph.drawn_link_types
+            ):
+                node.parent.parent.insert(
+                    node.parent.parent.index(node.parent) + 1, legend
+                )
 
 
 def _get_link_to_need(

--- a/sphinx_needs/directives/needflow/_graphviz.py
+++ b/sphinx_needs/directives/needflow/_graphviz.py
@@ -32,6 +32,7 @@ from ._model import (
     build_graph,
     resolve_link_types,
 )
+from ._options import graphviz_rankdir
 from ._shared import create_filter_paragraph
 
 try:
@@ -121,6 +122,16 @@ def process_needflow_graphviz(
                 for key, value in attributes["graphviz_style"][etype].items():
                     content += f"  {key}={_quote(str(value))};\n"
                 content += "]\n"
+
+        # the config blob is a preamble of defaults, so the direction is written after
+        # all of it and wins -- including after the `graph [...]` block, since a graph
+        # attribute statement overrides an earlier one and that is where the shipped
+        # `lefttoright`/`toptobottom` configs put their `rankdir`.
+        # Nothing is written for a diagram already drawn the way it asks to be.
+        if (
+            rankdir := graphviz_rankdir(graph.direction, graph.config_direction)
+        ) is not None:
+            content += f"rankdir={_quote(rankdir)};\n"
 
         # calculate node definitions
         content += "\n// node definitions\n"

--- a/sphinx_needs/directives/needflow/_graphviz.py
+++ b/sphinx_needs/directives/needflow/_graphviz.py
@@ -32,7 +32,7 @@ from ._model import (
     build_graph,
     resolve_link_types,
 )
-from ._options import graphviz_rankdir
+from ._options import LinkLabels, graphviz_rankdir
 from ._shared import create_filter_paragraph
 
 try:
@@ -148,7 +148,7 @@ def process_needflow_graphviz(
         # calculate edge definitions
         content += "\n// edge definitions\n"
         for edge in graph.edges:
-            content += _render_edge(edge, graph.show_link_names, cluster_ids)
+            content += _render_edge(edge, graph.link_labels, cluster_ids)
 
         # note this lists only the need types that were actually drawn, whereas the
         # plantuml engine lists every configured type, so the same `:show_legend:` gives
@@ -380,13 +380,13 @@ def _label(
 
 def _render_edge(
     edge: GraphEdge,
-    show_links: bool,
+    link_labels: LinkLabels,
     cluster_ids: dict[str, str | None],
 ) -> str:
     """Render an edge in the graphviz format.
 
     :param edge: The edge to render.
-    :param show_links: Whether to label the edge with the link type.
+    :param link_labels: What to label the edge with, if anything.
     :param cluster_ids: The cluster ids collected by :func:`_render_node`.
     """
     if not (edge.source_drawn and edge.target_drawn):
@@ -395,8 +395,8 @@ def _render_edge(
 
     params: list[tuple[str, str]] = []
 
-    if show_links:
-        params.append(("label", _quote(edge.link_type.display.outgoing)))
+    if (label := edge.label(link_labels)) is not None:
+        params.append(("label", _quote(label)))
 
     params.extend(
         # TODO also use link_type.display.color?

--- a/sphinx_needs/directives/needflow/_model.py
+++ b/sphinx_needs/directives/needflow/_model.py
@@ -22,8 +22,6 @@ either of them draws -- and are called out at the point where they happen:
 - ``parent_needs`` is dropped from the allowed link types *before* the root walk, so
   ``root_id`` never follows the need hierarchy.
 - The root walk runs before the filter, not after it.
-- ``show_link_names`` is OR-ed with ``needs_flow_show_links``, so the configuration can
-  only ever turn labels on.
 - An edge may point at a need that is not drawn as a node (see :class:`GraphEdge`).
 """
 
@@ -51,7 +49,9 @@ from sphinx_needs.views import NeedsView
 
 from ._options import (
     FlowDirection,
+    LinkLabels,
     resolve_direction,
+    resolve_link_labels,
 )
 
 LOGGER = get_logger(__name__)
@@ -237,6 +237,22 @@ class GraphEdge:
             else self.link_type.display.style
         )
 
+    def label(self, labels: LinkLabels) -> str | None:
+        """The text to write on this edge.
+
+        :param labels: What the diagram labels its edges with.
+        :return: The label, or ``None`` for an unlabelled edge.
+        """
+        match labels:
+            case "outgoing":
+                return self.link_type.display.outgoing
+            case "incoming":
+                return self.link_type.display.incoming
+            case "type":
+                return self.link_type.name
+            case _:
+                return None
+
 
 @dataclass
 class NeedflowGraph:
@@ -257,8 +273,8 @@ class NeedflowGraph:
     edges: list[GraphEdge]
     """Every link between needs of the result, in the order the engines emit them."""
 
-    show_link_names: bool
-    """Whether edges are to be labelled with the link type."""
+    link_labels: LinkLabels
+    """What edges are to be labelled with, if anything."""
 
     direction: FlowDirection
     """The direction the diagram is drawn in, as an intent rather than an engine token.
@@ -406,8 +422,9 @@ def build_graph(
         roots=roots,
         nodes=drawn,
         edges=collect_edges(found_needs, allowed_link_types, drawn),
-        # the configuration can only ever turn link names on; it is kept as is
-        show_link_names=attributes["show_link_names"] or needs_config.flow_show_links,
+        link_labels=resolve_link_labels(
+            attributes["show_link_names_value"], needs_config.flow_show_links
+        ),
         direction=resolve_direction(
             attributes["direction"],
             attributes["config_direction"],

--- a/sphinx_needs/directives/needflow/_model.py
+++ b/sphinx_needs/directives/needflow/_model.py
@@ -49,6 +49,11 @@ from sphinx_needs.needs_schema import FieldsSchema, LinkSchema
 from sphinx_needs.variants import match_variants
 from sphinx_needs.views import NeedsView
 
+from ._options import (
+    FlowDirection,
+    resolve_direction,
+)
+
 LOGGER = get_logger(__name__)
 
 #: The location accepted by the warning machinery of the values resolved here.
@@ -255,6 +260,17 @@ class NeedflowGraph:
     show_link_names: bool
     """Whether edges are to be labelled with the link type."""
 
+    direction: FlowDirection
+    """The direction the diagram is drawn in, as an intent rather than an engine token.
+
+    Each engine spells this in its own syntax, and degrades it if it must."""
+
+    config_direction: FlowDirection | None
+    """The direction the engine configuration already sets, if any.
+
+    An engine needs this to know whether it has to restate a direction in order to
+    override the configuration blob it emits first."""
+
 
 def resolve_link_types(
     attributes: NeedsFlowType,
@@ -392,6 +408,13 @@ def build_graph(
         edges=collect_edges(found_needs, allowed_link_types, drawn),
         # the configuration can only ever turn link names on; it is kept as is
         show_link_names=attributes["show_link_names"] or needs_config.flow_show_links,
+        direction=resolve_direction(
+            attributes["direction"],
+            attributes["config_direction"],
+            needs_config.flow_direction,
+            location=location,
+        ),
+        config_direction=attributes["config_direction"],
     )
 
 

--- a/sphinx_needs/directives/needflow/_model.py
+++ b/sphinx_needs/directives/needflow/_model.py
@@ -34,7 +34,7 @@ from typing import Literal
 from docutils import nodes
 from sphinx.application import Sphinx
 
-from sphinx_needs.config import NeedsSphinxConfig
+from sphinx_needs.config import NeedsSphinxConfig, NeedType
 from sphinx_needs.data import NeedsFlowType, SphinxNeedsData
 from sphinx_needs.filter_common import (
     apply_max_items,
@@ -49,8 +49,11 @@ from sphinx_needs.views import NeedsView
 
 from ._options import (
     FlowDirection,
+    LegendSpec,
     LinkLabels,
+    compile_legends,
     resolve_direction,
+    resolve_legend,
     resolve_link_labels,
 )
 
@@ -276,6 +279,15 @@ class NeedflowGraph:
     link_labels: LinkLabels
     """What edges are to be labelled with, if anything."""
 
+    legend: LegendSpec | None
+    """The legend to describe the diagram with, or ``None`` for no legend."""
+
+    drawn_types: list[NeedType]
+    """The configured need types the diagram actually drew, in configuration order."""
+
+    drawn_link_types: list[LinkSchema]
+    """The link fields the diagram actually drew edges for, in schema order."""
+
     direction: FlowDirection
     """The direction the diagram is drawn in, as an intent rather than an engine token.
 
@@ -416,12 +428,43 @@ def build_graph(
         ),
     )
 
+    edges = collect_edges(found_needs, allowed_link_types, drawn)
+
+    # what the legend describes is what was drawn, so it is derived from the graph and
+    # not from the configuration -- a legend listing things the reader cannot find in
+    # the picture is worse than no legend at all
+    drawn_type_names = {node.need["type"] for node in drawn.values()}
+    drawn_link_type_names = {edge.link_type.name for edge in edges}
+
     return NeedflowGraph(
         needs=found_needs,
         total_needs=total_needs,
         roots=roots,
         nodes=drawn,
-        edges=collect_edges(found_needs, allowed_link_types, drawn),
+        edges=edges,
+        drawn_types=[
+            need_type
+            for need_type in needs_config.types
+            if need_type["directive"] in drawn_type_names
+        ],
+        drawn_link_types=[
+            link_type
+            for link_type in allowed_link_types
+            if link_type.name in drawn_link_type_names
+        ],
+        legend=resolve_legend(
+            attributes["show_legend"],
+            attributes["show_legend_key"],
+            needs_config.flow_show_legend,
+            # `location=None`: the shape of `needs_flow_legends` is a `conf.py` matter,
+            # so its warnings belong to the project rather than to whichever diagram
+            # was drawn first. `validate_flow_config` has already emitted them at read
+            # time with the same text, so Sphinx's `once` filter suppresses these; the
+            # call is repeated per diagram because the compiled result is cheap and
+            # holding it would mean caching build-scoped state on a module
+            compile_legends(needs_config.flow_legends, location=None),
+            location=location,
+        ),
         link_labels=resolve_link_labels(
             attributes["show_link_names_value"], needs_config.flow_show_links
         ),

--- a/sphinx_needs/directives/needflow/_options.py
+++ b/sphinx_needs/directives/needflow/_options.py
@@ -24,12 +24,13 @@ build stays silent.
 from __future__ import annotations
 
 from collections.abc import Mapping
+from dataclasses import dataclass
 from typing import Any, Literal, get_args
 
 from docutils.parsers.rst import directives
 
 from sphinx_needs.data import GraphvizStyleType
-from sphinx_needs.logging import get_logger, log_warning
+from sphinx_needs.logging import WarningSubTypes, get_logger, log_warning
 
 LOGGER = get_logger(__name__)
 
@@ -84,6 +85,67 @@ _PLANTUML_DIRECTION: Mapping[FlowDirection, str] = {
 LinkLabels = Literal["none", "outgoing", "incoming", "type"]
 """What to write on an edge, if anything."""
 
+LegendPart = Literal["types", "links"]
+"""A section of the out-of-diagram legend."""
+
+LegendPlacement = Literal["internal", "external"]
+"""Where a legend is asked to be drawn."""
+
+
+#: The keys a ``needs_flow_legends`` entry may set.
+_LEGEND_KEYS = frozenset(("parts", "placement"))
+
+#: The placement an engine of this build uses when a legend does not ask for one.
+#:
+#: ``placement`` unset means "the engine's default placement" rather than any fixed
+#: value, because the honest answer differs per engine: both engines here can draw a
+#: types legend inside the picture and have always done so, while an engine with no
+#: legend construct at all has only the external table to default to.  Writing the rule
+#: this way is what keeps two tools describing one contract instead of each documenting
+#: its own answer as if it were universal.
+ENGINE_DEFAULT_PLACEMENT: LegendPlacement = "internal"
+
+
+@dataclass(frozen=True)
+class LegendSpec:
+    """A resolved legend configuration."""
+
+    parts: tuple[LegendPart, ...] = ("types",)
+    """Which sections the legend describes, **in the order they are shown**.
+
+    Order is part of the contract, not an artefact of how the list was written: a
+    reader scanning two diagrams should find the same section in the same place, so
+    ``["links", "types"]`` puts links first and stays that way on every engine.
+    """
+
+    placement: LegendPlacement | None = None
+    """Where the legend is asked to go, or ``None`` for the engine's own default.
+
+    This is a *preference*, not a requirement. An engine that cannot draw a good legend
+    inside the diagram renders the external table instead, silently: the two carry
+    identical information and differ only in where they sit, which makes the
+    substitution a decorative nearest form rather than an intent that went unhonoured.
+    """
+
+    @property
+    def internal(self) -> bool:
+        """Whether this legend can actually be drawn inside the diagram.
+
+        Neither in-diagram legend here can describe link types, so a legend that asks
+        for them is drawn beside the diagram whatever it would have preferred.
+        """
+        placement = self.placement or ENGINE_DEFAULT_PLACEMENT
+        return placement == "internal" and self.parts == ("types",)
+
+
+#: The legend a diagram gets when nothing names one.
+#:
+#: Both engines here can draw a types legend inside the diagram, and both have always
+#: done so for a bare ``:show_legend:``, so that is the default and a bare option keeps
+#: drawing byte-identically to before this option took a key at all. An engine with no
+#: good in-diagram legend resolves the same preference to the external table.
+ENGINE_DEFAULT_LEGEND = LegendSpec()
+
 
 def direction_option(argument: str) -> FlowDirection:
     """Parse the ``:direction:`` option value.
@@ -115,6 +177,21 @@ def show_link_names_option(argument: str | None) -> LinkLabels:
     if not (value := (argument or "").strip().lower()):
         return "outgoing"
     return directives.choice(value, get_args(LinkLabels))  # type: ignore[no-any-return]
+
+
+def show_legend_option(argument: str | None) -> str:
+    """Parse the ``:show_legend:`` option value.
+
+    The option takes the *key* of a legend configuration, or nothing at all. It never
+    takes the sections inline: a project is free to name its legends whatever it likes,
+    and an inline vocabulary would mean a legend called ``types`` collided with the
+    section called ``types`` and needed a precedence rule nobody should have to learn.
+    One namespace, no reserved words.
+
+    :param argument: The raw option value, ``None`` or empty when written bare.
+    :return: The key, or ``""`` when written bare.
+    """
+    return (argument or "").strip()
 
 
 def plantuml_direction(
@@ -304,6 +381,214 @@ def validated_config_enum(
     return default
 
 
+def compile_legends(
+    legends: Mapping[str, Any], *, location: LocationType
+) -> dict[str, LegendSpec]:
+    """Turn the ``needs_flow_legends`` configuration into resolved legend specifications.
+
+    :param legends: The ``needs_flow_legends`` configuration value.
+    :param location: Where to report an unusable entry.
+    :return: The usable legend configurations, by name.
+    """
+    compiled: dict[str, LegendSpec] = {}
+    if not isinstance(legends, Mapping):
+        log_warning(
+            LOGGER,
+            f"'needs_flow_legends' must be a mapping of names to legend configurations, "
+            f"but is {type(legends).__name__}",
+            "config",
+            location=location,
+            once=True,
+        )
+        return compiled
+    for name, spec in legends.items():
+        if str(name) != str(name).strip() or not str(name).strip():
+            # `:show_legend:` strips its value, and an empty one means "no name given",
+            # so such a name can never be matched however the author writes it; keeping
+            # it would leave a legend that silently never appears, and would pad the
+            # "available:" list of an unknown-key warning with untypable names
+            log_warning(
+                LOGGER,
+                f"legend {name!r} in 'needs_flow_legends' can never be selected, "
+                "because a name is matched with surrounding whitespace removed and "
+                "an empty one means no name was given; it is ignored",
+                "config",
+                location=location,
+                once=True,
+            )
+            continue
+        if not isinstance(spec, Mapping):
+            log_warning(
+                LOGGER,
+                f"legend {name!r} in 'needs_flow_legends' must be a mapping, "
+                f"but is {type(spec).__name__}",
+                "config",
+                location=location,
+                once=True,
+            )
+            continue
+        if unknown := set(spec) - _LEGEND_KEYS:
+            log_warning(
+                LOGGER,
+                f"unknown key(s) {sorted(unknown)} of legend {name!r} in "
+                f"'needs_flow_legends', allowed keys: {', '.join(sorted(_LEGEND_KEYS))}",
+                "config",
+                location=location,
+                once=True,
+            )
+        raw_parts = spec.get("parts", ["types"])
+        if not isinstance(raw_parts, (list, tuple)):
+            # a scalar is the shape this mistake actually takes, and both scalars fail
+            # badly if let through: a number is not iterable at all, and a string
+            # iterates character by character, warning about single letters and then
+            # quietly drawing the default legend instead of the one that was asked for.
+            # Only a list is accepted -- a second accepted spelling would have to mean
+            # the same thing in both tools forever, and `parts` is ordered, which a
+            # single name cannot express
+            log_warning(
+                LOGGER,
+                f"'parts' of legend {name!r} must be a list, e.g. "
+                f'parts = ["types"], but is {type(raw_parts).__name__}',
+                "config",
+                location=location,
+                once=True,
+            )
+            raw_parts = ["types"]
+        parts: list[LegendPart] = []
+        for raw in raw_parts:
+            part = str(raw).strip().lower()
+            if part not in get_args(LegendPart):
+                log_warning(
+                    LOGGER,
+                    f"unknown legend section {raw!r} of legend {name!r}, "
+                    f"allowed values: {', '.join(get_args(LegendPart))}",
+                    "config",
+                    location=location,
+                    once=True,
+                )
+                continue
+            if part not in parts:
+                parts.append(part)  # type: ignore[arg-type]
+        placement: LegendPlacement | None = None
+        if (raw_placement := spec.get("placement")) is not None:
+            candidate = str(raw_placement).strip().lower()
+            if candidate not in get_args(LegendPlacement):
+                log_warning(
+                    LOGGER,
+                    f"unknown placement {raw_placement!r} of legend {name!r}, "
+                    f"allowed values: {', '.join(get_args(LegendPlacement))}",
+                    "config",
+                    location=location,
+                    once=True,
+                )
+            else:
+                placement = candidate  # type: ignore[assignment]
+        compiled[str(name)] = LegendSpec(
+            parts=tuple(parts) or ("types",), placement=placement
+        )
+    return compiled
+
+
+def resolve_legend(
+    present: bool,
+    option_key: str,
+    project_key: Any,
+    compiled: Mapping[str, LegendSpec],
+    *,
+    location: LocationType,
+) -> LegendSpec | None:
+    """Decide which legend a diagram shows, if any.
+
+    Whether there is a legend is decided by the directive alone -- the configuration
+    only ever says *which* one -- so a project default cannot give a legend to a diagram
+    that never asked for one, and the key namespace needs no value meaning "off" that
+    a legend could accidentally be named after.
+
+    *Which* one is a chain, not a switch: the option, then the configuration, then the
+    engine's own legend. A key that names nothing is **treated as unset**, which is the
+    rule the rest of this vocabulary already follows -- an unusable
+    ``needs_flow_show_links`` string warns and then behaves as though it had not been
+    written -- so it warns and hands on to the next step rather than replacing it. A
+    typo in one directive must not silently cost the project the legend it configured.
+
+    The two steps warn differently because they are different mistakes. An option key is
+    the directive's own text, so it is reported there, every time. A project key is one
+    ``conf.py`` line, so it is reported once for the whole build; repeating it at every
+    needflow would bury the directive-level warnings an author can act on.
+
+    Both keys are coerced before they are matched, so a configuration value that is not a
+    string at all names nothing and hands on, exactly as a misspelt one does -- rather than
+    reaching :meth:`str.strip` and ending the build. The read-time check coerces the same
+    way, so the two still emit the same text and Sphinx's ``once`` filter collapses them.
+
+    :param present: Whether ``:show_legend:`` was given at all.
+    :param option_key: The key the option named, empty when written bare.
+    :param project_key: The ``needs_flow_show_legend`` configuration value, which the
+        configuration hands through unchanged and so need not be a string.
+    :param compiled: The configured legends, from :func:`compile_legends`.
+    :param location: Where to report an unknown option key.
+    :return: The legend to draw, or ``None`` for no legend.
+    """
+    if not present:
+        return None
+    # the steps of the chain, each with the tier its own mistake belongs to: the option
+    # is authored per directive and reported there every time, the configuration is one
+    # `conf.py` line and reported once for the build
+    steps: tuple[tuple[str, str, WarningSubTypes, LocationType, bool], ...] = (
+        (option_key.strip(), "", "needflow", location, False),
+        (
+            str(project_key).strip(),
+            " of 'needs_flow_show_legend'",
+            "config",
+            None,
+            True,
+        ),
+    )
+    for key, named, subtype, where, once in steps:
+        if not key:
+            continue
+        if (found := compiled.get(key)) is not None:
+            return found
+        warn_unknown_legend_key(
+            key, compiled, named=named, subtype=subtype, location=where, once=once
+        )
+    return ENGINE_DEFAULT_LEGEND
+
+
+def warn_unknown_legend_key(
+    key: str,
+    compiled: Mapping[str, LegendSpec],
+    *,
+    named: str,
+    subtype: WarningSubTypes,
+    location: LocationType,
+    once: bool,
+) -> None:
+    """Report a legend name that ``needs_flow_legends`` does not define.
+
+    Shared by the read-time check and the per-diagram resolution so that the two emit
+    the *same* text: Sphinx's ``once`` filter dedupes on the message, so identical
+    wording is what lets the read-time warning -- which knows no directive -- win, and
+    keeps a ``conf.py`` mistake from being reported against an ``index.rst`` line.
+
+    :param key: The name that was asked for.
+    :param compiled: The configured legends, from :func:`compile_legends`.
+    :param named: Where the name came from, as a phrase, empty for a directive option.
+    :param subtype: The warning subtype to report under.
+    :param location: Where to report it, ``None`` for the project.
+    :param once: Whether to report it only once for the build.
+    """
+    known = ", ".join(sorted(compiled)) or "none are defined"
+    log_warning(
+        LOGGER,
+        f"legend key {key!r}{named} is not defined in 'needs_flow_legends' "
+        f"(available: {known})",
+        subtype,
+        location=location,
+        once=once,
+    )
+
+
 def validated_config_show_links(
     value: bool | str, *, location: LocationType
 ) -> LinkLabels:
@@ -352,7 +637,13 @@ def resolve_link_labels(
     return validated_config_show_links(project_default, location=None)
 
 
-def validate_flow_config(*, direction: str, show_links: bool | str) -> None:
+def validate_flow_config(
+    *,
+    direction: str,
+    show_links: bool | str,
+    legends: Mapping[str, Any],
+    show_legend: Any,
+) -> None:
     """Report every unusable needflow configuration value, once, as it is read.
 
     Checking these as a diagram is drawn means a project that misconfigures one and
@@ -364,6 +655,9 @@ def validate_flow_config(*, direction: str, show_links: bool | str) -> None:
 
     :param direction: The ``needs_flow_direction`` value.
     :param show_links: The ``needs_flow_show_links`` value.
+    :param legends: The ``needs_flow_legends`` value.
+    :param show_legend: The ``needs_flow_show_legend`` value, which the configuration
+        hands through unchanged and so need not be a string.
     """
     validated_config_enum(
         direction,
@@ -373,3 +667,17 @@ def validate_flow_config(*, direction: str, show_links: bool | str) -> None:
         location=None,
     )
     validated_config_show_links(show_links, location=None)
+    compiled = compile_legends(legends, location=None)
+    # coerced rather than trusted: `types: (str,)` makes Sphinx warn about a wrong type and
+    # then hand the raw value through, so a non-string reached `str.strip` and ended the
+    # build with a traceback -- which is precisely what this function exists to prevent, and
+    # what every sibling key here already guards against
+    if (key := str(show_legend).strip()) and key not in compiled:
+        warn_unknown_legend_key(
+            key,
+            compiled,
+            named=" of 'needs_flow_show_legend'",
+            subtype="config",
+            location=None,
+            once=True,
+        )

--- a/sphinx_needs/directives/needflow/_options.py
+++ b/sphinx_needs/directives/needflow/_options.py
@@ -81,6 +81,10 @@ _PLANTUML_DIRECTION: Mapping[FlowDirection, str] = {
 }
 
 
+LinkLabels = Literal["none", "outgoing", "incoming", "type"]
+"""What to write on an edge, if anything."""
+
+
 def direction_option(argument: str) -> FlowDirection:
     """Parse the ``:direction:`` option value.
 
@@ -93,6 +97,24 @@ def direction_option(argument: str) -> FlowDirection:
         (argument or "").strip().lower(), tuple(DIRECTION_ALIASES)
     )
     return DIRECTION_ALIASES[value]
+
+
+def show_link_names_option(argument: str | None) -> LinkLabels:
+    """Parse the ``:show_link_names:`` option value.
+
+    The option began as a bare flag meaning "label edges with the outgoing title", which
+    is exactly one of the values below -- so it is widened rather than replaced, and a
+    bare ``:show_link_names:`` still means what it always did.  docutils hands a
+    valueless option ``None`` or ``''`` depending on how it was written, and both mean
+    bare.
+
+    :param argument: The raw option value, ``None`` or empty when written bare.
+    :return: What to label edges with.
+    :raises ValueError: If the value is not a known kind of label.
+    """
+    if not (value := (argument or "").strip().lower()):
+        return "outgoing"
+    return directives.choice(value, get_args(LinkLabels))  # type: ignore[no-any-return]
 
 
 def plantuml_direction(
@@ -282,7 +304,55 @@ def validated_config_enum(
     return default
 
 
-def validate_flow_config(*, direction: str) -> None:
+def validated_config_show_links(
+    value: bool | str, *, location: LocationType
+) -> LinkLabels:
+    """Check the configured project default for edge labels.
+
+    The value was a boolean before it named a kind of label, and both spellings stay
+    valid: ``True`` is the ``outgoing`` it has always drawn and ``False`` is ``none``.
+    An unusable string warns once and falls back, like every other enumerated value.
+
+    Anything that is neither a string nor a boolean is read for its truth, because that
+    is what a value declared ``bool`` for years actually did: ``1`` drew labels and drew
+    them silently, so it still does. Only a *string* is held to the enumeration, since a
+    string is someone naming a value rather than leaning on truthiness.
+
+    :param value: The ``needs_flow_show_links`` configuration value.
+    :param location: Where to report an unusable value, if anywhere.
+    :return: What to label edges with by default.
+    """
+    if not isinstance(value, str):
+        return "outgoing" if value else "none"
+    return validated_config_enum(  # type: ignore[return-value]
+        str(value),
+        get_args(LinkLabels),
+        "none",
+        name="needs_flow_show_links",
+        location=location,
+    )
+
+
+def resolve_link_labels(
+    option: LinkLabels | None, project_default: bool | str
+) -> LinkLabels:
+    """Decide what a diagram's edges are labelled with.
+
+    Only an unset option consults the configuration, so a diagram always has the last
+    word -- which it did not before the option took a value: the flag and the
+    configuration were OR-ed together, so a project that turned labels on left no way of
+    turning them off again for one diagram.
+
+    :param option: The ``:show_link_names:`` option, ``None`` if it was not given.
+    :param project_default: The ``needs_flow_show_links`` configuration value.
+    :return: What to label edges with.
+    """
+    if option is not None:
+        return option
+    return validated_config_show_links(project_default, location=None)
+
+
+def validate_flow_config(*, direction: str, show_links: bool | str) -> None:
     """Report every unusable needflow configuration value, once, as it is read.
 
     Checking these as a diagram is drawn means a project that misconfigures one and
@@ -293,6 +363,7 @@ def validate_flow_config(*, direction: str) -> None:
     first, because this call has no directive location to attach.
 
     :param direction: The ``needs_flow_direction`` value.
+    :param show_links: The ``needs_flow_show_links`` value.
     """
     validated_config_enum(
         direction,
@@ -301,3 +372,4 @@ def validate_flow_config(*, direction: str) -> None:
         name="needs_flow_direction",
         location=None,
     )
+    validated_config_show_links(show_links, location=None)

--- a/sphinx_needs/directives/needflow/_options.py
+++ b/sphinx_needs/directives/needflow/_options.py
@@ -1,0 +1,303 @@
+"""The portable ``needflow`` option vocabulary.
+
+Every option collected here expresses an *intent* -- a layout direction, what to label
+an edge with, what a legend describes -- and never the syntax of one particular engine.
+Each engine then spells that intent in its own language, so a document written with these
+options renders on any engine rather than only on the one its author happened to use.
+
+Where an engine cannot express an intent, it degrades rather than fails: a plainer
+diagram beats a failed build.  The degradation is graded, and the grade decides who
+hears about it:
+
+1. *Silent best-effort* -- a decorative nearest form exists.
+2. *Warn once per project* -- a named intent has no counterpart on this engine
+   (``:direction: up`` on PlantUML, which has no bottom-up primitive).
+3. *Warn per directive* -- the author made a mistake (an option that disagrees with the
+   engine configuration it is written beside).
+4. *Error* -- a closed enumeration was violated, which docutils reports as the option
+   is parsed.
+
+Nothing here may warn unless the author actually used the feature: an option-free
+build stays silent.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Literal, get_args
+
+from docutils.parsers.rst import directives
+
+from sphinx_needs.data import GraphvizStyleType
+from sphinx_needs.logging import get_logger, log_warning
+
+LOGGER = get_logger(__name__)
+
+#: The location accepted by the warning machinery.
+LocationType = Any
+
+
+FlowDirection = Literal["down", "up", "right", "left"]
+"""The direction a diagram flows in, as an intent rather than an engine token."""
+
+#: Every spelling accepted by ``:direction:``, mapped to the neutral value.
+#: The two-letter forms are the tokens Graphviz and Mermaid users already know, and are
+#: accepted so that they do not have to be unlearned.
+DIRECTION_ALIASES: Mapping[str, FlowDirection] = {
+    "down": "down",
+    "up": "up",
+    "right": "right",
+    "left": "left",
+    "tb": "down",
+    "td": "down",
+    "bt": "up",
+    "lr": "right",
+    "rl": "left",
+}
+
+#: The axis mate of each direction, i.e. the same axis drawn the other way round.
+#: PlantUML has ``top to bottom direction`` and ``left to right direction`` and nothing
+#: else -- ``bottom to top direction`` and ``right to left direction`` are syntax
+#: errors -- so a reversed direction degrades to its mate there.
+_AXIS_MATE: Mapping[FlowDirection, FlowDirection] = {
+    "down": "down",
+    "up": "down",
+    "right": "right",
+    "left": "right",
+}
+
+#: The Graphviz ``rankdir`` token for each direction.  Graphviz supports all four.
+GRAPHVIZ_RANKDIR: Mapping[FlowDirection, str] = {
+    "down": "TB",
+    "up": "BT",
+    "right": "LR",
+    "left": "RL",
+}
+
+#: The PlantUML statement for each direction it can actually draw.
+_PLANTUML_DIRECTION: Mapping[FlowDirection, str] = {
+    "down": "top to bottom direction",
+    "right": "left to right direction",
+}
+
+
+def direction_option(argument: str) -> FlowDirection:
+    """Parse the ``:direction:`` option value.
+
+    :param argument: The raw option value.
+    :return: The neutral direction.
+    :raises ValueError: If the value is not a known direction (a closed enumeration,
+        which docutils reports against the directive).
+    """
+    value = directives.choice(
+        (argument or "").strip().lower(), tuple(DIRECTION_ALIASES)
+    )
+    return DIRECTION_ALIASES[value]
+
+
+def plantuml_direction(
+    direction: FlowDirection,
+    config_direction: FlowDirection | None,
+    *,
+    location: LocationType,
+) -> str | None:
+    """Compute the PlantUML statement that realises a direction, if one is needed.
+
+    PlantUML draws only two of the four directions, so a reversed one degrades to its
+    axis mate and is warned about once for the whole project (tier 2): the diagram is
+    still drawn, on the right axis, just not reversed.
+
+    Nothing is emitted for a diagram that is already drawn the way it asks to be, so
+    that a diagram which does not use the option keeps exactly the source it had
+    before the option existed.
+
+    :param direction: The resolved direction.
+    :param config_direction: The direction the engine config blob already sets, if any,
+        which has to be overridden even when the resolved direction is the default.
+    :param location: Where to report the degradation.
+    :return: The statement to emit, or ``None`` if none is needed.
+    """
+    drawn = _AXIS_MATE[direction]
+    if drawn != direction:
+        log_warning(
+            LOGGER,
+            f"the plantuml engine cannot draw {direction!r}, "
+            f"so the diagram is drawn {drawn!r} instead",
+            "needflow",
+            location=location,
+            once=True,
+        )
+    if drawn == config_direction or (drawn == "down" and config_direction is None):
+        # already how the diagram is drawn, whether because PlantUML draws that way by
+        # default or because the config blob already said so, and restating it would
+        # move the bytes of a diagram that never asked for anything
+        return None
+    return _PLANTUML_DIRECTION[drawn]
+
+
+def graphviz_rankdir(
+    direction: FlowDirection, config_direction: FlowDirection | None
+) -> str | None:
+    """Compute the Graphviz ``rankdir`` value for a direction, if one is needed.
+
+    Graphviz draws all four directions, so nothing degrades here.
+
+    :param direction: The resolved direction.
+    :param config_direction: The direction the engine config blob already sets, if any.
+    :return: The ``rankdir`` value to emit, or ``None`` if none is needed.
+    """
+    if direction == config_direction or (
+        direction == "down" and config_direction is None
+    ):
+        # already how the diagram is drawn, whether because Graphviz draws that way by
+        # default or because the config blob already said so, and restating it would
+        # move the bytes of a diagram that never asked for anything
+        return None
+    return GRAPHVIZ_RANKDIR[direction]
+
+
+def plantuml_config_direction(config: str) -> FlowDirection | None:
+    """Detect the direction a PlantUML config blob sets, if any.
+
+    The blob is raw PlantUML, so this is a text search rather than a parse; it exists
+    only to notice a disagreement with an explicit ``:direction:`` and to know when a
+    default direction has to be restated in order to win.
+
+    :param config: The resolved config text.
+    :return: The direction the blob sets, or ``None``.
+    """
+    lowered = config.lower()
+    for direction, statement in _PLANTUML_DIRECTION.items():
+        if statement in lowered:
+            return direction
+    return None
+
+
+def graphviz_config_direction(style: GraphvizStyleType) -> FlowDirection | None:
+    """Detect the direction a Graphviz config blob sets, if any (see above).
+
+    ``rankdir`` is a graph attribute, so a blob can set it either as a bare top level
+    statement (the ``root`` section) or inside a ``graph [...]`` block -- and the
+    shipped ``lefttoright``/``toptobottom`` configs use the latter.  The emitter writes
+    ``root`` first and ``graph`` after it, and the later statement wins, so the sections
+    are consulted in that same order of increasing authority.
+
+    :param style: The resolved Graphviz style.
+    :return: The direction the blob's ``rankdir`` sets, or ``None``.
+    """
+    found: FlowDirection | None = None
+    for section in ("root", "graph"):
+        attributes = style.get(section, {})
+        if not isinstance(attributes, Mapping):
+            continue
+        rankdir = str(attributes.get("rankdir", "")).strip().upper()
+        for direction, token in GRAPHVIZ_RANKDIR.items():
+            if rankdir == token:
+                found = direction
+    return found
+
+
+def resolve_direction(
+    option: FlowDirection | None,
+    config_direction: FlowDirection | None,
+    project_default: str,
+    *,
+    location: LocationType,
+) -> FlowDirection:
+    """Decide which direction a diagram is drawn in.
+
+    An explicit option always wins -- over the engine config blob it is written beside,
+    and over the project default.  The blob is a preamble of defaults and the option a
+    per-element value, which is the same precedence the engines already give them.
+    A disagreement between the two is reported, because it is the one case where the
+    author has plainly said two different things.
+
+    :param option: The ``:direction:`` option, ``None`` if it was not given.
+    :param config_direction: The direction the engine config blob sets, if any.
+    :param project_default: The ``needs_flow_direction`` configuration value.
+    :param location: Where to report a disagreement.
+    :return: The direction to draw.
+    """
+    if option is not None:
+        if config_direction is not None and config_direction != option:
+            log_warning(
+                LOGGER,
+                f"the engine config sets a {config_direction!r} layout, which "
+                f"disagrees with the direction {option!r}; the option is used",
+                "needflow",
+                location=location,
+            )
+        return option
+    if config_direction is not None:
+        return config_direction
+    return validated_config_enum(  # type: ignore[return-value]
+        project_default,
+        get_args(FlowDirection),
+        "down",
+        name="needs_flow_direction",
+        location=None,
+    )
+
+
+def validated_config_enum(
+    value: str,
+    allowed: tuple[str, ...],
+    default: str,
+    *,
+    name: str,
+    location: LocationType,
+) -> str:
+    """Check a configured value against a closed enumeration, without failing the build.
+
+    An out-of-enum value is a mistake in one line of ``conf.py``, not a reason to end a
+    build with a traceback: every value here reaches a lookup table sooner or later, and
+    reaching one unchecked is how a typo becomes a ``KeyError``.  The value is reported
+    once, with the allowed values, and the documented default is used instead.
+
+    Case and surrounding whitespace are ignored, which is what the matching *option*
+    already does -- docutils' ``choice`` lowercases and strips before matching, so
+    ``:direction: Right`` is accepted while the same word in ``conf.py`` would otherwise
+    warn and fall back to something else entirely.  That asymmetry is internal to
+    Sphinx-Needs, and it would also make two implementations of this vocabulary
+    disagree.  The warning still quotes the value as it was written, so it can be found
+    in ``conf.py``.
+
+    :param value: The configured value.
+    :param allowed: The values the configuration accepts.
+    :param default: The value to fall back to.
+    :param name: The configuration key, for the message.
+    :param location: Where to report the value, if anywhere.
+    :return: The normalised value, or the default if it is not usable.
+    """
+    if (normalised := str(value).strip().lower()) in allowed:
+        return normalised
+    log_warning(
+        LOGGER,
+        f"Invalid {name!r} value {value!r}, "
+        f"allowed values: {', '.join(allowed)}; {default!r} is used",
+        "config",
+        location=location,
+        once=True,
+    )
+    return default
+
+
+def validate_flow_config(*, direction: str) -> None:
+    """Report every unusable needflow configuration value, once, as it is read.
+
+    Checking these as a diagram is drawn means a project that misconfigures one and
+    happens to have no needflow is never told.  The checks are the same functions the
+    resolution uses, and they warn only once for a given message, so a project with
+    needflows hears about a bad value exactly once rather than twice -- and hears it
+    against ``conf.py`` rather than against whichever directive happened to be drawn
+    first, because this call has no directive location to attach.
+
+    :param direction: The ``needs_flow_direction`` value.
+    """
+    validated_config_enum(
+        direction,
+        get_args(FlowDirection),
+        "down",
+        name="needs_flow_direction",
+        location=None,
+    )

--- a/sphinx_needs/directives/needflow/_plantuml.py
+++ b/sphinx_needs/directives/needflow/_plantuml.py
@@ -26,7 +26,7 @@ from ._model import (
     resolve_link_types,
 )
 from ._options import plantuml_direction
-from ._shared import create_filter_paragraph
+from ._shared import create_filter_paragraph, create_legend_nodes
 
 logger = get_logger(__name__)
 
@@ -314,11 +314,11 @@ def process_needflow_plantuml(
             puml_node["uml"] += "\n' Connection definition \n\n"
             puml_node["uml"] += render_connections(graph, entity_names)
 
-            # Create a legend
+            # Create a legend, inside the diagram where that is what was asked for
             # note this lists every configured need type, whereas the graphviz engine
-            # lists only the types it actually drew, so the same `:show_legend:` gives
-            # the two engines different legends; it is kept as is
-            if current_needflow["show_legend"]:
+            # lists only the types it actually drew, so the same bare `:show_legend:`
+            # gives the two engines different legends; it is kept as is
+            if graph.legend is not None and graph.legend.internal:
                 puml_node["uml"] += create_legend(needs_config.types)
 
             puml_node["uml"] += "\n@enduml"
@@ -329,6 +329,12 @@ def process_needflow_plantuml(
             puml_node["scale"] = scale
 
             puml_node = nodes.figure("", puml_node)
+            # `:class:` is assigned explicitly. docutils already copies the classes of
+            # the node being replaced onto its replacement, so this changes nothing today
+            # and is not a fix; it states the intent locally, so that returning a legend
+            # node alongside the figure cannot come to depend on that copy
+            # -- verified: the rendered class attribute is identical with and without it
+            puml_node["classes"] += current_needflow["classes"]
 
             if current_needflow["align"]:
                 puml_node["align"] = current_needflow["align"]
@@ -362,6 +368,13 @@ def process_needflow_plantuml(
             puml_node.line = current_needflow["lineno"]
 
             content.append(puml_node)
+            # ...and beside it otherwise, as a document table identical on every engine
+            if graph.legend is not None and not graph.legend.internal:
+                content.extend(
+                    create_legend_nodes(
+                        graph.legend.parts, graph.drawn_types, graph.drawn_link_types
+                    )
+                )
         else:  # no needs found
             content.append(
                 no_needs_found_paragraph(current_needflow.get("filter_warning"))

--- a/sphinx_needs/directives/needflow/_plantuml.py
+++ b/sphinx_needs/directives/needflow/_plantuml.py
@@ -415,9 +415,8 @@ def render_connections(graph: NeedflowGraph, entity_names: Mapping[str, str]) ->
     """
     puml_connections = ""
     for edge in graph.edges:
-        if graph.show_link_names:
-            desc = edge.link_type.display.outgoing + "\\n"
-            comment = f": {desc}"
+        if (label := edge.label(graph.link_labels)) is not None:
+            comment = f": {label}\\n"
         else:
             comment = ""
 

--- a/sphinx_needs/directives/needflow/_plantuml.py
+++ b/sphinx_needs/directives/needflow/_plantuml.py
@@ -25,6 +25,7 @@ from ._model import (
     build_graph,
     resolve_link_types,
 )
+from ._options import plantuml_direction
 from ._shared import create_filter_paragraph
 
 logger = get_logger(__name__)
@@ -291,6 +292,15 @@ def process_needflow_plantuml(
                 puml_node["uml"] += "\n' Config\n\n"
                 puml_node["uml"] += config
                 puml_node["uml"] += "\n\n"
+
+            # the config blob is a preamble of defaults, so the direction is written
+            # after it and wins; nothing is written for a diagram already drawn that way
+            if (
+                direction := plantuml_direction(
+                    graph.direction, graph.config_direction, location=node
+                )
+            ) is not None:
+                puml_node["uml"] += f"\n' Direction\n\n{direction}\n"
 
             # the entity names must be assigned for the whole diagram at once,
             # so that ids sanitising to the same name stay distinct nodes

--- a/sphinx_needs/directives/needflow/_shared.py
+++ b/sphinx_needs/directives/needflow/_shared.py
@@ -3,13 +3,25 @@
 The graph both engines draw lives in :mod:`~sphinx_needs.directives.needflow._model`;
 this module only holds the document content that neither of them writes in its own
 diagram syntax.
+
+The out-of-diagram legend is the clearest case of that.  Each engine draws one inside
+the picture, in its own syntax and to its own scope rule, so the same option produces
+two different legends; the one built here is a document table instead, which means one
+implementation, one scope rule, and a legend that is selectable text rather than pixels.
 """
 
 from __future__ import annotations
 
+import html
+from collections.abc import Iterable, Sequence
+
 from docutils import nodes
 
+from sphinx_needs.config import NeedType
 from sphinx_needs.data import NeedsFlowType
+from sphinx_needs.needs_schema import LinkSchema
+
+from ._options import LegendPart
 
 
 def create_filter_paragraph(data: NeedsFlowType) -> nodes.paragraph:
@@ -42,3 +54,121 @@ def create_filter_paragraph(data: NeedsFlowType) -> nodes.paragraph:
     para += filter_node
 
     return para
+
+
+def _table(
+    head: Sequence[str], rows: Sequence[Sequence[nodes.Node]], part: LegendPart
+) -> nodes.table:
+    """Build a simple docutils table.
+
+    :param head: The column titles.
+    :param rows: The cell contents of each body row, one entry per column.
+    :param part: Which legend section this is, which names the table so that a reader's
+        stylesheet -- and the conformance corpus -- can address one section rather than
+        having to count tables.
+    :return: The table.
+    """
+    table = nodes.table(classes=["needflow_legend_table", f"needflow_legend_{part}"])
+    group = nodes.tgroup(cols=len(head))
+    table += group
+    for _ in head:
+        group += nodes.colspec(colwidth=1)
+
+    header = nodes.thead()
+    group += header
+    header_row = nodes.row()
+    header += header_row
+    for title in head:
+        entry = nodes.entry()
+        entry += nodes.paragraph("", "", nodes.Text(title))
+        header_row += entry
+
+    body = nodes.tbody()
+    group += body
+    for cells in rows:
+        row = nodes.row()
+        body += row
+        for cell in cells:
+            entry = nodes.entry()
+            entry += nodes.paragraph("", "", cell)
+            row += entry
+
+    return table
+
+
+def _color_swatch(color: str) -> nodes.Node:
+    """Show a color as a small block of it, falling back to its value as text.
+
+    HTML output gets the block; a builder that cannot show one is left with the color
+    value written out, which is what the in-diagram legends have always displayed.
+
+    :param color: The configured color of a need type.
+    :return: The node to put in the cell.
+    """
+    escaped = html.escape(color, quote=True)
+    return nodes.raw(
+        "",
+        f'<span class="needflow_legend_swatch" '
+        f'style="background-color:{escaped}">&#160;&#160;&#160;</span> {escaped}',
+        format="html",
+    )
+
+
+def create_legend_nodes(
+    parts: Iterable[LegendPart],
+    need_types: Sequence[NeedType],
+    link_types: Sequence[LinkSchema],
+) -> list[nodes.Element]:
+    """Describe what a diagram drew, as document tables beside it.
+
+    Only what was actually drawn is described: a legend that lists need types or link
+    types the reader cannot find anywhere in the picture is worse than no legend, and
+    it is the reason this is computed from the graph rather than from the configuration.
+
+    :param parts: The legend sections to draw, in the order they were asked for.
+    :param need_types: The configured need types that the diagram drew, in
+        configuration order.
+    :param link_types: The link fields that the diagram drew edges for, in schema order.
+    :return: The nodes to place after the diagram, empty if there is nothing to say.
+    """
+    tables: list[nodes.Element] = []
+    for part in parts:
+        if part == "types" and need_types:
+            tables.append(
+                _table(
+                    ("Color", "Type"),
+                    [
+                        (
+                            # 'color' is optional, and a type without one keeps its
+                            # row rather than being dropped from the legend
+                            _color_swatch(color)
+                            if (color := need_type.get("color"))
+                            else nodes.Text(""),
+                            nodes.Text(need_type["title"]),
+                        )
+                        for need_type in need_types
+                    ],
+                    "types",
+                )
+            )
+        elif part == "links" and link_types:
+            tables.append(
+                _table(
+                    ("Link", "Description"),
+                    [
+                        (
+                            nodes.literal("", link_type.name),
+                            nodes.Text(link_type.display.outgoing),
+                        )
+                        for link_type in link_types
+                    ],
+                    "links",
+                )
+            )
+
+    if not tables:
+        return []
+
+    container = nodes.container(classes=["needflow_legend"])
+    container += tables
+    return [container]

--- a/sphinx_needs/needs.py
+++ b/sphinx_needs/needs.py
@@ -74,6 +74,7 @@ from sphinx_needs.directives.needflow import (
     process_needflow_graphviz,
     process_needflow_plantuml,
 )
+from sphinx_needs.directives.needflow._options import validate_flow_config
 from sphinx_needs.directives.needgantt import (
     Needgantt,
     NeedganttDirective,
@@ -1124,6 +1125,10 @@ def create_schema(app: Sphinx, env: BuildEnvironment, _docnames: list[str]) -> N
             schema.add_link_field(link_field)
         except Exception as exc:
             raise NeedsConfigException(f"Invalid link {name!r}: {exc}") from exc
+
+    # validated where the configuration is read, so that a project which misconfigures
+    # one of these and happens to have no needflow anywhere is still told, exactly once
+    validate_flow_config(direction=needs_config.flow_direction)
 
     if needs_config._global_options:
         log_warning(

--- a/sphinx_needs/needs.py
+++ b/sphinx_needs/needs.py
@@ -1131,6 +1131,8 @@ def create_schema(app: Sphinx, env: BuildEnvironment, _docnames: list[str]) -> N
     validate_flow_config(
         direction=needs_config.flow_direction,
         show_links=needs_config.flow_show_links,
+        legends=needs_config.flow_legends,
+        show_legend=needs_config.flow_show_legend,
     )
 
     if needs_config._global_options:

--- a/sphinx_needs/needs.py
+++ b/sphinx_needs/needs.py
@@ -1128,7 +1128,10 @@ def create_schema(app: Sphinx, env: BuildEnvironment, _docnames: list[str]) -> N
 
     # validated where the configuration is read, so that a project which misconfigures
     # one of these and happens to have no needflow anywhere is still told, exactly once
-    validate_flow_config(direction=needs_config.flow_direction)
+    validate_flow_config(
+        direction=needs_config.flow_direction,
+        show_links=needs_config.flow_show_links,
+    )
 
     if needs_config._global_options:
         log_warning(

--- a/tests/conformance/needflow/cases/direction-config-default.yaml
+++ b/tests/conformance/needflow/cases/direction-config-default.yaml
@@ -1,0 +1,54 @@
+id: direction-config-default
+title: direction as a project default
+purpose: |
+  The configuration half of `direction`, which no other case drives: a project default must reach a diagram that says nothing about its layout, and must reach it through the same emission path an explicit option uses -- so the source is the horizontal one of `direction-right` even though this diagram names no direction at all.
+needs:
+- id: REQ_1
+  type: req
+  title: Requirement one
+  links:
+    links:
+    - REQ_2
+- id: REQ_2
+  type: req
+  title: Requirement two
+config:
+  direction: right
+expect:
+  plantuml:
+    source: |
+      @startuml
+
+      ' Direction
+
+      left to right direction
+
+      ' Nodes definition
+
+      node "<size:12>Requirement</size>\n**Requirement one**\n<size:10>REQ_1</size>" as REQ_1 [[<NODE_URL:REQ_1>]]
+      node "<size:12>Requirement</size>\n**Requirement two**\n<size:10>REQ_2</size>" as REQ_2 [[<NODE_URL:REQ_2>]]
+
+      ' Connection definition
+
+      REQ_1 --> REQ_2
+
+      @enduml
+  graphviz:
+    source: |
+      digraph needflow {
+      compound=true;
+      node [
+        margin="0.21,0.11";
+      ]
+      edge [
+        minlen="2";
+      ]
+      rankdir="LR";
+
+      // node definitions
+      "REQ_1" [label=<<font point-size="12">Requirement</font><br align="left"/><b>Requirement one</b><br align="left"/><font point-size="10">REQ_1</font><br align="left"/>>, tooltip="REQ_1", href="<NODE_URL:REQ_1>", target="_top", shape="box3d"];
+      "REQ_2" [label=<<font point-size="12">Requirement</font><br align="left"/><b>Requirement two</b><br align="left"/><font point-size="10">REQ_2</font><br align="left"/>>, tooltip="REQ_2", href="<NODE_URL:REQ_2>", target="_top", shape="box3d"];
+
+      // edge definitions
+      "REQ_1" -> "REQ_2" [arrowhead=vee];
+      }

--- a/tests/conformance/needflow/cases/direction-down.yaml
+++ b/tests/conformance/needflow/cases/direction-down.yaml
@@ -1,0 +1,49 @@
+id: direction-down
+title: ':direction: down'
+purpose: |
+  The default. It must emit no direction statement at all -- a diagram that does not ask for a layout keeps the source it had before the option existed.
+needs:
+- id: REQ_1
+  type: req
+  title: Requirement one
+  links:
+    links:
+    - REQ_2
+- id: REQ_2
+  type: req
+  title: Requirement two
+options:
+  direction: down
+expect:
+  plantuml:
+    source: |
+      @startuml
+
+      ' Nodes definition
+
+      node "<size:12>Requirement</size>\n**Requirement one**\n<size:10>REQ_1</size>" as REQ_1 [[<NODE_URL:REQ_1>]]
+      node "<size:12>Requirement</size>\n**Requirement two**\n<size:10>REQ_2</size>" as REQ_2 [[<NODE_URL:REQ_2>]]
+
+      ' Connection definition
+
+      REQ_1 --> REQ_2
+
+      @enduml
+  graphviz:
+    source: |
+      digraph needflow {
+      compound=true;
+      node [
+        margin="0.21,0.11";
+      ]
+      edge [
+        minlen="2";
+      ]
+
+      // node definitions
+      "REQ_1" [label=<<font point-size="12">Requirement</font><br align="left"/><b>Requirement one</b><br align="left"/><font point-size="10">REQ_1</font><br align="left"/>>, tooltip="REQ_1", href="<NODE_URL:REQ_1>", target="_top", shape="box3d"];
+      "REQ_2" [label=<<font point-size="12">Requirement</font><br align="left"/><b>Requirement two</b><br align="left"/><font point-size="10">REQ_2</font><br align="left"/>>, tooltip="REQ_2", href="<NODE_URL:REQ_2>", target="_top", shape="box3d"];
+
+      // edge definitions
+      "REQ_1" -> "REQ_2" [arrowhead=vee];
+      }

--- a/tests/conformance/needflow/cases/direction-left.yaml
+++ b/tests/conformance/needflow/cases/direction-left.yaml
@@ -1,0 +1,58 @@
+id: direction-left
+title: ':direction: left'
+purpose: |
+  Tier-2 degradation on the horizontal axis: PlantUML has no right-to-left primitive either, so 'left' degrades to 'right' with one warning, while Graphviz draws rankdir=RL natively.
+needs:
+- id: REQ_1
+  type: req
+  title: Requirement one
+  links:
+    links:
+    - REQ_2
+- id: REQ_2
+  type: req
+  title: Requirement two
+options:
+  direction: left
+expect:
+  plantuml:
+    source: |
+      @startuml
+
+      ' Direction
+
+      left to right direction
+
+      ' Nodes definition
+
+      node "<size:12>Requirement</size>\n**Requirement one**\n<size:10>REQ_1</size>" as REQ_1 [[<NODE_URL:REQ_1>]]
+      node "<size:12>Requirement</size>\n**Requirement two**\n<size:10>REQ_2</size>" as REQ_2 [[<NODE_URL:REQ_2>]]
+
+      ' Connection definition
+
+      REQ_1 --> REQ_2
+
+      @enduml
+    degradations:
+    - id: direction-horizontal-unsupported
+      tier: 2
+      once: true
+  graphviz:
+    source: |
+      digraph needflow {
+      compound=true;
+      node [
+        margin="0.21,0.11";
+      ]
+      edge [
+        minlen="2";
+      ]
+      rankdir="RL";
+
+      // node definitions
+      "REQ_1" [label=<<font point-size="12">Requirement</font><br align="left"/><b>Requirement one</b><br align="left"/><font point-size="10">REQ_1</font><br align="left"/>>, tooltip="REQ_1", href="<NODE_URL:REQ_1>", target="_top", shape="box3d"];
+      "REQ_2" [label=<<font point-size="12">Requirement</font><br align="left"/><b>Requirement two</b><br align="left"/><font point-size="10">REQ_2</font><br align="left"/>>, tooltip="REQ_2", href="<NODE_URL:REQ_2>", target="_top", shape="box3d"];
+
+      // edge definitions
+      "REQ_1" -> "REQ_2" [arrowhead=vee];
+      }

--- a/tests/conformance/needflow/cases/direction-right.yaml
+++ b/tests/conformance/needflow/cases/direction-right.yaml
@@ -1,0 +1,54 @@
+id: direction-right
+title: ':direction: right'
+purpose: |
+  The horizontal axis, which every engine can draw. It is the control for the 'left' case: same axis, no degradation anywhere.
+needs:
+- id: REQ_1
+  type: req
+  title: Requirement one
+  links:
+    links:
+    - REQ_2
+- id: REQ_2
+  type: req
+  title: Requirement two
+options:
+  direction: right
+expect:
+  plantuml:
+    source: |
+      @startuml
+
+      ' Direction
+
+      left to right direction
+
+      ' Nodes definition
+
+      node "<size:12>Requirement</size>\n**Requirement one**\n<size:10>REQ_1</size>" as REQ_1 [[<NODE_URL:REQ_1>]]
+      node "<size:12>Requirement</size>\n**Requirement two**\n<size:10>REQ_2</size>" as REQ_2 [[<NODE_URL:REQ_2>]]
+
+      ' Connection definition
+
+      REQ_1 --> REQ_2
+
+      @enduml
+  graphviz:
+    source: |
+      digraph needflow {
+      compound=true;
+      node [
+        margin="0.21,0.11";
+      ]
+      edge [
+        minlen="2";
+      ]
+      rankdir="LR";
+
+      // node definitions
+      "REQ_1" [label=<<font point-size="12">Requirement</font><br align="left"/><b>Requirement one</b><br align="left"/><font point-size="10">REQ_1</font><br align="left"/>>, tooltip="REQ_1", href="<NODE_URL:REQ_1>", target="_top", shape="box3d"];
+      "REQ_2" [label=<<font point-size="12">Requirement</font><br align="left"/><b>Requirement two</b><br align="left"/><font point-size="10">REQ_2</font><br align="left"/>>, tooltip="REQ_2", href="<NODE_URL:REQ_2>", target="_top", shape="box3d"];
+
+      // edge definitions
+      "REQ_1" -> "REQ_2" [arrowhead=vee];
+      }

--- a/tests/conformance/needflow/cases/direction-up.yaml
+++ b/tests/conformance/needflow/cases/direction-up.yaml
@@ -1,0 +1,54 @@
+id: direction-up
+title: ':direction: up'
+purpose: |
+  Tier-2 degradation: PlantUML has no bottom-up primitive (verified: 'bottom to top direction' is a syntax error), so the axis-mate fallback must fire exactly one warning per project, while an engine that can draw it says nothing.
+needs:
+- id: REQ_1
+  type: req
+  title: Requirement one
+  links:
+    links:
+    - REQ_2
+- id: REQ_2
+  type: req
+  title: Requirement two
+options:
+  direction: up
+expect:
+  plantuml:
+    source: |
+      @startuml
+
+      ' Nodes definition
+
+      node "<size:12>Requirement</size>\n**Requirement one**\n<size:10>REQ_1</size>" as REQ_1 [[<NODE_URL:REQ_1>]]
+      node "<size:12>Requirement</size>\n**Requirement two**\n<size:10>REQ_2</size>" as REQ_2 [[<NODE_URL:REQ_2>]]
+
+      ' Connection definition
+
+      REQ_1 --> REQ_2
+
+      @enduml
+    degradations:
+    - id: direction-vertical-unsupported
+      tier: 2
+      once: true
+  graphviz:
+    source: |
+      digraph needflow {
+      compound=true;
+      node [
+        margin="0.21,0.11";
+      ]
+      edge [
+        minlen="2";
+      ]
+      rankdir="BT";
+
+      // node definitions
+      "REQ_1" [label=<<font point-size="12">Requirement</font><br align="left"/><b>Requirement one</b><br align="left"/><font point-size="10">REQ_1</font><br align="left"/>>, tooltip="REQ_1", href="<NODE_URL:REQ_1>", target="_top", shape="box3d"];
+      "REQ_2" [label=<<font point-size="12">Requirement</font><br align="left"/><b>Requirement two</b><br align="left"/><font point-size="10">REQ_2</font><br align="left"/>>, tooltip="REQ_2", href="<NODE_URL:REQ_2>", target="_top", shape="box3d"];
+
+      // edge definitions
+      "REQ_1" -> "REQ_2" [arrowhead=vee];
+      }

--- a/tests/conformance/needflow/cases/legend-both.yaml
+++ b/tests/conformance/needflow/cases/legend-both.yaml
@@ -1,0 +1,74 @@
+id: legend-both
+title: an external legend of both sections, in order
+purpose: |
+  Both sections, in the order asked for. Order is contract: a reader scanning two diagrams should find the same section in the same place.
+needs:
+- id: REQ_1
+  type: req
+  title: Requirement one
+  links:
+    links:
+    - REQ_2
+- id: REQ_2
+  type: req
+  title: Requirement two
+types:
+- directive: req
+  title: Requirement
+  prefix: R_
+  color: '#BFD8D2'
+- directive: undrawn
+  title: Never Drawn
+  prefix: U_
+  color: '#CCCCCC'
+legends:
+  beside:
+    parts:
+    - types
+    - links
+    placement: external
+options:
+  show_legend: beside
+expect:
+  plantuml:
+    source: |
+      @startuml
+
+      ' Nodes definition
+
+      node "<size:12>Requirement</size>\n**Requirement one**\n<size:10>REQ_1</size>" as REQ_1 [[<NODE_URL:REQ_1>]] #BFD8D2
+      node "<size:12>Requirement</size>\n**Requirement two**\n<size:10>REQ_2</size>" as REQ_2 [[<NODE_URL:REQ_2>]] #BFD8D2
+
+      ' Connection definition
+
+      REQ_1 --> REQ_2
+
+      @enduml
+    legend:
+      types:
+      - Requirement
+      links:
+      - links
+  graphviz:
+    source: |
+      digraph needflow {
+      compound=true;
+      node [
+        margin="0.21,0.11";
+      ]
+      edge [
+        minlen="2";
+      ]
+
+      // node definitions
+      "REQ_1" [label=<<font point-size="12">Requirement</font><br align="left"/><b>Requirement one</b><br align="left"/><font point-size="10">REQ_1</font><br align="left"/>>, tooltip="REQ_1", href="<NODE_URL:REQ_1>", target="_top", shape="box3d", style="filled", fillcolor="#BFD8D2"];
+      "REQ_2" [label=<<font point-size="12">Requirement</font><br align="left"/><b>Requirement two</b><br align="left"/><font point-size="10">REQ_2</font><br align="left"/>>, tooltip="REQ_2", href="<NODE_URL:REQ_2>", target="_top", shape="box3d", style="filled", fillcolor="#BFD8D2"];
+
+      // edge definitions
+      "REQ_1" -> "REQ_2" [arrowhead=vee];
+      }
+    legend:
+      types:
+      - Requirement
+      links:
+      - links

--- a/tests/conformance/needflow/cases/legend-config-default.yaml
+++ b/tests/conformance/needflow/cases/legend-config-default.yaml
@@ -1,0 +1,71 @@
+id: legend-config-default
+title: the project default supplies the legend key a bare option does not name
+purpose: |
+  The configuration half of the legend chain, which no other case drives: a diagram asks for a legend without naming one, and the project default says which one it gets. This is the step that distinguishes the chain from a switch -- the configuration says *which*, never *whether*, so the option still has to be present for anything to be drawn at all. The companion case `legend-option-beats-config` covers a diagram overriding it.
+needs:
+- id: REQ_1
+  type: req
+  title: Requirement one
+  links:
+    links:
+    - REQ_2
+- id: REQ_2
+  type: req
+  title: Requirement two
+types:
+- directive: req
+  title: Requirement
+  prefix: R_
+  color: '#BFD8D2'
+- directive: undrawn
+  title: Never Drawn
+  prefix: U_
+  color: '#CCCCCC'
+legends:
+  beside:
+    parts:
+    - types
+    placement: external
+config:
+  show_legend: beside
+options:
+  show_legend: ''
+expect:
+  plantuml:
+    source: |
+      @startuml
+
+      ' Nodes definition
+
+      node "<size:12>Requirement</size>\n**Requirement one**\n<size:10>REQ_1</size>" as REQ_1 [[<NODE_URL:REQ_1>]] #BFD8D2
+      node "<size:12>Requirement</size>\n**Requirement two**\n<size:10>REQ_2</size>" as REQ_2 [[<NODE_URL:REQ_2>]] #BFD8D2
+
+      ' Connection definition
+
+      REQ_1 --> REQ_2
+
+      @enduml
+    legend:
+      types:
+      - Requirement
+  graphviz:
+    source: |
+      digraph needflow {
+      compound=true;
+      node [
+        margin="0.21,0.11";
+      ]
+      edge [
+        minlen="2";
+      ]
+
+      // node definitions
+      "REQ_1" [label=<<font point-size="12">Requirement</font><br align="left"/><b>Requirement one</b><br align="left"/><font point-size="10">REQ_1</font><br align="left"/>>, tooltip="REQ_1", href="<NODE_URL:REQ_1>", target="_top", shape="box3d", style="filled", fillcolor="#BFD8D2"];
+      "REQ_2" [label=<<font point-size="12">Requirement</font><br align="left"/><b>Requirement two</b><br align="left"/><font point-size="10">REQ_2</font><br align="left"/>>, tooltip="REQ_2", href="<NODE_URL:REQ_2>", target="_top", shape="box3d", style="filled", fillcolor="#BFD8D2"];
+
+      // edge definitions
+      "REQ_1" -> "REQ_2" [arrowhead=vee];
+      }
+    legend:
+      types:
+      - Requirement

--- a/tests/conformance/needflow/cases/legend-links.yaml
+++ b/tests/conformance/needflow/cases/legend-links.yaml
@@ -1,0 +1,69 @@
+id: legend-links
+title: an external legend of the drawn link types
+purpose: |
+  A link legend describes the link types the diagram drew edges for. No in-diagram legend could ever do this, so the expectation is new behaviour rather than a preserved one.
+needs:
+- id: REQ_1
+  type: req
+  title: Requirement one
+  links:
+    links:
+    - REQ_2
+- id: REQ_2
+  type: req
+  title: Requirement two
+types:
+- directive: req
+  title: Requirement
+  prefix: R_
+  color: '#BFD8D2'
+- directive: undrawn
+  title: Never Drawn
+  prefix: U_
+  color: '#CCCCCC'
+legends:
+  beside:
+    parts:
+    - links
+    placement: external
+options:
+  show_legend: beside
+expect:
+  plantuml:
+    source: |
+      @startuml
+
+      ' Nodes definition
+
+      node "<size:12>Requirement</size>\n**Requirement one**\n<size:10>REQ_1</size>" as REQ_1 [[<NODE_URL:REQ_1>]] #BFD8D2
+      node "<size:12>Requirement</size>\n**Requirement two**\n<size:10>REQ_2</size>" as REQ_2 [[<NODE_URL:REQ_2>]] #BFD8D2
+
+      ' Connection definition
+
+      REQ_1 --> REQ_2
+
+      @enduml
+    legend:
+      links:
+      - links
+  graphviz:
+    source: |
+      digraph needflow {
+      compound=true;
+      node [
+        margin="0.21,0.11";
+      ]
+      edge [
+        minlen="2";
+      ]
+
+      // node definitions
+      "REQ_1" [label=<<font point-size="12">Requirement</font><br align="left"/><b>Requirement one</b><br align="left"/><font point-size="10">REQ_1</font><br align="left"/>>, tooltip="REQ_1", href="<NODE_URL:REQ_1>", target="_top", shape="box3d", style="filled", fillcolor="#BFD8D2"];
+      "REQ_2" [label=<<font point-size="12">Requirement</font><br align="left"/><b>Requirement two</b><br align="left"/><font point-size="10">REQ_2</font><br align="left"/>>, tooltip="REQ_2", href="<NODE_URL:REQ_2>", target="_top", shape="box3d", style="filled", fillcolor="#BFD8D2"];
+
+      // edge definitions
+      "REQ_1" -> "REQ_2" [arrowhead=vee];
+      }
+    legend:
+      links:
+      - links

--- a/tests/conformance/needflow/cases/legend-option-beats-config.yaml
+++ b/tests/conformance/needflow/cases/legend-option-beats-config.yaml
@@ -1,0 +1,80 @@
+id: legend-option-beats-config
+title: a diagram names its own legend against a project default naming another
+purpose: |
+  The first step of the chain wins outright. The two legends here differ in their `parts` ORDER as well as their content, so the expectation cannot be satisfied by accident: a tool that let the project default win, or that merged the two, renders the sections the other way round and fails.
+needs:
+- id: REQ_1
+  type: req
+  title: Requirement one
+  links:
+    links:
+    - REQ_2
+- id: REQ_2
+  type: req
+  title: Requirement two
+types:
+- directive: req
+  title: Requirement
+  prefix: R_
+  color: '#BFD8D2'
+- directive: undrawn
+  title: Never Drawn
+  prefix: U_
+  color: '#CCCCCC'
+legends:
+  beside:
+    parts:
+    - types
+    placement: external
+  reversed:
+    parts:
+    - links
+    - types
+    placement: external
+config:
+  show_legend: beside
+options:
+  show_legend: reversed
+expect:
+  plantuml:
+    source: |
+      @startuml
+
+      ' Nodes definition
+
+      node "<size:12>Requirement</size>\n**Requirement one**\n<size:10>REQ_1</size>" as REQ_1 [[<NODE_URL:REQ_1>]] #BFD8D2
+      node "<size:12>Requirement</size>\n**Requirement two**\n<size:10>REQ_2</size>" as REQ_2 [[<NODE_URL:REQ_2>]] #BFD8D2
+
+      ' Connection definition
+
+      REQ_1 --> REQ_2
+
+      @enduml
+    legend:
+      links:
+      - links
+      types:
+      - Requirement
+  graphviz:
+    source: |
+      digraph needflow {
+      compound=true;
+      node [
+        margin="0.21,0.11";
+      ]
+      edge [
+        minlen="2";
+      ]
+
+      // node definitions
+      "REQ_1" [label=<<font point-size="12">Requirement</font><br align="left"/><b>Requirement one</b><br align="left"/><font point-size="10">REQ_1</font><br align="left"/>>, tooltip="REQ_1", href="<NODE_URL:REQ_1>", target="_top", shape="box3d", style="filled", fillcolor="#BFD8D2"];
+      "REQ_2" [label=<<font point-size="12">Requirement</font><br align="left"/><b>Requirement two</b><br align="left"/><font point-size="10">REQ_2</font><br align="left"/>>, tooltip="REQ_2", href="<NODE_URL:REQ_2>", target="_top", shape="box3d", style="filled", fillcolor="#BFD8D2"];
+
+      // edge definitions
+      "REQ_1" -> "REQ_2" [arrowhead=vee];
+      }
+    legend:
+      links:
+      - links
+      types:
+      - Requirement

--- a/tests/conformance/needflow/cases/legend-order.yaml
+++ b/tests/conformance/needflow/cases/legend-order.yaml
@@ -1,0 +1,74 @@
+id: legend-order
+title: an external legend whose sections are asked for in reverse
+purpose: |
+  `parts` is an ordered LIST, and the order is contract rather than an artefact of how the list was written. This case asks for `[links, types]` -- the reverse of every other legend case -- so a tool that treats `parts` as a set, or as a string enum with a fixed section order, renders the two tables the wrong way round and fails here. It is the only case that can catch that, which is why it exists separately from `legend-both`.
+needs:
+- id: REQ_1
+  type: req
+  title: Requirement one
+  links:
+    links:
+    - REQ_2
+- id: REQ_2
+  type: req
+  title: Requirement two
+types:
+- directive: req
+  title: Requirement
+  prefix: R_
+  color: '#BFD8D2'
+- directive: undrawn
+  title: Never Drawn
+  prefix: U_
+  color: '#CCCCCC'
+legends:
+  reversed:
+    parts:
+    - links
+    - types
+    placement: external
+options:
+  show_legend: reversed
+expect:
+  plantuml:
+    source: |
+      @startuml
+
+      ' Nodes definition
+
+      node "<size:12>Requirement</size>\n**Requirement one**\n<size:10>REQ_1</size>" as REQ_1 [[<NODE_URL:REQ_1>]] #BFD8D2
+      node "<size:12>Requirement</size>\n**Requirement two**\n<size:10>REQ_2</size>" as REQ_2 [[<NODE_URL:REQ_2>]] #BFD8D2
+
+      ' Connection definition
+
+      REQ_1 --> REQ_2
+
+      @enduml
+    legend:
+      links:
+      - links
+      types:
+      - Requirement
+  graphviz:
+    source: |
+      digraph needflow {
+      compound=true;
+      node [
+        margin="0.21,0.11";
+      ]
+      edge [
+        minlen="2";
+      ]
+
+      // node definitions
+      "REQ_1" [label=<<font point-size="12">Requirement</font><br align="left"/><b>Requirement one</b><br align="left"/><font point-size="10">REQ_1</font><br align="left"/>>, tooltip="REQ_1", href="<NODE_URL:REQ_1>", target="_top", shape="box3d", style="filled", fillcolor="#BFD8D2"];
+      "REQ_2" [label=<<font point-size="12">Requirement</font><br align="left"/><b>Requirement two</b><br align="left"/><font point-size="10">REQ_2</font><br align="left"/>>, tooltip="REQ_2", href="<NODE_URL:REQ_2>", target="_top", shape="box3d", style="filled", fillcolor="#BFD8D2"];
+
+      // edge definitions
+      "REQ_1" -> "REQ_2" [arrowhead=vee];
+      }
+    legend:
+      links:
+      - links
+      types:
+      - Requirement

--- a/tests/conformance/needflow/cases/legend-types.yaml
+++ b/tests/conformance/needflow/cases/legend-types.yaml
@@ -1,0 +1,69 @@
+id: legend-types
+title: an external legend of the drawn need types
+purpose: |
+  The legend describes the need types the diagram DREW, not every type the project configures -- an undrawn type in the configuration must not appear. That scope rule is the whole reason the portable legend exists: the two in-diagram legends disagreed about it.
+needs:
+- id: REQ_1
+  type: req
+  title: Requirement one
+  links:
+    links:
+    - REQ_2
+- id: REQ_2
+  type: req
+  title: Requirement two
+types:
+- directive: req
+  title: Requirement
+  prefix: R_
+  color: '#BFD8D2'
+- directive: undrawn
+  title: Never Drawn
+  prefix: U_
+  color: '#CCCCCC'
+legends:
+  beside:
+    parts:
+    - types
+    placement: external
+options:
+  show_legend: beside
+expect:
+  plantuml:
+    source: |
+      @startuml
+
+      ' Nodes definition
+
+      node "<size:12>Requirement</size>\n**Requirement one**\n<size:10>REQ_1</size>" as REQ_1 [[<NODE_URL:REQ_1>]] #BFD8D2
+      node "<size:12>Requirement</size>\n**Requirement two**\n<size:10>REQ_2</size>" as REQ_2 [[<NODE_URL:REQ_2>]] #BFD8D2
+
+      ' Connection definition
+
+      REQ_1 --> REQ_2
+
+      @enduml
+    legend:
+      types:
+      - Requirement
+  graphviz:
+    source: |
+      digraph needflow {
+      compound=true;
+      node [
+        margin="0.21,0.11";
+      ]
+      edge [
+        minlen="2";
+      ]
+
+      // node definitions
+      "REQ_1" [label=<<font point-size="12">Requirement</font><br align="left"/><b>Requirement one</b><br align="left"/><font point-size="10">REQ_1</font><br align="left"/>>, tooltip="REQ_1", href="<NODE_URL:REQ_1>", target="_top", shape="box3d", style="filled", fillcolor="#BFD8D2"];
+      "REQ_2" [label=<<font point-size="12">Requirement</font><br align="left"/><b>Requirement two</b><br align="left"/><font point-size="10">REQ_2</font><br align="left"/>>, tooltip="REQ_2", href="<NODE_URL:REQ_2>", target="_top", shape="box3d", style="filled", fillcolor="#BFD8D2"];
+
+      // edge definitions
+      "REQ_1" -> "REQ_2" [arrowhead=vee];
+      }
+    legend:
+      types:
+      - Requirement

--- a/tests/conformance/needflow/cases/link-labels-config-default.yaml
+++ b/tests/conformance/needflow/cases/link-labels-config-default.yaml
@@ -1,0 +1,53 @@
+id: link-labels-config-default
+title: link_labels as a project default, overridden by one diagram
+purpose: |
+  The configuration half of `link_labels`, which no other case drives: a project default must reach a diagram that says nothing about labels. It also pins `type` as the bare field name when it arrives from configuration -- a distinction a containment check cannot make, because `links` is a substring of both configured titles. The companion case `link-labels-option-beats-config` covers a diagram overriding it.
+needs:
+- id: REQ_1
+  type: req
+  title: Requirement one
+  links:
+    links:
+    - REQ_2
+- id: REQ_2
+  type: req
+  title: Requirement two
+links:
+- option: links
+  incoming: is linked by
+  outgoing: links to
+config:
+  link_labels: type
+expect:
+  plantuml:
+    source: |
+      @startuml
+
+      ' Nodes definition
+
+      node "<size:12>Requirement</size>\n**Requirement one**\n<size:10>REQ_1</size>" as REQ_1 [[<NODE_URL:REQ_1>]]
+      node "<size:12>Requirement</size>\n**Requirement two**\n<size:10>REQ_2</size>" as REQ_2 [[<NODE_URL:REQ_2>]]
+
+      ' Connection definition
+
+      REQ_1 --> REQ_2: links\n
+
+      @enduml
+  graphviz:
+    source: |
+      digraph needflow {
+      compound=true;
+      node [
+        margin="0.21,0.11";
+      ]
+      edge [
+        minlen="2";
+      ]
+
+      // node definitions
+      "REQ_1" [label=<<font point-size="12">Requirement</font><br align="left"/><b>Requirement one</b><br align="left"/><font point-size="10">REQ_1</font><br align="left"/>>, tooltip="REQ_1", href="<NODE_URL:REQ_1>", target="_top", shape="box3d"];
+      "REQ_2" [label=<<font point-size="12">Requirement</font><br align="left"/><b>Requirement two</b><br align="left"/><font point-size="10">REQ_2</font><br align="left"/>>, tooltip="REQ_2", href="<NODE_URL:REQ_2>", target="_top", shape="box3d"];
+
+      // edge definitions
+      "REQ_1" -> "REQ_2" [label="links", arrowhead=vee];
+      }

--- a/tests/conformance/needflow/cases/link-labels-incoming.yaml
+++ b/tests/conformance/needflow/cases/link-labels-incoming.yaml
@@ -1,0 +1,53 @@
+id: link-labels-incoming
+title: ':link_labels: incoming'
+purpose: |
+  The reverse title. New in the portable vocabulary -- the flag it replaces could only ever say 'outgoing'.
+needs:
+- id: REQ_1
+  type: req
+  title: Requirement one
+  links:
+    links:
+    - REQ_2
+- id: REQ_2
+  type: req
+  title: Requirement two
+links:
+- option: links
+  incoming: is linked by
+  outgoing: links to
+options:
+  link_labels: incoming
+expect:
+  plantuml:
+    source: |
+      @startuml
+
+      ' Nodes definition
+
+      node "<size:12>Requirement</size>\n**Requirement one**\n<size:10>REQ_1</size>" as REQ_1 [[<NODE_URL:REQ_1>]]
+      node "<size:12>Requirement</size>\n**Requirement two**\n<size:10>REQ_2</size>" as REQ_2 [[<NODE_URL:REQ_2>]]
+
+      ' Connection definition
+
+      REQ_1 --> REQ_2: is linked by\n
+
+      @enduml
+  graphviz:
+    source: |
+      digraph needflow {
+      compound=true;
+      node [
+        margin="0.21,0.11";
+      ]
+      edge [
+        minlen="2";
+      ]
+
+      // node definitions
+      "REQ_1" [label=<<font point-size="12">Requirement</font><br align="left"/><b>Requirement one</b><br align="left"/><font point-size="10">REQ_1</font><br align="left"/>>, tooltip="REQ_1", href="<NODE_URL:REQ_1>", target="_top", shape="box3d"];
+      "REQ_2" [label=<<font point-size="12">Requirement</font><br align="left"/><b>Requirement two</b><br align="left"/><font point-size="10">REQ_2</font><br align="left"/>>, tooltip="REQ_2", href="<NODE_URL:REQ_2>", target="_top", shape="box3d"];
+
+      // edge definitions
+      "REQ_1" -> "REQ_2" [label="is linked by", arrowhead=vee];
+      }

--- a/tests/conformance/needflow/cases/link-labels-none.yaml
+++ b/tests/conformance/needflow/cases/link-labels-none.yaml
@@ -1,0 +1,53 @@
+id: link-labels-none
+title: ':link_labels: none'
+purpose: |
+  The default: no labels at all. Anything else here would mean an engine is labelling edges nobody asked to have labelled.
+needs:
+- id: REQ_1
+  type: req
+  title: Requirement one
+  links:
+    links:
+    - REQ_2
+- id: REQ_2
+  type: req
+  title: Requirement two
+links:
+- option: links
+  incoming: is linked by
+  outgoing: links to
+options:
+  link_labels: none
+expect:
+  plantuml:
+    source: |
+      @startuml
+
+      ' Nodes definition
+
+      node "<size:12>Requirement</size>\n**Requirement one**\n<size:10>REQ_1</size>" as REQ_1 [[<NODE_URL:REQ_1>]]
+      node "<size:12>Requirement</size>\n**Requirement two**\n<size:10>REQ_2</size>" as REQ_2 [[<NODE_URL:REQ_2>]]
+
+      ' Connection definition
+
+      REQ_1 --> REQ_2
+
+      @enduml
+  graphviz:
+    source: |
+      digraph needflow {
+      compound=true;
+      node [
+        margin="0.21,0.11";
+      ]
+      edge [
+        minlen="2";
+      ]
+
+      // node definitions
+      "REQ_1" [label=<<font point-size="12">Requirement</font><br align="left"/><b>Requirement one</b><br align="left"/><font point-size="10">REQ_1</font><br align="left"/>>, tooltip="REQ_1", href="<NODE_URL:REQ_1>", target="_top", shape="box3d"];
+      "REQ_2" [label=<<font point-size="12">Requirement</font><br align="left"/><b>Requirement two</b><br align="left"/><font point-size="10">REQ_2</font><br align="left"/>>, tooltip="REQ_2", href="<NODE_URL:REQ_2>", target="_top", shape="box3d"];
+
+      // edge definitions
+      "REQ_1" -> "REQ_2" [arrowhead=vee];
+      }

--- a/tests/conformance/needflow/cases/link-labels-option-beats-config.yaml
+++ b/tests/conformance/needflow/cases/link-labels-option-beats-config.yaml
@@ -1,0 +1,59 @@
+id: link-labels-option-beats-config
+title: a diagram turns labels off against a project default that turns them on
+purpose: |
+  Only an unset option consults the configuration, so a diagram always has the last word. This
+  is the case that used to be inexpressible: the option and the project default were combined
+  such that the default could only ever turn labels on, leaving a project no way to draw one
+  unlabelled diagram. Every implementation must give the option precedence, so the expectation
+  here is an edge with no label at all despite the project asking for one.
+needs:
+- id: REQ_1
+  type: req
+  title: Requirement one
+  links:
+    links:
+    - REQ_2
+- id: REQ_2
+  type: req
+  title: Requirement two
+links:
+- option: links
+  incoming: is linked by
+  outgoing: links to
+config:
+  link_labels: outgoing
+options:
+  link_labels: none
+expect:
+  plantuml:
+    source: |
+      @startuml
+
+      ' Nodes definition
+
+      node "<size:12>Requirement</size>\n**Requirement one**\n<size:10>REQ_1</size>" as REQ_1 [[<NODE_URL:REQ_1>]]
+      node "<size:12>Requirement</size>\n**Requirement two**\n<size:10>REQ_2</size>" as REQ_2 [[<NODE_URL:REQ_2>]]
+
+      ' Connection definition
+
+      REQ_1 --> REQ_2
+
+      @enduml
+  graphviz:
+    source: |
+      digraph needflow {
+      compound=true;
+      node [
+        margin="0.21,0.11";
+      ]
+      edge [
+        minlen="2";
+      ]
+
+      // node definitions
+      "REQ_1" [label=<<font point-size="12">Requirement</font><br align="left"/><b>Requirement one</b><br align="left"/><font point-size="10">REQ_1</font><br align="left"/>>, tooltip="REQ_1", href="<NODE_URL:REQ_1>", target="_top", shape="box3d"];
+      "REQ_2" [label=<<font point-size="12">Requirement</font><br align="left"/><b>Requirement two</b><br align="left"/><font point-size="10">REQ_2</font><br align="left"/>>, tooltip="REQ_2", href="<NODE_URL:REQ_2>", target="_top", shape="box3d"];
+
+      // edge definitions
+      "REQ_1" -> "REQ_2" [arrowhead=vee];
+      }

--- a/tests/conformance/needflow/cases/link-labels-outgoing.yaml
+++ b/tests/conformance/needflow/cases/link-labels-outgoing.yaml
@@ -1,0 +1,53 @@
+id: link-labels-outgoing
+title: ':link_labels: outgoing'
+purpose: |
+  The outgoing title of the link type. Every implementation has a spelling that already meant exactly this before the portable vocabulary existed -- in sphinx-needs it is the bare `:show_link_names:` flag, which is why that option was widened to take a value rather than replaced. This case is therefore the byte-parity target each implementation checks its own pre-existing spelling against.
+needs:
+- id: REQ_1
+  type: req
+  title: Requirement one
+  links:
+    links:
+    - REQ_2
+- id: REQ_2
+  type: req
+  title: Requirement two
+links:
+- option: links
+  incoming: is linked by
+  outgoing: links to
+options:
+  link_labels: outgoing
+expect:
+  plantuml:
+    source: |
+      @startuml
+
+      ' Nodes definition
+
+      node "<size:12>Requirement</size>\n**Requirement one**\n<size:10>REQ_1</size>" as REQ_1 [[<NODE_URL:REQ_1>]]
+      node "<size:12>Requirement</size>\n**Requirement two**\n<size:10>REQ_2</size>" as REQ_2 [[<NODE_URL:REQ_2>]]
+
+      ' Connection definition
+
+      REQ_1 --> REQ_2: links to\n
+
+      @enduml
+  graphviz:
+    source: |
+      digraph needflow {
+      compound=true;
+      node [
+        margin="0.21,0.11";
+      ]
+      edge [
+        minlen="2";
+      ]
+
+      // node definitions
+      "REQ_1" [label=<<font point-size="12">Requirement</font><br align="left"/><b>Requirement one</b><br align="left"/><font point-size="10">REQ_1</font><br align="left"/>>, tooltip="REQ_1", href="<NODE_URL:REQ_1>", target="_top", shape="box3d"];
+      "REQ_2" [label=<<font point-size="12">Requirement</font><br align="left"/><b>Requirement two</b><br align="left"/><font point-size="10">REQ_2</font><br align="left"/>>, tooltip="REQ_2", href="<NODE_URL:REQ_2>", target="_top", shape="box3d"];
+
+      // edge definitions
+      "REQ_1" -> "REQ_2" [label="links to", arrowhead=vee];
+      }

--- a/tests/conformance/needflow/cases/link-labels-type.yaml
+++ b/tests/conformance/needflow/cases/link-labels-type.yaml
@@ -1,0 +1,53 @@
+id: link-labels-type
+title: ':link_labels: type'
+purpose: |
+  The bare link field name, for a diagram that wants the data model rather than prose. It must be the field name, not its title, on every engine.
+needs:
+- id: REQ_1
+  type: req
+  title: Requirement one
+  links:
+    links:
+    - REQ_2
+- id: REQ_2
+  type: req
+  title: Requirement two
+links:
+- option: links
+  incoming: is linked by
+  outgoing: links to
+options:
+  link_labels: type
+expect:
+  plantuml:
+    source: |
+      @startuml
+
+      ' Nodes definition
+
+      node "<size:12>Requirement</size>\n**Requirement one**\n<size:10>REQ_1</size>" as REQ_1 [[<NODE_URL:REQ_1>]]
+      node "<size:12>Requirement</size>\n**Requirement two**\n<size:10>REQ_2</size>" as REQ_2 [[<NODE_URL:REQ_2>]]
+
+      ' Connection definition
+
+      REQ_1 --> REQ_2: links\n
+
+      @enduml
+  graphviz:
+    source: |
+      digraph needflow {
+      compound=true;
+      node [
+        margin="0.21,0.11";
+      ]
+      edge [
+        minlen="2";
+      ]
+
+      // node definitions
+      "REQ_1" [label=<<font point-size="12">Requirement</font><br align="left"/><b>Requirement one</b><br align="left"/><font point-size="10">REQ_1</font><br align="left"/>>, tooltip="REQ_1", href="<NODE_URL:REQ_1>", target="_top", shape="box3d"];
+      "REQ_2" [label=<<font point-size="12">Requirement</font><br align="left"/><b>Requirement two</b><br align="left"/><font point-size="10">REQ_2</font><br align="left"/>>, tooltip="REQ_2", href="<NODE_URL:REQ_2>", target="_top", shape="box3d"];
+
+      // edge definitions
+      "REQ_1" -> "REQ_2" [label="links", arrowhead=vee];
+      }

--- a/tests/conformance/needflow/cases/option-conflict-direction.yaml
+++ b/tests/conformance/needflow/cases/option-conflict-direction.yaml
@@ -1,0 +1,73 @@
+id: option-conflict-direction
+title: 'An explicit :direction: disagreeing with an engine config'
+purpose: |
+  Registry id `option-conflict-direction`. The engine config is a preamble of defaults and a portable option is a per-element value, so the option wins -- but the author has plainly said two different things, so the build says so (tier 3). The emitted source must prove the option actually won, not merely that a warning was issued.
+needs:
+- id: REQ_1
+  type: req
+  title: Requirement one
+  links:
+    links:
+    - REQ_2
+- id: REQ_2
+  type: req
+  title: Requirement two
+config:
+  engine_config:
+    plantuml:
+      sideways: left to right direction
+    graphviz:
+      sideways:
+        graph:
+          rankdir: LR
+options:
+  direction: down
+  engine_config: sideways
+expect:
+  plantuml:
+    source: |
+      @startuml
+
+      ' Config
+
+      left to right direction
+
+
+      ' Direction
+
+      top to bottom direction
+
+      ' Nodes definition
+
+      node "<size:12>Requirement</size>\n**Requirement one**\n<size:10>REQ_1</size>" as REQ_1 [[<NODE_URL:REQ_1>]]
+      node "<size:12>Requirement</size>\n**Requirement two**\n<size:10>REQ_2</size>" as REQ_2 [[<NODE_URL:REQ_2>]]
+
+      ' Connection definition
+
+      REQ_1 --> REQ_2
+
+      @enduml
+    degradations:
+    - id: option-conflict-direction
+      tier: 3
+      once: false
+  graphviz:
+    source: |
+      digraph needflow {
+      compound=true;
+      graph [
+        rankdir="LR";
+      ]
+      rankdir="TB";
+
+      // node definitions
+      "REQ_1" [label=<<font point-size="12">Requirement</font><br align="left"/><b>Requirement one</b><br align="left"/><font point-size="10">REQ_1</font><br align="left"/>>, tooltip="REQ_1", href="<NODE_URL:REQ_1>", target="_top", shape="box3d"];
+      "REQ_2" [label=<<font point-size="12">Requirement</font><br align="left"/><b>Requirement two</b><br align="left"/><font point-size="10">REQ_2</font><br align="left"/>>, tooltip="REQ_2", href="<NODE_URL:REQ_2>", target="_top", shape="box3d"];
+
+      // edge definitions
+      "REQ_1" -> "REQ_2" [arrowhead=vee];
+      }
+    degradations:
+    - id: option-conflict-direction
+      tier: 3
+      once: false

--- a/tests/conformance/needflow/manifest.json
+++ b/tests/conformance/needflow/manifest.json
@@ -1,11 +1,29 @@
 {
-  "corpus_version": 1,
+  "corpus_version": 2,
   "readme": "98e1ebde016249b3dee7def42ff6de12912a530f77b5d65633a8490d2e0c5b5d",
   "cases": {
     "baseline-defaults.yaml": "4390170ffc2039bea4457893ad07af8d5e745fb9c1d11a6c15ffad2d6694d678",
+    "direction-config-default.yaml": "eb1f76c127fec30a22547075e7ea3537b67a967c8738dc9a99e881eccb35a0ef",
+    "direction-down.yaml": "b93d818f30b3148f1211e7de388210f68d81c5b6a5ad1d6710b8536b4613d883",
+    "direction-left.yaml": "e3adda3c1fc77c27836281fdd9a3cfad4e6bcc074cc361273f9391d5e5d0b054",
+    "direction-right.yaml": "3416e691613f858b04363aecbde050c74dc10e8a75740d4af859daaa2b7d6a70",
+    "direction-up.yaml": "5b3356aaab27dcddc74a867d70f78399549033f118f2bd3a0107435f9efdd378",
     "edge-empty-label.yaml": "7700590a537cfd0eeaf5d09b8cfca2629189e08c51a4b0ffb2c5e70c74fdeac4",
+    "legend-both.yaml": "997cd4d4e316b8e15a112098de842d768b526ba51534d9e28b5759f773fa4738",
+    "legend-config-default.yaml": "a15858428a8f89a0e39b475b920d95c2a6fc676ea451e71e6da65f4fd3d8c8a3",
     "legend-engine-default.yaml": "e9fd26952a1885c4cf29762370c517165649e5b0d708e0d53ed0f00c6a089c3a",
+    "legend-links.yaml": "e05f9c663dd5342ed2e79ea4c1b90accab1642efd221d706f54aa7381e9fe3c2",
+    "legend-option-beats-config.yaml": "399de65e68da88f484fb39443a6186a5151dc78a7a9b4ec16108ece98a3ddfc7",
+    "legend-order.yaml": "e312ef05c9b8fa5504f1c93cde46509deb442b3ae3884243ac6d4a0ea1d86c4a",
+    "legend-types.yaml": "3991702aed8bed93367cd1c98f577486fbb810b6bfe691969bbb996fa690ee3b",
+    "link-labels-config-default.yaml": "6f034fb6f0fbde52e2f74bd02315e2d4984b1afd0724d905d1d8c1669241a872",
+    "link-labels-incoming.yaml": "26599499d8b9029cd68fd61d1d225a423df6e10f3645168a956778dc6de908ea",
+    "link-labels-none.yaml": "84c9f3549698c56e2e86da9e9f021b9aa41c5b0c4bc379e7d18ecbd8b5f51986",
+    "link-labels-option-beats-config.yaml": "21cdc7f6fa325f5ab1ed9793a351ca53de2980c3717696b01fa7eb1b747511ee",
+    "link-labels-outgoing.yaml": "dd0122bb7aa3896470d7751e7f6d9d164db6c3984e36811734776d715f007787",
+    "link-labels-type.yaml": "c053eb59e6283462612be593441817308c3a51e7dc69130adffd25bb06ee62a8",
     "node-id-injectivity.yaml": "5fa3f6058c6acd5c60f741133d451eb917a26f4e32622bc0521eb6bb2854fbf6",
+    "option-conflict-direction.yaml": "7534bb58e3c45c2f5001bdb5fc018afc0f1a8b7a26f4be86e2b8c00bc098ca30",
     "percent-neutralisation.yaml": "f265c0123c31ef32f49ca229c06207f3c38aa285482485c59cbd4dc026124bf6"
   }
 }

--- a/tests/conformance/needflow/test_conformance.py
+++ b/tests/conformance/needflow/test_conformance.py
@@ -141,19 +141,37 @@ DEGRADATION_IDS = frozenset(
 # is refused rather than quietly built without it.
 
 #: Portable configuration keys, mapped to the ``conf.py`` name that carries the same
-#: intent.  Deliberately empty: none of the format's configuration keys has a
-#: Sphinx-Needs counterpart yet.  ``needs_flow_show_links`` is the near miss -- it is the
-#: project default behind ``link_labels`` -- but no shipped case sets a project default,
-#: and a mapping row no case exercises is a claim nothing checks.
-CONFIG_KEYS: dict[str, str] = {}
+#: intent.  The neutral names are the corpus's, not this repository's user-facing
+#: spelling: ``link_labels`` is what the corpus calls the label selector that
+#: Sphinx-Needs spells ``needs_flow_show_links``, the flag it widened.
+#:
+#: ``styles`` is absent -- there is no ``needs_flow_styles`` here yet.
+CONFIG_KEYS: dict[str, str] = {
+    "direction": "needs_flow_direction",
+    "show_legend": "needs_flow_show_legend",
+    "link_labels": "needs_flow_show_links",
+}
+
+#: The portable ``engine_config`` configuration, mapped per engine.
+#:
+#: It is not a row of :data:`CONFIG_KEYS` because it is *split* rather than renamed:
+#: Sphinx-Needs keeps the two engines' registries in two separate configuration values
+#: instead of under one engine-keyed roof, so a case naming this key only ever reaches
+#: the registry of the engine being drawn with.
+ENGINE_CONFIG_KEYS = {
+    "plantuml": "needs_flow_configs",
+    "graphviz": "needs_graphviz_styles",
+}
 
 #: Portable directive options, mapped to the Sphinx-Needs option of the same intent.
 #: The neutral names are the corpus's, not either repository's user-facing spelling:
 #: ``link_labels`` is what the corpus calls the label selector that both tools spell
-#: ``:show_link_names:``.
+#: ``:show_link_names:``, and ``engine_config`` the escape hatch spelled ``:config:``.
 OPTION_NAMES = {
+    "direction": "direction",
     "show_legend": "show_legend",
     "link_labels": "show_link_names",
+    "engine_config": "config",
 }
 
 #: Written after the option name to mean "emit it as a bare flag, with no value".
@@ -161,16 +179,30 @@ _BARE: str | None = None
 
 #: The portable *values* each mapped option accepts here, and how to write each one.
 #:
-#: Both options are still bare flags in this repository, so only the value that the bare
-#: flag already means is mapped: ``link_labels: outgoing`` (the flag labels an edge with
-#: its link type's outgoing title) and ``show_legend: ""`` (a legend was asked for
-#: without naming a configuration).  ``none``/``incoming``/``type``, and naming a legend
-#: configuration, arrive with the slices that widen the two options -- and this is the
-#: case that pins the bytes those slices have to preserve.
+#: A closed enumeration is listed exhaustively, so that a value this repository cannot
+#: express is refused rather than written through and silently ignored.
 OPTION_VALUES: dict[str, dict[str, str | None]] = {
-    "show_legend": {"": _BARE},
-    "link_labels": {"outgoing": _BARE},
+    "direction": {
+        "down": "down",
+        "up": "up",
+        "right": "right",
+        "left": "left",
+    },
+    "link_labels": {
+        "none": "none",
+        # the bare flag is what this value has always meant, and the merged
+        # `legend-engine-default`/`edge-empty-label` cases pin those bytes, so it is
+        # deliberately still written bare rather than spelled out
+        "outgoing": _BARE,
+        "incoming": "incoming",
+        "type": "type",
+    },
 }
+
+#: Mapped options whose value is a *name* rather than a member of an enumeration -- a
+#: legend key, an engine config name -- and so is written through verbatim.
+#: An empty value stays special: it means the option was written bare.
+OPTION_FREE_VALUES = frozenset(("show_legend", "engine_config"))
 
 #: Keys of a ``types`` entry this repository can put into ``needs_types``.  ``shape`` is
 #: absent: the portable shape enum has no counterpart here yet, only the legacy plantuml
@@ -182,15 +214,37 @@ TYPE_KEYS = frozenset(("directive", "title", "prefix", "color"))
 #: emitter reads it, so mapping it would let a case claim a colour that never renders.
 LINK_KEYS = frozenset(("option", "incoming", "outgoing"))
 
-#: The degradations of the registry this repository can observe, each mapped to its tier
-#: and to the warning it emits.
+#: The degradations of the registry this repository can observe, each mapped to its
+#: tier, to the Sphinx-Needs warning subtype it is reported under, and to a pattern
+#: matching the message.
 #:
-#: Empty, because every registry entry degrades an option this repository does not have
-#: yet: there is no ``:direction:`` to fall back from, no portable shape enum to leave
-#: unmapped, no style classes to miss.  So every warning a corpus build emits here is an
-#: unexpected one -- which is exactly the fence the shipped cases assert -- and the slice
-#: that adds an option adds its degradation row along with it.
-DEGRADATIONS: dict[str, tuple[int, re.Pattern[str]]] = {}
+#: The subtype is part of the mapping rather than assumed, because a warning that says
+#: the right thing under the wrong subtype cannot be suppressed by the documented
+#: ``suppress_warnings`` entry -- so the pair is the contract, not the message alone.
+#: Several ids here share one subtype, which is why the message is matched too.
+#: ubCode maps the same ids onto its own ``needs.option_*`` diagnostic codes.
+#:
+#: The rest of the registry degrades options this repository does not have yet -- no
+#: portable shape enum to leave unmapped, no style classes to miss -- so a warning
+#: matching none of these is an unexpected one, which is the fence the shipped cases
+#: assert.
+DEGRADATIONS: dict[str, tuple[int, str, re.Pattern[str]]] = {
+    "direction-vertical-unsupported": (
+        2,
+        "needs.needflow",
+        re.compile(r"cannot draw 'up'"),
+    ),
+    "direction-horizontal-unsupported": (
+        2,
+        "needs.needflow",
+        re.compile(r"cannot draw 'left'"),
+    ),
+    "option-conflict-direction": (
+        3,
+        "needs.needflow",
+        re.compile(r"disagrees with the direction"),
+    ),
+}
 
 #: Warnings that are not degradations and must not be counted as unexpected ones.
 #: Nothing in the corpus may use a deprecated spelling, so a deprecation notice here
@@ -198,10 +252,9 @@ DEGRADATIONS: dict[str, tuple[int, re.Pattern[str]]] = {}
 _IGNORED_WARNINGS = re.compile(r"WARNING: (?:document isn't included|.*toctree)")
 
 #: The class the corpus reserves for out-of-diagram legend markup, and so what
-#: :func:`_legend_rows` reads.  No engine here renders one today (both draw their legend
-#: inside the diagram, where ``source`` asserts it byte-exactly), so the reader finds
-#: nothing for every shipped case; the slice that adds an external legend upstream must
-#: use this class for the harness to see it.
+#: :func:`_legend_rows` reads.  Both engines here render one for a legend whose
+#: ``placement`` is ``external``, and draw their own inside the diagram otherwise --
+#: where ``source`` asserts it byte-exactly and this reader correctly finds nothing.
 _LEGEND_CLASS = "needflow_legend"
 
 
@@ -389,13 +442,10 @@ def _conf_py(case: dict[str, Any], engine: str, plantuml_command: str) -> str:
     :return: The ``conf.py`` source.
     :raises AssertionError: If the case names configuration with no surface here.
     """
-    if case.get("legends"):
-        raise AssertionError(
-            "legends: the corpus format lets a case name legend configurations, but "
-            "this repository has no configuration surface for them yet; the slice that "
-            "adds one wires them here"
-        )
-    _require_mapped(case.get("config") or {}, CONFIG_KEYS, "config")
+    config = dict(case.get("config") or {})
+    # split rather than renamed, so it is popped before the simple renames are checked
+    engine_config = config.pop("engine_config", None)
+    _require_mapped(config, CONFIG_KEYS, "config")
 
     types = case.get("types") or [
         {"directive": "req", "title": "Requirement", "prefix": "R_"}
@@ -420,7 +470,15 @@ def _conf_py(case: dict[str, Any], engine: str, plantuml_command: str) -> str:
     ]
     if links:
         lines.append(f"needs_links = {links!r}")
-    for key, value in (case.get("config") or {}).items():
+    if legends := case.get("legends"):
+        lines.append(f"needs_flow_legends = {legends!r}")
+    if engine_config is not None:
+        # only this engine's half of the registry, which is where the split shows: a
+        # case naming an engine config for one engine says nothing about the other
+        lines.append(
+            f"{ENGINE_CONFIG_KEYS[engine]} = {(engine_config.get(engine) or {})!r}"
+        )
+    for key, value in config.items():
         lines.append(f"{CONFIG_KEYS[key]} = {value!r}")
     return "\n".join(lines) + "\n"
 
@@ -448,13 +506,18 @@ def _index_rst(case: dict[str, Any]) -> str:
     lines.append("   :debug:")
     for key, value in (case.get("options") or {}).items():
         _require_mapped([key], OPTION_NAMES, "options")
-        accepted = OPTION_VALUES[key]
-        if value not in accepted:
-            raise AssertionError(
-                f"options: this repository cannot express {key}: {value!r} yet, "
-                f"only {sorted(accepted)}; the slice that widens the option maps it here"
-            )
-        written = accepted[value]
+        if key in OPTION_FREE_VALUES:
+            # a name rather than an enumeration member, so it is written through as it
+            # stands; an empty one means the option was written bare
+            written = str(value) or _BARE
+        else:
+            accepted = OPTION_VALUES[key]
+            if value not in accepted:
+                raise AssertionError(
+                    f"options: this repository cannot express {key}: {value!r} yet, only "
+                    f"{sorted(accepted)}; the slice that widens the option maps it here"
+                )
+            written = accepted[value]
         name = OPTION_NAMES[key]
         lines.append(f"   :{name}:" if written is _BARE else f"   :{name}: {written}")
     lines.append("")
@@ -606,8 +669,8 @@ def _classify_warnings(text: str) -> tuple[list[str], list[str]]:
     for line in strip_colors(text).splitlines():
         if not line.strip() or _IGNORED_WARNINGS.search(line):
             continue
-        for name, (_tier, pattern) in DEGRADATIONS.items():
-            if pattern.search(line):
+        for name, (_tier, subtype, pattern) in DEGRADATIONS.items():
+            if subtype in line and pattern.search(line):
                 observed.append(name)
                 break
         else:
@@ -744,7 +807,7 @@ def test_conformance_case(
         # recorded, never asserted: under regeneration the rendered legend IS the new
         # expectation, so checking it against the old one would only ever reject the
         # rewrite this run exists to produce
-        _rewrite_expectation(path, engine, source, _legend_rows(app))
+        _rewrite_expectation(path, engine, source, _legend_rows(app), observed)
         pytest.skip(f"{path.stem}: {engine} expectation rewritten")
 
     _compare_legend(_legend_rows(app), expected.get("legend"))
@@ -765,23 +828,40 @@ def _rewrite_expectation(
     engine: str,
     source: str,
     legend: dict[str, list[str]] | None,
+    observed: list[str],
 ) -> None:
     """Write a freshly emitted source back into a case file.
 
     Only ever reached under ``UBC_UPDATE_CORPUS``; the result is a diff to read, not an
-    expectation to accept.  Degradations are not written: none of the registry's entries
-    is observable in this repository yet (see :data:`DEGRADATIONS`), so there is nothing
-    to record, and the slice that adds the first one teaches this to record it.
+    expectation to accept.
+
+    The observed degradations are written too, and have to be: a regeneration that kept
+    only the source would silently *delete* the degradation entries of every case whose
+    point is a degradation, leaving them asserting the fallback source and nothing about
+    the warning that produced it.  ``tier`` comes from :data:`DEGRADATIONS` rather than
+    from the build, since a warning does not carry its own tier, and ``once`` from
+    whether the tier is 2 (warn once per project) -- both are properties of the registry
+    entry, so a regenerated case states them as the registry does.
 
     :param path: The case file.
     :param engine: The engine whose expectation to replace.
     :param source: The emitted source.
     :param legend: The external legend rows rendered, if any.
+    :param observed: The neutral degradation ids the build emitted.
     """
     case = yaml.safe_load(path.read_text("utf8"))
     entry: dict[str, Any] = {"source": source}
     if legend:
         entry["legend"] = legend
+    if observed:
+        entry["degradations"] = [
+            {
+                "id": name,
+                "tier": DEGRADATIONS[name][0],
+                "once": DEGRADATIONS[name][0] == 2,
+            }
+            for name in sorted(set(observed))
+        ]
     case.setdefault("expect", {})[engine] = entry
     # engines in a stable order, so that a re-sync diff is about content
     case["expect"] = {
@@ -971,12 +1051,8 @@ def test_validation_ignores_what_only_the_other_repository_can_draw() -> None:
     "case,fragment",
     [
         (
-            _probe(config={"direction": "up"}),
-            "config: the corpus format defines ['direction']",
-        ),
-        (
-            _probe(legends={"compact": {"parts": ["types"]}}),
-            "legends: the corpus format lets a case name legend configurations",
+            _probe(config={"styles": {"critical": {"fill": "#FF0000"}}}),
+            "config: the corpus format defines ['styles']",
         ),
         (
             _probe(types=[{"directive": "req", "shape": "rectangle"}]),
@@ -987,7 +1063,7 @@ def test_validation_ignores_what_only_the_other_repository_can_draw() -> None:
             "links entry: the corpus format defines ['arrow']",
         ),
     ],
-    ids=["config-key", "legend-config", "type-shape", "link-arrow"],
+    ids=["config-key", "type-shape", "link-arrow"],
 )
 def test_conf_py_refuses_configuration_with_no_surface_here(
     case: dict[str, Any], fragment: str
@@ -1004,23 +1080,49 @@ def test_conf_py_refuses_configuration_with_no_surface_here(
 @pytest.mark.parametrize(
     "options,fragment",
     [
-        ({"direction": "up"}, "options: the corpus format defines ['direction']"),
-        ({"link_labels": "incoming"}, "cannot express link_labels: 'incoming' yet"),
-        ({"show_legend": "compact"}, "cannot express show_legend: 'compact' yet"),
+        (
+            {"styles": "[type == 'req']:critical"},
+            "options: the corpus format defines ['styles']",
+        ),
+        ({"link_labels": "incomming"}, "cannot express link_labels: 'incomming' yet"),
+        ({"direction": "sideways"}, "cannot express direction: 'sideways' yet"),
     ],
-    ids=["unmapped-option", "unmapped-value", "unmapped-legend-key"],
+    ids=["unmapped-option", "misspelt-value", "unmapped-value"],
 )
 def test_index_rst_refuses_options_with_no_surface_here(
     options: dict[str, str], fragment: str
 ) -> None:
     """An option, or an option *value*, this repository cannot express must fail.
 
-    The value half matters as much as the name: both mapped options are still bare flags
-    here, so a case asking for ``link_labels: none`` would otherwise be built as the bare
-    flag -- which means the opposite.
+    The value half matters as much as the name.  For an option that is still a bare flag
+    a wrong value would be built as the flag -- which can mean the opposite -- and for an
+    enumerated one it would be written through to a directive that then reports it, so
+    the case would assert the fallback rather than what it asked for.  A value outside the
+    enumeration is refused here instead, whether it is a typo or a member only the other
+    tool has.
     """
     with pytest.raises(AssertionError, match=re.escape(fragment)):
         _index_rst(_probe(options=options))
+
+
+@pytest.mark.parametrize(
+    "options,written",
+    [
+        ({"show_legend": "compact"}, ":show_legend: compact"),
+        ({"engine_config": "corporate"}, ":config: corporate"),
+    ],
+    ids=["legend-key", "engine-config-name"],
+)
+def test_index_rst_writes_a_name_valued_option_verbatim(
+    options: dict[str, str], written: str
+) -> None:
+    """A legend key and an engine config name are names, not enumeration members.
+
+    Neither is a closed set -- a project calls its legends and its engine configs
+    whatever it likes -- so the value is written through as it stands, and there is no
+    table of accepted values to keep in step with every project's ``conf.py``.
+    """
+    assert written in _index_rst(_probe(options=options))
 
 
 def test_index_rst_writes_a_mapped_option_as_the_bare_flag() -> None:
@@ -1052,8 +1154,8 @@ def test_declared_degradations_must_be_observable_here() -> None:
 def test_a_warning_outside_the_registry_is_unexpected() -> None:
     """Every warning a build emits is either a mapped degradation or a failure.
 
-    With the registry empty here, the second is the only outcome -- which is what makes
-    the no-warning fence of the shipped cases a fence at all.
+    A warning that matches no registry entry is what makes the no-warning fence of the
+    shipped cases a fence at all: it cannot be absorbed as "some degradation".
     """
     observed, unexpected = _classify_warnings(
         "index.rst:4: WARNING: something happened [needs.needflow]\n"

--- a/tests/test_needflow.py
+++ b/tests/test_needflow.py
@@ -1452,3 +1452,246 @@ def test_normalisation_does_not_silence_a_genuinely_wrong_value(
     assert message in warnings
     # the author's own spelling is echoed, padding and all, so it can be found in conf.py
     assert repr(next(iter(override.values()))) in warnings
+
+
+LINK_LABELS_DOC = """\
+Link labels
+===========
+
+.. spec:: A
+   :id: AAAAA
+
+.. spec:: B
+   :id: BBBBB
+   :links: AAAAA
+
+.. needflow::
+   :show_link_names:{value}
+   :debug:
+"""
+
+
+@pytest.mark.parametrize(
+    "written,label",
+    [
+        ("", "links outgoing"),
+        (" outgoing", "links outgoing"),
+        (" incoming", "links incoming"),
+        (" type", "links"),
+        (" none", None),
+        # docutils' `choice` lowercases and strips, so these are the same values
+        (" Incoming ", "links incoming"),
+    ],
+    ids=["bare", "outgoing", "incoming", "type", "none", "padded"],
+)
+@pytest.mark.parametrize("engine", ["plantuml", "graphviz"])
+def test_show_link_names_takes_a_value(
+    make_app, tmp_path, plantuml_command, engine, written, label
+):
+    """Each accepted ``:show_link_names:`` value labels edges with what it names.
+
+    Written bare the option means ``outgoing``, which is exactly what the flag has
+    always drawn -- the option is widened rather than replaced, so no existing document
+    changes. ``none``, ``incoming`` and ``type`` are new: the flag could only ever say
+    "outgoing", and could not say "off" at all.
+    """
+    (tmp_path / "conf.py").write_text(CONF_PY, "utf8")
+    (tmp_path / "index.rst").write_text(LINK_LABELS_DOC.format(value=written), "utf8")
+
+    app = make_app(
+        srcdir=tmp_path,
+        buildername="html",
+        confoverrides={
+            "plantuml": plantuml_command,
+            "graphviz_output_format": "svg",
+            "needs_flow_engine": engine,
+        },
+    )
+    app.build()
+
+    assert strip_colors(app._warning.getvalue()).strip() == ""
+
+    source = _debug_source(Path(app.outdir), "index.html")
+    # only the edges are inspected: a graphviz *node* always carries an HTML label
+    edges = source.split(
+        "Connection definition" if engine == "plantuml" else "edge definitions"
+    )[-1]
+    if label is None:
+        # `none` must leave the edge bare, not label it with an empty string
+        assert ": " not in edges
+        assert "label=" not in edges
+    elif engine == "plantuml":
+        assert f": {label}\\n" in edges
+    else:
+        assert f'label="{label}"' in edges
+
+
+def test_unknown_show_link_names_value_is_rejected_as_it_is_parsed(
+    make_app, tmp_path, plantuml_command
+):
+    """``:show_link_names:`` is a closed enumeration once it takes a value."""
+    (tmp_path / "conf.py").write_text(CONF_PY, "utf8")
+    (tmp_path / "index.rst").write_text(
+        LINK_LABELS_DOC.format(value=" sideways"), "utf8"
+    )
+
+    app = make_app(
+        srcdir=tmp_path,
+        buildername="html",
+        confoverrides={"plantuml": plantuml_command},
+    )
+    app.build()  # must not raise
+
+    warnings = strip_colors(app._warning.getvalue())
+    assert '"sideways" unknown; choose from' in warnings
+    for accepted in ("none", "outgoing", "incoming", "type"):
+        assert f'"{accepted}"' in warnings
+
+
+@pytest.mark.parametrize(
+    "configured,label",
+    [
+        (True, "links outgoing"),
+        (False, None),
+        ("outgoing", "links outgoing"),
+        ("incoming", "links incoming"),
+        ("type", "links"),
+        ("none", None),
+        ("  Type  ", "links"),
+        # a value declared `bool` for years: a truthy non-boolean drew labels silently,
+        # so it still does rather than being held to the enumeration
+        (1, "links outgoing"),
+        (0, None),
+    ],
+    ids=[
+        "true",
+        "false",
+        "outgoing",
+        "incoming",
+        "type",
+        "none",
+        "padded",
+        "truthy-int",
+        "falsey-int",
+    ],
+)
+def test_needs_flow_show_links_accepts_a_value_or_a_boolean(
+    make_app, tmp_path, plantuml_command, configured, label
+):
+    """The project default takes a value, and keeps meaning what a boolean meant.
+
+    ``True`` is the ``outgoing`` it has always drawn and ``False`` is ``none``. Anything
+    that is neither a string nor a boolean is read for its truth, because that is what a
+    value declared ``bool`` for years actually did.
+    """
+    (tmp_path / "conf.py").write_text(CONF_PY, "utf8")
+    (tmp_path / "index.rst").write_text(
+        "Configured\n==========\n\n.. spec:: A\n   :id: AAAAA\n\n"
+        ".. spec:: B\n   :id: BBBBB\n   :links: AAAAA\n\n.. needflow::\n   :debug:\n",
+        "utf8",
+    )
+
+    app = make_app(
+        srcdir=tmp_path,
+        buildername="html",
+        confoverrides={
+            "plantuml": plantuml_command,
+            "needs_flow_show_links": configured,
+        },
+    )
+    app.build()
+
+    assert strip_colors(app._warning.getvalue()).strip() == ""
+
+    source = _debug_source(Path(app.outdir), "index.html")
+    if label is None:
+        assert ": " not in source.split("Connection definition")[-1]
+    else:
+        assert f": {label}\\n" in source
+
+
+def test_unusable_needs_flow_show_links_string_warns_and_falls_back(
+    make_app, tmp_path, plantuml_command
+):
+    """A *string* is someone naming a value, so it is held to the enumeration.
+
+    This is the one input whose behaviour changes: a non-enumerated string used to be
+    truthy and draw labels. It is reported where the configuration is read, once.
+    """
+    (tmp_path / "conf.py").write_text(CONF_PY, "utf8")
+    (tmp_path / "index.rst").write_text(NO_NEEDFLOW, "utf8")
+
+    app = make_app(
+        srcdir=tmp_path,
+        buildername="html",
+        confoverrides={
+            "plantuml": plantuml_command,
+            "needs_flow_show_links": "yes please",
+        },
+    )
+    app.build()  # must not raise
+
+    warnings = strip_colors(app._warning.getvalue())
+    assert "Invalid 'needs_flow_show_links' value 'yes please'" in warnings
+    assert "allowed values: none, outgoing, incoming, type" in warnings
+    assert "'none' is used" in warnings
+
+
+def test_show_link_names_option_beats_the_project_default(
+    make_app, tmp_path, plantuml_command
+):
+    """A diagram has the last word, which it could not have before.
+
+    The flag and the configuration used to be OR-ed, so a project that turned labels on
+    left no way of drawing one unlabelled diagram.
+    """
+    (tmp_path / "conf.py").write_text(CONF_PY, "utf8")
+    (tmp_path / "index.rst").write_text(LINK_LABELS_DOC.format(value=" none"), "utf8")
+
+    app = make_app(
+        srcdir=tmp_path,
+        buildername="html",
+        confoverrides={
+            "plantuml": plantuml_command,
+            "needs_flow_show_links": "outgoing",
+        },
+    )
+    app.build()
+
+    assert strip_colors(app._warning.getvalue()).strip() == ""
+    source = _debug_source(Path(app.outdir), "index.html")
+    assert "links outgoing" not in source
+
+
+@pytest.mark.parametrize("engine", ["plantuml", "graphviz"])
+def test_needgantt_and_needsequence_keep_their_bare_flag(
+    make_app, tmp_path, plantuml_command, engine
+):
+    """The widened option must not narrow the flag the other diagrams share.
+
+    ``show_link_names`` lives on the shared diagram data type, and needgantt and
+    needsequence still take it as a bare flag, so needflow's value lands beside it.
+    """
+    (tmp_path / "conf.py").write_text(CONF_PY, "utf8")
+    (tmp_path / "index.rst").write_text(
+        "Shared flag\n===========\n\n.. spec:: A\n   :id: AAAAA\n\n"
+        ".. spec:: B\n   :id: BBBBB\n   :links: AAAAA\n\n"
+        ".. needsequence::\n   :start: AAAAA\n   :show_link_names:\n\n"
+        ".. needgantt::\n   :show_link_names:\n",
+        "utf8",
+    )
+
+    app = make_app(
+        srcdir=tmp_path,
+        buildername="html",
+        confoverrides={
+            "plantuml": plantuml_command,
+            "graphviz_output_format": "svg",
+            "needs_flow_engine": engine,
+        },
+    )
+    app.build()  # must not raise
+
+    warnings = strip_colors(app._warning.getvalue())
+    assert "unknown option" not in warnings
+    assert "no arguments allowed" not in warnings

--- a/tests/test_needflow.py
+++ b/tests/test_needflow.py
@@ -1179,14 +1179,19 @@ Config direction
 
 
 @pytest.mark.parametrize(
-    "engine,config_name,emitted",
+    "engine,config_name,emitted,overridden",
     [
-        ("plantuml", "lefttoright", "top to bottom direction"),
-        ("graphviz", "lefttoright", 'rankdir="TB"'),
+        (
+            "plantuml",
+            "lefttoright",
+            "top to bottom direction",
+            "left to right direction",
+        ),
+        ("graphviz", "lefttoright", 'rankdir="TB"', 'rankdir="LR"'),
     ],
 )
 def test_explicit_direction_beats_the_engine_config(
-    make_app, tmp_path, plantuml_command, engine, config_name, emitted
+    make_app, tmp_path, plantuml_command, engine, config_name, emitted, overridden
 ):
     """An explicit ``:direction:`` must win over the config blob written beside it.
 
@@ -1194,6 +1199,12 @@ def test_explicit_direction_beats_the_engine_config(
     precedence both engines already give them -- but a *default* direction has to be
     restated to win, because emitting nothing would leave the blob's layout standing.
     The emitted source is asserted, so the test cannot pass on the warning alone.
+
+    *Where* it is restated is asserted too, because on both engines the later statement
+    is the one that takes effect: a ``rankdir`` written before the blob's ``graph [...]``
+    block -- which is where the shipped ``lefttoright`` config puts its own -- would be
+    emitted, matched by a containment check, and then overridden by the very blob it was
+    supposed to beat.
     """
     (tmp_path / "conf.py").write_text(CONF_PY, "utf8")
     (tmp_path / "index.rst").write_text(
@@ -1213,6 +1224,8 @@ def test_explicit_direction_beats_the_engine_config(
 
     source = _debug_source(Path(app.outdir), "index.html")
     assert emitted in source
+    # the option's statement must come after the blob's, or the blob wins at render time
+    assert source.index(emitted) > source.index(overridden)
 
     warnings = strip_colors(app._warning.getvalue())
     assert "disagrees with the direction 'down'" in warnings

--- a/tests/test_needflow.py
+++ b/tests/test_needflow.py
@@ -1695,3 +1695,564 @@ def test_needgantt_and_needsequence_keep_their_bare_flag(
     warnings = strip_colors(app._warning.getvalue())
     assert "unknown option" not in warnings
     assert "no arguments allowed" not in warnings
+
+
+LEGEND_CONF = (
+    CONF_PY
+    + """
+needs_types.append(
+    {
+        "directive": "undrawn",
+        "title": "Never Drawn",
+        "prefix": "U_",
+        "color": "#CCCCCC",
+        "style": "node",
+    }
+)
+needs_flow_legends = {
+    "inside": {"parts": ["types"]},
+    "beside": {"parts": ["types"], "placement": "external"},
+    "links": {"parts": ["links"], "placement": "external"},
+    "both": {"parts": ["types", "links"], "placement": "external"},
+    "reversed": {"parts": ["links", "types"], "placement": "external"},
+}
+"""
+)
+
+LEGEND_DOC = """\
+Legend
+======
+
+.. spec:: A
+   :id: AAAAA
+
+.. spec:: B
+   :id: BBBBB
+   :links: AAAAA
+
+.. needflow::
+   :show_legend:{value}
+   :debug:
+"""
+
+
+def _legend_sections(outdir: Path, file: str = "index.html") -> list[str]:
+    """The out-of-diagram legend sections rendered on a page, in document order.
+
+    :param outdir: The build output directory.
+    :param file: The page holding the needflow.
+    :return: The section name of each rendered legend table, in order.
+    """
+    tree = html_parser.parse(outdir / file)
+    tables = tree.xpath(
+        "//table[contains(concat(' ', normalize-space(@class), ' '),"
+        " ' needflow_legend_table ')]"
+    )
+    sections = []
+    for table in tables:
+        classes = str(table.get("class", "")).split()
+        for part in ("types", "links"):
+            if f"needflow_legend_{part}" in classes:
+                sections.append(part)
+    return sections
+
+
+def _legend_rows(outdir: Path, part: str, file: str = "index.html") -> list[str]:
+    """The label column of one rendered legend section.
+
+    :param outdir: The build output directory.
+    :param part: The section to read, ``types`` or ``links``.
+    :param file: The page holding the needflow.
+    :return: The label of each row, in order.
+    """
+    tree = html_parser.parse(outdir / file)
+    column = 2 if part == "types" else 1
+    tables = tree.xpath(
+        "//table[contains(concat(' ', normalize-space(@class), ' '),"
+        f" ' needflow_legend_{part} ')]"
+    )
+    assert len(tables) == 1, f"expected one {part!r} legend table, got {len(tables)}"
+    return [
+        cell.text_content().strip()
+        for cell in tables[0].xpath(f".//tbody/tr/td[{column}]")
+    ]
+
+
+def _build_legend(make_app, tmp_path, plantuml_command, engine, written, **overrides):
+    """Build the legend project with one ``:show_legend:`` spelling.
+
+    :param engine: The needflow engine to draw with.
+    :param written: What to write after ``:show_legend:``, empty for a bare option.
+    :param overrides: Extra configuration overrides.
+    :return: The built application.
+    """
+    (tmp_path / "conf.py").write_text(LEGEND_CONF, "utf8")
+    (tmp_path / "index.rst").write_text(LEGEND_DOC.format(value=written), "utf8")
+    app = make_app(
+        srcdir=tmp_path,
+        buildername="html",
+        confoverrides={
+            "plantuml": plantuml_command,
+            "graphviz_output_format": "svg",
+            "needs_flow_engine": engine,
+            **overrides,
+        },
+    )
+    app.build()
+    return app
+
+
+@pytest.mark.parametrize("engine", ["plantuml", "graphviz"])
+def test_bare_show_legend_still_draws_the_in_diagram_legend(
+    make_app, tmp_path, plantuml_command, engine
+):
+    """A bare ``:show_legend:`` must draw exactly the legend it always drew.
+
+    The option is widened to take a key, not replaced, so a document written before
+    keys existed keeps its in-image legend -- including the long-standing difference
+    that plantuml lists every configured type while graphviz lists only what it drew.
+    """
+    app = _build_legend(make_app, tmp_path, plantuml_command, engine, "")
+
+    assert strip_colors(app._warning.getvalue()).strip() == ""
+
+    source = _debug_source(Path(app.outdir), "index.html")
+    if engine == "plantuml":
+        assert "' Legend definition" in source
+        # every configured type, drawn or not
+        assert "Never Drawn" in source
+    else:
+        assert "<B>Legend</B>" in source
+        assert "Never Drawn" not in source
+
+    # and nothing beside the diagram
+    assert _legend_sections(Path(app.outdir)) == []
+
+
+@pytest.mark.parametrize("engine", ["plantuml", "graphviz"])
+def test_show_legend_key_selects_a_configured_legend(
+    make_app, tmp_path, plantuml_command, engine
+):
+    """A named legend renders the same table beside the diagram on either engine.
+
+    An external legend lists only what the diagram actually drew, which is the scope
+    rule the two in-image legends disagree about.
+    """
+    app = _build_legend(make_app, tmp_path, plantuml_command, engine, " beside")
+
+    assert strip_colors(app._warning.getvalue()).strip() == ""
+
+    outdir = Path(app.outdir)
+    assert _legend_sections(outdir) == ["types"]
+    assert _legend_rows(outdir, "types") == ["Specification"]
+
+    # the in-diagram legend is not drawn as well
+    source = _debug_source(outdir, "index.html")
+    assert "' Legend definition" not in source
+    assert "<B>Legend</B>" not in source
+
+
+@pytest.mark.parametrize("engine", ["plantuml", "graphviz"])
+def test_show_legend_can_describe_link_types(
+    make_app, tmp_path, plantuml_command, engine
+):
+    """A link legend describes the link types the diagram drew edges for.
+
+    No in-diagram legend here can do this, so a legend asking for links is always
+    drawn beside the diagram.
+    """
+    app = _build_legend(make_app, tmp_path, plantuml_command, engine, " links")
+
+    assert strip_colors(app._warning.getvalue()).strip() == ""
+
+    outdir = Path(app.outdir)
+    assert _legend_sections(outdir) == ["links"]
+    assert _legend_rows(outdir, "links") == ["links"]
+
+
+@pytest.mark.parametrize("engine", ["plantuml", "graphviz"])
+@pytest.mark.parametrize(
+    "key,expected",
+    [(" both", ["types", "links"]), (" reversed", ["links", "types"])],
+    ids=["both", "reversed"],
+)
+def test_legend_sections_keep_their_configured_order(
+    make_app, tmp_path, plantuml_command, engine, key, expected
+):
+    """``parts`` is an ordered list, and the order is contract.
+
+    A reader scanning two diagrams should find the same section in the same place, so
+    ``["links", "types"]`` puts links first and keeps it there. A tool treating ``parts``
+    as a set, or as an enum with a fixed section order, renders these the same way round
+    and fails one of the two.
+    """
+    app = _build_legend(make_app, tmp_path, plantuml_command, engine, key)
+
+    assert strip_colors(app._warning.getvalue()).strip() == ""
+    assert _legend_sections(Path(app.outdir)) == expected
+
+
+@pytest.mark.parametrize("engine", ["plantuml", "graphviz"])
+def test_internal_placement_that_cannot_be_honoured_degrades_silently(
+    make_app, tmp_path, plantuml_command, engine
+):
+    """A legend asking for links inside the diagram gets the table instead, silently.
+
+    Neither in-image legend here can describe link types, so the preference cannot be
+    met; the two legends carry identical information and differ only in where they sit,
+    so the substitution is decorative rather than an intent gone unhonoured.
+    """
+    (tmp_path / "conf.py").write_text(
+        LEGEND_CONF
+        + '\nneeds_flow_legends["inside"] = {"parts": ["types", "links"]}\n',
+        "utf8",
+    )
+    (tmp_path / "index.rst").write_text(LEGEND_DOC.format(value=" inside"), "utf8")
+    app = make_app(
+        srcdir=tmp_path,
+        buildername="html",
+        confoverrides={
+            "plantuml": plantuml_command,
+            "graphviz_output_format": "svg",
+            "needs_flow_engine": engine,
+        },
+    )
+    app.build()
+
+    assert strip_colors(app._warning.getvalue()).strip() == ""
+    assert _legend_sections(Path(app.outdir)) == ["types", "links"]
+
+
+def test_needs_flow_show_legend_supplies_the_key(make_app, tmp_path, plantuml_command):
+    """``needs_flow_show_legend`` says *which* legend a bare option gets."""
+    app = _build_legend(
+        make_app,
+        tmp_path,
+        plantuml_command,
+        "plantuml",
+        "",
+        needs_flow_show_legend="beside",
+    )
+
+    assert strip_colors(app._warning.getvalue()).strip() == ""
+    assert _legend_sections(Path(app.outdir)) == ["types"]
+
+
+def test_needs_flow_show_legend_never_says_whether(
+    make_app, tmp_path, plantuml_command
+):
+    """A project default cannot give a legend to a diagram that never asked for one.
+
+    Whether there is a legend stays with the directive; the configuration only ever
+    says which one. There is deliberately no project-wide way of putting a legend on
+    every diagram -- a legend describes one picture.
+    """
+    (tmp_path / "conf.py").write_text(LEGEND_CONF, "utf8")
+    (tmp_path / "index.rst").write_text(
+        "No legend\n=========\n\n.. spec:: A\n   :id: AAAAA\n\n.. needflow::\n   :debug:\n",
+        "utf8",
+    )
+    app = make_app(
+        srcdir=tmp_path,
+        buildername="html",
+        confoverrides={
+            "plantuml": plantuml_command,
+            "needs_flow_show_legend": "beside",
+        },
+    )
+    app.build()
+
+    assert strip_colors(app._warning.getvalue()).strip() == ""
+    assert _legend_sections(Path(app.outdir)) == []
+    assert "' Legend definition" not in _debug_source(Path(app.outdir), "index.html")
+
+
+def test_option_key_beats_the_project_key(make_app, tmp_path, plantuml_command):
+    """The directive's own key wins over ``needs_flow_show_legend``."""
+    app = _build_legend(
+        make_app,
+        tmp_path,
+        plantuml_command,
+        "plantuml",
+        " reversed",
+        needs_flow_show_legend="beside",
+    )
+
+    assert strip_colors(app._warning.getvalue()).strip() == ""
+    assert _legend_sections(Path(app.outdir)) == ["links", "types"]
+
+
+def test_unknown_option_key_warns_and_hands_on_to_the_project_key(
+    make_app, tmp_path, plantuml_command
+):
+    """An unknown option key is treated as unset, so the chain continues.
+
+    A key that names nothing warns and then behaves as though it had not been written,
+    which is the rule the rest of this vocabulary follows. A typo in one directive must
+    not silently cost the project the legend it configured.
+    """
+    app = _build_legend(
+        make_app,
+        tmp_path,
+        plantuml_command,
+        "plantuml",
+        " besidee",
+        needs_flow_show_legend="reversed",
+    )
+
+    warnings = strip_colors(app._warning.getvalue())
+    assert "legend key 'besidee' is not defined in 'needs_flow_legends'" in warnings
+    assert "available: beside, both, inside, links, reversed" in warnings
+    # ...and the project's own legend is still drawn
+    assert _legend_sections(Path(app.outdir)) == ["links", "types"]
+
+
+def test_unknown_option_key_falls_back_to_the_engine_legend(
+    make_app, tmp_path, plantuml_command
+):
+    """With nothing configured either, the chain ends at the engine's own legend."""
+    app = _build_legend(make_app, tmp_path, plantuml_command, "plantuml", " besidee")
+
+    warnings = strip_colors(app._warning.getvalue())
+    assert "legend key 'besidee' is not defined in 'needs_flow_legends'" in warnings
+    assert _legend_sections(Path(app.outdir)) == []
+    assert "' Legend definition" in _debug_source(Path(app.outdir), "index.html")
+
+
+def test_unknown_option_key_is_reported_per_directive(
+    make_app, tmp_path, plantuml_command
+):
+    """An option key is the directive's own text, so it is reported every time.
+
+    The author can act on each one, and two diagrams with the same typo are two
+    mistakes to fix.
+    """
+    (tmp_path / "conf.py").write_text(LEGEND_CONF, "utf8")
+    (tmp_path / "index.rst").write_text(
+        "Two typos\n=========\n\n.. spec:: A\n   :id: AAAAA\n\n"
+        ".. needflow::\n   :show_legend: besidee\n\n"
+        ".. needflow::\n   :show_legend: besidee\n",
+        "utf8",
+    )
+    app = make_app(
+        srcdir=tmp_path,
+        buildername="html",
+        confoverrides={"plantuml": plantuml_command},
+    )
+    app.build()
+
+    warnings = strip_colors(app._warning.getvalue())
+    assert warnings.count("legend key 'besidee' is not defined") == 2
+    # reported against the directives, under the needflow subtype
+    assert warnings.count("needs.needflow") == 2
+
+
+def test_unknown_project_key_is_reported_once_for_the_project(
+    make_app, tmp_path, plantuml_command
+):
+    """An unknown ``needs_flow_show_legend`` is one ``conf.py`` mistake, said once.
+
+    Repeating it at every needflow would bury the directive-level warnings an author
+    can act on, and reporting it against whichever ``index.rst`` line was drawn first
+    would point at the wrong file altogether.
+    """
+    (tmp_path / "conf.py").write_text(LEGEND_CONF, "utf8")
+    (tmp_path / "index.rst").write_text(
+        "Two diagrams\n============\n\n.. spec:: A\n   :id: AAAAA\n\n"
+        ".. needflow::\n   :show_legend:\n\n.. needflow::\n   :show_legend:\n",
+        "utf8",
+    )
+    app = make_app(
+        srcdir=tmp_path,
+        buildername="html",
+        confoverrides={
+            "plantuml": plantuml_command,
+            "needs_flow_show_legend": "besidee",
+        },
+    )
+    app.build()
+
+    warnings = strip_colors(app._warning.getvalue())
+    # said once, although two needflows asked for a legend
+    assert warnings.count("legend key 'besidee'") == 1
+    assert "of 'needs_flow_show_legend'" in warnings
+    # a conf.py problem, so no directive location and the config subtype
+    assert "needs.config" in warnings
+    assert "index.rst" not in warnings
+
+
+@pytest.mark.parametrize(
+    "legends,message",
+    [
+        ({"bad": {"parts": 5}}, "'parts' of legend 'bad' must be a list"),
+        ({"bad": {"parts": "both"}}, "'parts' of legend 'bad' must be a list"),
+        ({"bad": {"parts": ["sideways"]}}, "unknown legend section 'sideways'"),
+        ({"bad": {"placement": "nearby"}}, "unknown placement 'nearby'"),
+        ({"bad": {"nonsense": 1}}, "unknown key(s) ['nonsense'] of legend 'bad'"),
+        ({"bad": "types"}, "legend 'bad' in 'needs_flow_legends' must be a mapping"),
+        ({" bad ": {}}, "can never be selected"),
+        ({"": {}}, "can never be selected"),
+    ],
+    ids=[
+        "parts-int",
+        "parts-string",
+        "unknown-section",
+        "unknown-placement",
+        "unknown-key",
+        "not-a-mapping",
+        "padded-name",
+        "empty-name",
+    ],
+)
+def test_unusable_legend_config_warns_and_never_crashes(
+    make_app, tmp_path, plantuml_command, legends, message
+):
+    """A malformed ``needs_flow_legends`` entry is reported, and the build finishes.
+
+    ``parts: 5`` is not the hypothetical it looks like: a number is not iterable and
+    ended a build with a traceback, and a bare string iterates character by character,
+    warning about single letters and then drawing the default legend anyway.
+    """
+    (tmp_path / "conf.py").write_text(CONF_PY, "utf8")
+    (tmp_path / "index.rst").write_text(LEGEND_DOC.format(value=" bad"), "utf8")
+    app = make_app(
+        srcdir=tmp_path,
+        buildername="html",
+        confoverrides={
+            "plantuml": plantuml_command,
+            "needs_flow_legends": legends,
+        },
+    )
+    app.build()  # must not raise
+
+    assert message in strip_colors(app._warning.getvalue())
+
+
+def test_unusable_legend_config_is_reported_without_any_needflow(
+    make_app, tmp_path, plantuml_command
+):
+    """The legend configuration is checked where it is read, not where it is used."""
+    (tmp_path / "conf.py").write_text(CONF_PY, "utf8")
+    (tmp_path / "index.rst").write_text(NO_NEEDFLOW, "utf8")
+    app = make_app(
+        srcdir=tmp_path,
+        buildername="html",
+        confoverrides={
+            "plantuml": plantuml_command,
+            "needs_flow_legends": {"bad": {"parts": 5}},
+            "needs_flow_show_legend": "nowhere",
+        },
+    )
+    app.build()  # must not raise
+
+    warnings = strip_colors(app._warning.getvalue())
+    assert "'parts' of legend 'bad' must be a list" in warnings
+    assert "legend key 'nowhere' of 'needs_flow_show_legend'" in warnings
+
+
+@pytest.mark.parametrize(
+    "project_key,quoted",
+    [(5, "'5'"), (None, "'None'"), (True, "'True'")],
+    ids=["int", "none", "bool"],
+)
+def test_non_string_show_legend_key_is_reported_not_crashed(
+    make_app, tmp_path, plantuml_command, project_key, quoted
+):
+    """A non-string ``needs_flow_show_legend`` must warn, not end the build.
+
+    Its ``types: (str,)`` metadata makes Sphinx warn about the wrong type and then hand
+    the raw value through, so one line of ``conf.py`` reached ``str.strip`` on an ``int``
+    and killed the build with a traceback -- the very outcome the read-time validation
+    exists to prevent, and which every sibling key already guards against.
+
+    This is the read-time path, exercised with **no needflow anywhere**: the value is
+    coerced, fails the key lookup, and is reported as any other unknown name would be.
+    """
+    (tmp_path / "conf.py").write_text(CONF_PY, "utf8")
+    (tmp_path / "index.rst").write_text(NO_NEEDFLOW, "utf8")
+    app = make_app(
+        srcdir=tmp_path,
+        buildername="html",
+        confoverrides={
+            "plantuml": plantuml_command,
+            "needs_flow_show_legend": project_key,
+        },
+    )
+    app.build()  # must not raise
+
+    warnings = strip_colors(app._warning.getvalue())
+    assert f"legend key {quoted} of 'needs_flow_show_legend' is not defined" in warnings
+
+
+@pytest.mark.parametrize(
+    "project_key,quoted",
+    [(5, "'5'"), (None, "'None'"), (True, "'True'")],
+    ids=["int", "none", "bool"],
+)
+def test_non_string_show_legend_key_still_resolves_the_chain(
+    make_app, tmp_path, plantuml_command, project_key, quoted
+):
+    """The same value must not crash the *per-diagram* resolution either.
+
+    The read-time check and the chain each read this value, so guarding only the first
+    would move the crash to build time rather than remove it. Two needflows ask for a
+    legend without naming one, so the chain reaches the project key both times: it is
+    coerced, names nothing, and hands on to the engine's own legend -- which is drawn.
+
+    The warning is emitted once for the build, not once per diagram: the read-time site
+    and the chain produce the *same* text, which is what lets Sphinx's ``once`` filter
+    collapse them onto the one without a directive location.
+    """
+    (tmp_path / "conf.py").write_text(CONF_PY, "utf8")
+    (tmp_path / "index.rst").write_text(
+        "Two diagrams\n============\n\n.. spec:: A\n   :id: AAAAA\n\n"
+        ".. needflow::\n   :show_legend:\n   :debug:\n\n"
+        ".. needflow::\n   :show_legend:\n   :debug:\n",
+        "utf8",
+    )
+    app = make_app(
+        srcdir=tmp_path,
+        buildername="html",
+        confoverrides={
+            "plantuml": plantuml_command,
+            "needs_flow_show_legend": project_key,
+        },
+    )
+    app.build()  # must not raise
+
+    warnings = strip_colors(app._warning.getvalue())
+    assert f"legend key {quoted} of 'needs_flow_show_legend' is not defined" in warnings
+    # said once for the project, although two needflows consulted it
+    assert warnings.count(f"legend key {quoted}") == 1
+    # a conf.py problem, so no directive location
+    assert "index.rst" not in warnings
+
+    # the chain handed on rather than being replaced: the engine drew its own legend
+    outdir = Path(app.outdir)
+    assert "' Legend definition" in _debug_source(outdir, "index.html")
+    assert _legend_sections(outdir) == []
+
+
+def test_a_legend_beside_a_plantuml_figure_keeps_the_directive_classes(
+    make_app, tmp_path, plantuml_command
+):
+    """``:class:`` reaches the plantuml figure, which is where the option says it goes.
+
+    The option was collected and then dropped by this engine, so the same option styled
+    a graphviz diagram and did nothing to a plantuml one.
+    """
+    (tmp_path / "conf.py").write_text(LEGEND_CONF, "utf8")
+    (tmp_path / "index.rst").write_text(
+        "Classes\n=======\n\n.. spec:: A\n   :id: AAAAA\n\n"
+        ".. needflow::\n   :class: my-flow\n   :show_legend: beside\n",
+        "utf8",
+    )
+    app = make_app(
+        srcdir=tmp_path,
+        buildername="html",
+        confoverrides={"plantuml": plantuml_command},
+    )
+    app.build()
+
+    html = Path(app.outdir, "index.html").read_text()
+    assert "my-flow" in html

--- a/tests/test_needflow.py
+++ b/tests/test_needflow.py
@@ -995,3 +995,460 @@ def test_merging_configs_does_not_leak_into_the_next_diagram(test_app):
 
     assert 'rankdir="LR"' in plain
     assert 'bgcolor="transparent"' not in plain
+
+
+DIRECTION_DOC = """\
+Direction
+=========
+
+.. spec:: A
+   :id: AAAAA
+
+.. spec:: B
+   :id: BBBBB
+   :links: AAAAA
+
+.. needflow::
+   :direction: {value}
+   :debug:
+"""
+
+
+@pytest.mark.parametrize(
+    "value,plantuml_statement,rankdir",
+    [
+        ("down", None, None),
+        ("tb", None, None),
+        ("td", None, None),
+        ("right", "left to right direction", "LR"),
+        ("lr", "left to right direction", "LR"),
+        # PlantUML degrades `up` to its axis mate `down`, which is how it already draws,
+        # so the degraded diagram emits nothing at all -- byte-identical to the default
+        ("up", None, "BT"),
+        ("bt", None, "BT"),
+        ("left", "left to right direction", "RL"),
+        ("rl", "left to right direction", "RL"),
+    ],
+)
+@pytest.mark.parametrize("engine", ["plantuml", "graphviz"])
+def test_direction_option_per_engine(
+    make_app,
+    tmp_path,
+    plantuml_command,
+    engine,
+    value,
+    plantuml_statement,
+    rankdir,
+):
+    """Every accepted ``:direction:`` spelling reaches both engines.
+
+    PlantUML has only ``top to bottom direction`` and ``left to right direction``, so a
+    reversed direction is drawn by its axis mate; Graphviz draws all four with
+    ``rankdir``. ``down`` and its aliases must emit *nothing at all*, because a diagram
+    already drawn that way must keep the source it had before the option existed.
+    """
+    (tmp_path / "conf.py").write_text(CONF_PY, "utf8")
+    (tmp_path / "index.rst").write_text(DIRECTION_DOC.format(value=value), "utf8")
+
+    app = make_app(
+        srcdir=tmp_path,
+        buildername="html",
+        confoverrides={
+            "plantuml": plantuml_command,
+            "graphviz_output_format": "svg",
+            "needs_flow_engine": engine,
+        },
+    )
+    app.build()
+
+    source = _debug_source(Path(app.outdir), "index.html")
+    if engine == "plantuml":
+        assert ("' Direction" in source) is (plantuml_statement is not None)
+        if plantuml_statement is not None:
+            assert plantuml_statement in source
+    else:
+        assert ("rankdir=" in source) is (rankdir is not None)
+        if rankdir is not None:
+            assert f'rankdir="{rankdir}"' in source
+
+
+@pytest.mark.parametrize(
+    "value,warned",
+    [("up", "'up'"), ("bt", "'up'"), ("left", "'left'"), ("rl", "'left'")],
+)
+def test_plantuml_reports_the_direction_it_cannot_draw(
+    make_app, tmp_path, plantuml_command, value, warned
+):
+    """A direction PlantUML has no primitive for degrades with one warning per project.
+
+    ``bottom to top direction`` and ``right to left direction`` are syntax errors for
+    PlantUML (probed against 1.2020.02), so the axis mate is drawn instead. That is a
+    named intent going unhonoured rather than a decorative substitution, so it is
+    reported -- but once for the whole project, not once per diagram.
+    """
+    (tmp_path / "conf.py").write_text(CONF_PY, "utf8")
+    (tmp_path / "index.rst").write_text(
+        DIRECTION_DOC.format(value=value)
+        + f"\n.. needflow::\n   :direction: {value}\n",
+        "utf8",
+    )
+
+    app = make_app(
+        srcdir=tmp_path,
+        buildername="html",
+        confoverrides={"plantuml": plantuml_command},
+    )
+    app.build()
+
+    warnings = strip_colors(app._warning.getvalue())
+    assert f"the plantuml engine cannot draw {warned}" in warnings
+    # two diagrams ask for it, and the project is told once
+    assert warnings.count("the plantuml engine cannot draw") == 1
+
+
+def test_graphviz_draws_every_direction_without_warning(
+    make_app, tmp_path, plantuml_command
+):
+    """Graphviz supports all four directions, so none of them may warn.
+
+    The companion of the PlantUML degradation test: a tier-2 warning that fired on an
+    engine which *can* draw the direction would be noise, and would make an author
+    change a diagram that was already right.
+    """
+    document = "Directions\n==========\n\n.. spec:: A\n   :id: AAAAA\n\n"
+    for value in ("down", "up", "right", "left"):
+        document += f".. needflow::\n   :direction: {value}\n\n"
+    (tmp_path / "conf.py").write_text(CONF_PY, "utf8")
+    (tmp_path / "index.rst").write_text(document, "utf8")
+
+    app = make_app(
+        srcdir=tmp_path,
+        buildername="html",
+        confoverrides={
+            "plantuml": plantuml_command,
+            "graphviz_output_format": "svg",
+            "needs_flow_engine": "graphviz",
+        },
+    )
+    app.build()
+
+    assert strip_colors(app._warning.getvalue()).strip() == ""
+
+
+def test_unknown_direction_is_rejected_as_the_option_is_parsed(
+    make_app, tmp_path, plantuml_command
+):
+    """``:direction:`` is a closed enumeration, so docutils reports a bad value.
+
+    A layout nobody can draw is a mistake in the document rather than a degradation, and
+    docutils already reports it against the directive with the accepted values listed.
+    """
+    (tmp_path / "conf.py").write_text(CONF_PY, "utf8")
+    (tmp_path / "index.rst").write_text(DIRECTION_DOC.format(value="sideways"), "utf8")
+
+    app = make_app(
+        srcdir=tmp_path,
+        buildername="html",
+        confoverrides={"plantuml": plantuml_command},
+    )
+    app.build()  # must not raise
+
+    warnings = strip_colors(app._warning.getvalue())
+    # docutils' own `choice` message, which lists what the option accepts
+    assert '"sideways" unknown; choose from' in warnings
+    for accepted in ("down", "up", "right", "left", "tb", "td", "bt", "lr", "rl"):
+        assert f'"{accepted}"' in warnings
+
+
+CONFIG_DIRECTION_DOC = """\
+Config direction
+================
+
+.. spec:: A
+   :id: AAAAA
+
+.. spec:: B
+   :id: BBBBB
+   :links: AAAAA
+
+.. needflow::
+   :config: {config}
+   :direction: {value}
+   :debug:
+"""
+
+
+@pytest.mark.parametrize(
+    "engine,config_name,emitted",
+    [
+        ("plantuml", "lefttoright", "top to bottom direction"),
+        ("graphviz", "lefttoright", 'rankdir="TB"'),
+    ],
+)
+def test_explicit_direction_beats_the_engine_config(
+    make_app, tmp_path, plantuml_command, engine, config_name, emitted
+):
+    """An explicit ``:direction:`` must win over the config blob written beside it.
+
+    The blob is a preamble of defaults and the option a per-element value, which is the
+    precedence both engines already give them -- but a *default* direction has to be
+    restated to win, because emitting nothing would leave the blob's layout standing.
+    The emitted source is asserted, so the test cannot pass on the warning alone.
+    """
+    (tmp_path / "conf.py").write_text(CONF_PY, "utf8")
+    (tmp_path / "index.rst").write_text(
+        CONFIG_DIRECTION_DOC.format(config=config_name, value="down"), "utf8"
+    )
+
+    app = make_app(
+        srcdir=tmp_path,
+        buildername="html",
+        confoverrides={
+            "plantuml": plantuml_command,
+            "graphviz_output_format": "svg",
+            "needs_flow_engine": engine,
+        },
+    )
+    app.build()
+
+    source = _debug_source(Path(app.outdir), "index.html")
+    assert emitted in source
+
+    warnings = strip_colors(app._warning.getvalue())
+    assert "disagrees with the direction 'down'" in warnings
+
+
+@pytest.mark.parametrize("engine", ["plantuml", "graphviz"])
+def test_agreeing_engine_config_does_not_warn_or_restate(
+    make_app, tmp_path, plantuml_command, engine
+):
+    """A config blob that already draws the asked-for direction is left alone.
+
+    Nothing disagrees, so nothing is reported; and the direction is already in force, so
+    restating it would move the bytes of a diagram whose author changed nothing.
+    """
+    (tmp_path / "conf.py").write_text(CONF_PY, "utf8")
+    (tmp_path / "index.rst").write_text(
+        CONFIG_DIRECTION_DOC.format(config="lefttoright", value="right"), "utf8"
+    )
+
+    app = make_app(
+        srcdir=tmp_path,
+        buildername="html",
+        confoverrides={
+            "plantuml": plantuml_command,
+            "graphviz_output_format": "svg",
+            "needs_flow_engine": engine,
+        },
+    )
+    app.build()
+
+    assert strip_colors(app._warning.getvalue()).strip() == ""
+
+    source = _debug_source(Path(app.outdir), "index.html")
+    if engine == "plantuml":
+        assert "' Direction" not in source
+        assert source.count("left to right direction") == 1
+    else:
+        # the blob's own `rankdir` stands, and no second one is written after it
+        assert source.count("rankdir=") == 1
+
+
+def test_project_direction_default_applies_without_the_option(
+    make_app, tmp_path, plantuml_command
+):
+    """``needs_flow_direction`` is the default a diagram without the option gets."""
+    (tmp_path / "conf.py").write_text(CONF_PY, "utf8")
+    (tmp_path / "index.rst").write_text(
+        "Default\n=======\n\n.. spec:: A\n   :id: AAAAA\n\n.. needflow::\n   :debug:\n",
+        "utf8",
+    )
+
+    app = make_app(
+        srcdir=tmp_path,
+        buildername="html",
+        confoverrides={
+            "plantuml": plantuml_command,
+            "needs_flow_direction": "right",
+        },
+    )
+    app.build()
+
+    assert strip_colors(app._warning.getvalue()).strip() == ""
+    assert "left to right direction" in _debug_source(Path(app.outdir), "index.html")
+
+
+def test_option_beats_the_project_direction_default(
+    make_app, tmp_path, plantuml_command
+):
+    """A diagram always has the last word over ``needs_flow_direction``."""
+    (tmp_path / "conf.py").write_text(CONF_PY, "utf8")
+    (tmp_path / "index.rst").write_text(DIRECTION_DOC.format(value="down"), "utf8")
+
+    app = make_app(
+        srcdir=tmp_path,
+        buildername="html",
+        confoverrides={
+            "plantuml": plantuml_command,
+            "needs_flow_direction": "right",
+        },
+    )
+    app.build()
+
+    assert strip_colors(app._warning.getvalue()).strip() == ""
+    source = _debug_source(Path(app.outdir), "index.html")
+    assert "left to right direction" not in source
+    assert "' Direction" not in source
+
+
+NO_NEEDFLOW = """\
+No needflow at all
+==================
+
+.. spec:: A
+   :id: AAAAA
+"""
+
+
+def test_bad_flow_config_is_reported_without_any_needflow(
+    make_app, tmp_path, plantuml_command
+):
+    """An unusable ``needs_flow_*`` value is reported where the configuration is read.
+
+    Checking these as a diagram is drawn means a project that misconfigures one and
+    happens to have no needflow anywhere is never told about it -- and then gets a
+    different diagram the day somebody adds one.
+    """
+    (tmp_path / "conf.py").write_text(CONF_PY, "utf8")
+    (tmp_path / "index.rst").write_text(NO_NEEDFLOW, "utf8")
+
+    app = make_app(
+        srcdir=tmp_path,
+        buildername="html",
+        confoverrides={
+            "plantuml": plantuml_command,
+            "needs_flow_direction": "sideways",
+        },
+    )
+    app.build()  # must not raise
+
+    warnings = strip_colors(app._warning.getvalue())
+    assert "Invalid 'needs_flow_direction' value 'sideways'" in warnings
+    assert "allowed values: down, up, right, left" in warnings
+
+
+def test_bad_flow_config_is_reported_once_not_once_per_diagram(
+    make_app, tmp_path, plantuml_command
+):
+    """The read-time report is the only one, however many diagrams the project draws.
+
+    The resolution falls back through the same validator, with the same message, so
+    Sphinx's ``once`` filter collapses the two -- and the surviving warning is the one
+    without a directive location, because a ``conf.py`` mistake must not be reported
+    against whichever ``index.rst`` line happened to be drawn first.
+    """
+    document = "Two diagrams\n============\n\n.. spec:: A\n   :id: AAAAA\n\n"
+    document += ".. needflow::\n\n.. needflow::\n"
+    (tmp_path / "conf.py").write_text(CONF_PY, "utf8")
+    (tmp_path / "index.rst").write_text(document, "utf8")
+
+    app = make_app(
+        srcdir=tmp_path,
+        buildername="html",
+        confoverrides={
+            "plantuml": plantuml_command,
+            "needs_flow_direction": "sideways",
+        },
+    )
+    app.build()
+
+    warnings = strip_colors(app._warning.getvalue())
+    assert warnings.count("Invalid 'needs_flow_direction' value") == 1
+    # reported against the project, not against a line of the document
+    assert "index.rst" not in warnings
+
+
+NORMALISED_CONFIG = """\
+Config value normalisation
+==========================
+
+.. spec:: A
+   :id: AAAAA
+
+.. spec:: B
+   :id: BBBBB
+   :links: AAAAA
+
+.. needflow::
+   :debug:
+"""
+
+
+@pytest.mark.parametrize(
+    "override,needle",
+    [
+        ({"needs_flow_direction": "  RIGHT  "}, "left to right direction"),
+        ({"needs_flow_engine": "  GraphViz  "}, "digraph needflow"),
+    ],
+    ids=["direction", "engine"],
+)
+def test_enum_config_values_ignore_case_and_padding(
+    make_app, tmp_path, plantuml_command, override, needle
+):
+    """A configured enum value is matched the way the matching option value is.
+
+    The directive options go through docutils' ``choice``, which lowercases and strips
+    before matching, so ``:engine: PlantUML`` has always been accepted. The configuration
+    side matched exactly, so the same word in ``conf.py`` warned and fell back --
+    silently drawing something else.
+    """
+    (tmp_path / "conf.py").write_text(CONF_PY, "utf8")
+    (tmp_path / "index.rst").write_text(NORMALISED_CONFIG, "utf8")
+
+    app = make_app(
+        srcdir=tmp_path,
+        buildername="html",
+        confoverrides={
+            "plantuml": plantuml_command,
+            "graphviz_output_format": "svg",
+            **override,
+        },
+    )
+    app.build()
+
+    # the value is usable, so nothing is reported and nothing falls back
+    assert strip_colors(app._warning.getvalue()).strip() == ""
+    assert needle in _debug_source(Path(app.outdir), "index.html")
+
+
+@pytest.mark.parametrize(
+    "override,message",
+    [
+        ({"needs_flow_direction": "  sideways  "}, "Invalid 'needs_flow_direction'"),
+        ({"needs_flow_engine": "  crayon  "}, "unknown 'needs_flow_engine'"),
+    ],
+    ids=["direction", "engine"],
+)
+def test_normalisation_does_not_silence_a_genuinely_wrong_value(
+    make_app, tmp_path, plantuml_command, override, message
+):
+    """Tolerating case and padding must not turn a wrong value into a silent fallback.
+
+    The point of normalising is to accept what the author plainly meant, not to accept
+    anything -- so a value that is wrong after normalisation is still reported, and the
+    message quotes what was actually written.
+    """
+    (tmp_path / "conf.py").write_text(CONF_PY, "utf8")
+    (tmp_path / "index.rst").write_text(NORMALISED_CONFIG, "utf8")
+
+    app = make_app(
+        srcdir=tmp_path,
+        buildername="html",
+        confoverrides={"plantuml": plantuml_command, **override},
+    )
+    app.build()  # must not raise
+
+    warnings = strip_colors(app._warning.getvalue())
+    assert message in warnings
+    # the author's own spelling is echoed, padding and all, so it can be found in conf.py
+    assert repr(next(iter(override.values()))) in warnings


### PR DESCRIPTION
Third slice of the #1770 split (after #1780 and #1781): the presentation options.
It gives `needflow` an engine-neutral way to say which way the graph flows, what the edges are
labelled with, and what the legend contains — additive only, **zero deprecations**: two existing
options are widened rather than replaced, so the spellings in existing documents keep working
and keep producing the same bytes.

## Options

- **`:direction:`** (new) — `down` (default) / `up` / `right` / `left`, plus the `TB`/`TD`/`BT`/`LR`/`RL`
  two-letter forms Graphviz and Mermaid users already know, with a `needs_flow_direction` project
  default. An explicit option beats an engine-config(`:config:`)-derived direction on both engines,
  and disagreement warns. PlantUML has no bottom-to-top or right-to-left primitive (probed: both are
  syntax errors), so those degrade to their axis mate with a single warning per project.
- **`:show_link_names:` widened** — the flag now takes an optional value `none` / `outgoing` /
  `incoming` / `type`, and written bare still means exactly what it always meant (`outgoing`),
  byte-for-byte. `needs_flow_show_links` likewise accepts a string as well as a boolean
  (`True` ≡ `outgoing`, `False` ≡ `none`). The old OR of flag and config becomes a precedence —
  only an unset option consults the config — which fixes the interaction that made
  "project default on, this one diagram off" impossible to express.
- **`:show_legend:` widened** — it now takes the *name* of a legend defined in
  `needs_flow_legends`, or nothing. Deliberately key-only: an inline value set would collide with
  user-chosen names and need a precedence rule. Written bare it renders today's in-diagram legend,
  byte-for-byte.

## Config

`needs_flow_legends = {name: {...}}` defines legends — `parts`, an **ordered list** of the
sections to draw (`types`, `links`; a list only, and order is rendered as listed), and `placement`
(`internal` / `external`), a preference: unset takes the engine's own default placement, which is
internal for both engines here. A legend that includes `links` renders as a table beside the
diagram, since neither engine can draw link rows inside it.

`needs_flow_show_legend` names the legend a diagram gets when it asks for one without naming its
own; it selects *which*, never *whether* — presence stays per-directive, so there is no off-switch
value for a legend name to collide with.

An undefined key resolves as a **chain** — the directive's key, else the project's, else the
engine default — warning at each undefined step and handing on, because an unusable value is
treated as unset everywhere in this vocabulary. The two steps warn at different tiers: a bad
directive key per directive (`needs.needflow`), a bad `needs_flow_show_legend` once per project
(`needs.config`, no directive location — it is a `conf.py` mistake). All four new configs are
validated as they are read, so a project that misconfigures one and happens to have no needflow
is still told; the checks warn and fall back, never crash (including non-string values, `parts: 5`,
and `parts: "links"`). Enumerated config values are matched the way the option parsers already
match theirs — case-insensitively, ignoring surrounding whitespace — and `needs_flow_engine`'s
membership check from #1780 gets the same treatment.

## Nothing moves for existing projects — with one named edge

Verified by cross-commit diff of the generated diagram source on both engines (a five-needflow
probe using only pre-existing spellings, and a ten-shape matrix over every reachable
`show_link_names` shape), and independently reproduced in review: projects using only existing
spellings produce byte-identical output. No test fixture changed:
`git diff master -- tests/doc_test/` is empty, `.rst` and `conf.py` alike. The five conformance
cases merged in #1781 — including the bare-`:show_legend:` and bare-`:show_link_names:` parity
targets — pass **unregenerated**, with unchanged checksums.

The one edge, and why the changelog has a Breaking section: `needs_flow_show_links` set to a
**string** was never a supported spelling (the config was declared `bool`, and Sphinx already
warned about the type) but drew labels via truthiness. It is now read as a value: an unrecognised
string warns and draws no labels, and `'none'` — the sharpest case — now silently means what its
author meant instead of the opposite. Non-string truthiness (`1`, `0`) is deliberately preserved.

## Environment version

`ENV_DATA_VERSION` goes 6 → 7: the directive persists the resolved options in doctrees, and an
older reader over a newer doctree fails on the missing keys (reproduced by rebuilding across the
change and watching it raise, then fixed by the bump). No other open PR claims 7.

## Conformance corpus

`corpus_version` 1 → 2, 5 → 23 cases: direction (one per value, including the two PlantUML
degradations and the option-vs-engine-config conflict), the four link-label values plus
config-driven and option-beats-config cases, and six legend cases (explicit keys, order pinning,
the chain). Fifteen case files are byte-identical to the reviewed umbrella branch and pass here
unregenerated — a cross-check of this carve rather than a snapshot of it. The degradation mapping
table gains its first three live rows (tier + subtype + pattern), regeneration now records
degradation entries, and the per-engine `expect.<engine>.legend` key is exercised for the first
time by the external-placement cases. Regeneration is idempotent (verified over two full runs).

## Tests and review

Every behaviour was recorded failing before its implementation landed, and seven targeted
mutations each turn a test red — one of them (an option-beating-`:config:` assertion satisfiable
by a `rankdir` emitted in the wrong place) was caught by the byte-exact corpus case and now has a
dedicated ordering fence. The adversarial review reproduced the byte-preservation, the matrix, the
tier split, and the ENV crash independently, and found one real defect — a non-string
`needs_flow_show_legend` crashed the build — which is fixed at both affected sites with red-first
tests for both paths. Full suite: 1637 passed; the 47 remaining failures/errors are pre-existing
environmental ones, byte-identical to master's set. Docs build warning-count and warning-set
identical to master.

## Follow-ups (later slices of the #1770 split)

- Slice 4: link and type styling (`needs_links[].line/part_line/color/part_color/arrow`,
  `needs_types[].shape`) with the first deprecations.
- Slice 5: `:styles:` + `needs_flow_styles`, `:engine_config:`, the remaining deprecations, and
  moving the engine membership check into `validate_flow_config` (review measured today's #1780
  behaviour reporting a `conf.py` engine mistake against a directive location, and staying silent
  when no needflow exists — inherited there deliberately).