### PR TITLE
✨ list2need: build the needs directly, without generating reStructuredText

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -298,7 +298,7 @@ Breaking changes
   ID list2need derives is the hash of the title *before* the option area is removed
   from it, which is the ID an item without the ``()`` has always been given, while the
   second generator hashed the title after it. So ``* ()A title ((status="open"))``
-  moves from ``R_6AFF7`` to ``R_D7997`` — the ID ``* A title ((status="open"))``
+  moves from ``R_328F3`` to ``R_0FF10`` — the ID ``* A title ((status="open"))``
   already had.
 
 - ‼️ :ref:`needflow` ``:show_link_names:`` takes an optional value, and now wins over

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,36 @@ Unreleased
 Improvements
 ............
 
+- ✨ :ref:`list2need` works in Markdown documents, and records the line each need was
+  written on (:issue:`1349`, :pr:`1789`)
+
+  The directive used to render every item into a need directive through a template and
+  hand the result back to the parser. That step is gone: the items are built directly,
+  and a nested item is placed inside its parent. The syntax and its parsing are
+  untouched — the same list structure, the same ``(ID)`` capture, the same
+  ``:delimiter:`` split, the same ``((option="value"))`` region, the same validation —
+  so a list that built before builds the same needs, with the same IDs.
+
+  What the step cost, and is therefore fixed:
+
+  - A list written as a ``{list2need}`` fence in a MyST Markdown document produced no
+    needs at all, only an error naming a myst-parser internal. It now creates its needs,
+    like any other directive.
+  - Handing generated text back to the parser advanced its line counter for the rest of
+    the file, so every need from the directive onwards — the items themselves, and any
+    ordinary need directive written below them — was recorded at a line further down the
+    file than it was written, by an amount that grew with each list in the document.
+    Every ``lineno`` in ``needs.json`` is now the line the need was written on.
+  - An item written ``()`` with options, such as ``* ()A title ((status="open"))``, lost
+    them: they became body text. They are now set.
+  - A content line starting with ``:`` was indented by three further spaces to keep it
+    out of the generated need's option block, which could produce a stray
+    ``Definition list ends without a blank line`` warning. It is plain content now.
+
+  The content of a parent need no longer holds the generated reStructuredText of its
+  children — nesting is a property of the document, not of the parent's text — so
+  ``needs.json``, and a filter reading ``content``, see the item's own text only.
+
 - 👌 :ref:`needs_variant_data` is resolved while the configuration is being initialised
   (:issue:`1783`, :pr:`1787`)
 
@@ -231,6 +261,21 @@ Improvements
 
 Breaking changes
 ................
+
+- ‼️ A :ref:`list2need` item written ``()`` gets the same generated ID as one written
+  without brackets (:pr:`1789`)
+
+  Writing an empty bracketed group used to suppress the ID of the generated need, which
+  sent it down the need directives' own ID generator — a different one, which reads
+  :ref:`needs_id_from_title` where list2need's does not, and hashes the content when the
+  title is empty. One list could therefore carry two kinds of generated ID at once,
+  chosen by two characters of punctuation. The directive now derives every ID itself.
+
+  Under the default configuration the two generators agreed, so almost every project
+  sees no change. **A project that sets** ``needs_id_from_title``, **or writes** ``()``
+  **on an item with no title, gets a different ID for those items**, and any
+  ``:need:`` reference to the old ID has to be updated. Give such an item an explicit ID
+  — ``* (MY-ID)A title`` — if its ID has to stay as it was.
 
 - ‼️ :ref:`needflow` ``:show_link_names:`` takes an optional value, and now wins over
   :ref:`needs_flow_show_links` (:pr:`1782`)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,7 +15,7 @@ Improvements
 ............
 
 - ✨ :ref:`list2need` works in Markdown documents, and records the line each need was
-  written on (:issue:`1349`, :pr:`1789`)
+  written on (:issue:`1349`, :pr:`1790`)
 
   The directive used to render every item into a need directive through a template and
   hand the result back to the parser. That step is gone: the items are built directly,
@@ -278,7 +278,7 @@ Breaking changes
 ................
 
 - ‼️ A :ref:`list2need` item written ``()`` gets the same generated ID as one written
-  without brackets (:pr:`1789`)
+  without brackets (:pr:`1790`)
 
   Writing an empty bracketed group used to suppress the ID of the generated need, which
   sent it down the need directives' own ID generator — a different one, which reads

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -36,9 +36,6 @@ Improvements
     Every ``lineno`` in ``needs.json`` is now the line the need was written on.
   - An item written ``()`` with options, such as ``* ()A title ((status="open"))``, lost
     them: they became body text. They are now set.
-  - A content line starting with ``:`` was indented by three further spaces to keep it
-    out of the generated need's option block, which could produce a stray
-    ``Definition list ends without a blank line`` warning. It is plain content now.
 
   The content of a parent need no longer holds the generated reStructuredText of its
   children — nesting is a property of the document, not of the parent's text — so

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -358,10 +358,10 @@ Bug fixes
   the content a :ref:`need_pre_template` or :ref:`need_post_template` renders, is
   byte-identical to before.
 
-  Two things are deliberately unchanged: the needs :ref:`list2need` *generates* still
-  record their position inside the generated block rather than the line of the list
-  item that produced them, and ``lineno_content`` is still the parser's own counter,
-  because that is what it is used as.
+  One thing is deliberately unchanged: ``lineno_content`` is still the parser's own
+  counter, because that is what it is used as. (The needs :ref:`list2need` *generates*
+  recorded their position inside the generated block when this entry was written;
+  :pr:`1790` builds them directly, so they now record the line of their own list item.)
 
 - 🐛 Fix :ref:`needs_variant_data_file` triggering full rebuilds (:issue:`1783`, :pr:`1787`)
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -22,7 +22,8 @@ Improvements
   and a nested item is placed inside its parent. The syntax and its parsing are
   untouched — the same list structure, the same ``(ID)`` capture, the same
   ``:delimiter:`` split, the same ``((option="value"))`` region, the same validation —
-  so a list that built before builds the same needs, with the same IDs.
+  so a list that built before builds the same needs, with the same IDs, apart from the
+  one class of item named under Breaking changes below.
 
   What the step cost, and is therefore fixed:
 
@@ -33,9 +34,26 @@ Improvements
     the file, so every need from the directive onwards — the items themselves, and any
     ordinary need directive written below them — was recorded at a line further down the
     file than it was written, by an amount that grew with each list in the document.
-    Every ``lineno`` in ``needs.json`` is now the line the need was written on.
+    Every ``lineno`` in ``needs.json`` is now the line the need was written on, inside
+    an ``eval-rst`` block in a Markdown document too.
   - An item written ``()`` with options, such as ``* ()A title ((status="open"))``, lost
     them: they became body text. They are now set.
+
+  Four inputs that used to be errors are now defined, none of which a document that
+  built cleanly can contain:
+
+  - ``((id="MY-ID"))`` names the need. The template wrote both the derived ID and this
+    one as two ``:id:`` lines of the same generated need, which docutils refused with
+    ``duplicate option "id"``, so the item was dropped. The ID is applied before
+    ``:links-down:`` is built, so the links of the other items agree with it. An empty
+    ``((id=""))`` is refused with a diagnostic instead.
+  - An inline option naming the same link field as ``:links-down:`` — ``((links="X"))``
+    under ``:links-down: links`` — used to produce one corrupt link value and an
+    ``unknown outgoing link`` warning. The two sets of links are now merged.
+  - An item carrying ``((title_from_content="true"))`` reads it as a need directive
+    does.
+  - A child of a ``((hide="true"))`` item is rendered at the level above it, rather
+    than being placed inside a need that is taken out of the document.
 
   The content of a parent need no longer holds the generated reStructuredText of its
   children — nesting is a property of the document, not of the parent's text — so
@@ -268,11 +286,20 @@ Breaking changes
   title is empty. One list could therefore carry two kinds of generated ID at once,
   chosen by two characters of punctuation. The directive now derives every ID itself.
 
-  Under the default configuration the two generators agreed, so almost every project
-  sees no change. **A project that sets** ``needs_id_from_title``, **or writes** ``()``
-  **on an item with no title, gets a different ID for those items**, and any
-  ``:need:`` reference to the old ID has to be updated. Give such an item an explicit ID
-  — ``* (MY-ID)A title`` — if its ID has to stay as it was.
+  Under the default configuration the two generators agreed for an item whose title
+  carries no options, so almost every project sees no change. **A project that sets**
+  ``needs_id_from_title``, **writes** ``()`` **on an item with no title, or writes**
+  ``()`` **on an item that also carries an** ``((option="value"))`` **area, gets a
+  different ID for those items**, and any ``:need:`` reference to the old ID has to be
+  updated. Give such an item an explicit ID — ``* (MY-ID)A title`` — if its ID has to
+  stay as it was.
+
+  The third case is the widest of the three, because it needs no configuration: the
+  ID list2need derives is the hash of the title *before* the option area is removed
+  from it, which is the ID an item without the ``()`` has always been given, while the
+  second generator hashed the title after it. So ``* ()A title ((status="open"))``
+  moves from ``R_6AFF7`` to ``R_D7997`` — the ID ``* A title ((status="open"))``
+  already had.
 
 - ‼️ :ref:`needflow` ``:show_link_names:`` takes an optional value, and now wins over
   :ref:`needs_flow_show_links` (:pr:`1782`)

--- a/docs/directives/list2need.rst
+++ b/docs/directives/list2need.rst
@@ -56,8 +56,9 @@ For details please see :ref:`list2need_meta_data`.
 
    There are currently known limitations in the list parser.
    A content line starting with ``*`` begins a new need instead of continuing the one
-   above it, and a content line starting with ``:`` stays content —
-   it is rendered as a field list in the need's body, and is not read as an option.
+   above it, and a content line starting with ``:`` is content rather than an option —
+   it is indented by three spaces, which is what makes the options of a directive
+   written in an item's content line up underneath it.
 
 List structure
 --------------

--- a/docs/directives/list2need.rst
+++ b/docs/directives/list2need.rst
@@ -55,7 +55,9 @@ For details please see :ref:`list2need_meta_data`.
 .. warning::
 
    There are currently known limitations in the list parser.
-   For instance new content lines starting with ``*`` or ``:`` may get handled incorrectly.
+   A content line starting with ``*`` begins a new need instead of continuing the one
+   above it, and a content line starting with ``:`` stays content —
+   it is rendered as a field list in the need's body, and is not read as an option.
 
 List structure
 --------------
@@ -125,6 +127,18 @@ it changes whenever the title changes,
 and the same title used at two levels of one list gives two different IDs, one per prefix.
 See :ref:`needs_id_length` for the length and :ref:`needs_types` for the prefix of each type.
 
+.. versionchanged:: 8.4.0
+
+   A line whose bracketed group is empty, ``()``, gets its ID from the formula above,
+   exactly as a line with no brackets at all does.
+   Until 8.4.0 such a line was given its ID by the need directives' own generator
+   instead — which reads :ref:`needs_id_from_title`, and hashes the content when the
+   title is empty — so one list could produce two kinds of generated ID,
+   chosen by two characters of punctuation.
+   Under the default configuration both produced the same ID,
+   so only a project that sets ``needs_id_from_title``,
+   or writes ``()`` on a line with no title, sees a different ID than before.
+
 .. warning::
 
    Because the document is not part of the input,
@@ -136,11 +150,31 @@ See :ref:`needs_id_length` for the length and :ref:`needs_types` for the prefix 
 Markdown (MyST)
 ---------------
 
-``list2need`` currently works in reStructuredText documents only.
-Written as a fenced ``{list2need}`` directive in a MyST Markdown document,
-it reports an error and creates no needs.
+.. versionchanged:: 8.4.0
 
-As a workaround the directive can be written inside an ``eval-rst`` block:
+   Before 8.4.0 a ``{list2need}`` fence reported an error and created no needs,
+   and the ``eval-rst`` block below was the only way to reach the directive
+   from a Markdown document.
+
+``list2need`` can be written as a fenced directive in a MyST Markdown document:
+
+.. code-block:: markdown
+
+   ```{list2need}
+   :types: req, spec
+
+   * (MD-REQ-1) A requirement written from Markdown
+     * (MD-SPEC-1) And a specification below it
+   ```
+
+The list itself keeps the syntax described on this page:
+it is read by ``list2need`` rather than by the host parser,
+so it is the same in both kinds of document.
+The **content** of each need is parsed by the host, so it is Markdown in a
+``.md`` file and reStructuredText in an ``.rst`` file.
+
+The directive still works inside an ``eval-rst`` block, where its content is
+reStructuredText:
 
 .. code-block:: markdown
 
@@ -178,7 +212,7 @@ presentation
 ~~~~~~~~~~~~
 Defines how the single Sphinx-Needs objects shall be presented.
 
-:nested: Needs of level 2 are defined in the content of the parent need (level 1) and so on.
+:nested: Needs of level 2 are placed inside the parent need (level 1) and so on.
 :standalone: Each list element gets its own, independent need object. They are not nested.
 
 

--- a/docs/directives/list2need.rst
+++ b/docs/directives/list2need.rst
@@ -133,12 +133,19 @@ See :ref:`needs_id_length` for the length and :ref:`needs_types` for the prefix 
    A line whose bracketed group is empty, ``()``, gets its ID from the formula above,
    exactly as a line with no brackets at all does.
    Until 8.4.0 such a line was given its ID by the need directives' own generator
-   instead — which reads :ref:`needs_id_from_title`, and hashes the content when the
-   title is empty — so one list could produce two kinds of generated ID,
+   instead — which reads :ref:`needs_id_from_title`, hashes the content when the title
+   is empty, and hashes the title *after* any ``((option="value"))`` area has been
+   removed from it — so one list could produce two kinds of generated ID,
    chosen by two characters of punctuation.
-   Under the default configuration both produced the same ID,
-   so only a project that sets ``needs_id_from_title``,
-   or writes ``()`` on a line with no title, sees a different ID than before.
+
+   Three kinds of line get a different ID than before:
+   one written ``()`` in a project that sets ``needs_id_from_title``,
+   one written ``()`` with no title,
+   and one written ``()`` that also carries an ``((option="value"))`` area.
+   The last needs no configuration to reach:
+   ``* ()A title ((status="open"))`` now gets the ID that
+   ``* A title ((status="open"))`` has always been given.
+   Every other line keeps the ID it had.
 
 .. warning::
 

--- a/sphinx_needs/directives/list2need.py
+++ b/sphinx_needs/directives/list2need.py
@@ -346,7 +346,7 @@ class List2NeedDirective(SphinxDirective):
             else:
                 warn(f"Unknown option '{key}'")
 
-        content, lineno_content = self._content(list_need)
+        content, content_index = self._content(list_need)
 
         # the title is decided exactly as it is for a need directive: an item whose
         # own title is empty is one written without a directive argument
@@ -368,7 +368,17 @@ class List2NeedDirective(SphinxDirective):
                 need_source=NeedItemSourceDirective(
                     docname=self.env.docname,
                     lineno=lineno,
-                    lineno_content=lineno_content,
+                    # ``lineno_content`` and ``parser_lineno`` are parser coordinates
+                    # rather than source lines, exactly as a need directive gives them:
+                    # both are handed to ``nested_parse`` as the offset at which to
+                    # parse the item's content and its rendered pre/post template.
+                    # ``self.content_offset`` counts in that space, so the item's line
+                    # in it is the directive's first content line plus the item's own
+                    # index -- which is not the line it is written on as soon as
+                    # anything above has put text into the document (``rst_prolog``,
+                    # ``.. include::``).
+                    lineno_content=self.content_offset + 1 + content_index,
+                    parser_lineno=self.content_offset + 1 + list_need["line"],
                 ),
                 need_type=list_need["type"],
                 title=title,
@@ -388,7 +398,8 @@ class List2NeedDirective(SphinxDirective):
         block of any directive, so that an item whose title carries no content at all
         contributes an empty content rather than a leading empty line.
 
-        :return: The content, and the source line its first line was written on.
+        :return: The content, and the index within the directive's own content of the
+            line it starts at -- the item's own line, if the item has no content.
         """
         lines: list[str] = list(list_need["content"])
         indexes: list[int] = list(list_need["content_lines"])
@@ -401,11 +412,7 @@ class List2NeedDirective(SphinxDirective):
         content = StringList(
             lines, source=str(self.env.doc2path(self.env.docname)), items=items
         )
-        # ``items`` holds 0-based offsets, the need wants a 1-based line number
-        lineno_content = (
-            items[0][1] + 1 if items else self._source_line(list_need["line"])
-        )
-        return content, lineno_content
+        return content, indexes[0] if indexes else list_need["line"]
 
     def _content_is_source_mapped(self) -> bool:
         """Whether the content lines carry their true position in the source.

--- a/sphinx_needs/directives/list2need.py
+++ b/sphinx_needs/directives/list2need.py
@@ -35,6 +35,9 @@ OPTIONS_REGEX = re.compile(r"([^=,\s]*)=[\"']([^\"]*)[\"']")
 
 #: Need options an inline ``((name="value"))`` may set, on top of the extra fields
 #: and link types the project configures. Mirrors what the need directives accept.
+#: ``id`` is taken out earlier, and so are the three the need directives read as a
+#: boolean rather than as a string (``delete``, ``jinja_content``,
+#: ``title_from_content``), so only the rest are matched against this set.
 CORE_OPTIONS = frozenset(
     {
         "collapse",

--- a/sphinx_needs/directives/list2need.py
+++ b/sphinx_needs/directives/list2need.py
@@ -3,27 +3,25 @@ from __future__ import annotations
 import hashlib
 import re
 from collections.abc import Sequence
+from collections.abc import Set as AbstractSet
 from contextlib import suppress
 from typing import Any
 
 from docutils import nodes
 from docutils.parsers.rst import directives
+from docutils.statemachine import StringList
 from sphinx.errors import SphinxError, SphinxWarning
 from sphinx.util.docutils import SphinxDirective
 
-from sphinx_needs._jinja import render_template_string
+from sphinx_needs.api import InvalidNeedException, add_need
 from sphinx_needs.config import NeedsSphinxConfig
 from sphinx_needs.data import SphinxNeedsData
+from sphinx_needs.logging import get_logger, log_warning
+from sphinx_needs.need_item import NeedItemSourceDirective
+from sphinx_needs.nodes import Need
+from sphinx_needs.utils import add_doc, coerce_to_boolean
 
-NEED_TEMPLATE = """.. {{type}}:: {{title}}
-   {% if need_id is not none %}:id: {{need_id}}{%endif%}
-   {% if set_links_down %}:{{links_down_type}}: {{ links_down|join(', ') }}{%endif%}
-   {%- for name, value in options.items() %}:{{name}}: {{value}}
-   {% endfor %}
-
-   {{content}}
-
-"""
+LOGGER = get_logger(__name__)
 
 LINE_REGEX = re.compile(
     r"(?P<indent>[^\S\n]*)\*\s*(?P<text>.*)|[\S\*]*(?P<more_text>.*)"
@@ -33,6 +31,25 @@ ID_REGEX = re.compile(
 )  # Exclude some chars, which are used by option list
 OPTION_AREA_REGEX = re.compile(r"\(\((.*)\)\)")
 OPTIONS_REGEX = re.compile(r"([^=,\s]*)=[\"']([^\"]*)[\"']")
+
+#: Need options an inline ``((name="value"))`` may set, on top of the extra fields
+#: and link types the project configures. Mirrors what the need directives accept.
+CORE_OPTIONS = frozenset(
+    {
+        "collapse",
+        "constraints",
+        "hide",
+        "id",
+        "jinja_content",
+        "layout",
+        "post_template",
+        "pre_template",
+        "status",
+        "style",
+        "tags",
+        "template",
+    }
+)
 
 
 class List2Need(nodes.General, nodes.Element):
@@ -102,6 +119,12 @@ class List2NeedDirective(SphinxDirective):
         else:
             down_links_raw_list = [x.strip() for x in down_links_raw.split(",")]
         needs_schema = SphinxNeedsData(self.env).get_schema()
+        # the options an item may set inline, on top of the ones list2need computes
+        known_options = (
+            CORE_OPTIONS
+            | set(needs_schema.iter_extra_field_names())
+            | set(needs_schema.iter_link_field_names())
+        )
         link_types = [link.name for link in needs_schema.iter_link_fields()]
         for i, down_link_raw in enumerate(down_links_raw_list):
             down_links_types[i] = down_link_raw
@@ -116,7 +139,7 @@ class List2NeedDirective(SphinxDirective):
 
         list_needs = []
         # Storing the data in a sorted list
-        for content_line in content_raw.split("\n"):
+        for line_index, content_line in enumerate(content_raw.split("\n")):
             # for groups in line.findall(content_raw):
             match = LINE_REGEX.search(content_line)
             if not match:
@@ -151,12 +174,15 @@ class List2NeedDirective(SphinxDirective):
                         splitted_text[1:]
                     )  # Put the content together again
 
+                need_id = None
                 need_id_result = ID_REGEX.search(title)
                 if need_id_result:
                     need_id = need_id_result.group(2)
                     title = ID_REGEX.sub("", title)
-                else:
-                    # Calculate the hash value, so that we can later reuse it
+                if need_id is None:
+                    # Note the id is hashed from the title *before* any inline option
+                    # area is removed from it, which is what the id of a title
+                    # carrying options has always been.
                     prefix = ""
                     needs_id_length = needs_config.id_length
                     for need_type in needs_config.types:
@@ -170,33 +196,39 @@ class List2NeedDirective(SphinxDirective):
                     "title": title,
                     "need_id": need_id,
                     "type": types[level],
-                    "content": content.lstrip(),
+                    # the content is kept line by line, so that every line can be
+                    # handed to the need with the source position it was written at
+                    "content": [content.lstrip()],
+                    "content_lines": [line_index],
                     "level": level,
+                    "line": line_index,
                     "options": {},
                 }
                 list_needs.append(need)
             else:
                 more_text = more_text.lstrip()
-                if more_text.startswith(":"):
-                    more_text = f"   {more_text}"
-                list_needs[-1]["content"] = (
-                    f"{list_needs[-1]['content']}\n   {more_text}"
-                )
+                list_needs[-1]["content"].append(more_text)
+                list_needs[-1]["content_lines"].append(line_index)
 
-        # Finally creating the rst code
-        overall_text = []
-        for index, list_need in enumerate(list_needs):
+        # Extract the inline options of every item
+        for list_need in list_needs:
             # Search for meta data in the complete title/content
-            search_string = list_need["title"] + list_need["content"]
+            content_text = "\n".join(list_need["content"])
+            search_string = list_need["title"] + content_text
             result = OPTION_AREA_REGEX.search(search_string)
             if result is not None:  # An option was found
                 option_str = result.group(1)  # We only deal with the first finding
                 option_result = OPTIONS_REGEX.findall(option_str)
                 list_need["options"] = {x[0]: x[1] for x in option_result}
 
-                # Remove possible option-strings from title and content
+                # Remove possible option-strings from title and content.
+                # The option area cannot span a line break, so substituting on the
+                # joined content and splitting it up again preserves the line count,
+                # and with it every line's mapping back to its source position.
                 list_need["title"] = OPTION_AREA_REGEX.sub("", list_need["title"])
-                list_need["content"] = OPTION_AREA_REGEX.sub("", list_need["content"])
+                list_need["content"] = OPTION_AREA_REGEX.sub("", content_text).split(
+                    "\n"
+                )
 
             # Add tags defined at list level (if exists) to the ones potentially defined in the content
             if tags:
@@ -208,31 +240,197 @@ class List2NeedDirective(SphinxDirective):
                 else:
                     list_need["options"]["tags"] = tags
 
-            data = list_need
+            # an explicitly given id wins over the one derived from the title,
+            # and has to be known before the links-down of any other item are built
+            if given_id := list_need["options"].pop("id", None):
+                list_need["need_id"] = given_id
+
+        # Finally creating the needs
+        node_list: list[nodes.Node] = []
+        # the needs a nested item can be placed inside, innermost last
+        open_needs: list[tuple[int, Need]] = []
+        for index, list_need in enumerate(list_needs):
+            options = dict(list_need["options"])
+
             need_links_down = self.get_down_needs(list_needs, index)
             if (
                 down_links_types
                 and list_need["level"] in down_links_types
                 and need_links_down
             ):
-                data["links_down"] = need_links_down
-                data["links_down_type"] = down_links_types[list_need["level"]]
-                data["set_links_down"] = True
-            else:
-                data["set_links_down"] = False
+                links_down_type = down_links_types[list_need["level"]]
+                given = options.get(links_down_type)
+                joined = ", ".join(need_links_down)
+                options[links_down_type] = f"{given}, {joined}" if given else joined
 
-            text = render_template_string(NEED_TEMPLATE, list_need, autoescape=False)
-            text_list = text.split("\n")
+            need_nodes = self._create_need(list_need, options, known_options)
+
             if presentation == "nested":
-                indented_text_list = ["   " * list_need["level"] + x for x in text_list]
-                text_list = indented_text_list
-            overall_text += text_list
+                while open_needs and open_needs[-1][0] >= list_need["level"]:
+                    open_needs.pop()
+                if open_needs:
+                    parent_node = open_needs[-1][1]
+                    parent_node += need_nodes
+                else:
+                    node_list += need_nodes
+                for node in need_nodes:
+                    if isinstance(node, Need):
+                        open_needs.append((list_need["level"], node))
+                        break
+            else:
+                node_list += need_nodes
 
-        self.state_machine.insert_input(
-            overall_text, self.state_machine.document.attributes["source"]
+        if list_needs:
+            add_doc(self.env, self.env.docname)
+
+        return node_list
+
+    def _create_need(
+        self,
+        list_need: dict[str, Any],
+        options: dict[str, str],
+        known_options: AbstractSet[str],
+    ) -> list[nodes.Node]:
+        """Create a single need from one parsed list item.
+
+        :param list_need: The parsed item.
+        :param options: Its inline options, plus any ``links-down`` values.
+        :param known_options: The option names a need accepts.
+        :return: The nodes of the created need, or nothing if it could not be created.
+        """
+        lineno = self._source_line(list_need["line"])
+        location = (self.env.docname, lineno)
+
+        kwargs: dict[str, Any] = {}
+        # the two options a need directive reads as a boolean rather than a string
+        for name in ("delete", "jinja_content"):
+            if name not in options:
+                continue
+            try:
+                flag = coerce_to_boolean(options.pop(name))
+            except ValueError as err:
+                log_warning(
+                    LOGGER,
+                    f"Invalid value for {name!r} option: {err}",
+                    "directive",
+                    location=location,
+                )
+                return []
+            if name == "delete":
+                if flag:  # the item asked for no need to be created
+                    return []
+            else:
+                kwargs[name] = flag
+
+        for key, option_value in options.items():
+            if key in known_options:
+                kwargs[key] = option_value
+            else:
+                log_warning(
+                    LOGGER, f"Unknown option '{key}'", "directive", location=location
+                )
+
+        if (
+            not list_need["title"]
+            and not NeedsSphinxConfig(self.env.config).title_optional
+        ):
+            log_warning(
+                LOGGER,
+                "No title given, but title is required by configuration.",
+                "directive",
+                location=location,
+            )
+
+        content, lineno_content = self._content(list_need)
+
+        try:
+            return add_need(
+                app=self.env.app,
+                state=self.state,
+                need_source=NeedItemSourceDirective(
+                    docname=self.env.docname,
+                    lineno=lineno,
+                    lineno_content=lineno_content,
+                ),
+                need_type=list_need["type"],
+                title=list_need["title"],
+                id=list_need["need_id"],
+                content=content,
+                **kwargs,
+            )
+        except InvalidNeedException as err:
+            log_warning(
+                LOGGER,
+                f"Need could not be created: {err.message}",
+                "create_need",
+                location=location,
+            )
+            return []
+
+    def _content(self, list_need: dict[str, Any]) -> tuple[StringList, int]:
+        """Build the source mapped content of one parsed list item.
+
+        Blank lines are stripped from both ends, as the parser does for the content
+        block of any directive, so that an item whose title carries no content at all
+        contributes an empty content rather than a leading empty line.
+
+        :return: The content, and the source line its first line was written on.
+        """
+        lines: list[str] = list(list_need["content"])
+        indexes: list[int] = list(list_need["content_lines"])
+        while lines and not lines[0].strip():
+            del lines[0], indexes[0]
+        while lines and not lines[-1].strip():
+            del lines[-1], indexes[-1]
+
+        items = [self._source_info(index) for index in indexes]
+        content = StringList(
+            lines, source=str(self.env.doc2path(self.env.docname)), items=items
+        )
+        # ``items`` holds 0-based offsets, the need wants a 1-based line number
+        lineno_content = (
+            items[0][1] + 1 if items else self._source_line(list_need["line"])
+        )
+        return content, lineno_content
+
+    def _content_is_source_mapped(self) -> bool:
+        """Whether the content lines carry their true position in the source.
+
+        Under the reStructuredText parser they do, and that mapping is authoritative:
+        it survives ``.. include::`` and anything else that moves the parser's flat
+        line counter away from the file being read.
+
+        Under myst-parser they do not. Its mock state machine hands the directive a
+        content block whose entries are numbered from zero, so line *i* reports
+        offset *i* regardless of where the fence was written. There is no expression
+        for "the source line of content line *i*" that is correct in both hosts, so
+        the two are told apart here, once per directive, by whether the first content
+        line claims to be at offset 0 -- which real reStructuredText content never is,
+        the directive marker itself always occupying an earlier line.
+        """
+        try:
+            _, offset = self.content.info(0)
+        except (IndexError, TypeError):
+            return False
+        return bool(offset)
+
+    def _source_info(self, index: int) -> tuple[str, int]:
+        """Return the source and 0-based source offset of content line ``index``."""
+        if self._content_is_source_mapped():
+            source, offset = self.content.info(index)
+            return str(source), int(offset)
+        # myst-parser: rebuild the offset from the position of the directive itself
+        _, lineno = self.get_source_info()
+        if lineno is None:
+            lineno = self.lineno
+        return (
+            str(self.env.doc2path(self.env.docname)),
+            lineno + self.content_offset + index,
         )
 
-        return []
+    def _source_line(self, index: int) -> int:
+        """Return the 1-based source line number of content line ``index``."""
+        return self._source_info(index)[1] + 1
 
     def make_hashed_id(self, type_prefix: str, title: str, id_length: int) -> str:
         hashable_content = title

--- a/sphinx_needs/directives/list2need.py
+++ b/sphinx_needs/directives/list2need.py
@@ -407,17 +407,23 @@ class List2NeedDirective(SphinxDirective):
     def _content_is_source_mapped(self) -> bool:
         """Whether the content lines carry their true position in the source.
 
-        Under the reStructuredText parser they do, and that mapping is authoritative:
-        it survives ``.. include::`` and anything else that moves the parser's flat
-        line counter away from the file being read.
+        Content read from a reStructuredText file does, and that mapping is
+        authoritative: it survives ``.. include::`` and anything else that moves the
+        parser's flat line counter away from the file being read.
 
-        Under myst-parser they do not. Its mock state machine hands the directive a
+        Under myst-parser it does not. Its mock state machine hands the directive a
         content block whose entries are numbered from zero, so line *i* reports
         offset *i* regardless of where the fence was written. There is no expression
         for "the source line of content line *i*" that is correct in both hosts, so
         the two are told apart here, once per directive, by whether the first content
-        line claims to be at offset 0 -- which real reStructuredText content never is,
+        line claims to be at offset 0 -- which content read from a file never does,
         the directive marker itself always occupying an earlier line.
+
+        The question is therefore "is this content source-mapped", not "is this
+        reStructuredText": content that was itself generated -- a list inside the
+        rendered content of a ``:jinja_content:`` need, say -- is not mapped either,
+        and takes the second branch, which puts its needs at the line of the need
+        that generated them.
         """
         try:
             _, offset = self.content.info(0)

--- a/sphinx_needs/directives/list2need.py
+++ b/sphinx_needs/directives/list2need.py
@@ -207,6 +207,12 @@ class List2NeedDirective(SphinxDirective):
                 list_needs.append(need)
             else:
                 more_text = more_text.lstrip()
+                if more_text.startswith(":"):
+                    # a continuation line is stripped of the indentation it was written
+                    # with, so this restores the one indentation a line beginning with
+                    # ":" is likely to have needed: the options of a directive written
+                    # in the content of an item, which are one field list line each
+                    more_text = f"   {more_text}"
                 list_needs[-1]["content"].append(more_text)
                 list_needs[-1]["content_lines"].append(line_index)
 

--- a/sphinx_needs/directives/list2need.py
+++ b/sphinx_needs/directives/list2need.py
@@ -16,7 +16,8 @@ from sphinx.util.docutils import SphinxDirective
 from sphinx_needs.api import InvalidNeedException, add_need
 from sphinx_needs.config import NeedsSphinxConfig
 from sphinx_needs.data import SphinxNeedsData
-from sphinx_needs.logging import get_logger, log_warning
+from sphinx_needs.directives.need import _get_title
+from sphinx_needs.logging import WarningSubTypes, get_logger, log_warning
 from sphinx_needs.need_item import NeedItemSourceDirective
 from sphinx_needs.nodes import Need
 from sphinx_needs.utils import add_doc, coerce_to_boolean
@@ -247,14 +248,17 @@ class List2NeedDirective(SphinxDirective):
                     list_need["options"]["tags"] = tags
 
             # an explicitly given id wins over the one derived from the title,
-            # and has to be known before the links-down of any other item are built
-            if given_id := list_need["options"].pop("id", None):
+            # and has to be known before the links-down of any other item are built.
+            # An empty one is handed on as it stands, so that it is refused with a
+            # diagnostic instead of being silently replaced by the title hash.
+            if (given_id := list_need["options"].pop("id", None)) is not None:
                 list_need["need_id"] = given_id
 
         # Finally creating the needs
         node_list: list[nodes.Node] = []
         # the needs a nested item can be placed inside, innermost last
         open_needs: list[tuple[int, Need]] = []
+        created = False
         for index, list_need in enumerate(list_needs):
             options = dict(list_need["options"])
 
@@ -270,6 +274,7 @@ class List2NeedDirective(SphinxDirective):
                 options[links_down_type] = f"{given}, {joined}" if given else joined
 
             need_nodes = self._create_need(list_need, options, known_options)
+            created = created or bool(need_nodes)
 
             if presentation == "nested":
                 while open_needs and open_needs[-1][0] >= list_need["level"]:
@@ -281,12 +286,16 @@ class List2NeedDirective(SphinxDirective):
                     node_list += need_nodes
                 for node in need_nodes:
                     if isinstance(node, Need):
-                        open_needs.append((list_need["level"], node))
+                        # a hidden need is taken out of the document once it has been
+                        # read, so a child placed inside one would be rendered nowhere
+                        # and referenced by an anchor that never reaches the page
+                        if not node.get("hidden"):
+                            open_needs.append((list_need["level"], node))
                         break
             else:
                 node_list += need_nodes
 
-        if list_needs:
+        if created:
             add_doc(self.env, self.env.docname)
 
         return node_list
@@ -306,48 +315,48 @@ class List2NeedDirective(SphinxDirective):
         """
         lineno = self._source_line(list_need["line"])
         location = (self.env.docname, lineno)
+        needs_config = NeedsSphinxConfig(self.env.config)
 
-        kwargs: dict[str, Any] = {}
-        # the two options a need directive reads as a boolean rather than a string
-        for name in ("delete", "jinja_content"):
+        def warn(message: str, code: WarningSubTypes = "directive") -> None:
+            log_warning(LOGGER, message, code, location=location)
+
+        # the options a need directive reads as a boolean rather than as a string
+        flags: dict[str, bool] = {}
+        for name in ("delete", "jinja_content", "title_from_content"):
             if name not in options:
                 continue
             try:
-                flag = coerce_to_boolean(options.pop(name))
+                flags[name] = coerce_to_boolean(options.pop(name))
             except ValueError as err:
-                log_warning(
-                    LOGGER,
-                    f"Invalid value for {name!r} option: {err}",
-                    "directive",
-                    location=location,
-                )
+                warn(f"Invalid value for {name!r} option: {err}")
                 return []
-            if name == "delete":
-                if flag:  # the item asked for no need to be created
-                    return []
-            else:
-                kwargs[name] = flag
+        if flags.get("delete"):  # the item asked for no need to be created
+            return []
+
+        kwargs: dict[str, Any] = {}
+        if "jinja_content" in flags:
+            kwargs["jinja_content"] = flags["jinja_content"]
 
         for key, option_value in options.items():
             if key in known_options:
                 kwargs[key] = option_value
             else:
-                log_warning(
-                    LOGGER, f"Unknown option '{key}'", "directive", location=location
-                )
-
-        if (
-            not list_need["title"]
-            and not NeedsSphinxConfig(self.env.config).title_optional
-        ):
-            log_warning(
-                LOGGER,
-                "No title given, but title is required by configuration.",
-                "directive",
-                location=location,
-            )
+                warn(f"Unknown option '{key}'")
 
         content, lineno_content = self._content(list_need)
+
+        # the title is decided exactly as it is for a need directive: an item whose
+        # own title is empty is one written without a directive argument
+        title, full_title = _get_title(
+            [list_need["title"]] if list_need["title"].strip() else [],
+            content,
+            title_optional=needs_config.title_optional,
+            title_from_content=flags.get(
+                "title_from_content", needs_config.title_from_content
+            ),
+            max_title_length=needs_config.max_title_length,
+            warn=warn,
+        )
 
         try:
             return add_need(
@@ -359,18 +368,14 @@ class List2NeedDirective(SphinxDirective):
                     lineno_content=lineno_content,
                 ),
                 need_type=list_need["type"],
-                title=list_need["title"],
+                title=title,
+                full_title=full_title,
                 id=list_need["need_id"],
                 content=content,
                 **kwargs,
             )
         except InvalidNeedException as err:
-            log_warning(
-                LOGGER,
-                f"Need could not be created: {err.message}",
-                "create_need",
-                location=location,
-            )
+            warn(f"Need could not be created: {err.message}", "create_need")
             return []
 
     def _content(self, list_need: dict[str, Any]) -> tuple[StringList, int]:

--- a/tests/__snapshots__/test_list2need.ambr
+++ b/tests/__snapshots__/test_list2need.ambr
@@ -18,27 +18,7 @@
       'constraints_passed': True,
       'constraints_results': dict({
       }),
-      'content': '''
-        .. spec::  Sub-Need on level 2
-           :id: NEED-003
-           
-        
-           
-        
-        .. spec:: Another Sub-Need on level 2
-           :id: SP_69FFD
-           
-        
-           Where this sentence will be used
-           as content, the first one as title.
-        
-           .. test:: Sub-Need on level 3
-              :id: TC_EA5AF
-              
-           
-              With some rst-syntax supported for
-              the **content** by :ref:`test`
-      ''',
+      'content': '',
       'created_at': None,
       'docname': 'index',
       'doctype': '.rst',
@@ -59,8 +39,8 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 7,
-      'lineno_content': 32,
+      'lineno': 11,
+      'lineno_content': 11,
       'links': list([
       ]),
       'links_back': list([
@@ -146,8 +126,8 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 13,
-      'lineno_content': 35,
+      'lineno': 12,
+      'lineno_content': 12,
       'links': list([
       ]),
       'links_back': list([
@@ -232,8 +212,8 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 1,
-      'lineno_content': 24,
+      'lineno': 10,
+      'lineno_content': 10,
       'links': list([
       ]),
       'links_back': list([
@@ -318,8 +298,8 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 8,
-      'lineno_content': 32,
+      'lineno': 11,
+      'lineno_content': 11,
       'links': list([
       ]),
       'links_back': list([
@@ -407,8 +387,8 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 16,
-      'lineno_content': 39,
+      'lineno': 12,
+      'lineno_content': 12,
       'links': list([
         'NEED-1',
         'NEED-2',
@@ -496,8 +476,8 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 23,
-      'lineno_content': 49,
+      'lineno': 13,
+      'lineno_content': 14,
       'links': list([
         'NEED-3',
       ]),
@@ -583,8 +563,8 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 1,
-      'lineno_content': 23,
+      'lineno': 11,
+      'lineno_content': 11,
       'links': list([
       ]),
       'links_back': list([
@@ -669,8 +649,8 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 7,
-      'lineno_content': 29,
+      'lineno': 12,
+      'lineno_content': 12,
       'links': list([
       ]),
       'links_back': list([
@@ -756,7 +736,7 @@
       'jinja_content': False,
       'layout': None,
       'lineno': 13,
-      'lineno_content': 34,
+      'lineno_content': 13,
       'links': list([
       ]),
       'links_back': list([
@@ -841,8 +821,8 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 1,
-      'lineno_content': 26,
+      'lineno': 11,
+      'lineno_content': 11,
       'links': list([
       ]),
       'links_back': list([
@@ -930,8 +910,8 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 9,
-      'lineno_content': 34,
+      'lineno': 12,
+      'lineno_content': 12,
       'links': list([
       ]),
       'links_back': list([
@@ -1021,8 +1001,8 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 17,
-      'lineno_content': 42,
+      'lineno': 13,
+      'lineno_content': 13,
       'links': list([
         'NEED-W',
         'NEED-Y',
@@ -1112,8 +1092,8 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 25,
-      'lineno_content': 53,
+      'lineno': 14,
+      'lineno_content': 15,
       'links': list([
         'NEED-3',
       ]),
@@ -1183,13 +1163,6 @@
       'content': '''
         Where this sentence will be used
         as content, the first one as title.
-        
-        .. test:: Sub-Need on level 3
-           :id: TC_EA5AF
-           
-        
-           With some rst-syntax supported for
-           the **content** by :ref:`test`
       ''',
       'created_at': None,
       'docname': 'index',
@@ -1211,8 +1184,8 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 19,
-      'lineno_content': 42,
+      'lineno': 13,
+      'lineno_content': 13,
       'links': list([
       ]),
       'links_back': list([
@@ -1301,8 +1274,8 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 26,
-      'lineno_content': 49,
+      'lineno': 15,
+      'lineno_content': 15,
       'links': list([
       ]),
       'links_back': list([
@@ -1387,8 +1360,8 @@
       'is_part': False,
       'jinja_content': False,
       'layout': None,
-      'lineno': 1,
-      'lineno_content': 23,
+      'lineno': 10,
+      'lineno_content': 10,
       'links': list([
       ]),
       'links_back': list([

--- a/tests/test_list2need_behaviour.py
+++ b/tests/test_list2need_behaviour.py
@@ -30,6 +30,7 @@ from sphinx.testing.util import SphinxTestApp
 from sphinx.util.console import strip_colors
 
 from sphinx_needs.api import get_needs_view
+from sphinx_needs.data import SphinxNeedsData
 
 CONF = """\
 extensions = ["sphinx_needs"]
@@ -391,6 +392,76 @@ def test_inline_options(test_app: SphinxTestApp):
     assert built["OPT-SPLIT"]["tags"] == ["ab"]
 
 
+INLINE_IDS = """
+.. list2need::
+   :types: req, spec
+
+   * Alpha ((id="INL-1"))
+     * A child ((id="INL-CHILD"))
+   * Gamma ((id=""))
+"""
+
+
+@pytest.mark.parametrize("test_app", [params(INLINE_IDS)], indirect=True)
+def test_an_id_written_as_an_inline_option(test_app: SphinxTestApp):
+    """Pin that ``((id="..."))`` names the need, and that an empty one is reported.
+
+    The directive used to write the id it derived *and* the inline one as two
+    ``:id:`` field lines of the same generated need, which docutils refused with
+    ``duplicate option "id"`` -- so any item carrying the option was dropped. The
+    inline id is now the id, and is applied before ``links-down`` is built, so the
+    links of other items agree with it.
+
+    An empty value is not an id, and is now refused the way any other invalid id is,
+    rather than being quietly replaced by the hash of the title.
+    """
+    app = test_app
+    app.build()
+    built = needs(app)
+
+    assert built["INL-1"]["title"] == "Alpha"
+    assert built["INL-CHILD"]["parent_need"] == "INL-1"
+
+    assert "Gamma" not in {need["title"] for need in built.values()}
+    assert (
+        "Need could not be created: Given ID '' does not match configured regex"
+        in warnings(app)
+    )
+
+
+TITLE_FROM_CONTENT = """
+.. list2need::
+   :types: req, spec
+
+   * ((title_from_content="true")). the first sentence here. rest
+   * (TFC-TITLED) A real title ((title_from_content="true")). some content
+"""
+
+
+@pytest.mark.parametrize("test_app", [params(TITLE_FROM_CONTENT)], indirect=True)
+def test_title_from_content_behaves_as_it_does_on_a_need_directive(
+    test_app: SphinxTestApp,
+):
+    """Pin that the inline ``title_from_content`` option is the need directives' one.
+
+    It is the only option a need directive accepts that changes what the *title* is
+    rather than what a field holds, so it has to be read before the title is decided.
+    An item with no title of its own takes the first sentence of its content; an item
+    that has a title keeps it, and is told the option had no effect.
+    """
+    app = test_app
+    app.build()
+    built = needs(app)
+
+    # The item's own title is empty -- the option area was the whole of it.
+    assert built["R_D351E"]["title"] == "the first sentence here"
+
+    assert built["TFC-TITLED"]["title"] == "A real title"
+    assert "title_from_content set to True, but a title was provided." in warnings(app)
+    assert "Unknown option 'title_from_content'" not in warnings(app)
+    assert "No title given" not in warnings(app)
+
+
 UNQUOTED_OPTION = """
 .. list2need::
    :types: req, spec
@@ -623,6 +694,91 @@ def test_presentation_standalone_leaves_the_needs_unnested(test_app: SphinxTestA
     assert built["STA-CHILD"]["parent_need"] is None
     assert built["STA-PARENT"]["links"] == ["STA-CHILD"]
     assert built["STA-PARENT"]["content"] == ""
+
+
+HIDDEN_PARENT = """
+.. list2need::
+   :types: req, spec
+
+   * (HID-PARENT) A hidden parent ((hide="true"))
+     * (HID-CHILD) Its child
+
+See :need:`HID-CHILD`.
+"""
+
+
+@pytest.mark.parametrize("test_app", [params(HIDDEN_PARENT)], indirect=True)
+def test_a_hidden_parent_does_not_take_its_child_out_of_the_page(
+    test_app: SphinxTestApp,
+):
+    """Pin that a child of a ``hide``\\ den item is still rendered, and referenceable.
+
+    A hidden need is created and then removed from the document, so nesting a child
+    inside one would put the child's target in a node that never reaches the page --
+    the need would exist in ``needs.json`` while every ``:need:`` reference to it
+    pointed at an anchor that is not there. A hidden item is therefore not opened as a
+    parent, and its children are placed at the level above it instead.
+
+    Before the directive built its needs directly the child was not created at all:
+    it lived in generated text inside the parent's content, which a hidden need never
+    parses, and a reference to it reported ``linked need HID-CHILD not found``.
+    """
+    app = test_app
+    app.build()
+    built = needs(app)
+
+    assert built["HID-CHILD"]["title"] == "Its child"
+    # The hidden parent is not a parent in the document, so the child has none.
+    assert built["HID-CHILD"]["parent_need"] is None
+
+    index = Path(app.outdir, "index.html").read_text()
+    assert 'id="HID-CHILD"' in index
+    assert 'href="#HID-CHILD"' in index
+    assert warnings(app) == ""
+
+
+NO_NEED_CREATED_INDEX = """
+.. req:: The original
+   :id: DUP-1
+
+.. toctree::
+
+   other
+"""
+
+NO_NEED_CREATED_OTHER = """\
+OTHER
+=====
+
+.. list2need::
+   :types: req, spec
+
+   * (DUP-1) A duplicate of the need in index
+"""
+
+
+@pytest.mark.parametrize(
+    "test_app",
+    [params(NO_NEED_CREATED_INDEX, **{"other.rst": NO_NEED_CREATED_OTHER})],
+    indirect=True,
+)
+def test_a_list_that_creates_nothing_does_not_register_its_document(
+    test_app: SphinxTestApp,
+):
+    """Pin that a document is recorded as carrying needs only if it produced one.
+
+    ``other.rst`` holds one list2need whose only item duplicates an id defined in
+    ``index.rst``, so the item is refused and the document ends up with no needs at
+    all. Registering it anyway would put an empty document into everything that
+    iterates the need-carrying documents.
+    """
+    app = test_app
+    app.build()
+
+    assert "A need with ID 'DUP-1' already exists" in warnings(app)
+    docs = SphinxNeedsData(app.env).get_or_create_docs()["all"]
+    assert "index" in docs
+    assert "other" not in docs
 
 
 LEVEL_SKIP = """

--- a/tests/test_list2need_behaviour.py
+++ b/tests/test_list2need_behaviour.py
@@ -528,10 +528,48 @@ def test_continuation_lines(test_app: SphinxTestApp):
     assert built["CON-BLANK"]["content"] == "first paragraph\n\nsecond paragraph"
 
     # NOTE: current behaviour; see PR discussion.
-    # A continuation line starting with ":" is not an option; it is content, and is
-    # rendered as a field list in the need's body.
-    assert built["CON-COLON"]["content"] == ":status: open"
+    # A continuation line starting with ":" is not an option. It is indented by a
+    # further three spaces before being appended, which is what makes the options of a
+    # directive written in an item's content line up underneath it -- see
+    # :func:`test_a_directive_in_an_items_content_keeps_its_options`. Here there is no
+    # directive above the line, so it is left over-indented in the need's body.
+    assert built["CON-COLON"]["content"] == "   :status: open"
     assert built["CON-COLON"]["status"] is None
+
+
+DIRECTIVE_IN_CONTENT = """
+.. list2need::
+   :types: req, spec
+
+   * (DIR-PARENT) Parent
+     * (DIR-CHILD) A child with a directive in its content
+
+     .. rubric:: A rubric
+        :class: highlighted
+"""
+
+
+@pytest.mark.parametrize("test_app", [params(DIRECTIVE_IN_CONTENT)], indirect=True)
+def test_a_directive_in_an_items_content_keeps_its_options(test_app: SphinxTestApp):
+    """Pin what the three-space indent of a ``:``-continuation line is *for*.
+
+    Every continuation line is stripped of the indentation it was written with, so the
+    options of a directive written in an item's content would end up in the directive's
+    own column -- which is not a directive with options any more, but a directive
+    followed by an unindented field list, and docutils says so. The three spaces put
+    them back underneath it.
+
+    This is the ``rst-directives in lists`` example from the documentation, and the
+    empty warning stream below is what pins it: without the indent the build reports
+    ``Explicit markup ends without a blank line`` and the options are lost.
+    """
+    app = test_app
+    app.build()
+    built = needs(app)
+    assert (
+        built["DIR-CHILD"]["content"] == ".. rubric:: A rubric\n   :class: highlighted"
+    )
+    assert warnings(app) == ""
 
 
 NESTED = """

--- a/tests/test_list2need_behaviour.py
+++ b/tests/test_list2need_behaviour.py
@@ -144,7 +144,7 @@ def test_id_capture(test_app: SphinxTestApp):
     # NOTE: current behaviour; see PR discussion.
     # The inner group is optional, so a literal "()" matches with no id. It is stripped
     # from the title and the need falls through to an automatically generated id --
-    # see :func:`test_empty_parentheses_select_a_second_auto_id_function`.
+    # see :func:`test_empty_parentheses_match_the_plain_hash_by_default`.
     assert built["R_2E24B"]["title"] == "Empty parentheses title"
 
     # No brackets at all: list2need hashes the title itself.
@@ -202,12 +202,13 @@ EMPTY_PARENS = """
 
 @pytest.mark.parametrize("test_app", [params(EMPTY_PARENS)], indirect=True)
 def test_empty_parentheses_match_the_plain_hash_by_default(test_app: SphinxTestApp):
-    """Under the default configuration the two auto-id paths produce the same id.
+    """An item written ``()`` is given the same id as one written without brackets.
 
-    Writing ``()`` suppresses the ``:id:`` line in the generated need, which sends the
-    need down :func:`~sphinx_needs.api.need._make_hashed_id` instead of list2need's own
-    ``make_hashed_id``. The two agree here, which is why the split is normally
-    invisible -- see the companion test for the configuration that separates them.
+    ``ID_REGEX``'s inner group is optional, so a literal ``()`` matches with no id and
+    is stripped from the title; the item is then treated as if it carried no brackets
+    at all. These two ids are what the directive has always produced under the default
+    configuration -- see the companion test for the configuration that used to make a
+    second id function visible.
     """
     app = test_app
     app.build()
@@ -221,19 +222,57 @@ def test_empty_parentheses_match_the_plain_hash_by_default(test_app: SphinxTestA
     [params(EMPTY_PARENS, conf=CONF + "needs_id_from_title = True\n")],
     indirect=True,
 )
-def test_empty_parentheses_select_a_second_auto_id_function(test_app: SphinxTestApp):
-    """Pin that ``()`` selects a *different* id function, observable under config.
+def test_empty_parentheses_do_not_select_a_second_auto_id_function(
+    test_app: SphinxTestApp,
+):
+    """Pin that ``()`` uses the same generated id as any other item.
 
-    ``needs_id_from_title`` is honoured by :func:`~sphinx_needs.api.need._make_hashed_id`
-    and ignored by list2need's own ``make_hashed_id``, so the same list yields two id
-    schemes at once, chosen by two characters of punctuation in the title.
+    Until the directive built its needs directly, writing ``()`` suppressed the ``:id:``
+    of the generated need, which sent it down :func:`~sphinx_needs.api.need._make_hashed_id`
+    -- a second id function, honouring ``needs_id_from_title`` where list2need's own
+    does not. The same list could therefore carry two id schemes at once, selected by
+    two characters of punctuation. The directive now derives every id itself, so this
+    configuration leaves both ids alone; ``R_ALPHA`` was the id of the first need
+    before that change.
     """
     app = test_app
     app.build()
     built = needs(app)
-    # NOTE: current behaviour; see PR discussion.
-    assert built["R_ALPHA"]["title"] == "Alpha title"
+    assert built["R_D1EC6"]["title"] == "Alpha title"
     assert built["R_C1440"]["title"] == "Beta title"
+
+
+EMPTY_PARENS_OPTIONS = """
+.. list2need::
+   :types: req, spec
+
+   * ()Title with empty parens ((status="open"))
+   * Title with empty parens ((status="open"))
+"""
+
+
+@pytest.mark.parametrize("test_app", [params(EMPTY_PARENS_OPTIONS)], indirect=True)
+def test_empty_parentheses_and_inline_options_can_be_used_together(
+    test_app: SphinxTestApp,
+):
+    """Pin that ``()`` and an option area on the same item both take effect.
+
+    The two items differ only by the ``()``, and produce one need: the same title, the
+    same generated id -- hashed, as always, from the title before the option area is
+    removed from it -- and the same status, so the second is refused as a duplicate.
+
+    Writing ``()`` used to suppress the ``:id:`` of the generated need, which left the
+    line the option was rendered on blank; that ended the generated need's option block,
+    and every option after it became body text instead. ``status`` was unset and the
+    content read ``":status: open"``.
+    """
+    app = test_app
+    app.build()
+    built = needs(app)
+    assert built["R_D7997"]["title"] == "Title with empty parens"
+    assert built["R_D7997"]["status"] == "open"
+    assert built["R_D7997"]["content"] == ""
+    assert "A need with ID 'R_D7997' already exists" in warnings(app)
 
 
 COLLIDING = """
@@ -489,10 +528,9 @@ def test_continuation_lines(test_app: SphinxTestApp):
     assert built["CON-BLANK"]["content"] == "first paragraph\n\nsecond paragraph"
 
     # NOTE: current behaviour; see PR discussion.
-    # A continuation line starting with ":" is not an option. It is indented by a
-    # further three spaces before being appended, which keeps it out of the generated
-    # need's option block and leaves it in the body as a field list.
-    assert built["CON-COLON"]["content"] == "   :status: open"
+    # A continuation line starting with ":" is not an option; it is content, and is
+    # rendered as a field list in the need's body.
+    assert built["CON-COLON"]["content"] == ":status: open"
     assert built["CON-COLON"]["status"] is None
 
 
@@ -519,19 +557,23 @@ STANDALONE = """
 
 @pytest.mark.parametrize("test_app", [params(NESTED)], indirect=True)
 def test_presentation_nested_puts_the_child_inside_the_parent(test_app: SphinxTestApp):
-    """Pin that ``nested`` makes the child need part of the parent's content.
+    """Pin that ``nested`` places the child need inside the parent need.
 
-    The generated text for each item is indented by three spaces per level, so the
-    child's directive is parsed inside the parent's content block. ``links-down``
-    is set as well, and is therefore redundant with the visible nesting.
+    The child's nodes are appended to the parent's, which is what ``parent_need``
+    records. ``links-down`` is set as well, and is therefore redundant with the
+    visible nesting.
+
+    The parent's own content is empty: nesting is a property of the document tree,
+    not of the parent's text. It used to be the generated reStructuredText of the
+    child, ``".. spec::  Child\\n   :id: NST-CHILD"``, because the child was nested by
+    being re-parsed inside the parent's content block.
     """
     app = test_app
     app.build()
     built = needs(app)
     assert built["NST-CHILD"]["parent_need"] == "NST-PARENT"
     assert built["NST-PARENT"]["links"] == ["NST-CHILD"]
-    # The child is nested by being re-parsed inside the parent's content.
-    assert built["NST-PARENT"]["content"] == ".. spec::  Child\n   :id: NST-CHILD"
+    assert built["NST-PARENT"]["content"] == ""
 
 
 @pytest.mark.parametrize("test_app", [params(STANDALONE)], indirect=True)
@@ -686,7 +728,7 @@ def test_malformed_input_aborts_the_build(
 
 
 # ---------------------------------------------------------------------------
-# host: the directive works in reStructuredText only
+# host: reStructuredText and Markdown
 # ---------------------------------------------------------------------------
 
 MYST_CONF = CONF.replace('["sphinx_needs"]', '["sphinx_needs", "myst_parser"]')
@@ -744,26 +786,29 @@ evaluates before the ``test_app`` fixture builds anything.
 
 @requires_myst
 @pytest.mark.parametrize("test_app", [myst_params(MYST_INDEX)], indirect=True)
-def test_the_directive_does_not_run_in_a_markdown_document(test_app: SphinxTestApp):
-    """Pin that a ``{list2need}`` fence in a MyST document creates no needs.
+def test_the_directive_runs_in_a_markdown_document(test_app: SphinxTestApp):
+    """Pin that a ``{list2need}`` fence in a MyST document creates its needs.
 
-    The directive's one host-specific call is ``state_machine.insert_input``, which
-    myst-parser's mock state machine does not implement. The bespoke line grammar never
-    runs, so the error names a myst-parser internal rather than anything the author
-    wrote, and the list produces nothing. A need directive in the same document is
-    unaffected, which locates the fault precisely.
+    The directive holds no host-specific code: the bespoke line grammar is per-line
+    regular expression work on the directive's own content, and the needs are built
+    through :func:`~sphinx_needs.api.need.add_need`. It used to hand its generated
+    reStructuredText back to ``state_machine.insert_input``, which myst-parser's mock
+    state machine does not implement, and a list in a Markdown document therefore
+    produced nothing at all but a ``MockingError``. A need directive in the same
+    document was unaffected, which located the fault precisely; the control need below
+    is that assertion, kept.
     """
     app = test_app
     app.build()
     built = needs(app)
 
-    # NOTE: current behaviour; see PR discussion.
-    assert "MD-A" not in built
-    assert "MD-B" not in built
-    assert (
-        "Directive 'list2need' cannot be mocked: MockingError: MockStateMachine has "
-        "not yet implemented attribute 'insert_input'" in warnings(app)
-    )
+    assert built["MD-A"]["title"] == "A need on level one"
+    assert built["MD-B"]["title"] == "A sub need"
+    assert built["MD-B"]["parent_need"] == "MD-A"
+    assert built["MD-A"]["doctype"] == ".md"
+    # The items are on lines 6 and 7 of index.md.
+    assert (built["MD-A"]["lineno"], built["MD-B"]["lineno"]) == (6, 7)
+    assert warnings(app) == ""
     assert built["MD-CONTROL"]["title"] == "A control need"
 
 
@@ -772,11 +817,11 @@ def test_the_directive_does_not_run_in_a_markdown_document(test_app: SphinxTestA
 def test_a_markdown_document_can_reach_the_directive_through_eval_rst(
     test_app: SphinxTestApp,
 ):
-    """Pin the workaround available to MyST users today.
+    """Pin that the directive also works inside an ``{eval-rst}`` fence.
 
-    Inside an ``{eval-rst}`` fence the block is handed to a real reStructuredText
-    parse, so ``insert_input`` exists and the directive behaves as it does in an
-    ``.rst`` document.
+    The block is handed to a real reStructuredText parse, so the directive behaves as
+    it does in an ``.rst`` document. This was the only way to reach it from a Markdown
+    document until it stopped generating text for the parser to read back.
     """
     app = test_app
     app.build()
@@ -784,6 +829,9 @@ def test_a_markdown_document_can_reach_the_directive_through_eval_rst(
     assert built["MD-A"]["title"] == "A need on level one"
     assert built["MD-B"]["parent_need"] == "MD-A"
     assert built["MD-A"]["doctype"] == ".md"
+    # The items are on lines 7 and 8 of index.md; the enclosing fence does not shift
+    # them, because the block carries its position in the Markdown file.
+    assert (built["MD-A"]["lineno"], built["MD-B"]["lineno"]) == (7, 8)
 
 
 # ---------------------------------------------------------------------------
@@ -806,36 +854,28 @@ LINENOS = """
 
 
 @pytest.mark.parametrize("test_app", [params(LINENOS)], indirect=True)
-def test_a_list2need_shifts_the_line_numbers_after_it(test_app: SphinxTestApp):
+def test_the_needs_around_a_list2need_record_their_source_lines(
+    test_app: SphinxTestApp,
+):
     """Pin the recorded ``lineno`` of the needs around a list2need directive.
 
-    The generated needs are pushed back into the parser with ``insert_input``, which
-    advances the state machine's flat line counter by the length of the generated text.
-    An ordinary need directive written after the list used to record that shifted
-    counter -- 27 for a need on line 13 -- which is sphinx-needs issue #1349;
-    ``NeedDirective`` now resolves the counter back to the real line, so **LN-AFTER is
-    correct**.
-
-    What remains is the *generated* needs. They are re-parsed from a block whose
-    offsets restart at 1, so they record their position inside the generated text
-    rather than the line of the list item that produced them. That is exactly where a
-    warning raised inside one of them already points, so it is no worse than before,
-    but it is only fixed by building the needs directly instead of round-tripping them
-    through the parser -- the list2need reimplementation. The values below are pinned
-    so that landing it shows up here as a deliberate edit.
+    Every value here is the line the need was actually written on. They were not,
+    while the generated needs were pushed back into the parser with ``insert_input``:
+    that advances the state machine's flat line counter by the length of the generated
+    text, so each item, and every need directive after the list, was recorded further
+    down the file than it was written -- 14, 20 and 27 for the three below, an error
+    that compounded with each list2need in a document (sphinx-needs issue #1349).
     """
     app = test_app
     app.build()
     built = needs(app)
 
-    # Before the directive, the line number is correct.
+    # Before the directive, the line number was correct already.
     assert built["LN-BEFORE"]["lineno"] == 4
 
-    # NOTE: current behaviour; see PR discussion (#1349).
-    # LN-A is written on line 10 and LN-B on line 11; these are their offsets within
-    # the text list2need generated, which is what their own warnings report too.
-    assert built["LN-A"]["lineno"] == 1
-    assert built["LN-B"]["lineno"] == 7
+    # The two items of the list, written on lines 10 and 11.
+    assert built["LN-A"]["lineno"] == 10
+    assert built["LN-B"]["lineno"] == 11
 
     # LN-AFTER is an ordinary need directive, written on line 13.
     assert built["LN-AFTER"]["lineno"] == 13

--- a/tests/test_need_lineno.py
+++ b/tests/test_need_lineno.py
@@ -1,13 +1,14 @@
 """Regression tests for the ``lineno`` a need records for its own directive.
 
 A directive's ``self.lineno`` counts the lines of what the *parser* was handed, which
-stops being the lines of the file as soon as anything has put text into it. Three
-ordinary things do: Sphinx prepends ``rst_prolog`` to every document it parses, and
-both docutils' ``.. include::`` and sphinx-needs' own ``.. list2need::`` splice text
-in mid-parse with ``StateMachine.insert_input``. Each one advances the counter by the
-length of the text it added, the shifts compound, and a need directive after them used
-to record its real line *plus* all of that drift -- routinely past the end of the
-file. That is issue #1349.
+stops being the lines of the file as soon as anything has put text into it. Sphinx
+prepends ``rst_prolog`` to every document it parses, and docutils' ``.. include::``
+splices text in mid-parse with ``StateMachine.insert_input`` -- as sphinx-needs' own
+``.. list2need::`` did too, until it was reimplemented to build its needs rather than
+generate text for the parser to read back. Each one advances the counter by the length
+of the text it added, the shifts compound, and a need directive after them used to
+record its real line *plus* all of that drift -- routinely past the end of the file.
+That is issue #1349.
 
 ``NeedDirective`` now takes the line from ``self.get_source_info()``, the
 ``SphinxDirective`` accessor that maps that counter back onto a real
@@ -111,12 +112,15 @@ def needs(app: SphinxTestApp) -> dict[str, dict[str, Any]]:
     indirect=True,
 )
 def test_inserted_text_no_longer_shifts_the_recorded_lineno(test_app: SphinxTestApp):
-    """Every ordinary need directive records the line it is written on (#1349).
+    """Every need records the line it is written on (#1349).
 
-    The three needs asserted first sit after one, two and three such insertions
-    respectively, so before this fix each was wrong by a larger amount than the one
-    before it: lines 4, 9 and 18 were recorded as 7, 24 and 47 -- and this document is
-    nineteen lines long.
+    The three ordinary need directives asserted first sit after one, two and three
+    such insertions respectively, so before this fix each was wrong by a larger amount
+    than the one before it: lines 4, 9 and 18 were recorded as 7, 24 and 47 -- and this
+    document is nineteen lines long.
+
+    The two needs the ``.. list2need::`` produces were wrong in a second way, and are
+    right for a second reason -- see the note beside them.
     """
     app = test_app
     app.build()
@@ -139,14 +143,15 @@ def test_inserted_text_no_longer_shifts_the_recorded_lineno(test_app: SphinxTest
     assert built["LN-INSIDE-INCLUDE"]["lineno"] == 4
     assert built["LN-INSIDE-INCLUDE"]["docname"] == "index"
 
-    # NOTE: current behaviour. The needs list2need *generates* are re-parsed from a
-    # block whose source is the document but whose offsets restart at 1, so they record
-    # their position inside that generated block rather than the line of the list item
-    # that produced them. That is where their warnings already point, and it is no
-    # worse than before; it is fixed by giving the needs their line at construction
-    # time instead of round-tripping them through the parser.
-    assert built["LN-GENERATED-A"]["lineno"] == 1
-    assert built["LN-GENERATED-B"]["lineno"] == 7
+    # The needs list2need produces record the line of the list item they were written
+    # as -- lines 15 and 16 -- rather than a position inside a block of generated text.
+    # They are not resolved through ``get_source_info()`` like the three above: the
+    # directive builds them itself and gives each one the line of its own item, taken
+    # from the source mapping of the directive's content. Neither the ``rst_prolog``
+    # nor the ``.. include::`` above them shifts what they record, which is what makes
+    # this the strongest of the five assertions.
+    assert built["LN-GENERATED-A"]["lineno"] == 15
+    assert built["LN-GENERATED-B"]["lineno"] == 16
 
 
 MYST_CONF = """\

--- a/tests/test_need_lineno.py
+++ b/tests/test_need_lineno.py
@@ -28,6 +28,7 @@ from typing import Any
 
 import pytest
 from sphinx.testing.util import SphinxTestApp
+from sphinx.util.console import strip_colors
 
 from sphinx_needs.api import get_needs_view
 
@@ -204,3 +205,74 @@ def test_a_markdown_need_keeps_the_lineno_it_always_had(test_app: SphinxTestApp)
     app.build()
     built = needs(app)
     assert built["LN-MD"]["lineno"] == 5
+
+
+NO_PROLOG_CONF = CONF.replace(f"rst_prolog = {PROLOG!r}\n", "")
+""":data:`CONF` without the ``rst_prolog``, to build the same document both ways."""
+
+DRIFT_INDEX = """\
+TEST DOCUMENT
+=============
+
+.. list2need::
+   :types: req, spec
+
+   * (LN-DRIFT) An item ((pre_template="pre_content"))
+     Its content carries a bad role: :unknown_content:`x`
+"""
+"""The item is written on line 7 and its content line on line 8."""
+
+DRIFT_TEMPLATE = "A paragraph.\n\n:unknown_template:`x`\n"
+"""Rendered as the item's ``pre_template``; its bad role is on line 3 of the template."""
+
+
+@pytest.mark.parametrize(
+    ("test_app", "prolog"),
+    [
+        (
+            params(
+                conf=NO_PROLOG_CONF,
+                index=DRIFT_INDEX,
+                **{"needs_templates/pre_content.need": DRIFT_TEMPLATE},
+            ),
+            False,
+        ),
+        (
+            params(
+                conf=CONF,
+                index=DRIFT_INDEX,
+                **{"needs_templates/pre_content.need": DRIFT_TEMPLATE},
+            ),
+            True,
+        ),
+    ],
+    ids=["no-prolog", "prolog"],
+    indirect=["test_app"],
+)
+def test_a_generated_needs_warnings_do_not_move_with_the_line_counter(
+    test_app: SphinxTestApp, prolog: bool
+):
+    """The same list2need item warns in the same places, prolog or no prolog.
+
+    A need carries two numbers that are *not* source lines: ``lineno_content``, the
+    offset its content is parsed at, and ``parser_lineno``, the offset a rendered
+    ``pre_template``/``post_template`` is parsed at. Both are offsets into the parser's
+    own counter, which ``rst_prolog`` shifts -- so giving them as resolved source lines
+    puts every warning raised inside an item's content, or inside its template, that
+    many lines from where it belongs.
+
+    Both locations are asserted for both builds, deliberately rather than by comparing
+    the two runs, because "the same lines, on a document whose counter has been
+    shifted" is the whole claim. The content role is on line 8, where it is written;
+    the template role is on line 9, its own third line counted from the item's.
+    """
+    app = test_app
+    app.build()
+
+    index = Path(str(app.srcdir)) / "index.rst"
+    reported = sorted(
+        line.split(": ERROR:")[0]
+        for line in strip_colors(app._warning.getvalue()).splitlines()
+        if "Unknown interpreted text role" in line
+    )
+    assert reported == [f"{index}:8", f"{index}:9"]


### PR DESCRIPTION
`list2need` renders every item into a need directive through a template and hands the
result back to the parser with `state_machine.insert_input`. This replaces that step:
the items are built with `add_need`, and a nested item is placed inside its parent.

**The syntax and its parsing are untouched.** The same four regular expressions, the
same level→type mapping, the same `(ID)` capture, the same `:delimiter:` split, the same
`((option="value"))` extraction, the same `:tags:` merge, the same `:links-down:` walk,
the same validation and the same eleven inputs that end the build. Only the generation
mechanism changes.

This is offered as the answer to the question in #1427 — *"can we save the syntax
(mostly) but have a better implementation (without jinja)?"*

### What the step cost

**Markdown.** myst-parser's mock state machine does not implement `insert_input`, so a
`{list2need}` fence produced no needs at all — only an error naming a myst-parser
internal. It now works:

| | before | after |
|---|---|---|
| needs created | none | `MD-A`, `MD-B` |
| nesting | — | `MD-B.parent_need == "MD-A"` |
| diagnostics | `MockingError: MockStateMachine has not yet implemented attribute 'insert_input'` | none |

**Line numbers (#1349, the `list2need` half).** `insert_input` advances the parser's flat
line counter by the length of the generated text, for the rest of the file, and the error
compounds with each list. For a document with two items on lines 10 and 11 and an
ordinary `.. req::` on line 13:

| need | written on | `lineno` before | after |
|---|---|---|---|
| `LN-BEFORE` | 4 | 4 | 4 |
| `LN-A` | 10 | 14 | **10** |
| `LN-B` | 11 | 20 | **11** |
| `LN-AFTER` (an ordinary `.. req::`) | 13 | 27 | **13** |

In the repository's own `doc_list2need` fixture, `NEED-Z` was recorded at line 45 of a
19-line file. The general case — a `lineno` shifted by `rst_prolog` or an
`.. include::` — is a separate small PR, #1789.

**Template artefacts.** An item written `()` with options lost them: suppressing the
`:id:` left a blank line where it would have been, which ended the generated need's
option block, so every option after it became body text. And a parent need's stored
`content` was the generated reStructuredText of its children rather than its own text,
which `needs.json` and any filter reading `content` saw.

### The one deliberate change to an input that worked

Writing `()` used to suppress the `:id:` of the generated need, which sent it down the
need directives' own id generator — a **different** function, which honours
`needs_id_from_title` where `list2need`'s does not, hashes the *content* when the title
is empty, and hashes the title *after* the `((option="value"))` area has been removed
from it. One list could carry two id schemes at once, chosen by two characters of
punctuation. The directive now derives every id itself, from the same input at the same
point, so `()` means what no brackets at all means.

Three kinds of item therefore get a different generated id:

| item | before | after |
|---|---|---|
| `* ()Alpha title` with `needs_id_from_title = True` | `R_ALPHA` | `R_D1EC6`, the plain hash |
| `* (). some content here` (no title) | `R_EBC29`, the hash of the **content** | `R_DA39A`, the hash of the empty title |
| `* ()Title with empty parens ((status="open"))` | `R_6AFF7` | **`R_D7997`** — the id `* Title with empty parens ((status="open"))` already had |

The third needs no configuration to reach and is the one to watch for; the changelog
says so under Breaking changes, and the documentation carries a `versionchanged`.
Everything else keeps the id it had, which the untouched id tests prove.

### Four inputs that were errors, and are now defined

None of these can appear in a document that builds cleanly today, so nothing that
works can regress; they are listed because each is a decision the template used to
delegate to docutils and the directive now has to make.

- **`((id="MY-ID"))`** names the need. The template wrote the derived id *and* the
  inline one as two `:id:` lines of one generated need, which docutils refused with
  `duplicate option "id"`, dropping the item. The id is applied before `:links-down:`
  is built, so the other items' links agree with it. An empty `((id=""))` is refused
  with a diagnostic rather than quietly replaced by the title hash.
- **An inline option naming the same link field as `:links-down:`** — `((links="X"))`
  under `:links-down: links` — produced one corrupt link value (the template's
  `{%- for %}` glued the two field lines into `:links: C-2:links: X`) and an
  `unknown outgoing link` warning. The two sets are now merged.
- **`((title_from_content="true"))`** is read as a need directive reads it.
- **A child of a `((hide="true"))` item** is rendered at the level above it. A hidden
  need is taken out of the document once read, so nesting a child inside one would put
  its target where no page can reach it.

### Evidence

- The rendered HTML of `tests/doc_test/doc_list2need/` is **byte-identical** before and
  after, all four pages, apart from the per-build random `SNCB-…` container ids. Its
  `needs.json` keeps all 16 ids, every title, status, tag, link and `parent_need`; only
  the linenos and the two parent `content` strings change.
- The characterization suite added in #1788 is the safety net. The eleven build-aborting
  inputs and the `links-down` level-skip test pass **untouched** — this PR takes neither
  of those on. **Four** assertions are edited, each one pinning something the template
  did: the drifted linenos, the MyST failure (which inverts), the parent's
  generated-text content, and the second id function. A fifth prediction went the other
  way (below).
- Two tests gain an assertion: the Markdown ones now pin the items' line numbers.
  Linenos inside an `{eval-rst}` fence were wrong too — that block was the only way to
  reach the directive from a Markdown document, and its needs were recorded at 10 and
  16 for items written on 7 and 8.
- `tests/__snapshots__/test_list2need.ambr` is rewritten: every `lineno` in it was wrong.
- Six tests are added: the `()`-plus-options id, a directive written in an item's
  content, and one for each of the four inputs above.

One assertion moved the other way. Removing the three-space indent the parser prepends to
a `:`-continuation line looked like removing a workaround for the template — it is not:
it is the only thing standing in for the indentation `lstrip` removes, and without it the
options of a directive written in an item's content (the `rst-directives in lists`
example in the documentation) land in the directive's own column and are dropped. It is
kept, and now has a test.

Refs #1427, Refs #1349.
