### PR TITLE
🐛 A need records the line it is actually written on

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -274,7 +274,7 @@ These changes do not affect user-facing behaviour:
 Bug fixes
 .........
 
-- 🐛 A need records the line it is actually written on **(changed output)** (:issue:`1349`)
+- 🐛 A need records the line it is actually written on **(changed output)** (:issue:`1349`, :pr:`1789`)
 
   ``rst_prolog``, ``.. include::`` and :ref:`list2need` each put text into the document
   being parsed, and each one used to shift the ``lineno`` recorded for every need after

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -274,6 +274,20 @@ These changes do not affect user-facing behaviour:
 Bug fixes
 .........
 
+- 🐛 A need records the line it is actually written on **(changed output)** (:issue:`1349`)
+
+  ``rst_prolog``, ``.. include::`` and :ref:`list2need` each push text into the running
+  parse, and each one used to shift the ``lineno`` recorded for every need after it by
+  the length of the text it inserted. The shifts compound, so in a document with a
+  prolog and a couple of includes the recorded line was routinely past the end of the
+  file. The line is now resolved back to the one the directive stands on — the same
+  line Sphinx-Needs' own warnings have always reported for that need.
+
+  Two things are deliberately unchanged: the needs :ref:`list2need` *generates* still
+  record their position inside the generated block rather than the line of the list
+  item that produced them, and ``lineno_content`` is still the parser's own counter,
+  because that is what it is used as.
+
 - 🐛 Fix :ref:`needs_variant_data_file` triggering full rebuilds (:issue:`1783`, :pr:`1787`)
 
   The merged variant data was written back onto the configuration after Sphinx's

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -283,9 +283,11 @@ Bug fixes
   line is now resolved back to the one the directive stands on — the same line the
   directive's own warnings have always reported.
 
-  **Warning locations are unchanged**, everywhere, including inside the content a
-  :ref:`need_pre_template` or :ref:`need_post_template` renders, which is anchored at
-  the need's directive and is now anchored there explicitly.
+  **No warning location regresses.** The only warning locations that move are the
+  ones this corrects — sites that report at a need's stored line now name the true
+  one. Everything anchored through the directive's own location helper, including
+  the content a :ref:`need_pre_template` or :ref:`need_post_template` renders, is
+  byte-identical to before.
 
   Two things are deliberately unchanged: the needs :ref:`list2need` *generates* still
   record their position inside the generated block rather than the line of the list

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -276,12 +276,16 @@ Bug fixes
 
 - 🐛 A need records the line it is actually written on **(changed output)** (:issue:`1349`)
 
-  ``rst_prolog``, ``.. include::`` and :ref:`list2need` each push text into the running
-  parse, and each one used to shift the ``lineno`` recorded for every need after it by
-  the length of the text it inserted. The shifts compound, so in a document with a
-  prolog and a couple of includes the recorded line was routinely past the end of the
-  file. The line is now resolved back to the one the directive stands on — the same
-  line Sphinx-Needs' own warnings have always reported for that need.
+  ``rst_prolog``, ``.. include::`` and :ref:`list2need` each put text into the document
+  being parsed, and each one used to shift the ``lineno`` recorded for every need after
+  it by the length of that text. The shifts compound, so in a document with a prolog and
+  a couple of includes the recorded line was routinely past the end of the file. The
+  line is now resolved back to the one the directive stands on — the same line the
+  directive's own warnings have always reported.
+
+  **Warning locations are unchanged**, everywhere, including inside the content a
+  :ref:`need_pre_template` or :ref:`need_post_template` renders, which is anchored at
+  the need's directive and is now anchored there explicitly.
 
   Two things are deliberately unchanged: the needs :ref:`list2need` *generates* still
   record their position inside the generated block rather than the line of the list

--- a/sphinx_needs/api/need.py
+++ b/sphinx_needs/api/need.py
@@ -34,6 +34,7 @@ from sphinx_needs.functions.functions import DynamicFunctionParsed
 from sphinx_needs.logging import get_logger, log_warning
 from sphinx_needs.need_item import (
     NeedItem,
+    NeedItemSourceDirective,
     NeedItemSourceProtocol,
     NeedItemSourceUnknown,
     NeedLink,
@@ -729,6 +730,27 @@ def add_need(
     return _create_need_node(needs_info, app.env, state, content)
 
 
+def _template_parse_offset(data: NeedItem) -> int:
+    """The offset at which to parse a need's rendered ``pre``/``post`` template content.
+
+    That content exists in no file, so the only sensible place to anchor a warning
+    raised inside it is the need's own directive. ``nested_parse`` resolves a nested
+    parse's locations through the *enclosing* state machine
+    (``abs_line_number()`` = ``line_offset + input_offset + 1``), so the anchor has to be
+    given in that machine's line space -- the same space ``lineno_content`` is kept in,
+    and **not** the resolved source line a need records since #1349. A need directive
+    keeps the unresolved number as ``parser_lineno`` for exactly this; every other kind
+    of source still stores it in ``lineno`` itself.
+    """
+    source = data.source
+    parser_lineno = (
+        source.parser_lineno if isinstance(source, NeedItemSourceDirective) else None
+    )
+    if parser_lineno is None:
+        parser_lineno = data["lineno"]
+    return (parser_lineno - 1) if parser_lineno else 0
+
+
 @contextmanager
 def _reset_rst_titles(state: RSTState) -> Iterator[None]:
     """Temporarily reset the title styles and section level in the parser state,
@@ -786,7 +808,7 @@ def _create_need_node(
         with _reset_rst_titles(state):
             state.nested_parse(
                 StringList(pre_content.splitlines(), source=source),
-                (data["lineno"] - 1) if data["lineno"] else 0,
+                _template_parse_offset(data),
                 node,
                 match_titles=True,
             )
@@ -854,7 +876,7 @@ def _create_need_node(
         with _reset_rst_titles(state):
             state.nested_parse(
                 StringList(post_content.splitlines(), source=source),
-                (data["lineno"] - 1) if data["lineno"] else 0,
+                _template_parse_offset(data),
                 node,
                 match_titles=True,
             )

--- a/sphinx_needs/directives/need.py
+++ b/sphinx_needs/directives/need.py
@@ -166,16 +166,18 @@ class NeedDirective(SphinxDirective):
         # ``.. list2need::``. Resolve it back to the line the directive is actually
         # written on (see #1349).
         # ``get_source_info`` is what ``get_location`` -- and so every warning this
-        # extension emits -- is already built on, so the two now agree.
+        # directive itself emits -- is already built on, so the two now agree.
         # It returns ``(None, None)`` if the state machine cannot map the line.
-        # ``lineno_content`` deliberately stays on the flat counter: it is handed to
-        # ``nested_parse`` in ``create_need_node`` as an offset into that same flat
-        # line space, not read as a source line.
+        # The unresolved number is kept as ``parser_lineno``, and ``lineno_content``
+        # stays on the parser's counter as well: both are handed to ``nested_parse`` in
+        # ``_create_need_node`` as offsets into that counter's space, not read as source
+        # lines.
         _, resolved_lineno = self.get_source_info()
         source = NeedItemSourceDirective(
             docname=self.env.docname,
             lineno=resolved_lineno or self.lineno,
             lineno_content=self.content_offset + 1,
+            parser_lineno=self.lineno,
         )
 
         try:

--- a/sphinx_needs/directives/need.py
+++ b/sphinx_needs/directives/need.py
@@ -160,9 +160,21 @@ class NeedDirective(SphinxDirective):
                 self._log_warning(f"Invalid value for '{key}' option: {err}")
                 return []
 
+        # ``self.lineno`` counts the lines of what the parser was handed, which anything
+        # putting text into the document shifts for everything after it -- Sphinx's
+        # ``rst_prolog``, and the ``insert_input`` of ``.. include::`` and
+        # ``.. list2need::``. Resolve it back to the line the directive is actually
+        # written on (see #1349).
+        # ``get_source_info`` is what ``get_location`` -- and so every warning this
+        # extension emits -- is already built on, so the two now agree.
+        # It returns ``(None, None)`` if the state machine cannot map the line.
+        # ``lineno_content`` deliberately stays on the flat counter: it is handed to
+        # ``nested_parse`` in ``create_need_node`` as an offset into that same flat
+        # line space, not read as a source line.
+        _, resolved_lineno = self.get_source_info()
         source = NeedItemSourceDirective(
             docname=self.env.docname,
-            lineno=self.lineno,
+            lineno=resolved_lineno or self.lineno,
             lineno_content=self.content_offset + 1,
         )
 

--- a/sphinx_needs/need_item.py
+++ b/sphinx_needs/need_item.py
@@ -72,6 +72,20 @@ class NeedItemSourceDirective:
     docname: str
     lineno: int
     lineno_content: int
+    parser_lineno: int | None = None
+    """The directive's line in the *parser's* own line space, where that differs from
+    ``lineno``.
+
+    ``lineno`` is the line the directive is written on, resolved back through the state
+    machine. The parser counts the lines it was handed instead, and anything that puts
+    text into the document -- ``rst_prolog``, ``.. include::``, ``.. list2need::`` --
+    shifts that count. Content that exists in no file (a rendered
+    ``pre_template``/``post_template``) is parsed at an offset into *that* space, so the
+    unresolved number has to survive alongside the resolved one.
+
+    Deliberately not part of ``dict_repr``: it is a parser coordinate rather than need
+    data, and never reaches ``needs.json``. ``None`` means the two are the same.
+    """
     dict_repr: NeedsSourceInfoType = field(init=False, default_factory=dict, repr=False)  # type: ignore[assignment]
 
     def __post_init__(self) -> None:

--- a/tests/__snapshots__/test_list2need.ambr
+++ b/tests/__snapshots__/test_list2need.ambr
@@ -59,7 +59,7 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 26,
+      'lineno': 7,
       'lineno_content': 32,
       'links': list([
       ]),
@@ -146,7 +146,7 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 32,
+      'lineno': 13,
       'lineno_content': 35,
       'links': list([
       ]),
@@ -232,7 +232,7 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 20,
+      'lineno': 1,
       'lineno_content': 24,
       'links': list([
       ]),
@@ -318,7 +318,7 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 27,
+      'lineno': 8,
       'lineno_content': 32,
       'links': list([
       ]),
@@ -407,7 +407,7 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 35,
+      'lineno': 16,
       'lineno_content': 39,
       'links': list([
         'NEED-1',
@@ -496,7 +496,7 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 42,
+      'lineno': 23,
       'lineno_content': 49,
       'links': list([
         'NEED-3',
@@ -583,7 +583,7 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 19,
+      'lineno': 1,
       'lineno_content': 23,
       'links': list([
       ]),
@@ -669,7 +669,7 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 25,
+      'lineno': 7,
       'lineno_content': 29,
       'links': list([
       ]),
@@ -755,7 +755,7 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 31,
+      'lineno': 13,
       'lineno_content': 34,
       'links': list([
       ]),
@@ -841,7 +841,7 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 21,
+      'lineno': 1,
       'lineno_content': 26,
       'links': list([
       ]),
@@ -930,7 +930,7 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 29,
+      'lineno': 9,
       'lineno_content': 34,
       'links': list([
       ]),
@@ -1021,7 +1021,7 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 37,
+      'lineno': 17,
       'lineno_content': 42,
       'links': list([
         'NEED-W',
@@ -1112,7 +1112,7 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 45,
+      'lineno': 25,
       'lineno_content': 53,
       'links': list([
         'NEED-3',
@@ -1211,7 +1211,7 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 38,
+      'lineno': 19,
       'lineno_content': 42,
       'links': list([
       ]),
@@ -1301,7 +1301,7 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 45,
+      'lineno': 26,
       'lineno_content': 49,
       'links': list([
       ]),
@@ -1387,7 +1387,7 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 20,
+      'lineno': 1,
       'lineno_content': 23,
       'links': list([
       ]),

--- a/tests/test_list2need_behaviour.py
+++ b/tests/test_list2need_behaviour.py
@@ -811,13 +811,18 @@ def test_a_list2need_shifts_the_line_numbers_after_it(test_app: SphinxTestApp):
 
     The generated needs are pushed back into the parser with ``insert_input``, which
     advances the state machine's flat line counter by the length of the generated text.
-    Every ``lineno`` from the directive onwards is therefore offset, including that of
-    ordinary need directives written after it, and the offset compounds with each
-    list2need in a document. This is sphinx-needs issue #1349.
+    An ordinary need directive written after the list used to record that shifted
+    counter -- 27 for a need on line 13 -- which is sphinx-needs issue #1349;
+    ``NeedDirective`` now resolves the counter back to the real line, so **LN-AFTER is
+    correct**.
 
-    The values below are wrong -- they are the real line number plus the drift -- and
-    are pinned so that a change to the mechanism is visible here rather than only in
-    users' ``needs.json``.
+    What remains is the *generated* needs. They are re-parsed from a block whose
+    offsets restart at 1, so they record their position inside the generated text
+    rather than the line of the list item that produced them. That is exactly where a
+    warning raised inside one of them already points, so it is no worse than before,
+    but it is only fixed by building the needs directly instead of round-tripping them
+    through the parser -- the list2need reimplementation. The values below are pinned
+    so that landing it shows up here as a deliberate edit.
     """
     app = test_app
     app.build()
@@ -827,10 +832,10 @@ def test_a_list2need_shifts_the_line_numbers_after_it(test_app: SphinxTestApp):
     assert built["LN-BEFORE"]["lineno"] == 4
 
     # NOTE: current behaviour; see PR discussion (#1349).
-    # LN-A is written on line 10 and LN-B on line 11.
-    assert built["LN-A"]["lineno"] == 14
-    assert built["LN-B"]["lineno"] == 20
+    # LN-A is written on line 10 and LN-B on line 11; these are their offsets within
+    # the text list2need generated, which is what their own warnings report too.
+    assert built["LN-A"]["lineno"] == 1
+    assert built["LN-B"]["lineno"] == 7
 
-    # NOTE: current behaviour; see PR discussion (#1349).
     # LN-AFTER is an ordinary need directive, written on line 13.
-    assert built["LN-AFTER"]["lineno"] == 27
+    assert built["LN-AFTER"]["lineno"] == 13

--- a/tests/test_need_lineno.py
+++ b/tests/test_need_lineno.py
@@ -1,0 +1,201 @@
+"""Regression tests for the ``lineno`` a need records for its own directive.
+
+A directive's ``self.lineno`` counts the lines of what the *parser* was handed, which
+stops being the lines of the file as soon as anything has put text into it. Three
+ordinary things do: Sphinx prepends ``rst_prolog`` to every document it parses, and
+both docutils' ``.. include::`` and sphinx-needs' own ``.. list2need::`` splice text
+in mid-parse with ``StateMachine.insert_input``. Each one advances the counter by the
+length of the text it added, the shifts compound, and a need directive after them used
+to record its real line *plus* all of that drift -- routinely past the end of the
+file. That is issue #1349.
+
+``NeedDirective`` now takes the line from ``self.get_source_info()``, the
+``SphinxDirective`` accessor that maps that counter back onto a real
+``(source, line)`` pair. It is the same accessor the warning path (``get_location()``)
+is built on, so a need's recorded ``lineno`` and the line sphinx-needs' own warnings
+print for that need are now the same number.
+
+The projects are built inline (``files``) so that each case's input sits next to the
+line numbers it produces.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+import pytest
+from sphinx.testing.util import SphinxTestApp
+
+from sphinx_needs.api import get_needs_view
+
+PROLOG = """\
+.. |project| replace:: The Project
+.. |release| replace:: 1.2.3
+"""
+"""A two-line ``rst_prolog``.
+
+Sphinx prepends it, plus a blank line, to every document it parses, which is what
+shifts the line counter for the whole of :data:`INDEX`.
+"""
+
+CONF = f"""\
+extensions = ["sphinx_needs"]
+needs_types = [
+    dict(directive="req", title="Requirement", prefix="R_", color="#BFD8D2", style="node"),
+    dict(directive="spec", title="Specification", prefix="S_", color="#FEDCD2", style="node"),
+]
+needs_id_regex = r"^[A-Za-z0-9_.\\-]+$"
+rst_prolog = {PROLOG!r}
+# the fragment is spliced into index.rst by ``.. include::``; excluding it keeps
+# Sphinx from also reading it as a document of its own and duplicating its need.
+exclude_patterns = ["fragment.rst"]
+"""
+
+INDEX = """\
+TEST DOCUMENT
+=============
+
+.. req:: Before anything else
+   :id: LN-FIRST
+
+.. include:: fragment.rst
+
+.. req:: After the include
+   :id: LN-AFTER-INCLUDE
+
+.. list2need::
+   :types: req, spec
+
+   * (LN-GENERATED-A) First item
+   * (LN-GENERATED-B) Second item
+
+.. req:: After the list
+   :id: LN-AFTER-LIST2NEED
+"""
+"""One document carrying all three sources of drift, in the order they compound.
+
+``LN-FIRST`` is on line 4, ``LN-AFTER-INCLUDE`` on line 9 and ``LN-AFTER-LIST2NEED``
+on line 18; each of the three is preceded by one more insertion than the last.
+"""
+
+FRAGMENT = """\
+A section inside the fragment
+-----------------------------
+
+.. spec:: Inside the include
+   :id: LN-INSIDE-INCLUDE
+
+Prose that makes the fragment several lines longer than the one line the
+``.. include::`` directive occupies in the including document.
+"""
+""":data:`INDEX` includes this. ``LN-INSIDE-INCLUDE`` is on line 4 **of this file**."""
+
+
+def params(conf: str = CONF, index: str = INDEX, **extra: str) -> dict[str, object]:
+    """Build the :func:`test_app` parameters for a single case."""
+    files = [(Path("conf.py"), conf), (Path("index.rst"), index)]
+    files.extend((Path(name), text) for name, text in extra.items())
+    return {"buildername": "html", "files": files, "no_plantuml": True}
+
+
+def needs(app: SphinxTestApp) -> dict[str, dict[str, Any]]:
+    """The built needs as plain dictionaries, keyed by id."""
+    return {k: {**v} for k, v in get_needs_view(app).items()}
+
+
+@pytest.mark.parametrize(
+    "test_app",
+    [params(**{"fragment.rst": FRAGMENT})],
+    indirect=True,
+)
+def test_inserted_text_no_longer_shifts_the_recorded_lineno(test_app: SphinxTestApp):
+    """Every ordinary need directive records the line it is written on (#1349).
+
+    The three needs asserted first sit after one, two and three such insertions
+    respectively, so before this fix each was wrong by a larger amount than the one
+    before it: lines 4, 9 and 18 were recorded as 7, 24 and 47 -- and this document is
+    nineteen lines long.
+    """
+    app = test_app
+    app.build()
+    built = needs(app)
+
+    # ``rst_prolog`` alone already shifts this one; it is the original report in #1349.
+    assert built["LN-FIRST"]["lineno"] == 4
+
+    # ... and the ``.. include::`` above it adds the length of the included file.
+    assert built["LN-AFTER-INCLUDE"]["lineno"] == 9
+
+    # ... and the ``.. list2need::`` above *that* adds the length of the text it
+    # generated, which is what put this need's recorded line past the end of the file.
+    assert built["LN-AFTER-LIST2NEED"]["lineno"] == 18
+
+    # A need written inside the included file gets its line *within that file*, which
+    # is the location sphinx-needs' warnings already report for it. ``docname``
+    # deliberately still names the including document, so for this need alone the pair
+    # spans two files -- as it must until needs can record a source path of their own.
+    assert built["LN-INSIDE-INCLUDE"]["lineno"] == 4
+    assert built["LN-INSIDE-INCLUDE"]["docname"] == "index"
+
+    # NOTE: current behaviour. The needs list2need *generates* are re-parsed from a
+    # block whose source is the document but whose offsets restart at 1, so they record
+    # their position inside that generated block rather than the line of the list item
+    # that produced them. That is where their warnings already point, and it is no
+    # worse than before; it is fixed by giving the needs their line at construction
+    # time instead of round-tripping them through the parser.
+    assert built["LN-GENERATED-A"]["lineno"] == 1
+    assert built["LN-GENERATED-B"]["lineno"] == 7
+
+
+MYST_CONF = """\
+extensions = ["sphinx_needs", "myst_parser"]
+needs_types = [
+    dict(directive="req", title="Requirement", prefix="R_", color="#BFD8D2", style="node"),
+]
+needs_id_regex = r"^[A-Za-z0-9_.\\-]+$"
+"""
+
+FENCE = "```"
+
+MYST_INDEX = f"""\
+# Test document
+
+Some prose.
+
+{FENCE}{{req}} A need in a Markdown document
+:id: LN-MD
+{FENCE}
+"""
+
+requires_myst = pytest.mark.skipif(
+    importlib.util.find_spec("myst_parser") is None,
+    reason="myst-parser is not installed",
+)
+
+
+@requires_myst
+@pytest.mark.parametrize(
+    "test_app",
+    [
+        {
+            "buildername": "html",
+            "files": [(Path("conf.py"), MYST_CONF), (Path("index.md"), MYST_INDEX)],
+            "no_plantuml": True,
+        }
+    ],
+    indirect=True,
+)
+def test_a_markdown_need_keeps_the_lineno_it_always_had(test_app: SphinxTestApp):
+    """Pin that the fix is a no-op for Markdown hosts.
+
+    myst-parser hands directives a ``MockStateMachine`` whose ``get_source_and_line``
+    returns the line it was given, so ``get_source_info()`` resolves to exactly the
+    flat counter it replaced. Markdown needs are unaffected by this change -- neither
+    helped nor harmed -- and this test is here to keep it that way.
+    """
+    app = test_app
+    app.build()
+    built = needs(app)
+    assert built["LN-MD"]["lineno"] == 5

--- a/tests/test_proper_warning.py
+++ b/tests/test_proper_warning.py
@@ -28,3 +28,43 @@ def test_proper_warning(test_app: Sphinx):
     assert 'href="#SP_TOO_000" title="SP_TOO_000">SP_TOO_000' in html
     assert 'href="#SP_TOO_001" title="SP_TOO_001">SP_TOO_001' in html
     assert 'href="#SP_TOO_002" title="SP_TOO_002">SP_TOO_002' in html
+
+
+@pytest.mark.parametrize(
+    "test_app",
+    [
+        {
+            "buildername": "html",
+            "srcdir": "doc_test/doc_warning",
+            "no_plantuml": True,
+            "confoverrides": {"rst_prolog": ".. |drift| replace:: drift\n"},
+        }
+    ],
+    indirect=True,
+)
+def test_proper_warning_is_unaffected_by_rst_prolog(test_app: Sphinx):
+    """The same document, built with a prolog in front of it, warns in the same places.
+
+    Sphinx prepends ``rst_prolog`` to every document it parses, so the parser's own line
+    numbers no longer line up with the file's. Nothing a reader sees should move because
+    of that: the five lines below are the ones :func:`test_proper_warning` asserts,
+    repeated deliberately rather than shared, because "the same locations, on a document
+    whose line counter has been shifted" is the whole claim.
+
+    Two of the five are the interesting ones. ``unknown0`` and ``unknown4`` come from
+    ``:pre_template:``/``:post_template:`` content, which exists in no file at all and is
+    therefore anchored at the need's own directive; that anchor is an offset into the
+    parser's shifted line space, so it has to be given in those coordinates rather than
+    in the resolved ones a need now records (see #1349).
+    """
+    test_app.build()
+
+    warnings = strip_colors(test_app._warning.getvalue()).splitlines()
+    prefix = " [docutils]" if version_info >= (8, 0) else ""
+    assert warnings == [
+        f'{Path(str(test_app.srcdir)) / "index.rst"}:9: ERROR: Unknown interpreted text role "unknown0".{prefix}',
+        f'{Path(str(test_app.srcdir)) / "index.rst"}:16: ERROR: Unknown interpreted text role "unknown1".{prefix}',
+        f'{Path(str(test_app.srcdir)) / "index.rst"}:24: ERROR: Unknown interpreted text role "unknown2".{prefix}',
+        f'{Path(str(test_app.srcdir)) / "index.rst"}:31: ERROR: Unknown interpreted text role "unknown3".{prefix}',
+        f'{Path(str(test_app.srcdir)) / "index.rst"}:6: ERROR: Unknown interpreted text role "unknown4".{prefix}',
+    ]


### PR DESCRIPTION
### The change

`NeedDirective` stored `self.lineno`, which counts the lines of what the *parser* was
handed rather than the lines of the file. Three perfectly ordinary things put text
into a document and shift that count for everything after: Sphinx prepends
`rst_prolog` to every document it parses, and both docutils' `.. include::` and our
own `.. list2need::` splice text in mid-parse with `StateMachine.insert_input`. The
shifts compound, so the recorded line routinely landed past the end of the file.

The line now comes from `SphinxDirective.get_source_info()`, which is exactly
`state_machine.get_source_and_line(self.lineno)` — the accessor `get_location()`, and
so every warning the directive itself emits, is already built on. **The stored
`lineno` now agrees with the line our own warnings have been printing all along.** On
a document with an `rst_prolog` and a `list2need`, for a need written on
`index.rst:9`:

| | before | after |
|---|---|---|
| what the warning printed | `index.rst:9` | `index.rst:9` |
| what `needs.json` recorded | `19` | `9` |

The accessor returns `(None, None)` when the state machine cannot map the line, in
which case the old value is kept.

**No warning location regresses.** The only warning locations that move are the ones
this corrects — the sites that report at a need's stored `(docname, lineno)` now name
the true line. Everything anchored through the directive's own location helper is
byte-identical to before. The one place that had to be taught the
difference is the rendered content of `:pre_template:`/`:post_template:`. That content
exists in no file, so it is anchored at the need's own directive, and `nested_parse`
resolves a nested parse through the *enclosing* state machine — meaning the anchor has
to be given in the parser's line space, not in the resolved one a need now records.
`NeedItemSourceDirective` therefore also keeps the unresolved number (`parser_lineno`,
internal — not in `needs.json`), and `_create_need_node` uses it for those two offsets.
`tests/test_proper_warning.py` pins these locations already; its values are unchanged,
and a second test now builds **the same fixture** with an `rst_prolog` in front of it
and asserts **the same five locations**, which without this would report 7 and 4 where
the file says 9 and 6.

### What that looks like across the three causes

A 19-line document with all three, from the new test:

| need | written on | before | after |
|---|---|---|---|
| after `rst_prolog` only | `index.rst:4` | 7 | **4** |
| after an `.. include::` | `index.rst:9` | 24 | **9** |
| after a `.. list2need::` | `index.rst:18` | 47 | **18** |

### Deliberately not changed

- **`docname`** stays `self.env.docname`. #1692 also derived it from the resolved
  source path; measured, that turns `docname` into a filesystem path for any need
  inside an `.. include::`d file and silently breaks the `:need:` hyperlinks pointing
  at it. Changing `docname` changes link resolution, which is a separate question
  from getting the line right.
- **`lineno_content`** stays `self.content_offset + 1`. It is not read as a source
  line: `_create_need_node` hands it to `nested_parse` as an offset into the parser's
  own line space, which is what lets a need nested inside another need's content report
  sensible lines. Making the two agree wants a new field rather than a change to this
  one; noted as a follow-up.
- **Needs that `list2need` generates** still record their position inside the
  generated block rather than the line of the list item that produced them — that is
  where their warnings already point, so it is no worse than before, and it is only
  properly fixed by building those needs directly instead of round-tripping them
  through the parser.
- **One honest trade.** For a need written inside an `.. include::`d file, inside a
  `list2need` block, or in a Python docstring, the number now indexes a *different*
  file from the one `docname` names, and it looks like an ordinary line of that
  document — where the old value announced itself as wrong by sitting past the end of
  the file. Both are wrong; the new one is wrong *plausibly*. It is deliberate: the new
  number is the one that need's own warnings already print, and the real fix is for a
  need to carry a source path of its own rather than for `docname` to change meaning.
- **Markdown is a no-op.** myst-parser's `MockStateMachine.get_source_and_line`
  returns the line it is given, so `.md` needs are byte-identical before and after.
  There is a test pinning that.

### Tests

- `tests/test_need_lineno.py` (new) — one project carrying all three shift sources,
  pinning the true line for every ordinary need directive, plus the Markdown no-op.
- `tests/test_list2need_behaviour.py` — the lineno characterization test added in
  #1788 now records the *correct* line for the need after the list, and keeps the
  generated needs' offsets pinned as the remaining residue.
- `tests/__snapshots__/test_list2need.ambr` — 16 generated-need linenos, each checked
  against the generated text.
- `tests/test_proper_warning.py` — its existing pins are untouched; a new case rebuilds
  the same fixture behind an `rst_prolog` and asserts the same warning locations.

Closes #1349.

Credit where it is due: #1692 (sebastiansetzer) identified this fix and its
direction. This PR carries its `need.py` line-number piece on its own.
