### PR TITLE
🐛 needextract: six inputs that ended the build are now reported

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,64 @@
 Changelog
 =========
 
+.. _`release:unreleased`:
+
+Unreleased
+----------
+
+:Released: Unreleased
+
+Bug fixes
+.........
+
+- 🐛 Six :ref:`needextract` inputs that ended the build are now reported instead
+  **(changed output)** (:pr:`1794`)
+
+  Each of these ended the whole build with a Python traceback and a "please report this
+  to the developers" banner, three of them from the directive's own option surface:
+
+  - an argument that looks like a need ID but names no need,
+  - an argument and ``:filter:`` together — the combination the documentation warns
+    about,
+  - ``needs_include_needs = False`` with any needextract in the project, which gave no
+    diagnostic at all,
+  - a ``needtable`` in the content of an extracted need,
+  - a ``needextract`` in the content of an extracted need,
+  - a footnote reference in the content of an extracted need.
+
+  The first three were one defect: the name holding a needextract's filter result was
+  assigned inside the loop over a document's nodes and read once after it, so any node
+  taking an early exit left it unbound. All three are now reported (or, under
+  ``needs_include_needs = False``, silently dropped, exactly as every other view
+  directive drops itself) and the rest of the build stands.
+
+  The other three come from *when* a need's content is copied. It is snapshotted while
+  the need's directive runs, before any of its document's transforms, and spliced into
+  the extract's document after all of *that* document's transforms — so it sees neither
+  document's pipeline, and a handful of transforms are replayed over it by hand. One of
+  those replays, ``env.resolve_references()``, ends by emitting ``doctree-resolved``,
+  with the detached container holding the copy standing in for a document: every
+  listener of the event ran a second time on a node that is not a document, this
+  extension's own listeners included. Sphinx's post-transforms are now applied directly
+  instead, so the event is emitted once per document and always with a document — a
+  guarantee a third-party listener gets too.
+
+  What a copy cannot render is now dropped from it and named, rather than reaching a
+  processor or the writer that cannot cope:
+
+  - ``needbar``, ``needextract``, ``needpie``, ``needtable`` and ``needuml`` in the
+    content of an extracted need are omitted from the copy, each reported at the
+    needextract site.
+  - A footnote reference in it is rendered as the marker its author wrote, without the
+    trailing ``_``, and reported. The footnote's own text stays where it is, so nothing
+    disappears from the page.
+
+  Everything else a copy carries is unchanged, byte for byte: rich markup, code blocks,
+  images, substitutions, nested needs, figures under ``numfig``, and needs extracted in
+  their own document or defined later in the build. In particular the reference contract
+  is untouched — a ``:ref:`` or ``:need:`` inside extracted content still resolves to
+  the page the need is written on, and so does the extract card's own ID chip.
+
 .. _`release:8.4.0`:
 
 8.4.0

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,7 +15,7 @@ Bug fixes
 .........
 
 - 🐛 Six :ref:`needextract` inputs that ended the build are now reported instead
-  **(changed output)** (:pr:`1794`)
+  **(changed output)** (:pr:`1795`)
 
   Each of these ended the whole build with a Python traceback and a "please report this
   to the developers" banner, three of them from the directive's own option surface:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -49,9 +49,9 @@ Bug fixes
   What a copy cannot render is now dropped from it and named, rather than reaching a
   processor or the writer that cannot cope:
 
-  - ``needbar``, ``needextract``, ``needpie``, ``needtable`` and ``needuml`` in the
-    content of an extracted need are omitted from the copy, each reported at the
-    needextract site.
+  - ``needbar``, ``needextract``, ``needpie``, ``needtable`` and ``needuml`` — and so
+    ``needarch``, which is ``needuml`` restricted to a need's content — in the content of
+    an extracted need are omitted from the copy, each reported at the needextract site.
   - A footnote reference in it is rendered as the marker its author wrote, without the
     trailing ``_``, and reported. The footnote's own text stays where it is, so nothing
     disappears from the page.

--- a/sphinx_needs/directives/needextract.py
+++ b/sphinx_needs/directives/needextract.py
@@ -40,7 +40,8 @@ class Needextract(nodes.General, nodes.Element):
     pass
 
 
-#: View directives that an extract cannot render, and so drops from its copy.
+#: View directives that an extract cannot render, and so drops from its copy,
+#: mapped to what they are called in a document.
 #:
 #: A need's content is snapshotted while its directive runs, which is before
 #: docutils' ``PropagateTargets`` transform has moved the id of the target
@@ -50,7 +51,22 @@ class Needextract(nodes.General, nodes.Element):
 #: the document *after* ``process_needextract`` has walked it, so no listener ever
 #: reaches a nested one and it arrives at the writer instead.  Every one of the
 #: five used to end the build.
-_UNRENDERABLE_IN_EXTRACT: Final = (Needbar, Needextract, Needpie, Needtable, Needuml)
+#:
+#: The names are held here rather than taken from the node class, because
+#: ``needarch`` -- which is ``needuml`` restricted to a need's content, and so the
+#: one of these most likely to be written there -- emits a ``Needuml`` node
+#: (``NeedarchDirective(NeedumlDirective)``).  A report naming only ``needuml``
+#: sends a reader grepping their source for a directive they never wrote.
+_UNRENDERABLE_IN_EXTRACT: Final[dict[type[nodes.Node], str]] = {
+    Needbar: "'needbar'",
+    Needextract: "'needextract'",
+    Needpie: "'needpie'",
+    Needtable: "'needtable'",
+    Needuml: "'needuml' (or 'needarch')",
+}
+
+#: The keys of :data:`_UNRENDERABLE_IN_EXTRACT`, for ``isinstance``.
+_UNRENDERABLE_NODE_TYPES: Final = tuple(_UNRENDERABLE_IN_EXTRACT)
 
 
 class NeedextractDirective(FilterBase):
@@ -258,11 +274,12 @@ def _drop_unrenderable_nodes(
     :param need_data: The need being extracted
     :param extract_node: The needextract node the copy is being built for
     """
-    for child in list(node.findall(lambda n: isinstance(n, _UNRENDERABLE_IN_EXTRACT))):
+    for child in list(node.findall(lambda n: isinstance(n, _UNRENDERABLE_NODE_TYPES))):
         log_warning(
             LOGGER,
-            f"A {type(child).__name__.lower()!r} directive in the content of need "
-            f"{need_data['id']!r} cannot be rendered by needextract, and is omitted.",
+            f"A {_UNRENDERABLE_IN_EXTRACT[type(child)]} directive in the content of "
+            f"need {need_data['id']!r} cannot be rendered by needextract, and is "
+            "omitted.",
             "needextract",
             location=extract_node,
         )

--- a/sphinx_needs/directives/needextract.py
+++ b/sphinx_needs/directives/needextract.py
@@ -221,6 +221,7 @@ def _build_needextract(
     dummy_need.extend(need_node.children)
 
     _drop_unrenderable_nodes(dummy_need, need_data, extract_node)
+    _degrade_footnote_references(dummy_need, need_data, extract_node)
 
     find_and_replace_node_content(dummy_need, env, need_data)
 
@@ -263,6 +264,44 @@ def _drop_unrenderable_nodes(
             location=extract_node,
         )
         child.parent.remove(child)
+
+
+def _degrade_footnote_references(
+    node: nodes.Element, need_data: NeedItem, extract_node: Needextract
+) -> None:
+    """Render the copied footnote references as text, and report that.
+
+    A need's content is snapshotted while its directive runs, which is before
+    docutils' ``references.Footnotes`` transform has given each
+    ``footnote_reference`` in it the ``refid`` of the footnote it points at.  The
+    reference reached the HTML writer without one and ended the build with
+    ``KeyError: 'refid'``.
+
+    There is no faithful way to supply the id here: the footnote may be defined
+    outside the need's content altogether, and a copy that numbered its own
+    footnotes would disagree with the numbers on the page the need is written on.
+    So the reference is rendered as the marker the author wrote, without its
+    trailing ``_``, and the footnote's own text is left in the copy where it is.
+
+    :param node: The copy of the need's content
+    :param need_data: The need being extracted
+    :param extract_node: The needextract node the copy is being built for
+    """
+    references = list(node.findall(nodes.footnote_reference))
+    if not references:
+        return
+
+    log_warning(
+        LOGGER,
+        f"A footnote reference in the content of need {need_data['id']!r} cannot be "
+        "resolved by needextract, and is rendered as plain text.",
+        "needextract",
+        location=extract_node,
+    )
+    for reference in references:
+        reference.parent.replace(
+            reference, nodes.Text(reference.rawsource.removesuffix("_"))
+        )
 
 
 def _apply_post_transforms(app: Sphinx, node: nodes.Element, docname: str) -> None:

--- a/sphinx_needs/directives/needextract.py
+++ b/sphinx_needs/directives/needextract.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
+from copy import copy, deepcopy
 from typing import Final
 
 from docutils import nodes
 from docutils.parsers.rst import directives
 from docutils.transforms.references import Substitutions
 from sphinx.application import Sphinx
+from sphinx.environment import BuildEnvironment
 from sphinx.environment.collectors.asset import DownloadFileCollector, ImageCollector
 from sphinx.transforms import SphinxTransformer
 from sphinx.util.logging import getLogger
@@ -304,40 +307,72 @@ def _degrade_footnote_references(
         )
 
 
+@contextmanager
+def _scratch_document_state(env: BuildEnvironment, docname: str) -> Iterator[None]:
+    """Give the post-transforms a throwaway per-document state, named *docname*.
+
+    This is what ``BuildEnvironment.apply_post_transforms`` does around its own
+    call to the transformer, and it is a *replacement*, not a mutation: the state
+    the post-transforms are handed is a copy pointed at the document being
+    resolved, and the original is put back afterwards, so whatever they write
+    into it is discarded rather than carried into the rest of the build.
+
+    Sphinx moved that state from ``env.temp_data``, a plain dict, to
+    ``env.current_document``, an object reached through a read-only ``temp_data``
+    alias, so the save and restore is written twice -- once for each shape the
+    supported range of Sphinx has, chosen at runtime.
+
+    :param env: The build environment
+    :param docname: The document the post-transforms are to run for
+    """
+    if hasattr(env, "current_document"):
+        # Sphinx >= 8.2
+        backup = env.current_document
+        scratch = deepcopy(backup)
+        scratch.docname = docname
+        env.current_document = scratch
+        try:
+            yield
+        finally:
+            env.current_document = backup
+    else:
+        backup_temp_data = copy(env.temp_data)
+        env.temp_data["docname"] = docname
+        try:
+            yield
+        finally:
+            env.temp_data = backup_temp_data
+
+
 def _apply_post_transforms(app: Sphinx, node: nodes.Element, docname: str) -> None:
     """Run Sphinx's post-transforms over a detached node, resolving its references.
 
     This is ``BuildEnvironment.apply_post_transforms`` without its closing
-    ``doctree-resolved`` emission.  ``env.resolve_references()`` was called here
-    instead, and it goes through that emission -- with the detached
-    ``nodes.container`` this function is given standing in for a document.  Every
-    listener of the event was therefore run a second time, on a node that is not
-    a document and holds one need's copied content: Sphinx-Needs' own listeners
-    included, and so this function's own caller.  Content holding any node one of
-    them handles ended the build rather than rendering: a ``needtable`` in an
-    extracted need with ``list index out of range``, a nested ``needextract``
-    with ``'container' object has no attribute 'settings'``.
+    ``doctree-resolved`` emission, and with nothing else left out: the
+    per-document state the post-transforms run against is replaced for the
+    duration, exactly as that method replaces it (see
+    :func:`_scratch_document_state`).
+
+    ``env.resolve_references()`` was called here instead, and it goes through that
+    emission -- with the detached ``nodes.container`` this function is given
+    standing in for a document.  Every listener of the event was therefore run a
+    second time, on a node that is not a document and holds one need's copied
+    content: Sphinx-Needs' own listeners included, and so this function's own
+    caller.  Content holding any node one of them handles ended the build rather
+    than rendering: a ``needtable`` in an extracted need with ``list index out of
+    range``, a nested ``needextract`` with ``'container' object has no attribute
+    'settings'``.
 
     :param app: Sphinx application
     :param node: The detached node whose references are to be resolved
     :param docname: The document the node is about to be inserted into
     """
     env = app.env
-    # what a post-transform reads as "the document being processed"; ``temp_data``
-    # is Sphinx's own compatibility alias for it, and is what the collectors above
-    # are given too
-    previous_docname = env.temp_data.get("docname")
-    env.temp_data["docname"] = docname
-    try:
+    with _scratch_document_state(env, docname):
         transformer = SphinxTransformer(node)  # type: ignore[arg-type]
         transformer.set_environment(env)
         transformer.add_transforms(app.registry.get_post_transforms())
         transformer.apply_transforms()
-    finally:
-        if previous_docname is None:
-            del env.temp_data["docname"]
-        else:
-            env.temp_data["docname"] = previous_docname
 
 
 def _replace_pending_xref_refdoc(node: nodes.Element, new_refdoc: str) -> None:

--- a/sphinx_needs/directives/needextract.py
+++ b/sphinx_needs/directives/needextract.py
@@ -2,17 +2,23 @@ from __future__ import annotations
 
 import re
 from collections.abc import Sequence
+from typing import Final
 
 from docutils import nodes
 from docutils.parsers.rst import directives
 from docutils.transforms.references import Substitutions
 from sphinx.application import Sphinx
 from sphinx.environment.collectors.asset import DownloadFileCollector, ImageCollector
+from sphinx.transforms import SphinxTransformer
 from sphinx.util.logging import getLogger
 
 from sphinx_needs.config import NeedsSphinxConfig
 from sphinx_needs.data import NeedsExtractType, SphinxNeedsData
 from sphinx_needs.debug import measure_time
+from sphinx_needs.directives.needbar import Needbar
+from sphinx_needs.directives.needpie import Needpie
+from sphinx_needs.directives.needtable import Needtable
+from sphinx_needs.directives.needuml import Needuml
 from sphinx_needs.directives.utils import (
     no_needs_found_paragraph,
     used_filter_paragraph,
@@ -29,6 +35,19 @@ LOGGER = getLogger(__name__)
 
 class Needextract(nodes.General, nodes.Element):
     pass
+
+
+#: View directives that an extract cannot render, and so drops from its copy.
+#:
+#: A need's content is snapshotted while its directive runs, which is before
+#: docutils' ``PropagateTargets`` transform has moved the id of the target
+#: preceding each of these nodes onto the node itself -- and each of the four
+#: view directives reads that id when it renders, as ``node["ids"][0]``.
+#: ``Needextract`` is unrenderable for a different reason: a copy is spliced into
+#: the document *after* ``process_needextract`` has walked it, so no listener ever
+#: reaches a nested one and it arrives at the writer instead.  Every one of the
+#: five used to end the build.
+_UNRENDERABLE_IN_EXTRACT: Final = (Needbar, Needextract, Needpie, Needtable, Needuml)
 
 
 class NeedextractDirective(FilterBase):
@@ -201,13 +220,15 @@ def _build_needextract(
 
     dummy_need.extend(need_node.children)
 
+    _drop_unrenderable_nodes(dummy_need, need_data, extract_node)
+
     find_and_replace_node_content(dummy_need, env, need_data)
 
     # resolve_references() ignores the given docname and takes the docname from the pending_xref node.
     # Therefore, we need to manipulate this first, before we can ask Sphinx to perform the normal
     # reference handling for us.
     _replace_pending_xref_refdoc(dummy_need, extract_data["docname"])
-    env.resolve_references(dummy_need, extract_data["docname"], app.builder)  # type: ignore[arg-type]
+    _apply_post_transforms(app, dummy_need, extract_data["docname"])
 
     dummy_need.attributes["ids"].append(need_data["id"])
     rendered_node = build_need_repr(
@@ -220,6 +241,64 @@ def _build_needextract(
     )
 
     return rendered_node
+
+
+def _drop_unrenderable_nodes(
+    node: nodes.Element, need_data: NeedItem, extract_node: Needextract
+) -> None:
+    """Remove the copied nodes an extract cannot render, and report each one.
+
+    See :data:`_UNRENDERABLE_IN_EXTRACT` for what cannot be rendered, and why.
+
+    :param node: The copy of the need's content
+    :param need_data: The need being extracted
+    :param extract_node: The needextract node the copy is being built for
+    """
+    for child in list(node.findall(lambda n: isinstance(n, _UNRENDERABLE_IN_EXTRACT))):
+        log_warning(
+            LOGGER,
+            f"A {type(child).__name__.lower()!r} directive in the content of need "
+            f"{need_data['id']!r} cannot be rendered by needextract, and is omitted.",
+            "needextract",
+            location=extract_node,
+        )
+        child.parent.remove(child)
+
+
+def _apply_post_transforms(app: Sphinx, node: nodes.Element, docname: str) -> None:
+    """Run Sphinx's post-transforms over a detached node, resolving its references.
+
+    This is ``BuildEnvironment.apply_post_transforms`` without its closing
+    ``doctree-resolved`` emission.  ``env.resolve_references()`` was called here
+    instead, and it goes through that emission -- with the detached
+    ``nodes.container`` this function is given standing in for a document.  Every
+    listener of the event was therefore run a second time, on a node that is not
+    a document and holds one need's copied content: Sphinx-Needs' own listeners
+    included, and so this function's own caller.  Content holding any node one of
+    them handles ended the build rather than rendering: a ``needtable`` in an
+    extracted need with ``list index out of range``, a nested ``needextract``
+    with ``'container' object has no attribute 'settings'``.
+
+    :param app: Sphinx application
+    :param node: The detached node whose references are to be resolved
+    :param docname: The document the node is about to be inserted into
+    """
+    env = app.env
+    # what a post-transform reads as "the document being processed"; ``temp_data``
+    # is Sphinx's own compatibility alias for it, and is what the collectors above
+    # are given too
+    previous_docname = env.temp_data.get("docname")
+    env.temp_data["docname"] = docname
+    try:
+        transformer = SphinxTransformer(node)  # type: ignore[arg-type]
+        transformer.set_environment(env)
+        transformer.add_transforms(app.registry.get_post_transforms())
+        transformer.apply_transforms()
+    finally:
+        if previous_docname is None:
+            del env.temp_data["docname"]
+        else:
+            env.temp_data["docname"] = previous_docname
 
 
 def _replace_pending_xref_refdoc(node: nodes.Element, new_refdoc: str) -> None:

--- a/sphinx_needs/directives/needextract.py
+++ b/sphinx_needs/directives/needextract.py
@@ -21,7 +21,7 @@ from sphinx_needs.filter_common import FilterBase, process_filters
 from sphinx_needs.functions.functions import find_and_replace_node_content
 from sphinx_needs.layout import build_need_repr
 from sphinx_needs.logging import log_warning
-from sphinx_needs.need_item import NeedItem
+from sphinx_needs.need_item import NeedItem, NeedPartItem
 from sphinx_needs.utils import add_doc, remove_node_from_tree
 
 LOGGER = getLogger(__name__)
@@ -86,6 +86,10 @@ def process_needextract(
     """
     env = app.env
     needs_config = NeedsSphinxConfig(app.config)
+
+    # Initialised here, because every node in the loop below can take an early exit
+    # before the filter is run, and the value is read once after the loop.
+    found_needs: list[NeedItem | NeedPartItem] = []
 
     node: Needextract
     for node in found_nodes:  # type: ignore[assignment]

--- a/sphinx_needs/directives/needextract.py
+++ b/sphinx_needs/directives/needextract.py
@@ -69,6 +69,24 @@ _UNRENDERABLE_IN_EXTRACT: Final[dict[type[nodes.Node], str]] = {
 _UNRENDERABLE_NODE_TYPES: Final = tuple(_UNRENDERABLE_IN_EXTRACT)
 
 
+def _unrenderable_label(node: nodes.Node) -> str:
+    """Name the directive family a dropped node came from, as an author wrote it.
+
+    Looked up by ``isinstance`` rather than exact type, mirroring the ``findall``
+    predicate that matched the node: an exact-type lookup would raise on a future
+    subclass of one of the five (say, a ``needarch``-specific ``Needuml``
+    subclass) -- reintroducing the build-ending exception class this module's
+    fixes removed.
+
+    :param node: A node matched via :data:`_UNRENDERABLE_NODE_TYPES`
+    """
+    return next(
+        label
+        for node_type, label in _UNRENDERABLE_IN_EXTRACT.items()
+        if isinstance(node, node_type)
+    )
+
+
 class NeedextractDirective(FilterBase):
     """
     Directive to filter needs and present them as normal needs with given layout and style.
@@ -277,7 +295,7 @@ def _drop_unrenderable_nodes(
     for child in list(node.findall(lambda n: isinstance(n, _UNRENDERABLE_NODE_TYPES))):
         log_warning(
             LOGGER,
-            f"A {_UNRENDERABLE_IN_EXTRACT[type(child)]} directive in the content of "
+            f"A {_unrenderable_label(child)} directive in the content of "
             f"need {need_data['id']!r} cannot be rendered by needextract, and is "
             "omitted.",
             "needextract",

--- a/sphinx_needs/functions/functions.py
+++ b/sphinx_needs/functions/functions.py
@@ -211,7 +211,6 @@ def find_and_replace_node_content(
     :param node: Node to analyse
     :param env: Sphinx environment
     :param need: Need data
-    :param extract: If True, the function has been called from a needextract node
     """
     new_children = []
     if isinstance(node, NeedFunc):

--- a/tests/test_needextract.py
+++ b/tests/test_needextract.py
@@ -729,7 +729,7 @@ def _report(app, exception):
     state = app.env.temp_data
     Path(app.outdir, "state.log").write_text(
         f"sentinel={'PROBE_SENTINEL' in state}\\n"
-        f"highlight_language={state.get('highlight_language')!r}\\n"
+        f"highlight_language={state.get('highlight_language') or ''!r}\\n"
     )
 
 

--- a/tests/test_needextract.py
+++ b/tests/test_needextract.py
@@ -6,6 +6,19 @@ from lxml import html as html_parser
 from sphinx.util.console import strip_colors
 
 
+def build_warnings(app) -> list[str]:
+    """Return the warnings of a finished build, one per line.
+
+    The source directory is randomised per test run, so it is collapsed to
+    ``<srcdir>/`` to keep the expected strings readable and stable.
+    """
+    return (
+        strip_colors(app._warning.getvalue())
+        .replace(str(app.srcdir) + os.path.sep, "<srcdir>/")
+        .strip()
+    ).splitlines()
+
+
 @pytest.mark.parametrize(
     "test_app",
     [
@@ -107,3 +120,131 @@ def test_needextract_with_nested_needs(test_app):
     # dynamic functions should be executed
     assert "This is id SPEC_1 SPEC_1" in needextract_html
     assert "This is grandchild id SPEC_1_1_2 SPEC_1_1_2" in needextract_html
+
+
+# -- inputs that used to end the build ---------------------------------------
+#
+# ``found_needs`` was assigned inside the loop over a document's needextract
+# nodes and read once after it, so a node that took one of the three early
+# exits left the name unbound whenever it was the last (or only) one, and the
+# build ended with ``cannot access local variable 'found_needs' where it is not
+# associated with a value``.  Two of the three inputs below warn first and used
+# to end the build anyway; the third gave no diagnostic at all.
+
+CONF = """\
+extensions = ["sphinx_needs"]
+"""
+
+CONF_NEEDS_HIDDEN = """\
+extensions = ["sphinx_needs"]
+needs_include_needs = False
+"""
+
+UNKNOWN_ID_INDEX = """\
+Extract
+=======
+
+.. req:: One
+   :id: R_ONE
+
+   Body one.
+
+.. needextract:: R_NOPE
+"""
+
+ARG_AND_FILTER_INDEX = """\
+Extract
+=======
+
+.. req:: One
+   :id: R_ONE
+
+   Body one.
+
+.. needextract:: R_ONE
+   :filter: id == "R_ONE"
+"""
+
+PLAIN_EXTRACT_INDEX = """\
+Extract
+=======
+
+.. req:: One
+   :id: R_ONE
+
+   Body one.
+
+.. needextract:: R_ONE
+"""
+
+
+@pytest.mark.parametrize(
+    ("test_app", "expected_warnings", "expected_cards"),
+    [
+        pytest.param(
+            {
+                "buildername": "html",
+                "no_plantuml": True,
+                "files": [
+                    (Path("conf.py"), CONF),
+                    (Path("index.rst"), UNKNOWN_ID_INDEX),
+                ],
+            },
+            [
+                "<srcdir>/index.rst:9: WARNING: Requested need 'R_NOPE' not found. "
+                "[needs.needextract]"
+            ],
+            1,
+            id="unknown-id-argument",
+        ),
+        pytest.param(
+            {
+                "buildername": "html",
+                "no_plantuml": True,
+                "files": [
+                    (Path("conf.py"), CONF),
+                    (Path("index.rst"), ARG_AND_FILTER_INDEX),
+                ],
+            },
+            [
+                "<srcdir>/index.rst:9: WARNING: filter arguments and option filter "
+                "at the same time are disallowed. [needs.needextract]"
+            ],
+            1,
+            id="argument-and-filter-option",
+        ),
+        pytest.param(
+            {
+                "buildername": "html",
+                "no_plantuml": True,
+                "files": [
+                    (Path("conf.py"), CONF_NEEDS_HIDDEN),
+                    (Path("index.rst"), PLAIN_EXTRACT_INDEX),
+                ],
+            },
+            [],
+            0,
+            id="needs_include_needs-off",
+        ),
+    ],
+    indirect=["test_app"],
+)
+def test_needextract_early_exit_does_not_end_the_build(
+    test_app, expected_warnings, expected_cards
+):
+    """A needextract node that contributes nothing leaves the build standing.
+
+    Each input is reported (or, for ``needs_include_needs = False``, silently
+    dropped, exactly as every other view directive drops itself) and the page is
+    still written.  ``expected_cards`` counts the cards carrying the authored
+    need's anchor: one for the need itself, and none from the directive.
+    """
+    app = test_app
+    app.build()
+
+    assert build_warnings(app) == expected_warnings
+
+    # the page exists, and the directive contributed no need card to it
+    html = Path(app.outdir, "index.html").read_text(encoding="utf8")
+    assert "<h1>Extract" in html
+    assert html.count('id="R_ONE"') == expected_cards

--- a/tests/test_needextract.py
+++ b/tests/test_needextract.py
@@ -262,7 +262,10 @@ def test_needextract_early_exit_does_not_end_the_build(
 # directives whose rendering the copy cannot honour are dropped from it with a
 # warning naming each one.
 
-VIEW_IN_CONTENT_INDEX = """\
+
+def view_in_content_index(payload: str) -> str:
+    """Build a document whose need's content holds one view directive."""
+    return f"""\
 Index
 =====
 
@@ -275,9 +278,62 @@ Index
 
    Body, and then:
 
-   .. needtable::
+   {payload}
+"""
+
+
+VIEW_IN_CONTENT_INDEX = view_in_content_index(
+    """.. needtable::
       :columns: id
-      :style: table
+      :style: table"""
+)
+
+NEEDPIE_IN_CONTENT_INDEX = view_in_content_index(
+    """.. needpie::
+      :labels: reqs,rest
+
+      type == 'req'
+      type != 'req'"""
+)
+
+NEEDBAR_IN_CONTENT_INDEX = view_in_content_index(
+    """.. needbar:: A bar
+      :xlabels: FROM_DATA
+      :ylabels: FROM_DATA
+
+           , A
+      Reqs , type == 'req'"""
+)
+
+# ``needuml`` reads the id it was never given long before it reaches its
+# "is PlantUML installed" guard, so this needs no PlantUML to exercise.
+NEEDUML_IN_CONTENT_INDEX = view_in_content_index(
+    """.. needuml::
+
+      Alice -> Bob: hello"""
+)
+
+# one level deeper: the view directive is in a CHILD need's content, which the
+# copy carries along with everything else
+NEEDTABLE_IN_CHILD_INDEX = """\
+Index
+=====
+
+.. toctree::
+
+   extract
+
+.. req:: Has a child need
+   :id: R_VIEW
+
+   Outer body.
+
+   .. spec:: A child
+      :id: S_CHILD
+
+      .. needtable::
+         :columns: id
+         :style: table
 """
 
 NESTED_EXTRACT_INDEX = """\
@@ -341,6 +397,70 @@ def extract_doc(need_id: str) -> str:
             'id="R_OUTER"',
             'id="R_INNER"',
             id="needextract-in-content",
+        ),
+        pytest.param(
+            {
+                "buildername": "html",
+                "no_plantuml": True,
+                "files": [
+                    (Path("conf.py"), CONF),
+                    (Path("index.rst"), NEEDPIE_IN_CONTENT_INDEX),
+                    (Path("extract.rst"), extract_doc("R_VIEW")),
+                ],
+            },
+            "A 'needpie' directive in the content of need 'R_VIEW' cannot be "
+            "rendered by needextract, and is omitted.",
+            'id="R_VIEW"',
+            "_images/need_pie_",
+            id="needpie-in-content",
+        ),
+        pytest.param(
+            {
+                "buildername": "html",
+                "no_plantuml": True,
+                "files": [
+                    (Path("conf.py"), CONF),
+                    (Path("index.rst"), NEEDBAR_IN_CONTENT_INDEX),
+                    (Path("extract.rst"), extract_doc("R_VIEW")),
+                ],
+            },
+            "A 'needbar' directive in the content of need 'R_VIEW' cannot be "
+            "rendered by needextract, and is omitted.",
+            'id="R_VIEW"',
+            "_images/need_bar_",
+            id="needbar-in-content",
+        ),
+        pytest.param(
+            {
+                "buildername": "html",
+                "no_plantuml": True,
+                "files": [
+                    (Path("conf.py"), CONF),
+                    (Path("index.rst"), NEEDUML_IN_CONTENT_INDEX),
+                    (Path("extract.rst"), extract_doc("R_VIEW")),
+                ],
+            },
+            "A 'needuml' (or 'needarch') directive in the content of need 'R_VIEW' "
+            "cannot be rendered by needextract, and is omitted.",
+            'id="R_VIEW"',
+            "PlantUML is not available!",
+            id="needuml-in-content",
+        ),
+        pytest.param(
+            {
+                "buildername": "html",
+                "no_plantuml": True,
+                "files": [
+                    (Path("conf.py"), CONF),
+                    (Path("index.rst"), NEEDTABLE_IN_CHILD_INDEX),
+                    (Path("extract.rst"), extract_doc("R_VIEW")),
+                ],
+            },
+            "A 'needtable' directive in the content of need 'R_VIEW' cannot be "
+            "rendered by needextract, and is omitted.",
+            'id="S_CHILD"',
+            "-table_node",
+            id="needtable-in-a-child-need",
         ),
     ],
     indirect=["test_app"],

--- a/tests/test_needextract.py
+++ b/tests/test_needextract.py
@@ -583,3 +583,73 @@ def test_footnote_in_extracted_content_degrades_to_text(test_app):
     # the source page is untouched: its references still resolve
     index_html = Path(app.outdir, "index.html").read_text(encoding="utf8")
     assert 'class="footnote-reference brackets" href="#fn1"' in index_html
+
+
+# -- the per-document state the post-transforms run against ------------------
+
+LEAK_PROBE_CONF = """\
+from pathlib import Path
+
+from sphinx.transforms.post_transforms import SphinxPostTransform
+
+extensions = ["sphinx_needs"]
+
+
+class LeakProbe(SphinxPostTransform):
+    \"\"\"Write into the per-document state, as a third-party post-transform may.\"\"\"
+
+    default_priority = 999
+
+    def run(self, **kwargs):
+        self.env.temp_data["PROBE_SENTINEL"] = "written by a post-transform"
+        self.env.temp_data["highlight_language"] = "probe-language"
+
+
+def _report(app, exception):
+    state = app.env.temp_data
+    Path(app.outdir, "state.log").write_text(
+        f"sentinel={'PROBE_SENTINEL' in state}\\n"
+        f"highlight_language={state.get('highlight_language')!r}\\n"
+    )
+
+
+def setup(app):
+    app.add_post_transform(LeakProbe)
+    app.connect("build-finished", _report)
+"""
+
+
+@pytest.mark.parametrize(
+    "test_app",
+    [
+        {
+            "buildername": "html",
+            "no_plantuml": True,
+            "files": [
+                (Path("conf.py"), LEAK_PROBE_CONF),
+                # a need with a reference in it, so the post-transforms have
+                # something to resolve while the scratch state is in place
+                (Path("index.rst"), RECORDING_INDEX),
+                (Path("extract.rst"), extract_doc("R_ONE")),
+            ],
+        }
+    ],
+    indirect=True,
+)
+def test_needextract_discards_post_transform_state(test_app):
+    """Running the post-transforms for an extract leaves no state behind.
+
+    ``BuildEnvironment.apply_post_transforms`` hands the post-transforms a *copy*
+    of the per-document state and puts the original back afterwards, so what they
+    write into it is discarded.  Applying them for an extract does the same: a
+    third-party post-transform writing into ``env.temp_data`` -- and the sentinel
+    below stands in for one -- must not have its writes outlive the extract, and
+    must not be able to change a real field, such as the default highlighting
+    language, for the rest of the build.
+    """
+    app = test_app
+    app.build()
+    assert build_warnings(app) == []
+
+    state = Path(app.outdir, "state.log").read_text(encoding="utf8").split()
+    assert state == ["sentinel=False", "highlight_language=''"], state

--- a/tests/test_needextract.py
+++ b/tests/test_needextract.py
@@ -248,3 +248,265 @@ def test_needextract_early_exit_does_not_end_the_build(
     html = Path(app.outdir, "index.html").read_text(encoding="utf8")
     assert "<h1>Extract" in html
     assert html.count('id="R_ONE"') == expected_cards
+
+
+# -- Sphinx-Needs constructs in the copied content ---------------------------
+#
+# ``env.resolve_references()`` was called on the detached container holding one
+# need's copied content, and it ends by emitting ``doctree-resolved`` -- so every
+# listener of that event ran a second time with a container standing in for a
+# document, ``process_needextract`` itself included.  Content holding a
+# ``needtable`` ended the build with ``list index out of range``, and content
+# holding a nested ``needextract`` with ``'container' object has no attribute
+# 'settings'``.  The post-transforms now run without the emission, and the view
+# directives whose rendering the copy cannot honour are dropped from it with a
+# warning naming each one.
+
+VIEW_IN_CONTENT_INDEX = """\
+Index
+=====
+
+.. toctree::
+
+   extract
+
+.. req:: Has a view directive inside
+   :id: R_VIEW
+
+   Body, and then:
+
+   .. needtable::
+      :columns: id
+      :style: table
+"""
+
+NESTED_EXTRACT_INDEX = """\
+Index
+=====
+
+.. toctree::
+
+   extract
+
+.. req:: Inner
+   :id: R_INNER
+
+   Inner body.
+
+.. req:: Contains an extract
+   :id: R_OUTER
+
+   Outer body, and then:
+
+   .. needextract:: R_INNER
+"""
+
+
+def extract_doc(need_id: str) -> str:
+    """Build a second document that extracts one need."""
+    return f"Extract\n=======\n\n.. needextract:: {need_id}\n"
+
+
+@pytest.mark.parametrize(
+    ("test_app", "expected_warning", "still_rendered", "omitted"),
+    [
+        pytest.param(
+            {
+                "buildername": "html",
+                "no_plantuml": True,
+                "files": [
+                    (Path("conf.py"), CONF),
+                    (Path("index.rst"), VIEW_IN_CONTENT_INDEX),
+                    (Path("extract.rst"), extract_doc("R_VIEW")),
+                ],
+            },
+            "A 'needtable' directive in the content of need 'R_VIEW' cannot be "
+            "rendered by needextract, and is omitted.",
+            'id="R_VIEW"',
+            "-table_node",
+            id="needtable-in-content",
+        ),
+        pytest.param(
+            {
+                "buildername": "html",
+                "no_plantuml": True,
+                "files": [
+                    (Path("conf.py"), CONF),
+                    (Path("index.rst"), NESTED_EXTRACT_INDEX),
+                    (Path("extract.rst"), extract_doc("R_OUTER")),
+                ],
+            },
+            "A 'needextract' directive in the content of need 'R_OUTER' cannot be "
+            "rendered by needextract, and is omitted.",
+            'id="R_OUTER"',
+            'id="R_INNER"',
+            id="needextract-in-content",
+        ),
+    ],
+    indirect=["test_app"],
+)
+def test_unrenderable_view_in_extracted_content_warns(
+    test_app, expected_warning, still_rendered, omitted
+):
+    """A view directive the copy cannot render is reported, not fatal.
+
+    The extracted need is still rendered; only the directive inside its content
+    is left out, and the author is told which one and where.
+    """
+    app = test_app
+    app.build()
+
+    assert build_warnings(app) == [
+        f"<srcdir>/extract.rst:4: WARNING: {expected_warning} [needs.needextract]"
+    ]
+
+    # the source page renders the directive as it always did
+    assert omitted in Path(app.outdir, "index.html").read_text(encoding="utf8")
+
+    extract_html = Path(app.outdir, "extract.html").read_text(encoding="utf8")
+    assert still_rendered in extract_html
+    assert omitted not in extract_html
+
+
+# -- the reference contract of an extract ------------------------------------
+
+REFERENCE_CONTRACT_INDEX = """\
+Index
+=====
+
+.. toctree::
+
+   extract
+
+.. req:: Target of the need reference
+   :id: R_TARGET
+
+   Plain body.
+
+.. req:: Content with references
+   :id: R_REFS
+
+   .. _inner-target:
+
+   A paragraph to point at.
+
+   A ref to it: :ref:`the paragraph <inner-target>`.
+   A need ref: :need:`R_TARGET`.
+"""
+
+
+@pytest.mark.parametrize(
+    "test_app",
+    [
+        {
+            "buildername": "html",
+            "no_plantuml": True,
+            "files": [
+                (Path("conf.py"), CONF),
+                (Path("index.rst"), REFERENCE_CONTRACT_INDEX),
+                (Path("extract.rst"), extract_doc("R_REFS")),
+            ],
+        }
+    ],
+    indirect=True,
+)
+def test_extract_references_resolve_to_the_source_page(test_app):
+    """An extract is a view: every reference in it leads back to the original.
+
+    A ``:ref:`` to a target defined inside the copied content, a ``:need:`` role
+    in it, and the card's own ID chip all resolve to the page the need is written
+    on -- not to the copy.  The copy's references are resolved by Sphinx's
+    post-transforms; this pins that they still are, now that they are applied
+    without re-emitting ``doctree-resolved``.
+    """
+    app = test_app
+    app.build()
+    assert build_warnings(app) == []
+
+    extract_html = Path(app.outdir, "extract.html").read_text(encoding="utf8")
+
+    # the ref and the need role in the copied content point at the source page
+    assert 'href="index.html#inner-target"' in extract_html
+    assert 'href="index.html#R_TARGET"' in extract_html
+    # ... and not at the copy, whose own anchor for them is dead
+    assert 'href="#inner-target"' not in extract_html
+
+    # the card's ID chip navigates back to the canonical need
+    assert (
+        '<span class="needs-id"><a class="reference internal" '
+        'href="index.html#R_REFS" title="R_REFS">R_REFS</a>' in extract_html
+    )
+
+
+# -- the event is emitted once per document ----------------------------------
+
+RECORDING_CONF = """\
+from pathlib import Path
+
+extensions = ["sphinx_needs"]
+
+
+def _record(app, doctree, docname):
+    with open(Path(app.outdir, "resolved.log"), "a") as f:
+        f.write(f"{docname} {type(doctree).__name__}\\n")
+
+
+def setup(app):
+    app.connect("doctree-resolved", _record)
+"""
+
+RECORDING_INDEX = """\
+Index
+=====
+
+.. toctree::
+
+   extract
+
+.. req:: A need with a reference in it
+   :id: R_ONE
+
+   A need ref: :need:`R_TWO`.
+
+.. req:: Two
+   :id: R_TWO
+
+   Plain body.
+"""
+
+
+@pytest.mark.parametrize(
+    "test_app",
+    [
+        {
+            "buildername": "html",
+            "no_plantuml": True,
+            "files": [
+                (Path("conf.py"), RECORDING_CONF),
+                (Path("index.rst"), RECORDING_INDEX),
+                (Path("extract.rst"), extract_doc("R_ONE")),
+            ],
+        }
+    ],
+    indirect=True,
+)
+def test_needextract_does_not_re_emit_doctree_resolved(test_app):
+    """Building an extract does not run the ``doctree-resolved`` listeners again.
+
+    The copy's references used to be resolved with ``env.resolve_references()``,
+    which ends by emitting ``doctree-resolved`` -- so every listener of the event,
+    this extension's and any other's, was called a second time with the detached
+    ``nodes.container`` holding the copied content in place of a document.  A
+    listener may reasonably assume it is given a document, and the ones here
+    crashed on the container; the post-transforms are now applied without the
+    emission.
+    """
+    app = test_app
+    app.build()
+    assert build_warnings(app) == []
+
+    recorded = Path(app.outdir, "resolved.log").read_text(encoding="utf8").split()
+    # one emission per document, each with a document -- never a container
+    assert sorted(recorded) == sorted(["extract", "document", "index", "document"]), (
+        recorded
+    )

--- a/tests/test_needextract.py
+++ b/tests/test_needextract.py
@@ -510,3 +510,76 @@ def test_needextract_does_not_re_emit_doctree_resolved(test_app):
     assert sorted(recorded) == sorted(["extract", "document", "index", "document"]), (
         recorded
     )
+
+
+# -- footnotes in the copied content -----------------------------------------
+
+FOOTNOTE_INDEX = """\
+Index
+=====
+
+.. toctree::
+
+   extract
+
+.. req:: A need with footnotes
+   :id: R_FOOT
+
+   Auto-numbered. [#fn1]_
+   Manual. [1]_
+   Symbol. [*]_
+
+   .. [#fn1] The auto footnote text.
+
+   .. [1] The manual footnote text.
+
+   .. [*] The symbol footnote text.
+"""
+
+
+@pytest.mark.parametrize(
+    "test_app",
+    [
+        {
+            "buildername": "html",
+            "no_plantuml": True,
+            "files": [
+                (Path("conf.py"), CONF),
+                (Path("index.rst"), FOOTNOTE_INDEX),
+                (Path("extract.rst"), extract_doc("R_FOOT")),
+            ],
+        }
+    ],
+    indirect=True,
+)
+def test_footnote_in_extracted_content_degrades_to_text(test_app):
+    """A footnote reference in extracted content is reported, not fatal.
+
+    The content is snapshotted before docutils' ``Footnotes`` transform has given
+    each reference the ``refid`` of its footnote, and the reference used to reach
+    the HTML writer without one and end the build with ``KeyError: 'refid'``.  All
+    three kinds of reference -- auto-numbered, manual and auto-symbol -- are
+    covered, since each is numbered by that transform differently.
+    """
+    app = test_app
+    app.build()
+
+    assert build_warnings(app) == [
+        "<srcdir>/extract.rst:4: WARNING: A footnote reference in the content of "
+        "need 'R_FOOT' cannot be resolved by needextract, and is rendered as "
+        "plain text. [needs.needextract]"
+    ]
+
+    extract_html = Path(app.outdir, "extract.html").read_text(encoding="utf8")
+    # each reference is now the marker its author wrote, and links nowhere
+    assert "Auto-numbered. [#fn1]" in extract_html
+    assert "Manual. [1]" in extract_html
+    assert "Symbol. [*]" in extract_html
+    # the footnote text itself is still on the page
+    assert "The auto footnote text." in extract_html
+    assert "The manual footnote text." in extract_html
+    assert "The symbol footnote text." in extract_html
+
+    # the source page is untouched: its references still resolve
+    index_html = Path(app.outdir, "index.html").read_text(encoding="utf8")
+    assert 'class="footnote-reference brackets" href="#fn1"' in index_html

--- a/tests/test_needextract.py
+++ b/tests/test_needextract.py
@@ -496,10 +496,10 @@ def test_needextract_does_not_re_emit_doctree_resolved(test_app):
     The copy's references used to be resolved with ``env.resolve_references()``,
     which ends by emitting ``doctree-resolved`` -- so every listener of the event,
     this extension's and any other's, was called a second time with the detached
-    ``nodes.container`` holding the copied content in place of a document.  A
-    listener may reasonably assume it is given a document, and the ones here
-    crashed on the container; the post-transforms are now applied without the
-    emission.
+    ``nodes.container`` holding the copied content in place of a document.  The
+    post-transforms are now applied without that emission.  The listener this
+    project's ``conf.py`` registers stands in for any third-party one: it records
+    what it is handed, and a listener is entitled to be handed a document.
     """
     app = test_app
     app.build()


### PR DESCRIPTION
> **Before merging / filing anything alongside this.** The changelog entry cites this PR as
> `:pr:`1795`` — it was drafted as 1794 (a prediction) and corrected on the branch after the
> PR opened as #1795. The follow-up `needs_extract_mode = "reparse"` proposal is to be filed
> as an **issue** now that this PR holds its number.

## What happens today

Each of these ends the whole build with a Python traceback and a "please report this to
the developers" banner. Three are the directive's own option surface:

```rst
.. needextract:: R_NOPE          # id-shaped, no such need   -> warns, then aborts
.. needextract:: R_ONE           # + :filter: id == "R_ONE"  -> warns, then aborts
   :filter: id == "R_ONE"
.. needextract:: R_ONE           # with needs_include_needs = False -> aborts, silently
```

```
ExtensionError: Handler ... for event 'doctree-resolved' threw an exception
  (exception: cannot access local variable 'found_needs' where it is not associated with a value)
```

Three more are content in the extracted need:

```rst
.. req:: Has a view directive inside
   :id: R_VIEW

   .. needtable::          -> ExtensionError ... (exception: list index out of range)
      :columns: id
```

```rst
.. req:: Contains an extract
   :id: R_OUTER

   .. needextract:: R_INNER   -> ... (exception: 'container' object has no attribute 'settings')
```

```rst
.. req:: Footnote need
   :id: R_FOOT

   A footnote reference here. [#fn1]_    -> KeyError: 'refid' in sphinx/writers/html5.py

   .. [#fn1] The footnote text.
```

`needbar`, `needpie`, `needuml` and `needarch` in extracted content fail like the
`needtable`, and so does a `needtable` one level deeper, in the content of a child need.

## What this changes

**One unbound name.** `found_needs` was assigned inside the loop over a document's
needextract nodes and read once after it, so a node taking one of the three early exits
left it unbound whenever it was the last (or only) one. It is initialised before the loop.
The two inputs that warned still warn; `needs_include_needs = False` drops the directive
silently, exactly as every other view directive already drops itself under that switch
(eight sites, all bare `remove and continue` guards).

**One re-entrancy.** A copy's references were resolved with `env.resolve_references()`,
whose last act is to emit `doctree-resolved` — with the detached `nodes.container` holding
the copy standing in for a document. Every listener of the event therefore ran a second
time on a node that is not a document, this extension's own listeners included, and so
`process_needextract` itself. Sphinx's post-transforms are now applied directly, which is
what `resolve_references` does minus that emission — including its state handling: the
post-transforms are handed a copy of the per-document state and the original is put back,
so nothing they write into it leaks into the rest of the build. The event is emitted once
per document and always with a document, a guarantee a third-party listener gets too.

**Two content classes a copy cannot render.** A need's content is snapshotted while its
directive runs, before docutils' `PropagateTargets` has moved the preceding target's id
onto a view node — and `needbar`, `needpie`, `needtable` and `needuml` read
`node["ids"][0]` when they render. A copied `needextract` has a different problem: it is
spliced in after `process_needextract` has walked the document, so nothing renders it and
it reaches the writer. All five are dropped from the copy and reported, by the name the
author wrote (`needarch` emits a `Needuml` node, so it is named too):

```
extract.rst:4: WARNING: A 'needtable' directive in the content of need 'R_VIEW' cannot be
    rendered by needextract, and is omitted. [needs.needextract]
```

A footnote reference cannot be given a `refid` faithfully — the footnote may be defined
outside the need's content, and a copy numbering its own footnotes would disagree with the
page the need is written on — so it is rendered as the marker its author wrote, without
the trailing `_`, and reported. The footnote's own text stays in the copy.

```
extract.rst:4: WARNING: A footnote reference in the content of need 'R_FOOT' cannot be
    resolved by needextract, and is rendered as plain text. [needs.needextract]
```

**Nothing else in a copy changes.** A corpus of extracts covering rich markup, code
blocks, images, an explicit target with `:ref:`s to it, a `:need:` role, a source-local
substitution, a nested need, a `numfig` figure with `:numref:`, a same-document extract
and a later-defined need renders byte-for-byte identically before and after (modulo the
per-card random container id and build timestamps), with identical diagnostics. In
particular a `:ref:` or `:need:` inside extracted content still resolves to the page the
need is written on, and so does the extract card's own ID chip. `needlist`, `needflow`
(both engines), `needsequence`, `needgantt` and `needextend` in extracted content are
untouched — measured with PlantUML enabled, they do not fail today and are left alone.

Projects building with `-W` should note the two new warning sites (unrenderable content,
degraded footnotes; the unknown-id and filter-conflict warnings existed before this
change): they are the price of the build not ending.

## Tests

`tests/test_needextract.py` gains six tests / thirteen cases, all with inline `files`
fixtures: the three option-surface inputs, five content inputs (`needtable`,
`needextract`, `needpie`, `needbar`, `needuml`) plus a `needtable` inside a child need, the
footnote input, the reference contract, a pin that `doctree-resolved` is emitted once per
document with a document, and a pin that a post-transform's writes do not outlive an
extract. Each was checked to go red with its own fix — or its own entry in the
unrenderable set — reverted. The state-leak pin runs green on all three CI Sphinx rows
(7.4, 8.2, 9.x).

## Follow-ups (not in this PR)

- `docs/directives/needextract.rst`'s `caution` admonition says rendering "may be
  incorrect"; it could now also say which view directives are omitted from a copy and that
  footnote references are rendered as text.
- The vintage of the copy itself is untouched, so #347 (LaTeX), #890 (math) and #895
  (`list-table`) remain. A proposal for an opt-in
  `needs_extract_mode = "legacy" | "reparse"` — rendering an extract by parsing the need's
  stored `content` in the extract document's own parser state, as `add_need` and
  `needimport` already do — is drafted separately, to be filed as an issue now that this PR
  is open.