### PR TITLE
🐛 An invalid `predicates` expression warns instead of ending the build

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -274,7 +274,7 @@ These changes do not affect user-facing behaviour:
 Bug fixes
 .........
 
-- 🐛 An invalid ``predicates`` expression warns instead of ending the build
+- 🐛 An invalid ``predicates`` expression warns instead of ending the build (:pr:`1791`)
 
   A ``predicates`` match expression on a :ref:`needs_fields` or :ref:`needs_links`
   default that cannot be evaluated — one naming ``section_name`` or ``content``, say,

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -274,6 +274,28 @@ These changes do not affect user-facing behaviour:
 Bug fixes
 .........
 
+- 🐛 An invalid ``predicates`` expression warns instead of ending the build
+
+  A ``predicates`` match expression on a :ref:`needs_fields` or :ref:`needs_links`
+  default that cannot be evaluated — one naming ``section_name`` or ``content``, say,
+  neither of which a predicate has access to — used to raise out of the need's creation
+  and end the whole build with a traceback and a "please report this to the developers"
+  banner. No need was created, no other warning in the project was ever reported, and
+  nothing said which document the expression had failed on.
+
+  Such an expression is now reported as a ``needs.config`` warning, located at a need it
+  was evaluated against and naming the field, the expression and the underlying error,
+  and is then skipped: the remaining predicates are still evaluated, and if none of them
+  matches then the plain ``default`` applies, exactly as it does for a predicate that
+  simply did not match. A statically malformed ``predicates`` value — the wrong number
+  of items in a pair, say — has always been reported this way; only the expression
+  itself was left to end the build.
+
+  The warning is deduplicated on its full message, so a single configuration mistake --
+  such as the name typo above, which fails identically for every need -- is reported once
+  rather than once per need. An expression that fails only for some needs, or for
+  different reasons on different needs, is reported once per distinct error.
+
 - 🐛 A need records the line it is actually written on **(changed output)** (:issue:`1349`, :pr:`1789`)
 
   ``rst_prolog``, ``.. include::`` and :ref:`list2need` each put text into the document

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -344,6 +344,8 @@ For ``predicates``, the match expression is a string, using Python syntax, that 
 - :ref:`needs_links` (``tuple[str, ...]``)
 - :ref:`needs_variant_data` (via the ``var`` namespace)
 
+An expression that cannot be evaluated, such as one naming something not in this list, is reported as a ``needs.config`` warning and then skipped, so that the remaining predicates and the ``default`` apply just as they would for an expression that did not match.
+
 For example:
 
 .. code-block:: python
@@ -455,6 +457,8 @@ For ``predicates``, the match expression is a string, using Python syntax, that 
 - :ref:`needs_fields`
 - :ref:`needs_links` (``tuple[str, ...]``)
 - :ref:`needs_variant_data` (via the ``var`` namespace)
+
+An expression that cannot be evaluated, such as one naming something not in this list, is reported as a ``needs.config`` warning and then skipped, so that the remaining predicates and the ``default`` apply just as they would for an expression that did not match.
 
 For example:
 

--- a/sphinx_needs/api/need.py
+++ b/sphinx_needs/api/need.py
@@ -9,7 +9,7 @@ from contextlib import contextmanager
 from copy import copy, deepcopy
 from dataclasses import replace
 from pathlib import Path
-from typing import Any, TypedDict, cast
+from typing import Any, TypedDict, TypeVar, cast
 
 from docutils import nodes
 from docutils.parsers.rst.states import RSTState
@@ -25,7 +25,7 @@ from sphinx_needs.data import (
     SphinxNeedsData,
 )
 from sphinx_needs.directives.needuml import Needuml, NeedumlException
-from sphinx_needs.exceptions import InvalidNeedException
+from sphinx_needs.exceptions import InvalidNeedException, NeedsInvalidFilter
 from sphinx_needs.filter_common import (
     PredicateContextData,
     apply_default_predicate,
@@ -334,6 +334,7 @@ def generate_need(
         "core": defaults_ctx,
         "extras": defaults_extras_ctx,
         "links": defaults_links_ctx,
+        "location": location,
     }
 
     # Apply defaults to core fields (title excluded - always required)
@@ -1062,6 +1063,54 @@ class DefaultContextData(TypedDict):
     core: PredicateContextData
     extras: dict[str, AllowedTypes | None]
     links: dict[str, list[str]]
+    location: tuple[str | None, int | None] | None
+
+
+_PredicateValue = TypeVar("_PredicateValue")
+
+
+def _match_predicate_default(
+    predicate_defaults: Sequence[tuple[str, _PredicateValue]],
+    config_name: str,
+    field_name: str,
+    config: NeedsSphinxConfig,
+    core: PredicateContextData,
+    extras: dict[str, AllowedTypes | None],
+    links: dict[str, list[str]],
+    location: tuple[str | None, int | None] | None,
+) -> _PredicateValue | None:
+    """Return the value of the first predicate that matches this need, if any.
+
+    A predicate that cannot be evaluated is reported and skipped:
+    it used to raise out of the need's creation and end the whole build with a
+    traceback, so a single mistake in the configuration cost the project every need.
+    The remaining predicates are still evaluated, and if none of them matches then
+    the caller falls back to the plain ``default``, exactly as an unmatched
+    predicate has always done.
+    """
+    for predicate, value in predicate_defaults:
+        try:
+            matched = apply_default_predicate(predicate, config, core, extras, links)
+        except NeedsInvalidFilter as err:
+            # once=True: a configuration mistake that breaks the expression outright
+            # would otherwise be repeated for every need in the project. The dedup
+            # key is the whole message, so a predicate that fails only for SOME
+            # needs, or for different reasons on different needs, is still reported
+            # once per distinct error -- evaluability is data-dependent, which is
+            # why the predicate must keep being evaluated per need rather than
+            # being marked broken and skipped wholesale.
+            log_warning(
+                logger,
+                f"{config_name}[{field_name!r}]['predicates']: {err} "
+                "The predicate is skipped.",
+                "config",
+                location,
+                once=True,
+            )
+            continue
+        if matched:
+            return value
+    return None
 
 
 def _get_field_default(
@@ -1070,13 +1119,24 @@ def _get_field_default(
     core: PredicateContextData,
     extras: dict[str, AllowedTypes | None],
     links: dict[str, list[str]],
+    location: tuple[str | None, int | None] | None,
 ) -> None | FieldLiteralValue | FieldFunctionArray:
     if scheme is None:
         return None  # TODO except (and catch upstream)
     # TODO if we stored default lists as tuples we could avoid the deepcopy here
-    for predicate, v in scheme.predicate_defaults:
-        if apply_default_predicate(predicate, config, core, extras, links):
-            return deepcopy(v)
+    if (
+        value := _match_predicate_default(
+            scheme.predicate_defaults,
+            "needs_fields",
+            scheme.name,
+            config,
+            core,
+            extras,
+            links,
+            location,
+        )
+    ) is not None:
+        return deepcopy(value)
     if scheme.default is not None:
         return deepcopy(scheme.default)
     return None
@@ -1088,13 +1148,24 @@ def _get_links_default(
     core: PredicateContextData,
     extras: dict[str, AllowedTypes | None],
     links: dict[str, list[str]],
+    location: tuple[str | None, int | None] | None,
 ) -> None | LinksLiteralValue | LinksFunctionArray:
     if scheme is None:
         return None  # TODO except (and catch upstream)
     # TODO if we stored default lists as tuples we could avoid the deepcopy here
-    for predicate, v in scheme.predicate_defaults:
-        if apply_default_predicate(predicate, config, core, extras, links):
-            return deepcopy(v)
+    if (
+        value := _match_predicate_default(
+            scheme.predicate_defaults,
+            "needs_links",
+            scheme.name,
+            config,
+            core,
+            extras,
+            links,
+            location,
+        )
+    ) is not None:
+        return deepcopy(value)
     if scheme.default is not None:
         return deepcopy(scheme.default)
     return None

--- a/tests/test_field_defaults.py
+++ b/tests/test_field_defaults.py
@@ -60,6 +60,122 @@ def test_doc_global_option(test_app, snapshot):
     )
 
 
+CONF_INVALID_PREDICATE = """\
+extensions = ["sphinx_needs"]
+
+needs_types = [
+    {"directive": "spec", "title": "Specification", "prefix": "SP_"}
+]
+
+needs_fields = {
+    # `section_name` is a field of the need, but is not available to a predicate,
+    # so evaluating these raises a NameError
+    "with_default": {
+        "predicates": [("section_name == 'Test'", "matched")],
+        "default": "fallback",
+    },
+    "without_default": {
+        "nullable": True,
+        "predicates": [("section_name == 'Test'", "matched")],
+    },
+    "later_predicate": {
+        "predicates": [
+            ("section_name == 'Test'", "unreachable"),
+            ("status == 'open'", "matched"),
+        ],
+        "default": "fallback",
+    },
+    "valid_only": {
+        "predicates": [("status == 'open'", "matched")],
+        "default": "fallback",
+    },
+}
+
+needs_links = {
+    "blocks": {
+        "incoming": "is blocked by",
+        "outgoing": "blocks",
+        # `content` is likewise not available to a predicate
+        "predicates": [("'body' in content", ["SPEC_2"])],
+        "default": ["SPEC_1"],
+    },
+}
+"""
+
+INDEX_INVALID_PREDICATE = """\
+Test
+====
+
+.. spec:: Specification 1
+    :id: SPEC_1
+    :status: open
+
+.. spec:: Specification 2
+    :id: SPEC_2
+    :status: open
+"""
+
+
+@pytest.mark.parametrize(
+    "test_app",
+    [
+        {
+            "buildername": "html",
+            "no_plantuml": True,
+            "files": [
+                (Path("conf.py"), CONF_INVALID_PREDICATE),
+                (Path("index.rst"), INDEX_INVALID_PREDICATE),
+            ],
+        }
+    ],
+    indirect=True,
+)
+def test_invalid_predicate_default(test_app):
+    """A predicate that cannot be evaluated warns and is skipped, and the build completes.
+
+    Such a predicate used to raise out of ``add_need`` and end the whole build with a
+    traceback, so a single mistake in ``needs_fields`` / ``needs_links`` cost the
+    project every need and every other warning in the build.
+    """
+    test_app.build()
+
+    warnings = strip_colors(
+        test_app._warning.getvalue().replace(str(test_app.srcdir) + os.sep, "srcdir/")
+    ).splitlines()
+    assert warnings == [
+        "srcdir/index.rst:4: WARNING: needs_fields['with_default']['predicates']: "
+        "Predicate \"section_name == 'Test'\" not valid. "
+        "Error: name 'section_name' is not defined. "
+        "The predicate is skipped. [needs.config]",
+        "srcdir/index.rst:4: WARNING: needs_fields['without_default']['predicates']: "
+        "Predicate \"section_name == 'Test'\" not valid. "
+        "Error: name 'section_name' is not defined. "
+        "The predicate is skipped. [needs.config]",
+        "srcdir/index.rst:4: WARNING: needs_fields['later_predicate']['predicates']: "
+        "Predicate \"section_name == 'Test'\" not valid. "
+        "Error: name 'section_name' is not defined. "
+        "The predicate is skipped. [needs.config]",
+        "srcdir/index.rst:4: WARNING: needs_links['blocks']['predicates']: "
+        "Predicate \"'body' in content\" not valid. "
+        "Error: name 'content' is not defined. "
+        "The predicate is skipped. [needs.config]",
+    ]
+
+    needs = SphinxNeedsData(test_app.env).get_needs_view()
+    assert set(needs) == {"SPEC_1", "SPEC_2"}
+    need = needs["SPEC_1"]
+    # the skipped predicate falls back to the plain default ...
+    assert need["with_default"] == "fallback"
+    # ... or, where there is none, leaves the field unset
+    assert need["without_default"] is None
+    # a later predicate is still evaluated, and still wins over the plain default
+    assert need["later_predicate"] == "matched"
+    # a predicate that evaluates is unaffected
+    assert need["valid_only"] == "matched"
+    # links behave the same way
+    assert need["blocks"] == ["SPEC_1"]
+
+
 @pytest.mark.parametrize(
     "test_app",
     [


### PR DESCRIPTION
A `predicates` match expression on a `needs_fields` or `needs_links` default that
cannot be evaluated ends the entire build with a traceback, rather than being
reported like every other bad expression in the project.

## What happens today

```python
# conf.py
needs_fields = {
    "p_section": {"default": "no", "predicates": [["section_name == 'Alpha'", "yes"]]},
}
```

```rst
Alpha
=====

.. spec:: Specification 1
    :id: SPEC_1
```

```
Sphinx error!
sphinx_needs.exceptions.NeedsInvalidFilter: Predicate "section_name == 'Alpha'" not valid. Error: name 'section_name' is not defined.

The full traceback has been saved in: /tmp/sphinx-err-....log
To report this error to the developers, please open an issue at <https://github.com/sphinx-doc/sphinx/issues/>. Thanks!
```

No need is created, no other warning in the project is ever reported, nothing names
the document the expression failed on, and the user is pointed at Sphinx's issue
tracker for what is a typo in their own `conf.py`. `needs_links` predicates fail the
same way (`"'body' in content"` → `name 'content' is not defined`).

The trap is easy to fall into, because the names most likely to be reached for —
`section_name`, `sections`, `content`, `lineno` — all work in ordinary filters, and
none of them is available to a predicate.

## What this changes

`NeedsInvalidFilter` is caught where the predicate is applied, in
`_get_field_default` / `_get_links_default`, and reported instead:

```
index.rst:4: WARNING: needs_fields['p_section']['predicates']: Predicate "section_name == 'Alpha'" not valid. Error: name 'section_name' is not defined. The predicate is skipped. [needs.config]
```

The predicate is then skipped: the remaining predicates are still evaluated, and if
none of them matches, the plain `default` applies — exactly as it does for a
predicate that simply did not match. The need is created and the build completes.

`apply_default_predicate` keeps its documented `:raises NeedsInvalidFilter:`
contract; the catch is at the call sites, which are the narrowest seam that has a
need location to report against.

## The warning subtype

`needs.config`, reusing an existing subtype rather than adding one:

- a *statically* malformed `predicates` value is already reported as
  `needs_fields['x']['predicates'] value is incorrect: ... [needs.config]` by
  `_set_predicates_on_field`. This is the runtime half of the same mistake on the
  same configuration key, and now reads as its sibling;
- #1780 took the same route for an unknown `needs_flow_engine` value — a bad
  configuration value, warned as `needs.config` at the use site with `once=True`,
  falling back to the sane default.

It is deduplicated `once=True` on its full message: a single configuration mistake —
like the name typo above, which fails identically for every need — is reported once
rather than once per need. An expression that fails only for some needs, or for
different reasons on different needs (say `int(status) > 1` across varying status
values), is reported once per distinct error, which keeps each real failure visible.

One recorded limitation: the message names the canonical `needs_fields` /
`needs_links` key, so a predicate configured through the deprecated
`needs_global_options`, a `needs_extra_links` entry, or `add_field(...)` is labelled
with the canonical key rather than the one the project wrote. The field name in the
message always identifies the culprit, and threading true origins through the schema
is out of scope for a single-purpose fix.

## Tests

`test_invalid_predicate_default` in `tests/test_field_defaults.py`, one build
covering: an invalid predicate on a field default (warning subtype, location and
text asserted; the plain `default` applies), the same on a link default, a field
whose plain `default` is absent (stays unset — current semantics pinned, not
changed), a valid predicate that still applies, and a valid predicate *after* a
broken one, which still wins over the plain `default`.

The test was written first and fails on `master` by killing the build out of
`app.build()`, which is the defect itself. The two existing tests in that module,
including their verbatim warning lists, are unchanged.

## Related

Same class as #1537 — one bad value costing far more than itself — though a
different cause; this is not a duplicate of it.

The `predicates` documentation did not say what happens to an expression that
cannot be evaluated, so one sentence has been added to the "Default values"
subsections of both `needs_fields` and `needs_links`.
