### PR TITLE
🔧 Add a scheduled `prek update` workflow

### DIFF
--- a/.github/workflows/prek-update.yaml
+++ b/.github/workflows/prek-update.yaml
@@ -1,0 +1,104 @@
+name: Prek update
+
+on:
+  # monthly, matching the cadence dependabot uses in this repository
+  schedule:
+    - cron: "0 6 1 * *"
+  # so the first run after merge can be triggered by hand as a smoke test
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  update:
+    name: Update hook versions
+    runs-on: ubuntu-latest
+    steps:
+      # the default GITHUB_TOKEN cannot be used for the writes below: a pull request it
+      # pushes does not trigger `pull_request` workflows, and master requires `Lint`,
+      # so such a pull request could never be merged
+      - name: Mint a token for the bot app
+        id: token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v10.0.1
+        with:
+          enable-cache: true
+
+      # `prek update` is workspace-aware: one invocation updates every
+      # .pre-commit-config.yaml in the tree, so the whole tree is checked for changes.
+      # The cooldown keeps day-zero hook releases out of the pull request.
+      - name: Update hook revisions
+        id: update
+        run: |
+          uv run prek update --cooldown-days 7
+          if git diff --quiet; then
+            echo "no hook updates eligible"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # run the hooks at the new revisions so that formatter and `--fix` churn arrives
+      # already applied. Findings that remain are reported, not fatal: a red but open
+      # pull request is the signal we want.
+      - name: Run the hooks
+        id: hooks
+        if: steps.update.outputs.changed == 'true'
+        env:
+          PREK_COLOR: always
+        run: |
+          if uv run prek run --all-files; then
+            echo "clean=yes" >> "$GITHUB_OUTPUT"
+          else
+            echo "clean=no" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Compose the pull request body
+        id: body
+        if: steps.update.outputs.changed == 'true'
+        env:
+          HOOKS_CLEAN: ${{ steps.hooks.outputs.clean }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          # pair every `rev:` with the `- repo:` it belongs to, so the old and new
+          # revisions of each repository can be reported on one line
+          # shellcheck disable=SC2016  # $2/$3 are awk fields, not shell expansions
+          map='
+            /^[[:space:]]*-[[:space:]]+repo:[[:space:]]/ { repo = $3 }
+            /^[[:space:]]*rev:[[:space:]]/ { print repo, $2 }
+          '
+          {
+            echo "body<<PR_BODY_EOF"
+            echo "Hook revisions updated by \`prek update --cooldown-days 7\`:"
+            echo
+            while IFS= read -r config; do
+              awk 'NR==FNR { was[$1] = $2; next }
+                   ($1 in was) && was[$1] != $2 { printf "- %s: `%s` -> `%s`\n", $1, was[$1], $2 }' \
+                <(git show "HEAD:$config" | awk "$map") <(awk "$map" "$config")
+            done < <(git diff --name-only -- '*.pre-commit-config.yaml')
+            echo
+            echo "hooks clean after autofix: ${HOOKS_CLEAN} — see [the workflow run](${RUN_URL})"
+            echo
+            echo "Opened by the scheduled \`Prek update\` workflow."
+            echo "PR_BODY_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      # a fixed branch means a re-run updates the existing pull request instead of
+      # opening a second one
+      - name: Open the pull request
+        if: steps.update.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ steps.token.outputs.token }}
+          branch: prek-update
+          delete-branch: true
+          commit-message: "🔧 Update pre-commit hook versions"
+          title: "🔧 Update pre-commit hook versions"
+          body: ${{ steps.body.outputs.body }}

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -53,6 +53,9 @@ To run the formatting and linting suite, `prek <https://prek.j178.dev/>`__ is us
 The hooks are declared in ``.pre-commit-config.yaml``, which prek reads unchanged,
 so `pre-commit <https://pre-commit.com/>`__ itself still works if you prefer it.
 
+Hook versions are bumped by the scheduled ``Prek update`` workflow, which opens a
+pull request with the new revisions.
+
 To run testing and documentation building, `tox <https://tox.readthedocs.io/>`__ is used:
 
 .. code-block:: bash


### PR DESCRIPTION
Adds `.github/workflows/prek-update.yaml`, a `Prek update` workflow that keeps the hook
revisions in `.pre-commit-config.yaml` current and opens a pull request with the result.
It replaces the weekly autoupdate PR that pre-commit.ci has been raising.

### What it does

Runs monthly — `cron: "0 6 1 * *"`, 06:00 UTC on the 1st, the same cadence dependabot
uses in this repo — and on `workflow_dispatch` for manual runs. Each run:

- `uv run prek update --cooldown-days 7`, on the same
  `astral-sh/setup-uv@v10.0.1 (enable-cache: true)` toolchain the `Lint` job uses. The
  seven-day cooldown keeps day-zero hook releases out: as of today it selects ruff
  `v0.16.4` and holds back `v0.16.5`, which is younger than a week.
- If nothing moved, the job logs `no hook updates eligible` and ends green having created
  nothing. No empty PRs.
- If something moved, it runs `prek run --all-files` over the updated tree, so formatter
  and `--fix` churn arrives already applied rather than landing on whoever merges. Hooks
  that still report findings do **not** fail the workflow — the PR is opened anyway, red,
  with `hooks clean after autofix: no` and a link to the run. A rev bump that needs human
  attention should be visible, not silently withheld.
- Opens the PR on the fixed branch `prek-update`, so a re-run updates the existing PR
  instead of stacking a new one. The body lists each repository with its old and new rev.

### Why a GitHub App token

A pull request created or pushed with the default `GITHUB_TOKEN` does not trigger
`pull_request` workflows — GitHub's anti-recursion rule. `Lint` is a required check on
master under strict mode, so such a PR would never become mergeable. The workflow
therefore mints a token from the org bot app (`BOT_APP_ID` / `BOT_PRIVATE_KEY`, both
repository secrets) and uses it for every write. Top-level permissions stay
`contents: read`; the default token only ever performs the checkout.

One setup item to confirm: the app needs `Contents` and `Pull requests` read/write, and
ideally `Workflows: Read & write` as well. `yamlfmt` is one of the hooks being bumped and
it formats `.github/workflows/*.yaml`, so a future yamlfmt release that changes its
formatting would put a workflow file in the PR, and GitHub rejects app pushes that touch
workflows without that permission. Runs fail loudly if it is missing, so it is safe to
add later.

### Why not keep pre-commit.ci

`prek update` is workspace-aware: one invocation updates every `.pre-commit-config.yaml`
in the tree. pre-commit.ci reads only the root config with vanilla pre-commit, so it
cannot follow the per-package configs the uv-workspace monorepo layout will introduce.
This workflow is monorepo-ready; pre-commit.ci is not.

### Merge ordering

**Merge this after #1805.** #1805 carries the same ruff and mypy rev bumps together with
the `select` pin that makes them tolerable. If this lands first, its next run re-proposes
those bumps *without* that pin — a rehearsal on current master produced 151 remaining
ruff findings and a mypy `unused-ignore`, across 23 rewritten files.

### After merge

1. Smoke-test it by hand: `gh workflow run prek-update.yaml`. With #1805 in, expect the
   no-op path — `no hook updates eligible`, green, no PR. That single run also proves the
   app token and its install, which cannot be checked any other way. The first real PR
   appears once a hook release clears the seven-day cooldown.
2. Uninstall the pre-commit.ci app. Its autofix pushes and its weekly autoupdate PR are
   both superseded — autofix by the `Lint` gate, autoupdate by this workflow. Nothing in
   this PR touches `.pre-commit-config.yaml`, so the `ci:` block question does not arise.
