### PR TITLE
✨ Accept the `cypher` option on `needpie` and `needbar` for ubCode compatibility

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,23 @@ Unreleased
 
 :Released: Unreleased
 
+Improvements
+............
+
+- ✨ The ``cypher`` directive option is now accepted on :ref:`needpie` for `ubCode`_
+  compatibility
+
+  :ref:`needpie` joins :ref:`needlist`, :ref:`needtable` and :ref:`needflow` in accepting this
+  ubCode-only option and then ignoring it, so that a document authored for ubCode also builds
+  with Sphinx-Needs, instead of failing with an ``unknown option`` error.
+  The option never reaches a node, the rendered output, or the ``needs.json`` file.
+
+  On :ref:`needpie` the no-op is visible in the chart, though, which it is not on the other three:
+  ubCode reads the query as the scope each content line is counted over, whereas Sphinx-Needs
+  counts every line over the whole project, so the same chart can show different numbers in the
+  two tools.
+  See :ref:`ubCode compatibility <ubcode_compat_options>` for the exact per-directive list.
+
 Bug fixes
 .........
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,14 +15,14 @@ Improvements
 ............
 
 - ✨ The ``cypher`` directive option is now accepted on :ref:`needpie` and :ref:`needbar`
-  for `ubCode`_ compatibility
+  for `ubCode`_ compatibility (:pr:`1818`)
 
   The two chart directives join :ref:`needlist`, :ref:`needtable` and :ref:`needflow` in
   accepting this option and then ignoring it, so that a document authored for ubCode also builds
   with Sphinx-Needs, instead of failing with an ``unknown option`` error.
   The option never reaches a node, the rendered output, or the ``needs.json`` file.
 
-  On :ref:`needpie` the no-op is visible in the chart, though, which it is not on the views:
+  On :ref:`needpie` the no-op is visible in the chart, though, which it is not on the three view directives:
   ubCode reads the query as the scope each content line is counted over, whereas Sphinx-Needs
   counts every line over the whole project, so the same chart can show different numbers in the
   two tools.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,18 +14,22 @@ Unreleased
 Improvements
 ............
 
-- ✨ The ``cypher`` directive option is now accepted on :ref:`needpie` for `ubCode`_
-  compatibility
+- ✨ The ``cypher`` directive option is now accepted on :ref:`needpie` and :ref:`needbar`
+  for `ubCode`_ compatibility
 
-  :ref:`needpie` joins :ref:`needlist`, :ref:`needtable` and :ref:`needflow` in accepting this
-  ubCode-only option and then ignoring it, so that a document authored for ubCode also builds
+  The two chart directives join :ref:`needlist`, :ref:`needtable` and :ref:`needflow` in
+  accepting this option and then ignoring it, so that a document authored for ubCode also builds
   with Sphinx-Needs, instead of failing with an ``unknown option`` error.
   The option never reaches a node, the rendered output, or the ``needs.json`` file.
 
-  On :ref:`needpie` the no-op is visible in the chart, though, which it is not on the other three:
+  On :ref:`needpie` the no-op is visible in the chart, though, which it is not on the views:
   ubCode reads the query as the scope each content line is counted over, whereas Sphinx-Needs
   counts every line over the whole project, so the same chart can show different numbers in the
   two tools.
+
+  On :ref:`needbar` the option is accepted ahead of any ubCode support for it — ubCode does not
+  read it there either, so today neither tool acts on it, and it is accepted only so that a
+  document already carrying it builds in both.
   See :ref:`ubCode compatibility <ubcode_compat_options>` for the exact per-directive list.
 
 Bug fixes

--- a/docs/directives/needbar.rst
+++ b/docs/directives/needbar.rst
@@ -34,6 +34,12 @@ the data comes from the content, so ``:filter:``, ``:filter-func:`` and
 ``:filter_warning:`` are not available on it,
 and a bar chart with only zeros is drawn as an empty chart.
 
+The ``cypher`` option is accepted and then ignored,
+ahead of any ubCode support for it:
+ubCode does not read it on ``needbar`` either,
+so today neither tool acts on it and no chart changes;
+see :ref:`ubCode compatibility <ubcode_compat_options>`.
+
 .. note::
 
     One image file is written per ``needbar``,

--- a/docs/directives/needpie.rst
+++ b/docs/directives/needpie.rst
@@ -36,6 +36,10 @@ or neither, the chart has no data and an error is logged.
 
 ``needpie`` takes no other filter options,
 so ``:filter:``, ``:status:``, ``:tags:`` and ``:types:`` are not available on it.
+The ubCode-only ``cypher`` option is accepted and then ignored,
+which for ``needpie`` means the content lines are counted over the whole project
+rather than over the needs the query selects;
+see :ref:`ubCode compatibility <ubcode_compat_options>`.
 
 .. note::
 

--- a/docs/filter.rst
+++ b/docs/filter.rst
@@ -323,7 +323,8 @@ To debug which filters are being used across your project and their run times, y
    The `ubCode <https://ubcode.useblocks.com>`__ editor extension supports a few directive options that Sphinx-Needs
    has no equivalent for:
 
-   * ``cypher`` on :ref:`needlist`, :ref:`needtable`, :ref:`needflow` and :ref:`needpie`
+   * ``cypher`` on :ref:`needlist`, :ref:`needtable`, :ref:`needflow`, :ref:`needpie`
+     and :ref:`needbar`
    * ``width`` and ``height`` on :ref:`needflow` and :ref:`needsequence`
 
    Sphinx-Needs accepts all of these options and then ignores them, so that a document authored for ubCode also
@@ -337,6 +338,10 @@ To debug which filters are being used across your project and their run times, y
    ubCode reads the query as the scope each content-line filter is counted over,
    whereas a Sphinx build ignores it and counts every line over the whole project,
    so the same chart can show different numbers here than in the ubCode preview.
+
+   ``cypher`` on :ref:`needbar` is accepted ahead of any ubCode support for it:
+   ubCode does not read the option on ``needbar`` either, so today neither tool acts on it,
+   and it is listed here only so that a document already carrying it builds in both.
 
    These options may gain native implementations in future Sphinx-Needs releases,
    in which case they would take effect here as well rather than being ignored.

--- a/docs/filter.rst
+++ b/docs/filter.rst
@@ -323,7 +323,7 @@ To debug which filters are being used across your project and their run times, y
    The `ubCode <https://ubcode.useblocks.com>`__ editor extension supports a few directive options that Sphinx-Needs
    has no equivalent for:
 
-   * ``cypher`` on :ref:`needlist`, :ref:`needtable` and :ref:`needflow`
+   * ``cypher`` on :ref:`needlist`, :ref:`needtable`, :ref:`needflow` and :ref:`needpie`
    * ``width`` and ``height`` on :ref:`needflow` and :ref:`needsequence`
 
    Sphinx-Needs accepts all of these options and then ignores them, so that a document authored for ubCode also
@@ -332,6 +332,11 @@ To debug which filters are being used across your project and their run times, y
 
    This includes ``width`` and ``height``: a diagram is rendered at its usual size and no warning is emitted,
    so nothing reports that the requested size had no effect.
+
+   ``cypher`` on :ref:`needpie` is the one option whose no-op changes a rendered number:
+   ubCode reads the query as the scope each content-line filter is counted over,
+   whereas a Sphinx build ignores it and counts every line over the whole project,
+   so the same chart can show different numbers here than in the ubCode preview.
 
    These options may gain native implementations in future Sphinx-Needs releases,
    in which case they would take effect here as well rather than being ignored.

--- a/sphinx_needs/directives/needbar.py
+++ b/sphinx_needs/directives/needbar.py
@@ -57,6 +57,8 @@ class NeedbarDirective(FilterBase):
         "sum_rotation": directives.unchanged_required,
         "transpose": directives.flag,
         "horizontal": directives.flag,
+        # ubCode compatibility: accepted and ignored by Sphinx-Needs.
+        "cypher": directives.unchanged,
     }
 
     # Algorithm:

--- a/sphinx_needs/directives/needpie.py
+++ b/sphinx_needs/directives/needpie.py
@@ -52,6 +52,8 @@ class NeedpieDirective(FilterBase):
         "shadow": directives.flag,
         "filter-func": FilterBase.base_option_spec["filter-func"],
         "filter_warning": FilterBase.base_option_spec["filter_warning"],
+        # ubCode compatibility: accepted and ignored by Sphinx-Needs.
+        "cypher": directives.unchanged,
     }
 
     # Update the options_spec only with value filter-func defined in the FilterBase class

--- a/tests/doc_test/doc_ubcode_compat/index.rst
+++ b/tests/doc_test/doc_ubcode_compat/index.rst
@@ -36,3 +36,8 @@ TEST DOCUMENT UBCODE COMPAT
 
    type == 'req'
    type == 'spec'
+
+.. needbar::
+   :cypher: MATCH (n:Need) RETURN n
+
+   type == 'req', type == 'spec'

--- a/tests/doc_test/doc_ubcode_compat/index.rst
+++ b/tests/doc_test/doc_ubcode_compat/index.rst
@@ -30,3 +30,9 @@ TEST DOCUMENT UBCODE COMPAT
    :max_items: 10
    :width: 400
    :height: 300
+
+.. needpie::
+   :cypher: MATCH (n:Need) RETURN n
+
+   type == 'req'
+   type == 'spec'

--- a/tests/test_ubcode_compat.py
+++ b/tests/test_ubcode_compat.py
@@ -7,9 +7,9 @@ still build, but they must never influence the Sphinx build in any way.
 ``max_items`` used to be one of them and is now implemented natively, see
 ``test_views_max_items.py``. The fixture still sets it, since a cap that is
 larger than the number of needs must leave the output untouched. The
-``needpie`` block is the exception: the directive has no ``max_items``, so a
-stray one there would be exactly the ``unknown option`` error these tests guard
-against.
+``needpie`` and ``needbar`` blocks are the exception: neither directive has
+``max_items``, so a stray one there would be exactly the ``unknown option``
+error these tests guard against.
 """
 
 from pathlib import Path
@@ -17,6 +17,7 @@ from pathlib import Path
 import pytest
 from sphinx.testing.util import SphinxTestApp
 
+from sphinx_needs.directives.needbar import Needbar
 from sphinx_needs.directives.needflow._directive import (
     NeedflowGraphiz,
     NeedflowPlantuml,
@@ -36,6 +37,7 @@ VIEW_NODES = (
     NeedflowGraphiz,
     Needsequence,
     Needpie,
+    Needbar,
 )
 """The node classes created by the directives that accept the compat options."""
 
@@ -63,6 +65,7 @@ def test_ubcode_compat_options_are_accepted(test_app: SphinxTestApp):
         "needflow-index-0",
         "needsequence-index-0",
         "needpie-index-0",
+        "needbar-index-0",
     ):
         assert f'id="{target_id}"' in html
 
@@ -90,6 +93,7 @@ def test_ubcode_compat_options_are_ignored(test_app: SphinxTestApp):
         "NeedflowPlantuml",
         "Needsequence",
         "Needpie",
+        "Needbar",
     }
 
     leaked = {

--- a/tests/test_ubcode_compat.py
+++ b/tests/test_ubcode_compat.py
@@ -6,7 +6,10 @@ still build, but they must never influence the Sphinx build in any way.
 
 ``max_items`` used to be one of them and is now implemented natively, see
 ``test_views_max_items.py``. The fixture still sets it, since a cap that is
-larger than the number of needs must leave the output untouched.
+larger than the number of needs must leave the output untouched. The
+``needpie`` block is the exception: the directive has no ``max_items``, so a
+stray one there would be exactly the ``unknown option`` error these tests guard
+against.
 """
 
 from pathlib import Path
@@ -19,13 +22,21 @@ from sphinx_needs.directives.needflow._directive import (
     NeedflowPlantuml,
 )
 from sphinx_needs.directives.needlist import Needlist
+from sphinx_needs.directives.needpie import Needpie
 from sphinx_needs.directives.needsequence import Needsequence
 from sphinx_needs.directives.needtable import Needtable
 
 COMPAT_OPTIONS = ("cypher", "width", "height")
 """All options that are accepted for ubCode compatibility and then ignored."""
 
-VIEW_NODES = (Needlist, Needtable, NeedflowPlantuml, NeedflowGraphiz, Needsequence)
+VIEW_NODES = (
+    Needlist,
+    Needtable,
+    NeedflowPlantuml,
+    NeedflowGraphiz,
+    Needsequence,
+    Needpie,
+)
 """The node classes created by the directives that accept the compat options."""
 
 
@@ -51,6 +62,7 @@ def test_ubcode_compat_options_are_accepted(test_app: SphinxTestApp):
         "needtable-index-0",
         "needflow-index-0",
         "needsequence-index-0",
+        "needpie-index-0",
     ):
         assert f'id="{target_id}"' in html
 
@@ -77,6 +89,7 @@ def test_ubcode_compat_options_are_ignored(test_app: SphinxTestApp):
         "Needtable",
         "NeedflowPlantuml",
         "Needsequence",
+        "Needpie",
     }
 
     leaked = {


### PR DESCRIPTION
[ubCode](https://ubcode.useblocks.com) is gaining a `:cypher:` option on `needpie`: a read-only Cypher **selection that scopes the chart**, so each content-line filter is counted only over the needs the query selects. Sphinx-Needs has no equivalent for it.

This adds `cypher` to `NeedpieDirective.option_spec` and `NeedbarDirective.option_spec` as **accepted and ignored**, exactly as `needlist`, `needtable` and `needflow` already accept it (#1760, released in 8.4.0). A document authored for ubCode therefore builds with Sphinx-Needs instead of failing with an `unknown option` error.

Nothing reads the value on either directive. Both build their node attributes from a closed literal, so an accepted-but-uncollected option cannot reach the doctree, the rendered output, or `needs.json`. The existing `test_ubcode_compat.py` pair asserts both halves and now covers the two chart directives as well: the target anchor is written (the directive was not replaced by a system message) and no compat option appears in any view node's attributes.

Two things about the chart directives differ from the three views, and the documentation says so:

- On `needpie` the no-op changes **a rendered number**. ubCode reads the query as the scope each content line is counted over, whereas a Sphinx build counts every line over the whole project, so the same chart can show different values here than in the ubCode preview.
- On `needbar` the option is accepted **ahead of any ubCode support**. ubCode does not read it there either, so today neither tool acts on it; it is accepted only so that a document already carrying it builds in both, without waiting on a Sphinx-Needs release if ubCode gains it later.

Companion ubCode PR: [useblocks/ubcode#3237](https://github.com/useblocks/ubcode/pull/3237) (the `needpie` scope implementation).

#### Changes

- `sphinx_needs/directives/needpie.py`, `sphinx_needs/directives/needbar.py`: `cypher` in `option_spec` as `directives.unchanged`, never read.
- `tests/doc_test/doc_ubcode_compat/index.rst`, `tests/test_ubcode_compat.py`: a `needpie` and a `needbar` carrying `:cypher:` in the compat fixture; `Needpie` and `Needbar` in the checked node classes and target ids.
- `docs/filter.rst`, `docs/directives/needpie.rst`, `docs/directives/needbar.rst`: the compat note lists both directives and states the two caveats above.
- `docs/changelog.rst`: one entry under *Unreleased → Improvements*.