### PR TITLE
📚 Label the three config sections intersphinx could not reach

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -123,6 +123,8 @@ For example to read from a ``[tool.needs]`` table:
 
 .. caution:: Any configuration specifying relative paths in the toml file will be resolved relative to the directory containing the :file:`conf.py` file.
 
+.. _`needs_include_needs`:
+
 needs_include_needs
 ~~~~~~~~~~~~~~~~~~~
 
@@ -1181,6 +1183,8 @@ any of the other four is reported as a ``needs.needreport`` warning.
       :ref:`needs_external_needs`, and :ref:`need parts <need_part>`, which each count as
       a need of their parent's type.
 
+.. _`needs_diagram_template`:
+
 needs_diagram_template
 ~~~~~~~~~~~~~~~~~~~~~~
 
@@ -1262,8 +1266,6 @@ exceed the setting from :ref:`needs_id_length`.
    The user needs to ensure the uniqueness of the given title, and also match the settings of
    :ref:`needs_id_length` and :ref:`needs_id_regex`.
 
-.. _`needs_title_optional`:
-
 .. _`needs_parse_dynamic_functions`:
 
 needs_parse_dynamic_functions
@@ -1291,6 +1293,8 @@ parsing enabled unless explicitly set to ``False`` per-field/link via
 
 By default this option is set to **True** for backward compatibility.
 In a future major release, the default will change to ``False``.
+
+.. _`needs_title_optional`:
 
 needs_title_optional
 ~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
`needs_title_optional`'s explicit label has been stranded above `needs_parse_dynamic_functions`
since that section was inserted between the label and its section:
every `` :ref:`needs_title_optional` `` — including the changelog's own reference —
renders the wrong title and lands on the wrong section,
and the `objects.inv` entry points there too, so intersphinx consumers inherit the same wrong target.
This moves the label onto its section.

`needs_include_needs` and `needs_diagram_template` are the only two options on the
configuration page with no explicit label at all, so they are absent from `objects.inv`
and cannot be referenced by other projects via intersphinx
(the ubCode docs link to both and currently have to fall back to raw URLs).
This gives them the labels every sibling section already has.

Docs-only, three labels moved/added; no code changes.

Surfaced by useblocks/ubcode#3124, which switches the ubCode docs' sphinx-needs
links to intersphinx references (no ordering dependency — that PR pins the
released 8.3.0 inventory; these labels take effect there once a release carries
them and the pin bumps).