### PR TITLE
👌 Resolve variant data while the configuration is initialised

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,25 +15,31 @@ Improvements
 ............
 
 - 👌 :ref:`needs_variant_data` is resolved while the configuration is being initialised
+  (:issue:`1783`)
 
   The :ref:`needs_variant_data_file` is loaded, and the inline
   :ref:`needs_variant_data` merged on top of it, during ``config-inited`` instead of
   when document reading starts. What is merged, and which value wins — inline over
   file, ``sphinx-build -D`` over :ref:`needs_from_toml` — is unchanged, as are the
   errors reported for a file that is missing or does not contain valid variant data.
-  Only the point in the build at which the work happens has moved.
+  Only the point in the build at which the work happens has moved. The full-rebuild
+  fix this also brings is described under Bug fixes below.
 
-  Two things follow for a project that loads variant data from a file. Such a file now
-  fails the build during configuration, before any document is read, rather than once
-  reading has begun. And an unchanged file is finally recognised as unchanged: the
-  merged map is now in place before Sphinx compares this build's configuration with the
-  last one, so a project stops re-reading every document on every build. Editing the
-  file's contents still re-reads them, which is what the :ref:`variant role
-  <role_variant>` previously advised a clean build for.
+  A file that cannot be used now fails the build during configuration, before any
+  document is read, rather than once reading has begun.
 
   An extension that handles ``config-inited`` after Sphinx-Needs can now read the merged
   map, which matters because configuration deciding which documents exist at all — such
   as ``exclude_patterns`` — can only be changed while that event is running.
+
+  In return, an extension that *writes* :ref:`needs_variant_data` from its own
+  ``config-inited`` handler no longer has the file merged into what it wrote, and no
+  longer has it validated: resolution has already happened by then, so the value is
+  taken as it stands. It is used consistently — the :ref:`variant role <role_variant>`
+  and ``var.*`` filter expressions always read the same map — but if you write the
+  configuration this way and rely on the merge or the validation, set
+  :ref:`needs_variant_data` in ``conf.py``, in :ref:`needs_from_toml`, or with
+  ``sphinx-build -D`` instead.
 
 - ✨ New :ref:`needflow` ``:direction:`` option and :ref:`needs_flow_direction`
   configuration (:pr:`1782`)
@@ -267,6 +273,23 @@ These changes do not affect user-facing behaviour:
 
 Bug fixes
 .........
+
+- 🐛 Fix :ref:`needs_variant_data_file` triggering full rebuilds (:issue:`1783`)
+
+  The merged variant data was written back onto the configuration after Sphinx's
+  ``config-inited`` checkpoint, so the pickled configuration held the merged map while
+  the next build compared it against the unmerged one — a difference Sphinx read as a
+  changed ``env`` value, re-reading every document on every incremental build. The
+  merge now happens before that checkpoint, so an unchanged file is recognised as
+  unchanged and nothing is re-read.
+
+  Editing the file's *contents* is now what triggers the rebuild, because the merged
+  map is part of the configuration being compared. The :ref:`variant role
+  <role_variant>` previously advised a clean build (``sphinx-build -E``) to pick such an
+  edit up; that advice is gone, along with the need for it.
+
+  Projects that set :ref:`needs_variant_data` inline only were never affected and are
+  unchanged.
 
 - 🐛 :ref:`needs_string_links` no longer makes a field value disappear when its template fails
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,27 @@ Unreleased
 Improvements
 ............
 
+- 👌 :ref:`needs_variant_data` is resolved while the configuration is being initialised
+
+  The :ref:`needs_variant_data_file` is loaded, and the inline
+  :ref:`needs_variant_data` merged on top of it, during ``config-inited`` instead of
+  when document reading starts. What is merged, and which value wins — inline over
+  file, ``sphinx-build -D`` over :ref:`needs_from_toml` — is unchanged, as are the
+  errors reported for a file that is missing or does not contain valid variant data.
+  Only the point in the build at which the work happens has moved.
+
+  Two things follow for a project that loads variant data from a file. Such a file now
+  fails the build during configuration, before any document is read, rather than once
+  reading has begun. And an unchanged file is finally recognised as unchanged: the
+  merged map is now in place before Sphinx compares this build's configuration with the
+  last one, so a project stops re-reading every document on every build. Editing the
+  file's contents still re-reads them, which is what the :ref:`variant role
+  <role_variant>` previously advised a clean build for.
+
+  An extension that handles ``config-inited`` after Sphinx-Needs can now read the merged
+  map, which matters because configuration deciding which documents exist at all — such
+  as ``exclude_patterns`` — can only be changed while that event is running.
+
 - ✨ New :ref:`needflow` ``:direction:`` option and :ref:`needs_flow_direction`
   configuration (:pr:`1782`)
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,7 +15,7 @@ Improvements
 ............
 
 - 👌 :ref:`needs_variant_data` is resolved while the configuration is being initialised
-  (:issue:`1783`)
+  (:issue:`1783`, :pr:`1787`)
 
   The :ref:`needs_variant_data_file` is loaded, and the inline
   :ref:`needs_variant_data` merged on top of it, during ``config-inited`` instead of
@@ -274,7 +274,7 @@ These changes do not affect user-facing behaviour:
 Bug fixes
 .........
 
-- 🐛 Fix :ref:`needs_variant_data_file` triggering full rebuilds (:issue:`1783`)
+- 🐛 Fix :ref:`needs_variant_data_file` triggering full rebuilds (:issue:`1783`, :pr:`1787`)
 
   The merged variant data was written back onto the configuration after Sphinx's
   ``config-inited`` checkpoint, so the pickled configuration held the merged map while

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -650,7 +650,7 @@ The file is read once per build, during configuration initialisation, so a missi
 or one whose contents are not valid variant data fails the build before any document is
 read. The merged result becomes the value of :ref:`needs_variant_data`, which means it is
 also what Sphinx compares between builds: editing the file changes the configuration and
-re-reads the affected documents, while leaving it alone no longer does.
+re-reads every document, while leaving it alone no longer does.
 
 Configuration example:
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -634,6 +634,10 @@ needs_variant_data_file
 
 .. versionadded:: 8.2.0
 
+.. versionchanged:: 8.4.0
+   The file is loaded while the configuration is being initialised, rather than
+   once document reading starts.
+
 Path to a JSON file containing variant data. The file is loaded and its contents
 are made available under the ``var`` namespace, just like :ref:`needs_variant_data`.
 
@@ -641,6 +645,12 @@ If both ``needs_variant_data_file`` and ``needs_variant_data`` are set, the file
 and the inline dictionary is deep-merged on top (inline values win on conflict).
 
 The path is resolved relative to the Sphinx ``confdir`` (the directory containing ``conf.py``).
+
+The file is read once per build, during configuration initialisation, so a missing file
+or one whose contents are not valid variant data fails the build before any document is
+read. The merged result becomes the value of :ref:`needs_variant_data`, which means it is
+also what Sphinx compares between builds: editing the file changes the configuration and
+re-reads the affected documents, while leaving it alone no longer does.
 
 Configuration example:
 

--- a/docs/roles.rst
+++ b/docs/roles.rst
@@ -269,6 +269,6 @@ warning and produces empty text.
 
     The value is resolved at parse time and baked into the document. Changing
     :ref:`needs_variant_data` triggers a full rebuild so the resolved values
-    stay current. Editing the *contents* of a :ref:`needs_variant_data_file`
-    without changing its path is not tracked as a build dependency, so run a
-    clean build (``sphinx-build -E``) in that case.
+    stay current, and so does editing the *contents* of a
+    :ref:`needs_variant_data_file` without changing its path, because the merged
+    data is part of the configuration that is compared between builds.

--- a/sphinx_needs/needs.py
+++ b/sphinx_needs/needs.py
@@ -145,7 +145,11 @@ from sphinx_needs.schema.process import process_schemas
 from sphinx_needs.services.github import GithubService
 from sphinx_needs.string_links import compile_string_links
 from sphinx_needs.utils import node_match
-from sphinx_needs.variant_data import VariantDataError, resolve_variant_data
+from sphinx_needs.variant_data import (
+    VariantDataError,
+    VariantDataProxy,
+    resolve_variant_data,
+)
 from sphinx_needs.warnings import process_warnings
 
 if sys.version_info >= (3, 11):
@@ -325,6 +329,10 @@ def setup(app: Sphinx) -> dict[str, Any]:
     ########################################################################
     # Make connections to events
     app.connect("config-inited", load_config_from_toml, priority=10)  # runs early
+    # runs directly after the toml config is loaded, which can set the variant data,
+    # and before anything that may want to read the merged map,
+    # up to and including configuration that decides which documents are read
+    app.connect("config-inited", resolve_variant_data_config, priority=11)
     app.connect("config-inited", load_config)
     app.connect("config-inited", merge_default_configs)
     # runs after the built-in layouts are merged in, and before the config is checked
@@ -682,27 +690,42 @@ def visitor_dummy(*_args: Any, **_kwargs: Any) -> None:
     pass
 
 
-def _resolve_variant_data_config(config: NeedsSphinxConfig, confdir: str) -> None:
+def resolve_variant_data_config(app: Sphinx, config: Config) -> None:
     """Resolve variant data from file + inline config, validate, and store back.
 
-    After this call, ``config.variant_data`` contains the fully merged result.
+    This runs during ``config-inited``, so that the merged map is available to
+    everything that follows, including configuration that decides which documents
+    are read at all (``exclude_patterns``), which can only be changed at that point.
+
+    After this call, ``needs_variant_data`` holds the fully merged result and
+    ``needs_variant_data_proxy`` the matching ``var`` proxy for filter expressions.
+
+    :param app: The Sphinx application.
+    :param config: The Sphinx configuration.
+    :raises NeedsConfigException: If the variant data file cannot be loaded,
+        or the variant data is invalid.
     """
-    if not config.variant_data and not config.variant_data_file:
-        return
+    needs_config = NeedsSphinxConfig(config)
 
-    # Resolve relative file paths against the Sphinx confdir
-    file_path = config.variant_data_file
-    if file_path and not Path(file_path).is_absolute():
-        file_path = str(Path(confdir) / file_path)
+    if needs_config.variant_data or needs_config.variant_data_file:
+        # Resolve relative file paths against the Sphinx confdir
+        file_path = needs_config.variant_data_file
+        if file_path and not Path(file_path).is_absolute():
+            file_path = str(Path(app.confdir) / file_path)
 
-    try:
-        resolved = resolve_variant_data(config.variant_data, file_path)
-    except VariantDataError as e:
-        from sphinx_needs.exceptions import NeedsConfigException
+        try:
+            resolved = resolve_variant_data(needs_config.variant_data, file_path)
+        except VariantDataError as e:
+            raise NeedsConfigException(str(e)) from e
+        # Store the resolved result back so downstream code sees the merged dict
+        needs_config.variant_data = resolved
 
-        raise NeedsConfigException(str(e)) from e
-    # Store the resolved result back so downstream code sees the merged dict
-    config.variant_data = resolved
+    # Cache the variant data proxy for use in filter expressions
+    needs_config.variant_data_proxy = (
+        VariantDataProxy(needs_config.variant_data)
+        if needs_config.variant_data
+        else None
+    )
 
 
 def prepare_env(app: Sphinx, env: BuildEnvironment, _docnames: list[str]) -> None:
@@ -711,17 +734,6 @@ def prepare_env(app: Sphinx, env: BuildEnvironment, _docnames: list[str]) -> Non
     """
     needs_config = NeedsSphinxConfig(app.config)
     data = SphinxNeedsData(env)
-
-    # Resolve variant data (load file + merge + validate) once for the build
-    _resolve_variant_data_config(needs_config, str(app.confdir))
-
-    # Cache the variant data proxy for use in filter expressions
-    if needs_config.variant_data:
-        from sphinx_needs.variant_data import VariantDataProxy
-
-        needs_config.variant_data_proxy = VariantDataProxy(needs_config.variant_data)
-    else:
-        needs_config.variant_data_proxy = None
 
     # Register embedded services
     services = data.get_or_create_services()

--- a/sphinx_needs/needs.py
+++ b/sphinx_needs/needs.py
@@ -690,6 +690,20 @@ def visitor_dummy(*_args: Any, **_kwargs: Any) -> None:
     pass
 
 
+def _derive_variant_data_proxy(config: NeedsSphinxConfig) -> None:
+    """Derive the ``var`` proxy from the variant data map as it currently stands.
+
+    This is a derivation, not a resolution: no file is read, nothing is merged and
+    nothing is validated. It exists so that the map and the proxy built from it can
+    never drift apart, whichever build phase last wrote the map.
+
+    :param config: The Sphinx-Needs configuration.
+    """
+    config.variant_data_proxy = (
+        VariantDataProxy(config.variant_data) if config.variant_data else None
+    )
+
+
 def resolve_variant_data_config(app: Sphinx, config: Config) -> None:
     """Resolve variant data from file + inline config, validate, and store back.
 
@@ -721,11 +735,7 @@ def resolve_variant_data_config(app: Sphinx, config: Config) -> None:
         needs_config.variant_data = resolved
 
     # Cache the variant data proxy for use in filter expressions
-    needs_config.variant_data_proxy = (
-        VariantDataProxy(needs_config.variant_data)
-        if needs_config.variant_data
-        else None
-    )
+    _derive_variant_data_proxy(needs_config)
 
 
 def prepare_env(app: Sphinx, env: BuildEnvironment, _docnames: list[str]) -> None:
@@ -734,6 +744,13 @@ def prepare_env(app: Sphinx, env: BuildEnvironment, _docnames: list[str]) -> Non
     """
     needs_config = NeedsSphinxConfig(app.config)
     data = SphinxNeedsData(env)
+
+    # The map may have been written after it was resolved, e.g. by another extension's
+    # ``config-inited`` handler. Such a value is used as-is (it is not merged with the
+    # file, nor validated), but the ``variant`` role reads the map while filter
+    # expressions read the proxy, so the proxy is derived again here to keep the two
+    # read paths from disagreeing within one build.
+    _derive_variant_data_proxy(needs_config)
 
     # Register embedded services
     services = data.get_or_create_services()

--- a/tests/doc_test/doc_variant_data_config_inited/conf.py
+++ b/tests/doc_test/doc_variant_data_config_inited/conf.py
@@ -1,0 +1,35 @@
+"""Project checking that variant data is resolved during ``config-inited``.
+
+The ``config-inited`` handler registered below runs at the default priority, so it
+records the variant data as any later handler of that event would see it, which is
+the fully merged map only if Sphinx-Needs has already resolved it by then.
+"""
+
+from copy import deepcopy
+
+extensions = ["sphinx_needs"]
+
+needs_types = [
+    {
+        "directive": "req",
+        "title": "Requirement",
+        "prefix": "REQ_",
+        "color": "#BFD8D2",
+        "style": "node",
+    },
+]
+
+# File provides: {"env": "production", "build": {"debug": true, "opt_level": 1}}
+needs_variant_data_file = "variant_data.json"
+
+# Inline overrides a single nested leaf; its siblings must survive the merge
+needs_variant_data = {"build": {"opt_level": 3}}
+
+
+def _record_variant_data(app, config):
+    """Record the variant data seen by a later ``config-inited`` handler."""
+    app.variant_data_at_config_inited = deepcopy(config.needs_variant_data)
+
+
+def setup(app):
+    app.connect("config-inited", _record_variant_data)

--- a/tests/doc_test/doc_variant_data_config_inited/index.rst
+++ b/tests/doc_test/doc_variant_data_config_inited/index.rst
@@ -1,0 +1,14 @@
+Variant Data Config Inited
+==========================
+
+.. req:: Optimised requirement
+   :id: REQ_OPT
+
+Built for :variant:`env` at optimisation level :variant:`build.opt_level`.
+
+Sibling keys survive the nested merge
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. needtable:: Debug Needs
+   :filter: var.build.debug == True
+   :style: table

--- a/tests/doc_test/doc_variant_data_config_inited/variant_data.json
+++ b/tests/doc_test/doc_variant_data_config_inited/variant_data.json
@@ -1,0 +1,7 @@
+{
+  "env": "production",
+  "build": {
+    "debug": true,
+    "opt_level": 1
+  }
+}

--- a/tests/doc_test/doc_variant_data_extension_write/conf.py
+++ b/tests/doc_test/doc_variant_data_extension_write/conf.py
@@ -1,0 +1,33 @@
+"""Project where an extension writes the variant data after it has been resolved.
+
+The ``config-inited`` handler registered below runs at the default priority, so it
+writes the map after Sphinx-Needs has resolved it, and its value is therefore neither
+merged with the file nor validated. What the build must not do is read two different
+maps: the ``variant`` role and ``var.*`` filter expressions have to agree on whatever
+value ends up in the configuration.
+"""
+
+extensions = ["sphinx_needs"]
+
+needs_types = [
+    {
+        "directive": "req",
+        "title": "Requirement",
+        "prefix": "REQ_",
+        "color": "#BFD8D2",
+        "style": "node",
+    },
+]
+
+# File provides: {"env": "production"}
+needs_variant_data_file = "variant_data.json"
+
+
+def _overwrite_variant_data(_app, config):
+    """Overwrite the resolved map, as a third-party extension could."""
+    config.needs_variant_data = {"env": "from_extension"}
+
+
+def setup(app):
+    # default priority (500), so this runs after Sphinx-Needs' resolution
+    app.connect("config-inited", _overwrite_variant_data)

--- a/tests/doc_test/doc_variant_data_extension_write/index.rst
+++ b/tests/doc_test/doc_variant_data_extension_write/index.rst
@@ -1,0 +1,14 @@
+Variant Data Extension Write
+============================
+
+.. req:: A requirement
+   :id: REQ_EXT
+
+Role renders: :variant:`env`
+
+The two counts below must agree with the role: the value the role renders is the one
+a ``var.*`` filter expression has to match.
+
+Extension value: :need_count:`var.env == "from_extension"`
+
+File value: :need_count:`var.env == "production"`

--- a/tests/doc_test/doc_variant_data_extension_write/variant_data.json
+++ b/tests/doc_test/doc_variant_data_extension_write/variant_data.json
@@ -1,0 +1,3 @@
+{
+  "env": "production"
+}

--- a/tests/test_variant_data_integration.py
+++ b/tests/test_variant_data_integration.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 
 import json
 import os
+import textwrap
 from pathlib import Path
 
 import pytest
 from sphinx.util.console import strip_colors
 from syrupy.extensions.json import JSONSnapshotExtension
+
+from sphinx_needs.exceptions import NeedsConfigException
 
 
 @pytest.mark.parametrize(
@@ -148,3 +151,149 @@ def test_variant_data_field_errors_html(test_app, snapshot_json):
 
     data = json.loads(Path(app.outdir, "needs.json").read_text())
     assert data["versions"][""]["needs"] == snapshot_json
+
+
+@pytest.mark.parametrize(
+    "test_app",
+    [
+        {
+            "buildername": "html",
+            "srcdir": "doc_test/doc_variant_data_config_inited",
+            "no_plantuml": True,
+        }
+    ],
+    indirect=True,
+)
+def test_variant_data_resolved_at_config_inited(test_app):
+    """The merged variant data must exist while ``config-inited`` is still running.
+
+    Configuration that decides which documents exist at all -- ``exclude_patterns``
+    above all -- can only be changed during ``config-inited``, so the merged map has
+    to be available to handlers of that event. The ``test_app`` fixture has created
+    the application, and so emitted ``config-inited``, but has not built it, hence
+    nothing from the read phase can have contributed to what is asserted here.
+    """
+    app = test_app
+
+    merged = {"env": "production", "build": {"debug": True, "opt_level": 3}}
+
+    # recorded by a default-priority ``config-inited`` handler in the project's conf.py
+    assert app.variant_data_at_config_inited == merged
+    # ... and stored back onto the config, before any document has been read
+    assert app.config.needs_variant_data == merged
+    assert app.config.needs_variant_data_proxy is not None
+
+
+@pytest.mark.parametrize(
+    "test_app",
+    [
+        {
+            "buildername": "html",
+            "srcdir": "doc_test/doc_variant_data_config_inited",
+            "no_plantuml": True,
+        }
+    ],
+    indirect=True,
+)
+def test_variant_data_nested_inline_overrides_file(test_app):
+    """Inline variant data deep-merges over the file: the leaf wins, siblings survive."""
+    app = test_app
+    app.build()
+
+    warnings = strip_colors(
+        app._warning.getvalue().replace(str(app.srcdir) + os.sep, "srcdir/")
+    ).splitlines()
+    assert warnings == []
+
+    index_html = Path(app.outdir, "index.html").read_text()
+
+    # "env" comes from the file, the nested "opt_level" from the inline override
+    assert "Built for production at optimisation level 3." in index_html
+    # the inline override of "build.opt_level" must not drop its sibling "build.debug",
+    # which this needtable filters on
+    assert "Debug Needs" in index_html
+    assert "REQ_OPT" in index_html
+
+
+@pytest.mark.parametrize(
+    ("file_content", "message", "names_file"),
+    [
+        pytest.param(None, "Variant data file not found", True, id="missing"),
+        pytest.param("{not json", "Invalid JSON in", True, id="malformed"),
+        # the two shape errors below are raised by the validator, which has never
+        # been told which file the data came from
+        pytest.param(
+            '["not", "an", "object"]', "must contain a JSON object", False, id="list"
+        ),
+        pytest.param(
+            '{"x": null}', "expected str/bool/int/float", False, id="bad_value"
+        ),
+    ],
+)
+def test_variant_data_file_errors_fail_the_build(
+    tmpdir, make_app, write_fixture_files, file_content, message, names_file
+):
+    """A missing or malformed variant data file fails the build, naming the file.
+
+    Only the phase in which this is reported changed; the exception type -- and so
+    the severity -- and the message are unchanged, which is what is pinned here by
+    wrapping both the application creation and the build.
+    """
+    write_fixture_files(
+        tmpdir,
+        {
+            "conf": textwrap.dedent("""\
+                extensions = ["sphinx_needs"]
+                needs_variant_data_file = "variant_data.json"
+                """),
+            "rst": "Title\n=====\n",
+        },
+    )
+    if file_content is not None:
+        Path(str(tmpdir), "variant_data.json").write_text(
+            file_content, encoding="utf-8"
+        )
+
+    with pytest.raises(NeedsConfigException) as excinfo:
+        app = make_app(srcdir=Path(str(tmpdir)), freshenv=True)
+        app.build()
+
+    assert message in str(excinfo.value)
+    assert ("variant_data.json" in str(excinfo.value)) is names_file
+
+
+def test_variant_data_file_confoverride_wins_over_toml(
+    tmpdir, make_app, write_fixture_files
+):
+    """``-D needs_variant_data_file=...`` still beats the value read from TOML."""
+    write_fixture_files(
+        tmpdir,
+        {
+            "conf": textwrap.dedent("""\
+                extensions = ["sphinx_needs"]
+                needs_from_toml = "ubproject.toml"
+                """),
+            "ubproject": textwrap.dedent("""\
+                [needs]
+                variant_data_file = "from_toml.json"
+                """),
+            "rst": "Title\n=====\n\nSource: :variant:`source`\n",
+        },
+    )
+    srcdir = Path(str(tmpdir))
+    (srcdir / "from_toml.json").write_text(
+        json.dumps({"source": "toml"}), encoding="utf-8"
+    )
+    (srcdir / "from_override.json").write_text(
+        json.dumps({"source": "override"}), encoding="utf-8"
+    )
+
+    app = make_app(
+        srcdir=srcdir,
+        freshenv=True,
+        confoverrides={"needs_variant_data_file": "from_override.json"},
+    )
+    app.build()
+
+    assert app.config.needs_variant_data == {"source": "override"}
+    assert "Source: override" in Path(app.outdir, "index.html").read_text()

--- a/tests/test_variant_data_integration.py
+++ b/tests/test_variant_data_integration.py
@@ -215,29 +215,14 @@ def test_variant_data_nested_inline_overrides_file(test_app):
     assert "REQ_OPT" in index_html
 
 
-@pytest.mark.parametrize(
-    ("file_content", "message", "names_file"),
-    [
-        pytest.param(None, "Variant data file not found", True, id="missing"),
-        pytest.param("{not json", "Invalid JSON in", True, id="malformed"),
-        # the two shape errors below are raised by the validator, which has never
-        # been told which file the data came from
-        pytest.param(
-            '["not", "an", "object"]', "must contain a JSON object", False, id="list"
-        ),
-        pytest.param(
-            '{"x": null}', "expected str/bool/int/float", False, id="bad_value"
-        ),
-    ],
-)
-def test_variant_data_file_errors_fail_the_build(
-    tmpdir, make_app, write_fixture_files, file_content, message, names_file
-):
-    """A missing or malformed variant data file fails the build, naming the file.
+def _write_variant_data_file_project(
+    tmpdir, write_fixture_files, file_content: str | None
+) -> Path:
+    """Write a project configured with ``needs_variant_data_file``.
 
-    Only the phase in which this is reported changed; the exception type -- and so
-    the severity -- and the message are unchanged, which is what is pinned here by
-    wrapping both the application creation and the build.
+    :param file_content: The contents to write to the file, or ``None`` to leave the
+        configured file missing.
+    :returns: The project's source directory.
     """
     write_fixture_files(
         tmpdir,
@@ -249,17 +234,69 @@ def test_variant_data_file_errors_fail_the_build(
             "rst": "Title\n=====\n",
         },
     )
+    srcdir = Path(str(tmpdir))
     if file_content is not None:
-        Path(str(tmpdir), "variant_data.json").write_text(
-            file_content, encoding="utf-8"
-        )
+        (srcdir / "variant_data.json").write_text(file_content, encoding="utf-8")
+    return srcdir
+
+
+@pytest.mark.parametrize(
+    ("file_content", "expected"),
+    [
+        pytest.param(
+            None, ("Variant data file not found", "variant_data.json"), id="missing"
+        ),
+        pytest.param(
+            "{not json", ("Invalid JSON in", "variant_data.json"), id="malformed"
+        ),
+        # The two shape errors below come from the validator, which is not told which
+        # file the data was read from, so their messages name no file. Naming it there
+        # would be an improvement (a follow-up), so this test does not pin the absence.
+        pytest.param(
+            '["not", "an", "object"]', ("must contain a JSON object",), id="list"
+        ),
+        pytest.param('{"x": null}', ("expected str/bool/int/float",), id="bad_value"),
+    ],
+)
+def test_variant_data_file_errors_fail_the_build(
+    tmpdir, make_app, write_fixture_files, file_content, expected
+):
+    """A missing or malformed variant data file fails the build.
+
+    Only the phase in which this is reported changed; the exception type -- and so
+    the severity -- and the message are unchanged, which is what is pinned here by
+    wrapping both the application creation and the build. The phase itself is pinned
+    separately, by ``test_variant_data_file_missing_fails_at_application_creation``.
+    """
+    srcdir = _write_variant_data_file_project(tmpdir, write_fixture_files, file_content)
 
     with pytest.raises(NeedsConfigException) as excinfo:
-        app = make_app(srcdir=Path(str(tmpdir)), freshenv=True)
+        app = make_app(srcdir=srcdir, freshenv=True)
         app.build()
 
-    assert message in str(excinfo.value)
-    assert ("variant_data.json" in str(excinfo.value)) is names_file
+    for fragment in expected:
+        assert fragment in str(excinfo.value)
+
+
+def test_variant_data_file_missing_fails_at_application_creation(
+    tmpdir, make_app, write_fixture_files
+):
+    """The error must escape application creation, before any document is read.
+
+    This is the one part of the error behaviour that is new, and the test that wraps
+    both creation and the build cannot see it: a version that resolved during
+    ``config-inited`` but deferred the raise to the read phase would satisfy that one
+    while making the documented "before any document is read" false. Wrapping only
+    ``make_app`` is the assertion -- reaching ``app.build()`` is impossible, because no
+    application is ever returned.
+    """
+    srcdir = _write_variant_data_file_project(tmpdir, write_fixture_files, None)
+
+    with pytest.raises(NeedsConfigException) as excinfo:
+        make_app(srcdir=srcdir, freshenv=True)
+
+    assert "Variant data file not found" in str(excinfo.value)
+    assert "variant_data.json" in str(excinfo.value)
 
 
 def test_variant_data_file_confoverride_wins_over_toml(
@@ -297,3 +334,41 @@ def test_variant_data_file_confoverride_wins_over_toml(
 
     assert app.config.needs_variant_data == {"source": "override"}
     assert "Source: override" in Path(app.outdir, "index.html").read_text()
+
+
+@pytest.mark.parametrize(
+    "test_app",
+    [
+        {
+            "buildername": "html",
+            "srcdir": "doc_test/doc_variant_data_extension_write",
+            "no_plantuml": True,
+        }
+    ],
+    indirect=True,
+)
+def test_variant_data_extension_write_stays_coherent(test_app):
+    """The role and ``var.*`` filters must read the same map, whatever it holds.
+
+    Resolution happens during ``config-inited``, so an extension that writes
+    ``needs_variant_data`` from its own handler afterwards no longer has the file
+    merged in or its values validated. That is a deliberate narrowing. What must
+    never happen is the two read paths disagreeing inside one build: the ``variant``
+    role reads ``needs_variant_data`` directly, while filter expressions read the
+    ``var`` proxy derived from it.
+    """
+    app = test_app
+    app.build()
+
+    warnings = strip_colors(
+        app._warning.getvalue().replace(str(app.srcdir) + os.sep, "srcdir/")
+    ).splitlines()
+    assert warnings == []
+
+    index_html = Path(app.outdir, "index.html").read_text()
+
+    # the role renders the value the extension wrote ...
+    assert "Role renders: from_extension" in index_html
+    # ... so a filter must match that same value, and not the one from the file
+    assert "Extension value: 1" in index_html
+    assert "File value: 0" in index_html


### PR DESCRIPTION
Closes #1783

`needs_variant_data_file` was loaded, and the inline `needs_variant_data` merged on top of
it, from `prepare_env` at `env-before-read-docs`. By then Sphinx has already computed the
document set from `exclude_patterns`, so the merged map did not exist during the only phase
in which that configuration can still be changed.

Resolution now runs as its own `config-inited` handler at priority 11: directly after
`load_config_from_toml` (priority 10), the one thing that can still set either key, and
before everything else, so every later `config-inited` handler — sphinx-needs' own and
anyone else's — sees the fully merged map. This is a move, not a duplication: nothing in the
codebase writes `needs_variant_data` after `config-inited`, so one resolution path remains.

The `var` proxy that filter expressions read is derived from the map in two places — once
where the map is resolved, and once at the top of `prepare_env` — through a single helper.
The second derivation matters because the map can be overwritten in between (see the
narrowing below): the `variant` role reads the map directly while filters read the proxy, so
deriving it once would have let the two read paths disagree inside one build.

### What is unchanged

- Merge semantics: the file loads first, inline data deep-merges on top, inline wins.
- Precedence: `sphinx-build -D needs_variant_data_file=...` still beats the value from
  `needs_from_toml`.
- Diagnostics: the same `NeedsConfigException`, with the same messages, for a file that is
  missing, is not valid JSON, is not a JSON object, or contains a disallowed value.
  `NeedsConfigException` is a `SphinxError`, which Sphinx re-raises untouched from any
  event, so the severity does not depend on the phase.

### What changes for users

- A project that loads variant data from a file stops re-reading every document on every
  build. The merged map used to be written onto the configuration *after* Sphinx's
  `config-inited` checkpoint, so the pickled configuration held the merged map while the
  next build compared it against the unmerged one — a difference Sphinx read as a changed
  `env` value. Editing the file's contents is now what triggers the rebuild, and that is
  the point: the variant role documentation used to tell readers to force it with a clean
  build. Inline-only projects were never affected.
- An unusable variant data file fails the build during configuration, before any document
  is read, instead of once reading has started. One consequence worth knowing when reading
  a report from that path: because the failure now happens before Sphinx has recorded the
  loaded extensions and recent messages, its crash report shows those as `None`. The
  exception type and message are byte-identical either way.
- An extension that *writes* `needs_variant_data` from its own `config-inited` handler no
  longer has the file merged into what it wrote, and no longer has it validated: resolution
  has already run by then, so the value is taken as it stands. It is used consistently — the
  `variant` role and `var.*` filter expressions read the same map — but a project relying on
  the merge or the validation should set the value in `conf.py`, in `needs_from_toml`, or
  with `sphinx-build -D`. Writing config values from a `config-inited` handler is not a
  documented sphinx-needs interface, and nothing in-tree does it.

### On the divergence from #1710

This repository has already fixed this exact symptom once, the other way round: #1710 /
PR #1712 stopped `needs_schema_definitions` triggering full rebuilds by moving the resolved
data **off** the config onto the env, "leaving the config object byte-equal across builds",
filed under Bug fixes. This change keeps the config mutation and moves it *before* the
checkpoint instead. That is deliberate, and it is the difference between the two cases: the
byte-equal route makes the stored configuration blind to the file's contents, so editing a
variant data file would go on being untracked and a clean build would still be needed. Here
the merged map IS the comparison key, so a content edit is picked up and an unchanged file
costs nothing — which is what lets the `sphinx-build -E` advice be deleted rather than
merely reworded. The schemas case had no equivalent user-visible content-tracking need.
Filed accordingly: the rebuild fix under Bug fixes, matching the precedent; the timing
change under Improvements.

### Tests

`tests/test_variant_data_integration.py`, with two new fixture projects:

- the merged map and its proxy exist at `config-inited` — asserted both on an application
  that has been created but not built, and on what a default-priority `config-inited`
  handler in the project's `conf.py` can see. Fails against the previous code.
- the role and `var.*` filters agree after an extension overwrites the map from its own
  `config-inited` handler. Fails without the second proxy derivation, and pins the
  narrowing as coherent rather than silently divergent.
- a nested inline key overrides the file's without dropping its siblings, end to end
  through the `variant` role and a `var.build.debug` needtable filter.
- a missing or malformed file fails the build with the same exception and message, pinned
  phase-agnostically by wrapping both application creation and the build; parametrised over
  four cases.
- the missing-file error escapes application *creation*, wrapping only `make_app`, so a
  version that resolved during `config-inited` but deferred the raise to the read phase
  cannot pass.
- `-D needs_variant_data_file=...` still wins over the value read from TOML.

### Docs

A Bug fixes entry for the rebuild fix and an Improvements entry for the timing change, both
referencing issue #1783 and this PR. `needs_variant_data_file` gains a `versionchanged` note
and a paragraph on when the file is read and what that means for rebuilds. The `variant`
role note no longer advises a clean build after editing a variant data file, because such an
edit is now tracked.