### PR TITLE
🔧 Switch the lint runner from pre-commit to prek

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,11 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - uses: astral-sh/setup-uv@v10
         with:
-          python-version: '3.10'
-      - uses: pre-commit/action@v3.0.1
+          enable-cache: true
+      - run: uv run prek run --all-files --show-diff-on-failure
+        env:
+          PREK_COLOR: always
 
   # ubc:
   #   name: ubc

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v10
+      - uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true
       - run: uv run prek run --all-files --show-diff-on-failure

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Install dev tools
         run: |
-          pip install tox tox-uv pre-commit
+          pip install tox tox-uv prek
 
       - name: Install pre-commit hooks
-        run: pre-commit install
+        run: prek install

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,8 +87,8 @@ tox -e ruff-check
 # Formatting with ruff
 tox -e ruff-fmt
 
-# Run pre-commit hooks on all files
-pre-commit run --all-files
+# Run the pre-commit hooks on all files (via prek)
+uv run prek run --all-files
 ```
 
 ## Code Style Guidelines

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -43,12 +43,15 @@ or using `uv <https://docs.astral.sh/uv/>`__ to install the dependencies into an
 
    uv sync
 
-To run the formatting and linting suite, `pre-commit <https://pre-commit.com/>`__ is used:
+To run the formatting and linting suite, `prek <https://prek.j178.dev/>`__ is used:
 
 .. code-block:: bash
 
-   pre-commit install  # to auto-run on every commit
-   pre-commit run --all-files  # to run manually
+   uv run prek install  # to auto-run on every commit
+   uv run prek run --all-files  # to run manually
+
+The hooks are declared in ``.pre-commit-config.yaml``, which prek reads unchanged,
+so `pre-commit <https://pre-commit.com/>`__ itself still works if you prefer it.
 
 To run testing and documentation building, `tox <https://tox.readthedocs.io/>`__ is used:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ theme-pds = ["pydata-sphinx-theme~=0.15.2"]
 theme-rtd = ["sphinx_rtd_theme>=3.0.2,<4"]
 
 [dependency-groups]
-dev = ["pre-commit~=3.0", "tox~=4.23", "tox-uv~=1.15"]
+dev = ["prek>=0.5.1", "tox~=4.23", "tox-uv~=1.15"]
 mypy = [
   "mypy==1.19.1",
   "sphinx==7.4.7",


### PR DESCRIPTION
### What

The hook set is unchanged; only the program that runs it changes.
[`prek`](https://prek.j178.dev/) is a single-binary reimplementation of `pre-commit` that
reads the same `.pre-commit-config.yaml`. The `lint` CI job drops
`actions/setup-python` + `pre-commit/action@v3.0.1` in favour of `astral-sh/setup-uv`
(with its cache enabled) plus `uv run prek run --all-files --show-diff-on-failure`; the
`dev` dependency group swaps `pre-commit~=3.0` for `prek>=0.5.1`; and the Copilot setup
steps, `docs/contributing.rst` and `AGENTS.md` follow. The job keeps its `lint` id and
`Lint` name, so the required-check configuration needs no change.

### Why

Tooling groundwork for the monorepo direction discussed in #1803 — prek is what
`sphinx-mounts` already uses, and aligning the hook runner now means one less difference
to reconcile later. It is also faster and lighter on its own merits: no Python bootstrap
step in CI, and prek's zero transitive dependencies make the dev environment three
packages smaller (`pre-commit`, `cfgv`, `identify` and `nodeenv` out, `prek` in).

### `.pre-commit-config.yaml` is untouched — plain pre-commit still works

The config file is **byte-identical** in this PR. Anyone who prefers the original tool
can keep running `pre-commit install` / `pre-commit run --all-files` against the same
file and get the same hooks; `docs/contributing.rst` now says so explicitly. This is
deliberately a runner swap and nothing more: no hook, rev or ruff-version changes ride
along.

(An aside discovered on this PR: pre-commit.ci **is** enabled for this repository — it
reports only on pull requests, which is why it never shows on master's check runs. Since
the config file is unchanged, it continues to run the same hooks here, alongside the new
lint job.)

### Verification

- All six hooks pass under prek 0.5.1 — via `uv run prek run --all-files` and,
  independently, `uvx prek run --all-files`. They also passed under the same config
  before this change, so nothing was silently fixed up.
- The exact CI command was rehearsed in a clean-room clone of this branch (no `.venv`,
  no lockfile): green in 6 s.
- `actionlint` is clean on both changed workflows (its one `ci.yaml` finding,
  `codecov-action@v3`, is pre-existing and in an untouched job).
- The `Copilot Setup Steps` workflow already ran green on this branch, exercising
  `pip install … prek` and `prek install` on `ubuntu-latest`.

One note on the command: `--frozen` is **not** passed, unlike the sphinx-mounts job this
mirrors, because `uv.lock` is git-ignored in this repository — there is no lockfile in a
fresh checkout for uv to honour. Whether to start tracking `uv.lock` (and gain the
reproducible, `--frozen` lint environment sphinx-mounts has) is a separate policy
question, worth its own PR.
