### PR TITLE
🔧 Unify the ruff and mypy pins, and pin the rule set that goes with them

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
         exclude: ^tests/conformance/
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.19.1
+    rev: v2.3.1
     hooks:
       - id: mypy
         files: sphinx_needs/.*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       - id: taplo-format
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.8
+    rev: v0.16.5
     hooks:
       - id: ruff-check
         args: [--fix]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ theme-rtd = ["sphinx_rtd_theme>=3.0.2,<4"]
 [dependency-groups]
 dev = ["prek>=0.5.1", "tox~=4.23", "tox-uv~=1.15"]
 mypy = [
-  "mypy==1.19.1",
+  "mypy==2.3.1",
   "sphinx==7.4.7",
   "docutils==0.20",
   "jsonschema-rs==0.37.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,11 @@ filterwarnings = [
 
 
 [tool.ruff.lint]
+# ruff's pre-0.16 default rule set, pinned explicitly.
+# ruff 0.16 replaced its default `select` wholesale, and this project only ever set
+# `extend-select`, so without this line the enabled set would change with every ruff
+# release. Adopting 0.16's much larger default set is a deliberate, separate decision.
+select = ["E4", "E7", "E9", "F"]
 extend-select = [
   "B",   # flake8-bugbear  
   "C4",  # flake8-comprehensions
@@ -112,7 +117,16 @@ extend-select = [
   "SIM", # flake8-simplify
   "UP",  # pyupgrade
 ]
-extend-ignore = ["B904", "ISC001", "ICN001", "N818", "RUF012"]
+# ISC004 is ignored for now: every occurrence here is a deliberately wrapped string
+# literal and its only fix is unsafe, so adopting it belongs with the wider ruleset review
+extend-ignore = ["B904", "ISC001", "ISC004", "ICN001", "N818", "RUF012"]
+
+[tool.ruff.format]
+# ruff 0.16 formats python code blocks embedded in markdown; the conformance corpus is
+# shared byte-for-byte with ubCode and checksummed in its own manifest (see the yamlfmt
+# exclude in .pre-commit-config.yaml), so a formatter local to this repository must not
+# rewrite markdown here
+exclude = ["*.md"]
 
 [tool.mypy]
 files = "sphinx_needs"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ mypy = [
   "types-docutils==0.20.0.20240201",
   "types-requests",
 ]
-ruff = ["ruff==0.14.11"]
+ruff = ["ruff==0.16.5"]
 
 [tool.pytest.ini_options]
 markers = [

--- a/sphinx_needs/api/configuration.py
+++ b/sphinx_needs/api/configuration.py
@@ -143,8 +143,8 @@ def add_field(
     *,
     schema: FieldSchemaTypes | None = None,
     nullable: bool | None = None,
-    default: None | Any = None,
-    predicates: None | list[tuple[str, Any]] = None,
+    default: Any | None = None,
+    predicates: list[tuple[str, Any]] | None = None,
     parse_variants: bool | None = None,
     parse_dynamic_functions: bool | None = None,
 ) -> None:

--- a/sphinx_needs/api/need.py
+++ b/sphinx_needs/api/need.py
@@ -76,26 +76,26 @@ def generate_need(
     title: str,
     *,
     need_source: NeedItemSourceProtocol | None = None,
-    docname: None | str = None,
-    lineno: None | int = None,
+    docname: str | None = None,
+    lineno: int | None = None,
     id: str | None = None,
     doctype: str = ".rst",
     content: str = "",
-    lineno_content: None | int = None,
+    lineno_content: int | None = None,
     status: str | None = None,
-    tags: None | str | list[str] = None,
-    constraints: None | str | list[str] = None,
+    tags: str | list[str] | None = None,
+    constraints: str | list[str] | None = None,
     parts: dict[str, NeedsPartType] | None = None,
     arch: dict[str, str] | None = None,
-    signature: None | str = None,
+    signature: str | None = None,
     sections: Sequence[str] | None = None,
     jinja_content: bool | None = None,
-    hide: None | bool | str = None,
-    collapse: None | bool | str = None,
-    style: None | str = None,
-    layout: None | str = None,
+    hide: bool | str | None = None,
+    collapse: bool | str | None = None,
+    style: str | None = None,
+    layout: str | None = None,
     template_root: Path | None = None,
-    template: None | str = None,
+    template: str | None = None,
     pre_template: str | None = None,
     post_template: str | None = None,
     is_import: bool = False,
@@ -264,7 +264,7 @@ def generate_need(
             f"Constraints {unknown_constraints!r} not in 'needs_constraints'.",
         )
 
-    extras_no_defaults: dict[str, None | FieldLiteralValue | FieldFunctionArray] = {}
+    extras_no_defaults: dict[str, FieldLiteralValue | FieldFunctionArray | None] = {}
     for extra_field in needs_schema.iter_extra_fields():
         if extra_field.name not in kwargs:
             extras_no_defaults[extra_field.name] = None
@@ -283,7 +283,7 @@ def generate_need(
                     f"Field {extra_field.name!r} is invalid: {err}",
                 ) from err
 
-    links_no_defaults: dict[str, None | LinksLiteralValue | LinksFunctionArray] = {}
+    links_no_defaults: dict[str, LinksLiteralValue | LinksFunctionArray | None] = {}
     for link_field in needs_schema.iter_link_fields():
         if link_field.name not in kwargs:
             links_no_defaults[link_field.name] = None
@@ -566,30 +566,30 @@ def _unwrap_field_value(
 
 def add_need(
     app: Sphinx,
-    state: None | RSTState = None,
-    docname: None | str = None,
-    lineno: None | int = None,
+    state: RSTState | None = None,
+    docname: str | None = None,
+    lineno: int | None = None,
     need_type: str = "",
     title: str = "",
     *,
     need_source: NeedItemSourceProtocol | None = None,
     id: str | None = None,
     content: str | StringList = "",
-    lineno_content: None | int = None,
-    doctype: None | str = None,
+    lineno_content: int | None = None,
+    doctype: str | None = None,
     status: str | None = None,
-    tags: None | str | list[str] = None,
-    constraints: None | str | list[str] = None,
+    tags: str | list[str] | None = None,
+    constraints: str | list[str] | None = None,
     parts: dict[str, NeedsPartType] | None = None,
     arch: dict[str, str] | None = None,
-    signature: None | str = None,
+    signature: str | None = None,
     sections: list[str] | None = None,
     jinja_content: bool | None = None,
-    hide: None | bool | str = None,
-    collapse: None | bool | str = None,
-    style: None | str = None,
-    layout: None | str = None,
-    template: None | str = None,
+    hide: bool | str | None = None,
+    collapse: bool | str | None = None,
+    style: str | None = None,
+    layout: str | None = None,
+    template: str | None = None,
     pre_template: str | None = None,
     post_template: str | None = None,
     is_import: bool = False,
@@ -968,7 +968,7 @@ def _prepare_template(
     needs_config: NeedsSphinxConfig,
     needs_info: NeedItem,
     template_name: str,
-    template_root: None | Path,
+    template_root: Path | None,
 ) -> str:
     template_folder = Path(needs_config.template_folder)
     if not template_folder.is_absolute():
@@ -1120,7 +1120,7 @@ def _get_field_default(
     extras: dict[str, AllowedTypes | None],
     links: dict[str, list[str]],
     location: tuple[str | None, int | None] | None,
-) -> None | FieldLiteralValue | FieldFunctionArray:
+) -> FieldLiteralValue | FieldFunctionArray | None:
     if scheme is None:
         return None  # TODO except (and catch upstream)
     # TODO if we stored default lists as tuples we could avoid the deepcopy here
@@ -1149,7 +1149,7 @@ def _get_links_default(
     extras: dict[str, AllowedTypes | None],
     links: dict[str, list[str]],
     location: tuple[str | None, int | None] | None,
-) -> None | LinksLiteralValue | LinksFunctionArray:
+) -> LinksLiteralValue | LinksFunctionArray | None:
     if scheme is None:
         return None  # TODO except (and catch upstream)
     # TODO if we stored default lists as tuples we could avoid the deepcopy here

--- a/sphinx_needs/card_layouts.py
+++ b/sphinx_needs/card_layouts.py
@@ -321,7 +321,7 @@ def _resolve_extends(
 def _parse_meta(
     value: Any,
     warn: Callable[[str], None],
-) -> MetaSpec | None | Literal[False]:
+) -> MetaSpec | Literal[False] | None:
     """Validate the ``meta`` key of a specification.
 
     :param value: The raw value of the ``meta`` key.
@@ -379,7 +379,7 @@ def _parse_meta(
 
 def _parse_side(
     value: Any, warn: Callable[[str], None]
-) -> SideSpec | None | Literal[False]:
+) -> SideSpec | Literal[False] | None:
     """Validate the ``side`` key of a specification.
 
     :param value: The raw value of the ``side`` key.

--- a/sphinx_needs/config.py
+++ b/sphinx_needs/config.py
@@ -63,14 +63,14 @@ class NewFieldParams:
     """Whether variants are parsed in this field."""
     parse_dynamic_functions: bool | None = None
     """Whether dynamic functions are parsed in this field."""
-    predicates: None | list[tuple[str, Any]] = None
+    predicates: list[tuple[str, Any]] | None = None
     """List of (need filter, value) pairs for default predicate values.
 
     Used if the field has not been specifically set.
 
     The value from the first matching filter will be used, if any.
     """
-    default: None | Any = None
+    default: Any | None = None
     """Default value for the field.
     
     Used if the field has not been specifically set, and no predicate matches.
@@ -129,11 +129,11 @@ class _Config:
         | FieldNumberSchemaType
         | FieldMultiValueSchemaType
         | None = None,
-        nullable: None | bool = None,
-        default: None | Any = None,
-        predicates: None | list[tuple[str, Any]] = None,
-        parse_variants: None | bool = None,
-        parse_dynamic_functions: None | bool = None,
+        nullable: bool | None = None,
+        default: Any | None = None,
+        predicates: list[tuple[str, Any]] | None = None,
+        parse_variants: bool | None = None,
+        parse_dynamic_functions: bool | None = None,
         override: bool = False,
     ) -> None:
         """Adds a need field to the configuration."""
@@ -648,7 +648,7 @@ class NeedsSphinxConfig:
         default=True, metadata={"rebuild": "html", "types": (bool,)}
     )
     """Show the link ID in the need incoming/outgoing roles."""
-    file: None | str = field(
+    file: str | None = field(
         default=None,
         metadata={"rebuild": "html", "types": (), "toml_convert": _abs_path},
     )
@@ -885,7 +885,7 @@ class NeedsSphinxConfig:
         default="clean", metadata={"rebuild": "html", "types": (str,)}
     )
     """The default layout to use for needs rendering."""
-    default_style: None | str = field(
+    default_style: str | None = field(
         default=None, metadata={"rebuild": "html", "types": ()}
     )
     """The default style to use for needs rendering."""

--- a/sphinx_needs/data.py
+++ b/sphinx_needs/data.py
@@ -429,7 +429,7 @@ class NeedsSourceInfoType(TypedDict):
     """Line number where the need is defined (None if external)."""
     lineno_content: int | None
     """Line number on which the need content starts (None if external)."""
-    external_url: None | str
+    external_url: str | None
     """URL of the need, if it is an external need."""
     is_import: bool
     """If true, the need was derived from an import."""
@@ -442,19 +442,19 @@ class NeedsContentInfoType(TypedDict):
 
     jinja_content: bool
     """Whether the content was pre-processed by jinja."""
-    template: None | str
+    template: str | None
     """The template key, if the content was created from a jinja template."""
-    pre_template: None | str
+    pre_template: str | None
     """The template key, if the pre_content was created from a jinja template."""
-    post_template: None | str
+    post_template: str | None
     """The template key, if the post_content was created from a jinja template."""
     doctype: str
     """The markup type of the content, denoted by the suffix of the source file, e.g. '.rst'."""
     content: str
     """The main content of the need."""
-    pre_content: None | str
+    pre_content: str | None
     """Additional content before the need."""
-    post_content: None | str
+    post_content: str | None
     """Additional content after the need."""
 
 
@@ -470,7 +470,7 @@ class NeedsInfoType(TypedDict):
     # meta information
     title: str
     """Title of the need."""
-    status: None | str
+    status: str | None
     tags: list[str]
 
     # rendering information
@@ -478,9 +478,9 @@ class NeedsInfoType(TypedDict):
     """Hide the meta-data information of the need."""
     hide: bool
     """If true, the need is not rendered."""
-    layout: None | str
+    layout: str | None
     """Key of the layout, which is used to render the need."""
-    style: None | str
+    style: str | None
     """Comma-separated list of CSS classes (all appended by `needs_style_`)."""
 
     external_css: str
@@ -503,7 +503,7 @@ class NeedsInfoType(TypedDict):
     # additional source information
     # set in analyse_need_locations transform
     sections: tuple[str, ...]
-    signature: None | str
+    signature: str | None
     """Derived from a docutils desc_name node."""
 
     # these default to False and are updated in resolve_links post-process
@@ -534,17 +534,17 @@ class NeedsInfoComputedType(TypedDict):
     """<parent ID>, or <self ID> if not a part."""
     id_complete: str
     """<parent ID>.<self ID>, or <self ID> if not a part."""
-    section_name: None | str
+    section_name: str | None
     """Simply the first section."""
-    parent_need: None | str
+    parent_need: str | None
     """Simply the first parent id."""
     # constraints information
     # set in process_need_nodes (-> process_constraints) transform
-    constraints_results: None | Mapping[str, Mapping[str, bool]]
+    constraints_results: Mapping[str, Mapping[str, bool]] | None
     """Mapping of constraint name, to check name, to result, None if not yet checked."""
-    constraints_error: None | str
+    constraints_error: str | None
     """An error message set if any constraint failed, and `error_message` field is set in config."""
-    constraints_passed: None | bool
+    constraints_passed: bool | None
     """True if all constraints passed, False if any failed, None if not yet checked."""
 
 
@@ -563,7 +563,7 @@ class NeedsBarType(NeedsBaseDataType):
     """Data for a single (matplotlib) bar diagram."""
 
     error_id: str
-    title: None | str
+    title: str | None
     content: str
     legend: bool
     x_axis_title: str
@@ -574,9 +574,9 @@ class NeedsBarType(NeedsBaseDataType):
     ylabels_rotation: str
     separator: str
     stacked: bool
-    show_sum: None | bool
-    show_top_sum: None | bool
-    sum_rotation: None | str
+    show_sum: bool | None
+    show_top_sum: bool | None
+    sum_rotation: str | None
     transpose: bool
     horizontal: bool
     style: str
@@ -620,10 +620,10 @@ class NeedsFilteredBaseType(NeedsBaseDataType):
     status: list[str]
     tags: list[str]
     types: list[str]
-    filter: None | str
-    sort_by: None | str
+    filter: str | None
+    sort_by: str | None
     filter_code: list[str]
-    filter_func: None | str
+    filter_func: str | None
     filter_warning: str | None
     """If set, the filter is exported with this ID in the needs.json file."""
 
@@ -646,9 +646,9 @@ class NeedsFilteredDiagramBaseType(NeedsFilteredBaseType):
     config_names: str
     scale: str
     highlight: str
-    align: None | str
+    align: str | None
     debug: bool
-    caption: None | str
+    caption: str | None
 
 
 class NeedsExtractType(NeedsFilteredBaseType):
@@ -657,7 +657,7 @@ class NeedsExtractType(NeedsFilteredBaseType):
     layout: str
     style: str
     show_filters: bool
-    filter_arg: None | str
+    filter_arg: str | None
 
 
 class GraphvizStyleType(TypedDict, total=False):
@@ -732,7 +732,7 @@ class NeedsGanttType(NeedsFilteredDiagramBaseType):
     starts_after_links: list[str]
     ends_with_links: list[str]
     milestone_filter: str
-    start_date: None | str
+    start_date: str | None
     timeline: Literal[None, "daily", "weekly", "monthly"]
     no_color: bool
     duration_option: str
@@ -756,13 +756,13 @@ class NeedsPieType(NeedsBaseDataType):
     title: str
     content: str
     legend: bool
-    explode: None | list[float]
-    style: None | str
-    labels: None | list[str]
-    colors: None | list[str]
-    text_color: None | str
+    explode: list[float] | None
+    style: str | None
+    labels: list[str] | None
+    colors: list[str] | None
+    text_color: str | None
     shadow: bool
-    filter_func: None | str
+    filter_func: str | None
     filter_warning: str | None
 
 
@@ -778,7 +778,7 @@ class NeedsSequenceType(NeedsFilteredDiagramBaseType):
 class NeedsTableType(NeedsFilteredBaseType):
     """Data for a single (filtered) needs table."""
 
-    caption: None | str
+    caption: str | None
     classes: list[str]
     columns: list[tuple[str, str]]
     """List of (name, title)"""
@@ -796,16 +796,16 @@ class NeedsTableType(NeedsFilteredBaseType):
 class NeedsUmlType(NeedsBaseDataType):
     """Data for a single (filtered) uml diagram."""
 
-    caption: None | str
+    caption: str | None
     content: str
     scale: str
     align: str
-    config_names: None | str
+    config_names: str | None
     config: str
     debug: bool
     extra: dict[str, str]
-    key: None | str
-    save: None | str
+    key: str | None
+    save: str | None
     is_arch: bool
     # set in process_needuml
     content_calculated: str

--- a/sphinx_needs/diagrams_common.py
+++ b/sphinx_needs/diagrams_common.py
@@ -197,7 +197,7 @@ def get_debug_container(puml_node: nodes.Element) -> nodes.container:
 def calculate_link(
     app: Sphinx,
     need_info: NeedItem | NeedPartItem,
-    _fromdocname: None | str,
+    _fromdocname: str | None,
     relative: str = "..",
 ) -> str:
     """

--- a/sphinx_needs/directives/needflow/_model.py
+++ b/sphinx_needs/directives/needflow/_model.py
@@ -110,7 +110,7 @@ def filter_by_tree(
     return needs_view.filter_ids(need_ids)
 
 
-def resolve_color(value: None | str | int | float | bool) -> str | None:
+def resolve_color(value: str | int | float | bool | None) -> str | None:
     """Normalise a resolved color option value to an engine neutral form.
 
     A color may be written with or without a leading ``#``, and each engine adds the

--- a/sphinx_needs/directives/needuml.py
+++ b/sphinx_needs/directives/needuml.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 
 class ProcessedDataType(TypedDict):
     art: str
-    key: None | str
+    key: str | None
     arguments: dict[str, Any]
 
 
@@ -179,8 +179,8 @@ class NeedarchDirective(NeedumlDirective):
 def transform_uml_to_plantuml_node(
     app: Sphinx,
     uml_content: str,
-    parent_need_id: None | str,
-    key: None | str,
+    parent_need_id: str | None,
+    key: str | None,
     kwargs: dict[str, Any],
     config: str,
     location: LocationType = None,
@@ -241,10 +241,10 @@ def get_debug_node_from_puml_node(puml_node: nodes.Element) -> nodes.container:
 
 def jinja2uml(
     app: Sphinx,
-    fromdocname: None | str,
+    fromdocname: str | None,
     uml_content: str,
-    parent_need_id: None | str,
-    key: None | str,
+    parent_need_id: str | None,
+    key: str | None,
     processed_need_ids: ProcessedNeedsType,
     kwargs: dict[str, Any],
     jinja_utils: JinjaFunctions | None = None,
@@ -337,8 +337,8 @@ class JinjaFunctions:
     def __init__(
         self,
         app: Sphinx,
-        fromdocname: None | str,
-        parent_need_id: None | str,
+        fromdocname: str | None,
+        parent_need_id: str | None,
         processed_need_ids: ProcessedNeedsType,
         location: LocationType = None,
     ) -> None:
@@ -354,7 +354,7 @@ class JinjaFunctions:
         self.processed_need_ids = processed_need_ids
         self.needs_config = NeedsSphinxConfig(app.config)
 
-    def set_parent_need_id(self, parent_need_id: None | str) -> None:
+    def set_parent_need_id(self, parent_need_id: str | None) -> None:
         """Update the parent need ID for a new recursion level."""
         if parent_need_id and parent_need_id not in self.needs:
             raise NeedumlException(
@@ -363,7 +363,7 @@ class JinjaFunctions:
         self.parent_need_id = parent_need_id
 
     def need_to_processed_data(
-        self, art: str, key: None | str, kwargs: dict[str, Any]
+        self, art: str, key: str | None, kwargs: dict[str, Any]
     ) -> ProcessedDataType:
         d: ProcessedDataType = {
             "art": art,
@@ -373,7 +373,7 @@ class JinjaFunctions:
         return d
 
     def append_need_to_processed_needs(
-        self, need_id: str, art: str, key: None | str, kwargs: dict[str, Any]
+        self, need_id: str, art: str, key: str | None, kwargs: dict[str, Any]
     ) -> None:
         data = self.need_to_processed_data(art=art, key=key, kwargs=kwargs)
         if need_id not in self.processed_need_ids:
@@ -499,7 +499,7 @@ class JinjaFunctions:
         return need_uml
 
     def ref(
-        self, need_id: str, option: None | str = None, text: None | str = None
+        self, need_id: str, option: str | None = None, text: str | None = None
     ) -> str:
         need_id_main, need_id_part = split_need_id(need_id)
 

--- a/sphinx_needs/filter_common.py
+++ b/sphinx_needs/filter_common.py
@@ -312,7 +312,7 @@ def apply_max_items(
 def filter_needs_mutable(
     needs: NeedsMutable,
     config: NeedsSphinxConfig,
-    filter_string: None | str = "",
+    filter_string: str | None = "",
     current_need: NeedItem | None = None,
     *,
     location: tuple[str, int | None] | nodes.Node | None = None,
@@ -445,7 +445,7 @@ def _analyze_and_apply_expr(
 def filter_needs_view(
     needs: NeedsView,
     config: NeedsSphinxConfig,
-    filter_string: None | str = "",
+    filter_string: str | None = "",
     current_need: NeedItem | None = None,
     *,
     location: tuple[str, int | None] | nodes.Node | None = None,
@@ -486,7 +486,7 @@ def filter_needs_view(
 def filter_needs_parts(
     needs: NeedsAndPartsListView,
     config: NeedsSphinxConfig,
-    filter_string: None | str = "",
+    filter_string: str | None = "",
     current_need: NeedItem | None = None,
     *,
     location: tuple[str, int | None] | nodes.Node | None = None,
@@ -528,7 +528,7 @@ def filter_needs_parts(
 def filter_needs(
     needs: Iterable[NeedItem],
     config: NeedsSphinxConfig,
-    filter_string: None | str = "",
+    filter_string: str | None = "",
     current_need: NeedItem | None = None,
     *,
     location: tuple[str, int | None] | nodes.Node | None = None,
@@ -550,7 +550,7 @@ def filter_needs(
 def filter_needs_and_parts(
     needs: Iterable[NeedItem | NeedPartItem],
     config: NeedsSphinxConfig,
-    filter_string: None | str = "",
+    filter_string: str | None = "",
     current_need: NeedItem | NeedPartItem | None = None,
     *,
     location: tuple[str, int | None] | nodes.Node | None = None,

--- a/sphinx_needs/functions/functions.py
+++ b/sphinx_needs/functions/functions.py
@@ -402,7 +402,7 @@ def resolve_functions(
 
 def _get_variant(
     variant: VariantFunctionParsed, variants: dict[str, str], context: dict[str, Any]
-) -> None | str | int | float | bool:
+) -> str | int | float | bool | None:
     for expr, _, value in variant.expressions:
         expr = variants.get(expr, expr)
         if bool(eval(expr, context.copy())):

--- a/sphinx_needs/layout.py
+++ b/sphinx_needs/layout.py
@@ -284,7 +284,7 @@ class LayoutHandler:
         )
 
         self.functions: dict[
-            str, Callable[..., None | nodes.Node | list[nodes.Node]]
+            str, Callable[..., nodes.Node | list[nodes.Node] | None]
         ] = {
             "meta": self.meta,  # type: ignore[dict-item]
             "meta_all": self.meta_all,
@@ -369,7 +369,7 @@ class LayoutHandler:
         :return: docutils nodes
         """
         return_nodes = []
-        result: None | nodes.Node | list[nodes.Node]
+        result: nodes.Node | list[nodes.Node] | None
         for node in section_nodes:
             if not isinstance(node, nodes.Text):
                 for child in node.children:

--- a/sphinx_needs/need_item.py
+++ b/sphinx_needs/need_item.py
@@ -438,7 +438,7 @@ class NeedItem:
         backlinks: dict[str, list[str]] | dict[str, list[NeedLink]] | None = None,
         parts: Sequence[NeedPartData] = (),
         modifications: Sequence[NeedModification] = (),
-        constraint_results: None | NeedConstraintResults = None,
+        constraint_results: NeedConstraintResults | None = None,
         dynamic_fields: dict[str, FieldFunctionArray | LinksFunctionArray]
         | None = None,
         _validate: bool = True,
@@ -637,7 +637,7 @@ class NeedItem:
         return self._modifications
 
     @property
-    def constraint_results(self) -> None | NeedConstraintResults:
+    def constraint_results(self) -> NeedConstraintResults | None:
         """Return the constraint results of the need item."""
         return self._constraint_results
 
@@ -1130,7 +1130,7 @@ class NeedItem:
 
     def set_constraint_results(
         self,
-        constraint_results: None | NeedConstraintResults,
+        constraint_results: NeedConstraintResults | None,
         *,
         _recompute: bool = True,
     ) -> None:

--- a/sphinx_needs/needs_schema.py
+++ b/sphinx_needs/needs_schema.py
@@ -56,7 +56,7 @@ class FieldSchema:
 
     The value from the first matching filter will be used, if any.
     """
-    default: None | FieldLiteralValue | FieldFunctionArray = None
+    default: FieldLiteralValue | FieldFunctionArray | None = None
     """ The default value for this field.
     
     Used if the field has not been specifically set, and no predicate matches.
@@ -111,7 +111,7 @@ class FieldSchema:
         return self.schema["type"]
 
     @property
-    def item_type(self) -> None | Literal["string", "boolean", "integer", "number"]:
+    def item_type(self) -> Literal["string", "boolean", "integer", "number"] | None:
         if self.schema["type"] == "array":
             return self.schema["items"]["type"]
         return None
@@ -382,7 +382,7 @@ class FieldSchema:
 
     def convert_or_type_check(
         self, value: Any, *, allow_coercion: bool
-    ) -> None | FieldLiteralValue | FieldFunctionArray:
+    ) -> FieldLiteralValue | FieldFunctionArray | None:
         """Convert a value to the correct type for this field, or check if it is of the correct type.
 
         :param value: The value to convert or check.
@@ -619,7 +619,7 @@ class LinkSchema:
 
     The value from the first matching filter will be used, if any.
     """
-    default: None | LinksLiteralValue | LinksFunctionArray = None
+    default: LinksLiteralValue | LinksFunctionArray | None = None
     """ The default value for this field.
     
     Used if the field has not been specifically set, and no predicate matches.

--- a/sphinx_needs/roles/need_ref.py
+++ b/sphinx_needs/roles/need_ref.py
@@ -199,7 +199,7 @@ def process_need_ref(
                 title = f"{title[: max_length - 3]}..."
                 dict_need["title"] = title
 
-            ref_name: None | str | nodes.Text = node_need_ref.children[0].children[0]  # type: ignore[assignment]
+            ref_name: str | nodes.Text | None = node_need_ref.children[0].children[0]  # type: ignore[assignment]
             # Only use ref_name, if it differs from ref_id
             if str(need_id_full) == str(ref_name):
                 ref_name = None

--- a/sphinx_needs/schema/config_utils.py
+++ b/sphinx_needs/schema/config_utils.py
@@ -517,7 +517,7 @@ def _get_core_field_type(
 ) -> (
     tuple[
         Literal["string", "boolean", "integer", "number", "array"],
-        None | Literal["string", "boolean", "integer", "number"],
+        Literal["string", "boolean", "integer", "number"] | None,
     ]
     | None
 ):

--- a/sphinx_needs/schema/core.py
+++ b/sphinx_needs/schema/core.py
@@ -645,7 +645,7 @@ def compile_validator(schema: NeedFieldsSchemaType) -> SchemaValidator:
         "$schema": _SCHEMA_VERSION,
         "type": "object",
         **{  # type: ignore[typeddict-item]
-            k: schema[k]  # type: ignore[literal-required]
+            k: schema[k]
             for k in ("properties", "allOf", "required", "unevaluatedProperties")
             if k in schema
         },

--- a/sphinx_needs/variants.py
+++ b/sphinx_needs/variants.py
@@ -89,7 +89,7 @@ def match_variants(
     variants: dict[str, str],
     *,
     location: str | tuple[str | None, int | None] | nodes.Node | None = None,
-) -> None | str | int | float | bool:
+) -> str | int | float | bool | None:
     """Evaluate an options list and return the first matching variant.
 
     Each item should have the format ``<expression>:<value>``,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -408,7 +408,7 @@ THIS_DIR = Path(__file__).parent
 
 
 def create_parameters(
-    *rel_paths: str, skip_files: None | list[str] = None
+    *rel_paths: str, skip_files: list[str] | None = None
 ) -> list[ParameterSet]:
     """Create parameters for a pytest param_file decorator."""
     paths: list[Path] = []

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -71,12 +71,15 @@ def test_consistent():
         elif type_str == "dict[str, str]":
             assert schema["type"] == "object", field
             assert schema["additionalProperties"]["type"] == "string", field
-        elif type_str.startswith("dict[") or type_str.startswith("Mapping["):
-            assert schema["type"] == "object", field
-        elif type_str.startswith("None | dict[") or type_str.startswith(
-            "None | Mapping["
+        # `None | X` and `X | None` are the same annotation, so both orders are accepted;
+        # the optional form must be tested first, or `Mapping[...] | None` would be
+        # swallowed by the non-optional branch below
+        elif type_str.startswith(("None | dict[", "None | Mapping[")) or (
+            type_str.startswith(("dict[", "Mapping[")) and type_str.endswith(" | None")
         ):
             assert schema["type"] == ["object", "null"], field
+        elif type_str.startswith(("dict[", "Mapping[")):
+            assert schema["type"] == "object", field
         else:
             raise ValueError(f"Unknown type: {type_str!r} for {field!r}")
 


### PR DESCRIPTION

`ruff` was pinned in two places that disagreed — `v0.15.8` in `.pre-commit-config.yaml`, `0.14.11`
in the `ruff` dependency group — so `uv run prek run` and `tox -e ruff-check` have been running
different linters. `mypy` is pinned in two places too. This moves ruff to **0.16.5** and mypy to
**2.3.1** in both places each, and adds the one config line that makes a ruff version bump mean
"a new ruff", not "a new rule set".

**ruff 0.16 replaced its default rule set.** In an empty project, `ruff check --isolated
--show-settings` reports **59** default rules on 0.15.8 and **413** on 0.16.5. This project only
ever set `extend-select`, never `select`, so its base set has always been whatever the installed
ruff happened to default to. On today's `master` that means:

| ruff | `ruff check` findings |
| --- | --- |
| 0.14.11 (dependency group) | 0 |
| 0.15.8 (hook) | 0 |
| 0.16.5, unpinned base set | **298** |
| 0.16.5, base set pinned | 148 |
| 0.16.5, base set pinned, as merged here | **0** |

The bump is only a version bump if `select` is pinned, so the first commit does that:

```toml
select = ["E4", "E7", "E9", "F"]   # ruff's pre-0.16 default
```

At the versions in force at that commit it is a byte-for-byte no-op (same 259 enabled rules, same
"All checks passed!", same 326 files already formatted). What it buys is that the enabled set is now
a property of this file rather than of the pinned version. Enabled-rule set diff, old config on
0.15.8 vs the config in this PR on 0.16.5 (`ruff check --show-settings`, counting
`linter.rules.enabled`): **259 -> 262, gained exactly `RUF036`, `RUF063`, `RUF068`, lost none** —
all three were preview-only in 0.15.8 and stabilised in 0.16. `ISC004` stabilised with them and is
added to `extend-ignore` next to the existing `ISC001`: all 35 occurrences here are deliberately
wrapped string literals and its only fix is unsafe.

So the entire lint surface of this bump is `RUF036 none-not-at-end-of-union`, 113 findings, all safe
autofixes, applied machine-wise with `ruff check --select RUF036 --fix` followed by `ruff format`.
Every one is `None | X` -> `X | None`: identical at runtime and to every type checker, already the
prevailing spelling here, and never evaluated at all, since these modules use `from __future__
import annotations`. `git diff -w` is the same as `git diff` — there is no reformatting hiding in
it.

**Why #1693 goes red in all 13 Core cells and this does not.** That same RUF036 autofix wave
rewrote `constraints_results: None | Mapping[str, Mapping[str, bool]]` to `Mapping[...] | None` in
`sphinx_needs/data.py`. `tests/test_data.py::test_consistent` cross-checks each `NeedsCoreFields`
entry against its `TypedDict` annotation by string-matching the raw `ForwardRef` text, and while its
scalar branches listed both union orders, its *container* branches only listed `None | dict[` /
`None | Mapping[` — so the reordered annotation fell into the non-optional branch and asserted
`"object"` against `["object", "null"]`. One brittle test, no runtime behaviour involved; this PR
teaches the container branches both orders (optional case tested first, so it cannot be swallowed)
and the suite is green.

**Why #1693's Lint job stays red as well.** Of the 298 findings the unpinned bump produces, **151
are not autofixable** — `BLE001` 43, `PLW1510` 30, `TRY004` 20, `DTZ005`/`TRY002` 4 each, and so on.
The bot force-pushes a partially-fixed tree, and no amount of re-running clears the rest.

**And one thing #1693 does silently.** `E402` (module-import-not-at-top-of-file) is in ruff's
pre-0.16 default set and *not* in 0.16's, along with 17 others (`E401 E402 E7xx E711-E714 E721 E731
E741-E743 F403 F405 F406 F722`). So on that branch E402 stopped being enforced and `RUF100
unused-noqa` then offered to delete all twelve `# noqa: E402` suppressions in `docs/conf.py` as
unused — lint coverage lost, plus a twelve-site re-annotation for whoever wants it back. Pinning
`select` keeps both the rule and the suppressions:

```
ruff check --isolated --select RUF100 docs/conf.py        ->  12x "Unused `noqa` (non-enabled: E402)"
ruff check --isolated --select RUF100,E402 docs/conf.py   ->  All checks passed!
```

**The ruleset expansion is deliberately deferred.** Those 151 findings are a real backlog worth
reviewing — but rule by rule, in its own PR, not as a side effect of a version pin. The `select` pin
is precisely what turns that into a clean opt-in: adopting 0.16's defaults will then be a legible
one-line diff with its own reviewable consequences.

`ruff format` in 0.16 also formats python code blocks embedded in markdown, which brings `AGENTS.md`
and `tests/conformance/needflow/README.md` into its scope. `[tool.ruff.format] exclude = ["*.md"]`
keeps it out — same reasoning as the existing yamlfmt `^tests/conformance/` exclude, since that
corpus is shared byte-for-byte with ubCode and checksummed in its own manifest. Without the exclude,
`ruff format` rewrites 25 lines of `AGENTS.md` on this branch.

**mypy 2.3.1** is folded in because its two pins have to move together: 1.19.1 *requires* the
`# type: ignore[literal-required]` in `compile_validator` and 2.3.1 rejects it as unused, so
splitting the change would force a bridging `[literal-required, unused-ignore]` into the tree and a
follow-up to take it out again. Moving both pins in one commit makes it a plain deletion. mypy 2.3.1
reports nothing else: no new error classes, no deprecation warnings, no config migration.

Two follow-ups this PR deliberately does not do:

- The mypy hook's `additional_dependencies` and the `mypy` dependency group are maintained by hand
  and have already drifted apart — the hook carries `minijinja~=2.15` and the dependency group does
  not, so `uv run prek run mypy` and `tox -e mypy` type-check against different environments. It is
  pre-existing and orthogonal to a version bump; the fix is one line (add `minijinja~=2.15` to the
  group) and belongs in its own PR.
- Routine hook autoupdates should be owned by a scheduled `prek autoupdate` job rather than by
  pre-commit.ci reopening a PR every release; that is a separate change. With `select` pinned, such
  updates are finally safe to take.

This supersedes #1693, which can be closed.




