### PR TITLE
‼️ Use minijinja's native wordwrap filter, and raise the floor to 2.24

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,43 @@ Unreleased
 
 :Released: Unreleased
 
+Improvements
+............
+
+- 👌 ``|wordwrap`` is now MiniJinja's own filter, and the minijinja floor is raised to
+  2.24 **(changed output)** (:pr:`1801`)
+
+  Sphinx-Needs shipped its own ``wordwrap``, written on Python's ``textwrap``, because the
+  minijinja wheel was built without minijinja-contrib's ``wordwrap`` Cargo feature and the
+  filter the default :ref:`needs_diagram_template` calls simply did not exist
+  (``unknown filter: filter wordwrap is unknown``).  The 2.24.0 wheel compiles it, so the
+  Python filter is deleted and the native one does the work.  The dependency is now
+  ``minijinja~=2.24``.
+
+  The feature the wheel compiles is contrib's plain ``wordwrap``, not its
+  ``unicode_wordwrap`` variant, and its **hyphen handling differs from Python's**
+  ``textwrap``.  A hyphenated word longer than the wrap width breaks right after the
+  hyphen, where ``textwrap`` filled the line first.  At the default width of 15 this needs
+  a long hyphenated word in a need title to show at all; at width 6 it is
+  ``abc-defghij`` → ``abc-`` / ``defghi`` / ``j``, where before it was ``abc-de`` /
+  ``fghij``.  The same holds when a non-letter precedes the hyphen: ``ab²-cdefghij`` →
+  ``ab²-`` / ``cdefgh`` / ``ij``, previously ``ab²-cd`` / ``efghij``.  Wrapping of text
+  without hyphens is unchanged, as are ``wrapstring``, ``break_long_words``, empty input,
+  and the independent wrapping of each existing line.
+
+  **The width must now be passed by name.**  The native filter takes no positional width,
+  so ``{{ title|wordwrap(15) }}`` — the jinja2 spelling — ends the build with
+  ``too many arguments``.  The built-in :ref:`needs_diagram_template` has been updated to
+  ``{{ title|wordwrap(width=15, wrapstring='**\\\\n**') }}``, which renders byte-identically;
+  **a custom template of your own calling** ``|wordwrap`` **with a positional width must
+  change to** ``width=`` **when you upgrade.**  Only the width is affected —
+  ``wrapstring`` and ``break_long_words`` were already keyword arguments.
+
+  Note that :ref:`needflow`'s ``graphviz`` engine wraps its labels with Python
+  ``textwrap`` directly rather than through a template, so it keeps the old hyphen
+  behaviour: a hyphenated title long enough to hit the width can now wrap differently
+  under the two engines.
+
 Bug fixes
 .........
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,11 +11,11 @@ Unreleased
 
 :Released: Unreleased
 
-Improvements
-............
+Breaking changes
+................
 
-- 👌 ``|wordwrap`` is now MiniJinja's own filter, and the minijinja floor is raised to
-  2.24 **(changed output)** (:pr:`1802`)
+- ‼️ ``|wordwrap`` is now MiniJinja's own filter — a positional width must become
+  ``width=`` **(changed output)** (:pr:`1802`)
 
   Sphinx-Needs shipped its own ``wordwrap``, written on Python's ``textwrap``, because the
   minijinja wheel was built without minijinja-contrib's ``wordwrap`` Cargo feature and the
@@ -23,6 +23,16 @@ Improvements
   (``unknown filter: filter wordwrap is unknown``).  The 2.24.0 wheel compiles it, so the
   Python filter is deleted and the native one does the work.  The dependency is now
   ``minijinja~=2.24``.
+
+  **The width must now be passed by name.**  The native filter takes no positional width,
+  so ``{{ title|wordwrap(15) }}`` — the jinja2 spelling — ends the build with
+  ``too many arguments``.  The built-in :ref:`needs_diagram_template` has been updated to
+  ``{{ title|wordwrap(width=15, wrapstring='**\\\\n**') }}``, which renders byte-identically;
+  **a custom template of your own calling** ``|wordwrap`` **with a positional width must
+  change to** ``width=`` **when you upgrade.**  Only the width is affected —
+  ``wrapstring`` and ``break_long_words`` were already keyword arguments.  The failure
+  names its own fix: on every template surface, the ``too many arguments`` error now
+  carries a hint to write ``wordwrap(width=15)`` instead of ``wordwrap(15)``.
 
   The feature the wheel compiles is contrib's plain ``wordwrap``, not its
   ``unicode_wordwrap`` variant, and its **hyphen handling differs from Python's**
@@ -34,14 +44,6 @@ Improvements
   ``ab²-`` / ``cdefgh`` / ``ij``, previously ``ab²-cd`` / ``efghij``.  Wrapping of text
   without hyphens is unchanged, as are ``wrapstring``, ``break_long_words``, empty input,
   and the independent wrapping of each existing line.
-
-  **The width must now be passed by name.**  The native filter takes no positional width,
-  so ``{{ title|wordwrap(15) }}`` — the jinja2 spelling — ends the build with
-  ``too many arguments``.  The built-in :ref:`needs_diagram_template` has been updated to
-  ``{{ title|wordwrap(width=15, wrapstring='**\\\\n**') }}``, which renders byte-identically;
-  **a custom template of your own calling** ``|wordwrap`` **with a positional width must
-  change to** ``width=`` **when you upgrade.**  Only the width is affected —
-  ``wrapstring`` and ``break_long_words`` were already keyword arguments.
 
   Note that :ref:`needflow`'s ``graphviz`` engine wraps its labels with Python
   ``textwrap`` directly rather than through a template, so it keeps the old hyphen

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,7 +15,7 @@ Improvements
 ............
 
 - 👌 ``|wordwrap`` is now MiniJinja's own filter, and the minijinja floor is raised to
-  2.24 **(changed output)** (:pr:`1801`)
+  2.24 **(changed output)** (:pr:`1802`)
 
   Sphinx-Needs shipped its own ``wordwrap``, written on Python's ``textwrap``, because the
   minijinja wheel was built without minijinja-contrib's ``wordwrap`` Cargo feature and the

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -326,7 +326,7 @@ needs_render_context = {
 # ]
 
 # You can uncomment some of the following lines to override the default configuration for Sphinx-Needs.
-# DEFAULT_DIAGRAM_TEMPLATE = "<size:12>{{type_name}}</size>\\n**{{title|wordwrap(15, wrapstring='**\\\\n**')}}**\\n<size:10>{{id}}</size>"
+# DEFAULT_DIAGRAM_TEMPLATE = "<size:12>{{type_name}}</size>\\n**{{title|wordwrap(width=15, wrapstring='**\\\\n**')}}**\\n<size:10>{{id}}</size>"
 # needs_diagram_template = DEFAULT_DIAGRAM_TEMPLATE
 
 # Absolute path to the needs_report_template_file based on the conf.py directory

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1206,9 +1206,9 @@ By default the following template is used:
 .. code-block:: jinja
 
    {%- if is_need -%}
-   <size:12>{{type_name}}</size>\\n**{{title|wordwrap(15, wrapstring='**\\\\n**')}}**\\n<size:10>{{id}}</size>
+   <size:12>{{type_name}}</size>\\n**{{title|wordwrap(width=15, wrapstring='**\\\\n**')}}**\\n<size:10>{{id}}</size>
    {%- else -%}
-   <size:12>{{type_name}} (part)</size>\\n**{{content|wordwrap(15, wrapstring='**\\\\n**')}}**\\n<size:10>{{id_parent}}.**{{id}}**</size>
+   <size:12>{{type_name}} (part)</size>\\n**{{content|wordwrap(width=15, wrapstring='**\\\\n**')}}**\\n<size:10>{{id_parent}}.**{{id}}**</size>
    {%- endif -%}
 
 .. _`needs_id_required`:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
   "sphinxcontrib-jquery~=4.0",      # needed for datatables in sphinx>=6
   "tomli; python_version < '3.11'", # for needs_from_toml configuration
   "typing-extensions>=4.14.0",      # for dict NotRequired type indication
-  "minijinja~=2.15",                # lightweight jinja2-compatible template engine
+  "minijinja~=2.24",                # lightweight jinja2-compatible template engine (2.24 compiles the native wordwrap filter)
 ]
 
 [project.optional-dependencies]

--- a/sphinx_needs/_jinja.py
+++ b/sphinx_needs/_jinja.py
@@ -9,7 +9,34 @@ from __future__ import annotations
 from functools import lru_cache
 from typing import Any
 
-from minijinja import Environment
+from minijinja import Environment, TemplateError
+
+_WORDWRAP_WIDTH_HINT = (
+    "hint: if this is the wordwrap filter rejecting a positional width — "
+    "MiniJinja's built-in wordwrap takes its width only by name: "
+    "write wordwrap(width=15), not wordwrap(15). "
+    "(sphinx-needs' former Python-side wordwrap accepted the jinja2 positional form.)"
+)
+
+
+def _hinted(err: TemplateError, template_string: str) -> TemplateError | None:
+    """Build a hinted copy of ``err`` for a positional-``wordwrap`` failure.
+
+    The switch from sphinx-needs' Python-side ``wordwrap`` to MiniJinja's
+    built-in made the jinja2 spelling ``wordwrap(15)`` a ``too many
+    arguments`` error, which surfaces as an unlocated build abort.  Appending
+    the migration hint here — the one choke point every template render goes
+    through — makes that failure actionable on every surface at once.
+
+    :param err: The error a render raised.
+    :param template_string: The template source that was being rendered.
+    :return: A ``TemplateError`` with the hint appended, or ``None`` when the
+        error is not the positional-``wordwrap`` shape (the caller should
+        re-raise the original unchanged).
+    """
+    if "too many arguments" in str(err) and "wordwrap(" in template_string:
+        return TemplateError(f"{err}\n{_WORDWRAP_WIDTH_HINT}")
+    return None
 
 
 def _new_env(
@@ -99,7 +126,12 @@ def render_template_string(
         if new_env
         else _get_cached_env(autoescape, variable_start_string, variable_end_string)
     )
-    return env.render_str(template_string, **context)
+    try:
+        return env.render_str(template_string, **context)
+    except TemplateError as err:
+        if (hinted := _hinted(err, template_string)) is not None:
+            raise hinted from err
+        raise
 
 
 class CompiledTemplate:
@@ -116,12 +148,15 @@ class CompiledTemplate:
     error messages, or per-node in PlantUML diagram generation).
     """
 
-    __slots__ = ("_env",)
+    __slots__ = ("_env", "_source")
 
     _TEMPLATE_NAME = "__compiled__"
 
-    def __init__(self, env: Environment) -> None:
+    def __init__(self, env: Environment, source: str) -> None:
         self._env = env
+        # kept only so a render failure can be matched against the source
+        # (see _hinted); rendering itself uses the template compiled into env
+        self._source = source
 
     def render(self, context: dict[str, Any]) -> str:
         """Render the compiled template with the given context.
@@ -129,7 +164,12 @@ class CompiledTemplate:
         :param context: Dictionary containing template variables.
         :return: The rendered template as a string.
         """
-        return self._env.render_template(self._TEMPLATE_NAME, **context)
+        try:
+            return self._env.render_template(self._TEMPLATE_NAME, **context)
+        except TemplateError as err:
+            if (hinted := _hinted(err, self._source)) is not None:
+                raise hinted from err
+            raise
 
 
 @lru_cache(maxsize=32)
@@ -166,4 +206,4 @@ def compile_template(
     """
     env = _new_env(autoescape, variable_start_string, variable_end_string)
     env.add_template(CompiledTemplate._TEMPLATE_NAME, template_string)
-    return CompiledTemplate(env)
+    return CompiledTemplate(env, template_string)

--- a/sphinx_needs/_jinja.py
+++ b/sphinx_needs/_jinja.py
@@ -6,59 +6,10 @@ centralizing all template rendering logic in one place.
 
 from __future__ import annotations
 
-import textwrap
 from functools import lru_cache
 from typing import Any
 
 from minijinja import Environment
-
-
-def _wordwrap_filter(value: str, width: int = 79, wrapstring: str = "\n") -> str:
-    """Jinja2-compatible wordwrap filter.
-
-    Wraps text to specified width, inserting wrapstring between wrapped lines.
-    This uses Python's textwrap module to match Jinja2's wordwrap behavior.
-
-    Like Jinja2, this preserves existing newlines and wraps each line independently.
-
-    Note: minijinja-contrib has a Rust-native wordwrap filter (since 2.12),
-    but it is gated behind the optional ``wordwrap`` Cargo feature flag.
-    The minijinja-py 2.15.1 wheel does not enable that feature
-    (see minijinja-py/Cargo.toml — only ``pycompat`` and ``html_entities``
-    are enabled from minijinja-contrib).  Once a future minijinja-py release
-    enables the ``wordwrap`` feature, this custom filter can be removed.
-    Upstream tracking: https://github.com/mitsuhiko/minijinja — no issue
-    filed yet; consider opening one.
-    """
-    if not value:
-        return value
-
-    # Preserve newlines by wrapping each line independently (matches Jinja2)
-    wrapped_lines = []
-    for line in value.splitlines():
-        # Use textwrap.wrap which matches jinja2's behavior
-        # break_on_hyphens=True is the Python/Jinja2 default
-        wrapped = textwrap.wrap(
-            line,
-            width=width,
-            break_long_words=True,
-            break_on_hyphens=True,
-        )
-        # textwrap.wrap returns empty list for empty strings, preserve empty lines
-        wrapped_lines.extend(wrapped or [""])
-
-    return wrapstring.join(wrapped_lines)
-
-
-def _setup_builtin_filters(env: Environment) -> None:
-    """Register filters missing from minijinja-py's compiled feature set.
-
-    The minijinja-py wheel currently ships without the ``wordwrap`` Cargo
-    feature of minijinja-contrib, so ``|wordwrap`` is unavailable by default.
-    This registers a Python-side replacement.  This function can be removed
-    once minijinja-py enables the ``wordwrap`` feature upstream.
-    """
-    env.add_filter("wordwrap", _wordwrap_filter)
 
 
 def _new_env(
@@ -66,7 +17,11 @@ def _new_env(
     variable_start_string: str = "{{",
     variable_end_string: str = "}}",
 ) -> Environment:
-    """Create a new Environment with standard setup (filters, autoescape).
+    """Create a new Environment with standard setup (delimiters, autoescape).
+
+    No filters are registered here: MiniJinja's own built-ins (including
+    ``wordwrap``, native since the minijinja 2.24 wheel) are all this
+    package uses.
 
     :param autoescape: Whether to enable autoescaping.
     :param variable_start_string: Delimiter that opens a variable expression
@@ -82,7 +37,6 @@ def _new_env(
     )
     if autoescape:
         env.auto_escape_callback = lambda _name: True
-    _setup_builtin_filters(env)
     return env
 
 

--- a/sphinx_needs/defaults.py
+++ b/sphinx_needs/defaults.py
@@ -8,9 +8,9 @@ if TYPE_CHECKING:
 
 DEFAULT_DIAGRAM_TEMPLATE = """
 {%- if is_need -%}
-<size:12>{{type_name}}</size>\\n**{{title|wordwrap(15, wrapstring='**\\\\n**')}}**\\n<size:10>{{id}}</size>
+<size:12>{{type_name}}</size>\\n**{{title|wordwrap(width=15, wrapstring='**\\\\n**')}}**\\n<size:10>{{id}}</size>
 {%- else -%}
-<size:12>{{type_name}} (part)</size>\\n**{{content|wordwrap(15, wrapstring='**\\\\n**')}}**\\n<size:10>{{id_parent}}.**{{id}}**</size>
+<size:12>{{type_name}} (part)</size>\\n**{{content|wordwrap(width=15, wrapstring='**\\\\n**')}}**\\n<size:10>{{id_parent}}.**{{id}}**</size>
 {%- endif -%}
 """
 

--- a/tests/test_jinja.py
+++ b/tests/test_jinja.py
@@ -91,18 +91,47 @@ def test_wordwrap_is_minijinjas_native_filter():
     assert result == "**A very long**\n**need title that**\n**must be wrapped**"
 
 
-def test_wordwrap_rejects_a_positional_width():
+def test_wordwrap_rejects_a_positional_width_with_a_hint():
     """The native filter is keyword-only, unlike jinja2's ``wordwrap``.
 
     This is the upgrade's one user-visible break, so it is pinned rather than
     left to be rediscovered: a custom ``needs_diagram_template`` written for
     jinja2 (or for the Python filter this replaced) fails the build until its
-    ``wordwrap(15)`` becomes ``wordwrap(width=15)``.
+    ``wordwrap(15)`` becomes ``wordwrap(width=15)``.  The error carries the
+    migration hint appended in ``_jinja``, so the failure names its own fix.
     """
-    with pytest.raises(TemplateError, match="too many arguments"):
+    with pytest.raises(TemplateError, match="too many arguments") as exc_info:
         render_template_string(
             "{{ title|wordwrap(15) }}", {"title": "a b c"}, autoescape=False
         )
+    assert "write wordwrap(width=15), not wordwrap(15)" in str(exc_info.value)
+
+
+def test_compiled_template_positional_wordwrap_carries_the_hint():
+    """The hint also reaches the compiled-template path.
+
+    ``needs_diagram_template`` — the template most likely to carry the old
+    positional spelling, since the shipped default used it — renders through
+    ``compile_template``, not ``render_template_string``, so the hint must be
+    attached on that path too.
+    """
+    compiled = compile_template(
+        "{{ content|wordwrap(15, wrapstring='**') }}", autoescape=False
+    )
+    with pytest.raises(TemplateError, match="too many arguments") as exc_info:
+        compiled.render({"content": "a b c"})
+    assert "write wordwrap(width=15), not wordwrap(15)" in str(exc_info.value)
+
+
+def test_too_many_arguments_without_wordwrap_gets_no_hint():
+    """The hint is scoped to templates that call ``wordwrap``.
+
+    An unrelated arity error must not be decorated with advice about a filter
+    the template never mentions.
+    """
+    with pytest.raises(TemplateError, match="too many arguments") as exc_info:
+        render_template_string("{{ v|upper(1) }}", {"v": "x"}, autoescape=False)
+    assert "wordwrap" not in str(exc_info.value)
 
 
 def test_wordwrap_preserves_existing_newlines():

--- a/tests/test_jinja.py
+++ b/tests/test_jinja.py
@@ -71,3 +71,43 @@ def test_compile_template_cache_is_keyed_on_delimiters():
 def test_compile_template_invalid_syntax_raises():
     with pytest.raises(TemplateError):
         compile_template("{{ unclosed ", autoescape=False)
+
+
+def test_wordwrap_is_minijinjas_native_filter():
+    """``wordwrap`` comes from the minijinja wheel, not from a Python filter.
+
+    sphinx-needs used to register its own ``textwrap``-based ``wordwrap``
+    because the wheel shipped without minijinja-contrib's ``wordwrap`` Cargo
+    feature.  The 2.24 wheel compiles it, the Python filter is gone, and this
+    test pins the native one in the exact shape
+    :data:`~sphinx_needs.defaults.DEFAULT_DIAGRAM_TEMPLATE` calls it —
+    ``width`` as a KEYWORD, since the native filter takes no positional width.
+    """
+    result = render_template_string(
+        "**{{ title|wordwrap(width=15, wrapstring='**\\n**') }}**",
+        {"title": "A very long need title that must be wrapped"},
+        autoescape=False,
+    )
+    assert result == "**A very long**\n**need title that**\n**must be wrapped**"
+
+
+def test_wordwrap_rejects_a_positional_width():
+    """The native filter is keyword-only, unlike jinja2's ``wordwrap``.
+
+    This is the upgrade's one user-visible break, so it is pinned rather than
+    left to be rediscovered: a custom ``needs_diagram_template`` written for
+    jinja2 (or for the Python filter this replaced) fails the build until its
+    ``wordwrap(15)`` becomes ``wordwrap(width=15)``.
+    """
+    with pytest.raises(TemplateError, match="too many arguments"):
+        render_template_string(
+            "{{ title|wordwrap(15) }}", {"title": "a b c"}, autoescape=False
+        )
+
+
+def test_wordwrap_preserves_existing_newlines():
+    """Each line wraps independently, as the Python filter did before it."""
+    result = render_template_string(
+        "{{ v|wordwrap(width=5) }}", {"v": "aaa bbb\n\nccc ddd"}, autoescape=False
+    )
+    assert result == "aaa\nbbb\n\nccc\nddd"

--- a/tests/test_jinja.py
+++ b/tests/test_jinja.py
@@ -111,3 +111,19 @@ def test_wordwrap_preserves_existing_newlines():
         "{{ v|wordwrap(width=5) }}", {"v": "aaa bbb\n\nccc ddd"}, autoescape=False
     )
     assert result == "aaa\nbbb\n\nccc\nddd"
+
+
+def test_wordwrap_breaks_after_a_hyphen_unlike_python_textwrap():
+    """The changelog's ``(changed output)`` behaviour, pinned.
+
+    The native filter starts the fragment after a hyphen on a fresh line,
+    where Python's ``textwrap`` back-filled the current line with its head
+    (giving ``abc-de\\nfghij`` here).  This is the one assertion that
+    separates the native filter from any ``textwrap``-based replacement,
+    so it turns red if a future wheel silently reverts to textwrap-style
+    hyphen filling.
+    """
+    result = render_template_string(
+        "{{ v|wordwrap(width=6) }}", {"v": "abc-defghij"}, autoescape=False
+    )
+    assert result == "abc-\ndefghi\nj"


### PR DESCRIPTION
## What this is

`sphinx_needs/_jinja.py` carried its own `wordwrap`, written on Python's `textwrap`, with
a comment explaining exactly when it could go:

> minijinja-contrib has a Rust-native wordwrap filter (since 2.12), but it is gated behind
> the optional `wordwrap` Cargo feature flag. The minijinja-py 2.15.1 wheel does not enable
> that feature. Once a future minijinja-py release enables the `wordwrap` feature, this
> custom filter can be removed.

[mitsuhiko/minijinja#931](https://github.com/mitsuhiko/minijinja/issues/931) is fixed and
**minijinja 2.24.0 is on PyPI with that feature compiled in**. This PR does what the
comment anticipated: deletes the Python filter and its `_setup_builtin_filters` helper,
and raises the dependency to `minijinja~=2.24` so the native filter is guaranteed rather
than merely likely. (`~=2.24` is PEP 440 for `>=2.24,<3`, and matches how every other
pinned dependency in the file is written.)

The premise was verified, not assumed: on the 2.22 wheel the repo had installed, a bare
`minijinja.Environment` gives `TemplateError: unknown filter: filter wordwrap is unknown`.
The Python filter really was the one doing the work.

## Measurements

Everything below was measured on a bare `Environment()` from a fresh venv holding only
`minijinja==2.24.0` — no sphinx-needs code on the path.

### The width must now be passed by name — the breaking change

| | |
|---|---|
| `{{ 'aaa bbb ccc'\|wordwrap(7) }}` | **`TemplateError: too many arguments`** |
| `{{ 'aaa bbb ccc'\|wordwrap(width=7) }}` | `'aaa bbb\nccc'` |

The native filter accepts no positional width. The shipped `DEFAULT_DIAGRAM_TEMPLATE`
used the jinja2 spelling `wordwrap(15, wrapstring='**\\n**')`, so deleting the Python
filter without touching it would have ended **every PlantUML diagram build**. It moves to
`wordwrap(width=15, wrapstring='**\\n**')`, which renders byte-identically — verified, and
the needuml/needarch snapshots are unchanged. `docs/configuration.rst` and the
commented-out sample in `docs/conf.py` mirror that template verbatim and move with it.

**This is a real break for custom templates.** A `needs_diagram_template` of your own — or
any template you render through Sphinx-Needs — calling `|wordwrap` with a positional width
fails the build until it becomes `width=`. It is called out in the changelog under
**Breaking changes** and pinned by a test. Only the width is affected; `wrapstring` and
`break_long_words` were already keyword arguments.

**How it fails, measured on a demo project**: a positional `wordwrap(15)` in a custom
`needs_diagram_template`, or in a `needuml` body, ends the build with an unlocated
`ExtensionError` traceback and Sphinx's "report this to the developers" banner. minijinja's
own error block is good — the template source with a caret under the offending call and the
referenced variables — but no document or directive is named (the abort-at-processing error
model is a pre-existing wart, catalogued in #1799, not this PR's to fix).

**Mitigation**: the failure now names its own fix. `_jinja.py`'s two render paths —
`render_template_string` and `CompiledTemplate.render`, the choke point every template
surface in the package goes through — append a migration hint to exactly this error
(`too many arguments` raised from a template that calls `wordwrap(`): *write
`wordwrap(width=15)`, not `wordwrap(15)`*. Verified end-to-end on the demo project: the
hint prints in the build output directly under minijinja's caret block, on both the
diagram-template and needuml-body surfaces. An unrelated arity error gets no hint.

A jinja2-compatible positional form would be a reasonable thing to ask minijinja-py for —
that would heal the break upstream in a later release. Noting it here rather than filing it.

### Which Cargo feature the wheel compiles: plain `wordwrap`

| input, `width=6` | native 2.24 | deleted Python filter | |
|---|---|---|---|
| `'ab²-cdefghij'` | `ab²-` / `cdefgh` / `ij` | `ab²-cd` / `efghij` | **differs** |
| `'abc-defghij'` | `abc-` / `defghi` / `j` | `abc-de` / `fghij` | **differs** |
| `'ab7-cdefghij'` | `ab7-` / `cdefgh` / `ij` | `ab7-` / `cdefgh` / `ij` | same |
| `'ab²cdefghij'` | `ab²cde` / `fghij` | `ab²cde` / `fghij` | same |

That first row is contrib's **plain `wordwrap`**, not its `unicode_wordwrap` variant —
settled by measurement.

The behaviour change is about **the hyphen, not Unicode**: the native filter breaks
immediately after a hyphen, where `textwrap` first fills the line to the width. The `ab²`
row is the same rule seen through a non-letter. Everything else matches: text without
hyphens, `wrapstring`, `break_long_words` (including its `True` default), empty input, and
the independent wrapping of each existing line.

The changelog entry carries the repo's `**(changed output)**` marker for this.

### No core drift

`{{ none }}` → `None` and `{{ [none, 1] }}` → `[None, 1]` on 2.24, so the #1754 snapshot
premise is intact. The full suite agrees: **no snapshot changed anywhere.**

## One consequence worth a second opinion

`needflow`'s `graphviz` engine doesn't render through a template — `_label()` wraps with
`textwrap.wrap(..., break_on_hyphens=True)` under a comment saying it *"mimics the jinja
wordwrap filter"*. That mimicry was faithful on hyphens against the Python filter and no longer is: a
hyphenated title long enough to hit width 15 can now wrap differently under `plantuml` and
under `graphviz`.

Left alone here deliberately — it is a rendered change to the graphviz engine and belongs
in its own PR with its own snapshot review — but it is noted in the changelog, and it is
the obvious follow-up if the divergence isn't acceptable.

## Tests

Seven new tests in `tests/test_jinja.py`, all going through `render_template_string` or
`compile_template` in the shapes real surfaces use, rather than poking the filter directly:

- the `wordwrap(width=15, wrapstring='**\n**')` shape, pinned to its measured output;
- `wordwrap(15)` raising `too many arguments` — the break — **with the migration hint in
  the error**, pinned so nobody has to rediscover either;
- the hint on the compiled-template path too (the path `needs_diagram_template` actually
  renders through);
- no hint on an unrelated arity error (the hint is scoped to templates calling `wordwrap`);
- existing newlines preserved, each line wrapped independently (a deliberate
  non-difference: the Python filter behaved the same way);
- the hyphen behaviour the changelog marks **(changed output)** — `abc-defghij` at
  width 6 — added in review as the one assertion that separates the native filter from
  any `textwrap`-based replacement, faithful or naive, so a wheel silently reverting
  turns CI red instead of contradicting the shipped changelog.

There was **no test on the deleted filter to replace** — it was covered only indirectly,
through the diagram snapshots. The pins were mutation-checked: mangling a pinned string
fails its test; re-registering a `textwrap`-based shadow of the deleted filter is
caught by the positional-signature pin and the hyphen pin; and neutering the hint turns
exactly the two hint tests red.

## Verification

- `tests/test_jinja.py`, `test_jinja_content_option.py`: 13 passed.
- `test_needuml`, `test_needarch`, `test_plantuml`, `test_needextract`, `test_basic_doc`,
  `test_needreport` (re-run after the hint landed): 98 passed total with the jinja files,
  12 snapshots passed.
- Whole unfiltered suite, HEAD vs a pristine `master` export: **1675 vs 1672 passed, 52
  failed on both, failure sets byte-identical.** The 52 are the pre-existing missing-`dot`
  family; the +3 is this PR's first three tests (the suite comparison ran before the
  review-added and hint tests; the affected families were re-run after).
- `ruff check`, `ruff format --check`, `mypy` (81 files), `pre-commit` on all changed
  files: clean.
- Docs build: 68 warnings, unchanged, all from offline intersphinx.
- Independently validated by a second adversarial pass: every measurement above was
  re-taken from scratch (bare wheel, the deleted filter's extracted source, live
  `textwrap`), and the doc mirrors of the default template verified verbatim.