### PR TITLE
✨ needpie / needbar: filter, status, tags and types scope the chart

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -24,9 +24,12 @@ Improvements
   none of the four counts over the whole project exactly as it did before.
 
   A scope holds what the same four options select on a view directive such as
-  :ref:`needlist`, so a chart and a list written with the same options cover the same
-  needs. On :ref:`needpie` a ``:filter-func:`` is handed the needs of the scope, so a
-  scope restricts what such a function counts from, not what it returns.
+  :ref:`needlist`, so a chart and a list written with the same options select the same
+  needs. On :ref:`needpie` a ``:filter-func:`` is handed the needs of the scope, as the
+  same view an unscoped chart hands it, so a scope restricts what such a function counts
+  from, not what it returns. The view gains one public method for that,
+  ``NeedsAndPartsListView.filter_id_complete``, which selects exactly the given needs and
+  parts by ``id_complete``.
 
   Neither directive gains an empty state it did not have: a pie of only filter lines
   whose scope selects nothing shows its ``:filter_warning:`` text, exactly as it does

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,7 +15,7 @@ Improvements
 ............
 
 - ✨ :ref:`needpie` and :ref:`needbar` now accept the ``:filter:``, ``:status:``,
-  ``:tags:`` and ``:types:`` options, as the scope a chart is counted over (:pr:`TBD`)
+  ``:tags:`` and ``:types:`` options, as the scope a chart is counted over (:pr:`1831`)
 
   The four options were rejected on both chart directives with an ``unknown option``
   error. They now select the needs and parts a chart counts over, once for the whole

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,30 @@ Unreleased
 Improvements
 ............
 
+- ✨ :ref:`needpie` and :ref:`needbar` now accept the ``:filter:``, ``:status:``,
+  ``:tags:`` and ``:types:`` options, as the scope a chart is counted over (:pr:`TBD`)
+
+  The four options were rejected on both chart directives with an ``unknown option``
+  error. They now select the needs and parts a chart counts over, once for the whole
+  chart: every content line or grid cell is counted as its own result restricted to
+  that scope, a static value such as ``10`` is left alone, and a chart that carries
+  none of the four counts over the whole project exactly as it did before.
+
+  A scope holds what the same four options select on a view directive such as
+  :ref:`needlist`, so a chart and a list written with the same options cover the same
+  needs. On :ref:`needpie` a ``:filter-func:`` is handed the needs of the scope, so a
+  scope restricts what such a function counts from, not what it returns.
+
+  Neither directive gains an empty state it did not have: a pie of only filter lines
+  whose scope selects nothing shows its ``:filter_warning:`` text, exactly as it does
+  for filters that match nothing, while a bar chart, which has no such text, draws all
+  zeros.
+
+  This is also the Sphinx-Needs half of a chart authored for `ubCode`_: the ``cypher``
+  query ubCode reads as a chart's scope is ignored by a Sphinx build, so writing the
+  same scope with these options beside the query makes both tools count over the same
+  needs. See :ref:`needpie_scope` and :ref:`needbar_scope`.
+
 - 👌 :ref:`Schema validation <schema_validation>` errors now name the failing keyword, and
   report ``$ref`` targets at their definition **(changed output)** (:pr:`1819`)
 
@@ -55,11 +79,9 @@ Improvements
 
   On :ref:`needpie` the no-op is visible in the chart, though, which it is not on the three view directives:
   ubCode reads the query as the scope each content line is counted over, whereas Sphinx-Needs
-  counts every line over the whole project, so the same chart can show different numbers in the
-  two tools.
+  ignores it, so the same chart can show different numbers in the two tools.
 
-  On :ref:`needbar` the option is accepted ahead of any ubCode support for it — ubCode does not
-  read it there either, so today neither tool acts on it, and it is accepted only so that a
+  On :ref:`needbar` the option is accepted ahead of any ubCode support for it, so that a
   document already carrying it builds in both.
   See :ref:`ubCode compatibility <ubcode_compat_options>` for the exact per-directive list.
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -81,8 +81,8 @@ Improvements
   ubCode reads the query as the scope each content line is counted over, whereas Sphinx-Needs
   ignores it, so the same chart can show different numbers in the two tools.
 
-  On :ref:`needbar` the option is accepted ahead of any ubCode support for it, so that a
-  document already carrying it builds in both.
+  On :ref:`needbar` the option is accepted so that a document already carrying it builds
+  in both.
   See :ref:`ubCode compatibility <ubcode_compat_options>` for the exact per-directive list.
 
 Internal changes

--- a/docs/directives/needbar.rst
+++ b/docs/directives/needbar.rst
@@ -518,7 +518,8 @@ if the scope holds that need as well.
 A static value such as ``10`` counts no needs at all and is never affected.
 
 A scope restricts what a cell counts, not what its filter can see:
-the ``needs`` variable of a content cell still holds every need of the project.
+the ``needs`` variable inside a content cell is exactly what it would be on the
+same chart without a scope.
 
 If the scope selects nothing, every filter cell counts zero, and a bar chart of
 only zeros is drawn as an empty chart -- ``needbar`` has no ``:filter_warning:``
@@ -540,6 +541,6 @@ text in a cell would need a separator of its own.
       :xlabels: requirement, specification
       :ylabels: open
       :status: open
-      :cypher: MATCH (n:Need) WHERE n.status = 'open' RETURN n
+      :cypher: n.status = 'open'
 
       type == 'req', type == 'spec'

--- a/docs/directives/needbar.rst
+++ b/docs/directives/needbar.rst
@@ -29,16 +29,19 @@ a simple enough expression, such as the bare field name ``tags``,
 is answered by the query fast path, which coerces the result with ``bool()``
 and counts the matching needs instead of warning.
 
-``needbar`` takes no filter options at all:
-the data comes from the content, so ``:filter:``, ``:filter-func:`` and
-``:filter_warning:`` are not available on it,
-and a bar chart with only zeros is drawn as an empty chart.
+``needbar`` used to take no filter options at all, and this page said so.
+The four :ref:`filter options <filter_options>` ``:filter:``, ``:status:``,
+``:tags:`` and ``:types:`` are now accepted, as the chart's scope -- the needs
+its content cells are counted over -- see :ref:`needbar_scope`.
+``:filter-func:`` and ``:filter_warning:`` are still not available on it:
+the data comes from the content, and a bar chart with only zeros is drawn as an
+empty chart rather than replaced by a text.
 
-The ``cypher`` option is accepted and then ignored,
-ahead of any ubCode support for it:
-ubCode does not read it on ``needbar`` either,
-so today neither tool acts on it and no chart changes;
-see :ref:`ubCode compatibility <ubcode_compat_options>`.
+The ``cypher`` option is accepted and then ignored.
+A chart that is to count the same needs in ubCode and in a Sphinx build
+therefore states its scope twice: once as the query ubCode reads, and once as
+the four options Sphinx-Needs reads.
+See :ref:`ubCode compatibility <ubcode_compat_options>`.
 
 .. note::
 
@@ -496,3 +499,47 @@ Useful styles are for example:
       Y,10,15,10
       X,15,10,20
       W,20,15,10
+
+.. _needbar_scope:
+
+common filters
+~~~~~~~~~~~~~~
+
+* :ref:`option_status`
+* :ref:`option_tags`
+* :ref:`option_types`
+* :ref:`option_filter`
+
+On a chart these four options do not select what is shown -- the content decides
+that -- they select the needs the chart counts over: its scope.
+The scope is resolved once for the whole chart, and every content cell is then
+counted as its own result restricted to the scope, so a cell counts a need only
+if the scope holds that need as well.
+A static value such as ``10`` counts no needs at all and is never affected.
+
+A scope restricts what a cell counts, not what its filter can see:
+the ``needs`` variable of a content cell still holds every need of the project.
+
+If the scope selects nothing, every filter cell counts zero, and a bar chart of
+only zeros is drawn as an empty chart -- ``needbar`` has no ``:filter_warning:``
+and no text to put in place of the chart, unlike :ref:`needpie <needpie_scope>`.
+
+Parts follow their need: ``:status:``, ``:tags:`` and ``:types:`` select needs,
+and the parts of a selected need are in the scope with it, while ``:filter:``
+is evaluated over needs and parts alike.
+This is what the same four options do on :ref:`needlist`, so a scope and a
+``needlist`` written with the same options cover the same needs.
+
+An option value is never split by the ``:separator:``, which a content cell is,
+so ``:filter: status in ['open', 'closed']`` works as written while the same
+text in a cell would need a separator of its own.
+
+.. syntax-example::
+
+   .. needbar:: Open requirements and specifications
+      :xlabels: requirement, specification
+      :ylabels: open
+      :status: open
+      :cypher: MATCH (n:Need) WHERE n.status = 'open' RETURN n
+
+      type == 'req', type == 'spec'

--- a/docs/directives/needbar.rst
+++ b/docs/directives/needbar.rst
@@ -529,7 +529,12 @@ Parts follow their need: ``:status:``, ``:tags:`` and ``:types:`` select needs,
 and the parts of a selected need are in the scope with it, while ``:filter:``
 is evaluated over needs and parts alike.
 This is what the same four options do on :ref:`needlist`, so a scope and a
-``needlist`` written with the same options cover the same needs.
+``needlist`` written with the same options select the same needs.
+
+Writing the scope twice, as the four options and as a ``:cypher:`` query, is the
+portable form: ubCode gives the query precedence over the options, Sphinx-Needs
+ignores the query and applies the options, so the two engines agree for as long
+as the two spellings do.
 
 An option value is never split by the ``:separator:``, which a content cell is,
 so ``:filter: status in ['open', 'closed']`` works as written while the same

--- a/docs/directives/needpie.rst
+++ b/docs/directives/needpie.rst
@@ -250,7 +250,8 @@ if the scope holds that need as well.
 A static value such as ``10`` counts no needs at all and is never affected.
 
 A scope restricts what a line counts, not what its filter can see:
-the ``needs`` variable of a content line still holds every need of the project.
+the ``needs`` variable inside a content line is exactly what it would be on the
+same chart without a scope.
 
 A ``:filter-func:`` receives only the needs in the scope.
 Its own numbers are whatever it returns, so the scope restricts what such a
@@ -275,7 +276,7 @@ This is what the same four options do on :ref:`needlist`, so a scope and a
    .. needpie:: Open requirements
       :labels: requirement, other
       :status: open
-      :cypher: MATCH (n:Need) WHERE n.status = 'open' RETURN n
+      :cypher: n.status = 'open'
 
       type == 'req'
       type != 'req'

--- a/docs/directives/needpie.rst
+++ b/docs/directives/needpie.rst
@@ -253,15 +253,17 @@ A scope restricts what a line counts, not what its filter can see:
 the ``needs`` variable inside a content line is exactly what it would be on the
 same chart without a scope.
 
-A ``:filter-func:`` receives only the needs in the scope.
+A ``:filter-func:`` receives only the needs in the scope, as the same view an
+unscoped chart receives, so a function may narrow it further.
 Its own numbers are whatever it returns, so the scope restricts what such a
 function counts from, not what it counts.
 
 If the scope selects nothing, every filter line counts zero.
-A pie whose lines are all filters is then all zero, and an all-zero pie is not
-drawn but shows the ``filter_warning`` text described above, exactly as it does
-for filters that match nothing; a pie that also has a static value still has
-something to draw and is drawn.
+A pie is replaced by the ``filter_warning`` text described above whenever every
+one of its values is zero -- a static ``0`` included -- exactly as it is for
+filters that match nothing, so a pie of only filter lines then shows that text
+while a pie with a non-zero static value still has something to draw and is
+drawn.
 ``needbar`` has no such empty state and draws all zeros instead,
 see :ref:`needbar_scope`.
 
@@ -269,7 +271,12 @@ Parts follow their need: ``:status:``, ``:tags:`` and ``:types:`` select needs,
 and the parts of a selected need are in the scope with it, while ``:filter:``
 is evaluated over needs and parts alike.
 This is what the same four options do on :ref:`needlist`, so a scope and a
-``needlist`` written with the same options cover the same needs.
+``needlist`` written with the same options select the same needs.
+
+Writing the scope twice, as the four options and as a ``:cypher:`` query, is the
+portable form: ubCode gives the query precedence over the options, Sphinx-Needs
+ignores the query and applies the options, so the two engines agree for as long
+as the two spellings do.
 
 .. syntax-example::
 

--- a/docs/directives/needpie.rst
+++ b/docs/directives/needpie.rst
@@ -34,12 +34,17 @@ You can use :ref:`filter_func` with Python codes to define custom filters for ``
 Give either content lines or ``:filter-func:``: if both are given,
 or neither, the chart has no data and an error is logged.
 
-``needpie`` takes no other filter options,
-so ``:filter:``, ``:status:``, ``:tags:`` and ``:types:`` are not available on it.
-The ubCode-only ``cypher`` option is accepted and then ignored,
-which for ``needpie`` means the content lines are counted over the whole project
-rather than over the needs the query selects;
-see :ref:`ubCode compatibility <ubcode_compat_options>`.
+The four :ref:`filter options <filter_options>` ``:filter:``, ``:status:``,
+``:tags:`` and ``:types:`` used to be unavailable on ``needpie``, and this page
+said so: they were rejected with an ``unknown option`` error.
+They are now accepted, as the chart's scope -- the needs its content lines are
+counted over -- see :ref:`needpie_scope`.
+
+The ubCode-only ``cypher`` option is still accepted and then ignored.
+A chart that is to count the same needs in ubCode and in a Sphinx build
+therefore states its scope twice: once as the query ubCode reads, and once as
+the four options Sphinx-Needs reads.
+See :ref:`ubCode compatibility <ubcode_compat_options>`.
 
 .. note::
 
@@ -226,6 +231,54 @@ Give the option without a value to show nothing at all.
       type == 'req' and status == 'no_such_status_a'
       type == 'req' and status == 'no_such_status_b'
 
+
+.. _needpie_scope:
+
+common filters
+~~~~~~~~~~~~~~
+
+* :ref:`option_status`
+* :ref:`option_tags`
+* :ref:`option_types`
+* :ref:`option_filter`
+
+On a chart these four options do not select what is shown -- the content decides
+that -- they select the needs the chart counts over: its scope.
+The scope is resolved once for the whole chart, and every content line is then
+counted as its own result restricted to the scope, so a line counts a need only
+if the scope holds that need as well.
+A static value such as ``10`` counts no needs at all and is never affected.
+
+A scope restricts what a line counts, not what its filter can see:
+the ``needs`` variable of a content line still holds every need of the project.
+
+A ``:filter-func:`` receives only the needs in the scope.
+Its own numbers are whatever it returns, so the scope restricts what such a
+function counts from, not what it counts.
+
+If the scope selects nothing, every filter line counts zero.
+A pie whose lines are all filters is then all zero, and an all-zero pie is not
+drawn but shows the ``filter_warning`` text described above, exactly as it does
+for filters that match nothing; a pie that also has a static value still has
+something to draw and is drawn.
+``needbar`` has no such empty state and draws all zeros instead,
+see :ref:`needbar_scope`.
+
+Parts follow their need: ``:status:``, ``:tags:`` and ``:types:`` select needs,
+and the parts of a selected need are in the scope with it, while ``:filter:``
+is evaluated over needs and parts alike.
+This is what the same four options do on :ref:`needlist`, so a scope and a
+``needlist`` written with the same options cover the same needs.
+
+.. syntax-example::
+
+   .. needpie:: Open requirements
+      :labels: requirement, other
+      :status: open
+      :cypher: MATCH (n:Need) WHERE n.status = 'open' RETURN n
+
+      type == 'req'
+      type != 'req'
 
 overlapping labels
 ~~~~~~~~~~~~~~~~~~

--- a/docs/filter.rst
+++ b/docs/filter.rst
@@ -17,7 +17,14 @@ The following filter options are supported by directives:
 * :ref:`needtable`
 * :ref:`needflow`
 * :ref:`needpie`
+* :ref:`needbar`
 * :ref:`needextend`
+
+On the two chart directives the options behave a little differently, because a
+chart evaluates one filter per content line rather than one filter per
+directive: there they select the needs each line is counted over, rather than
+the needs that are shown.
+See :ref:`needpie_scope` and :ref:`needbar_scope`.
 
 Related to the used directive and its representation, the filter options create a list of needs, which match the
 filters for status, tags, types and filter.
@@ -334,14 +341,13 @@ To debug which filters are being used across your project and their run times, y
    This includes ``width`` and ``height``: a diagram is rendered at its usual size and no warning is emitted,
    so nothing reports that the requested size had no effect.
 
-   ``cypher`` on :ref:`needpie` is the one option whose no-op changes a rendered number:
-   ubCode reads the query as the scope each content-line filter is counted over,
+   ``cypher`` on a chart is the one option whose no-op changes a rendered number:
+   ubCode reads the query as the scope the content lines are counted over,
    whereas a Sphinx build ignores it and counts every line over the whole project,
    so the same chart can show different numbers here than in the ubCode preview.
-
-   ``cypher`` on :ref:`needbar` is accepted ahead of any ubCode support for it:
-   ubCode does not read the option on ``needbar`` either, so today neither tool acts on it,
-   and it is listed here only so that a document already carrying it builds in both.
+   Write the same scope with ``:filter:``, ``:status:``, ``:tags:`` or ``:types:``
+   beside the query and both tools count over the same needs;
+   see :ref:`needpie_scope` and :ref:`needbar_scope`.
 
    These options may gain native implementations in future Sphinx-Needs releases,
    in which case they would take effect here as well rather than being ignored.

--- a/docs/filter.rst
+++ b/docs/filter.rst
@@ -254,8 +254,8 @@ to filter for needs only in the same document as the directive.
 
 It is available in the filters of the need-listing and diagram directives —
 including ``needsequence`` ``:filter:``, ``needflow`` ``:highlight:``,
-``needgantt`` ``:milestone_filter:`` and the filter lines of ``needpie``
-and ``needbar``.
+``needgantt`` ``:milestone_filter:`` and, on ``needpie`` and ``needbar``,
+both the filter lines and the scope ``:filter:``.
 It is *not* available to filters configured in **conf.py**,
 such as :ref:`needs_constraints` and :ref:`needs_warnings`,
 since those are not written in any document;
@@ -343,10 +343,10 @@ To debug which filters are being used across your project and their run times, y
 
    ``cypher`` on a chart is the one option whose no-op changes a rendered number:
    ubCode reads the query as the scope the content lines are counted over,
-   whereas a Sphinx build ignores it and counts every line over the whole project,
+   whereas a Sphinx build ignores it,
    so the same chart can show different numbers here than in the ubCode preview.
    Write the same scope with ``:filter:``, ``:status:``, ``:tags:`` or ``:types:``
-   beside the query and both tools count over the same needs;
+   beside the query and both tools select the same needs;
    see :ref:`needpie_scope` and :ref:`needbar_scope`.
 
    These options may gain native implementations in future Sphinx-Needs releases,

--- a/sphinx_needs/data.py
+++ b/sphinx_needs/data.py
@@ -560,7 +560,22 @@ class NeedsBaseDataType(TypedDict):
 
 
 class NeedsBarType(NeedsBaseDataType):
-    """Data for a single (matplotlib) bar diagram."""
+    """Data for a single (matplotlib) bar diagram.
+
+    The four selection fields are the chart's *scope*: the needs its content
+    cells are counted over, see ``filter_common.filter_scope_ids``.
+    A chart takes only these four of the filter options, so they are declared
+    here rather than inherited from ``NeedsFilteredBaseType``.
+    """
+
+    status: list[str]
+    """``:status:`` option values, empty if the option was not given."""
+    tags: list[str]
+    """``:tags:`` option values, empty if the option was not given."""
+    types: list[str]
+    """``:types:`` option values, empty if the option was not given."""
+    filter: str | None
+    """``:filter:`` option value, None if the option was not given."""
 
     error_id: str
     title: str | None
@@ -751,7 +766,22 @@ class NeedsListType(NeedsFilteredBaseType):
 
 
 class NeedsPieType(NeedsBaseDataType):
-    """Data for a single (matplotlib) pie chart."""
+    """Data for a single (matplotlib) pie chart.
+
+    The four selection fields are the chart's *scope*: the needs its content
+    lines are counted over, see ``filter_common.filter_scope_ids``.
+    A chart takes only these four of the filter options, so they are declared
+    here rather than inherited from ``NeedsFilteredBaseType``.
+    """
+
+    status: list[str]
+    """``:status:`` option values, empty if the option was not given."""
+    tags: list[str]
+    """``:tags:`` option values, empty if the option was not given."""
+    types: list[str]
+    """``:types:`` option values, empty if the option was not given."""
+    filter: str | None
+    """``:filter:`` option value, None if the option was not given."""
 
     title: str
     content: str

--- a/sphinx_needs/directives/needbar.py
+++ b/sphinx_needs/directives/needbar.py
@@ -10,7 +10,11 @@ from sphinx.application import Sphinx
 
 from sphinx_needs.config import NeedsSphinxConfig
 from sphinx_needs.data import NeedsBarType, SphinxNeedsData
-from sphinx_needs.filter_common import FilterBase, filter_needs_parts
+from sphinx_needs.filter_common import (
+    FilterBase,
+    filter_needs_parts,
+    filter_scope_ids,
+)
 from sphinx_needs.logging import get_logger, log_warning
 from sphinx_needs.utils import (
     add_doc,
@@ -57,9 +61,17 @@ class NeedbarDirective(FilterBase):
         "sum_rotation": directives.unchanged_required,
         "transpose": directives.flag,
         "horizontal": directives.flag,
+        "status": FilterBase.base_option_spec["status"],
+        "tags": FilterBase.base_option_spec["tags"],
+        "types": FilterBase.base_option_spec["types"],
+        "filter": FilterBase.base_option_spec["filter"],
         # ubCode compatibility: accepted and ignored by Sphinx-Needs.
         "cypher": directives.unchanged,
     }
+
+    # This replaces FilterBase's option_spec rather than extending it, since a chart
+    # takes only some of the filter options: the four selection options are its scope,
+    # and `filter-func` / `filter_warning` / `sort_by` have nothing to act on here.
 
     # Algorithm:
     # 1. define constants
@@ -129,10 +141,16 @@ class NeedbarDirective(FilterBase):
         transpose = "transpose" in self.options
         horizontal = "horizontal" in self.options
 
+        filter_attributes = self.collect_filter_attributes()
+
         data_attributes: NeedsBarType = {
             "docname": env.docname,
             "lineno": self.lineno,
             "target_id": targetid,
+            "status": filter_attributes["status"],
+            "tags": filter_attributes["tags"],
+            "types": filter_attributes["types"],
+            "filter": filter_attributes["filter"],
             "error_id": error_id,
             "title": title,
             "content": content,
@@ -299,6 +317,19 @@ def process_needbar(
         # adds parts to need_list
         need_list = needs_data.get_needs_view().to_list_with_parts()
 
+        # the selection options are the scope: the needs each content cell is
+        # counted over, resolved once for the whole chart (None if unscoped)
+        scope_ids = filter_scope_ids(
+            needs_data.get_needs_view(),
+            needs_config,
+            status=current_needbar["status"],
+            tags=current_needbar["tags"],
+            types=current_needbar["types"],
+            filter=current_needbar["filter"],
+            location=node,
+            origin_docname=current_needbar["docname"],
+        )
+
         for line in local_data:
             line_number = []
             for element in line:
@@ -306,16 +337,18 @@ def process_needbar(
                 if element.isdigit():
                     line_number.append(float(element))
                 else:
-                    result = len(
-                        filter_needs_parts(
-                            need_list,
-                            needs_config,
-                            element,
-                            location=node,
-                            origin_docname=current_needbar["docname"],
-                        )
+                    found = filter_needs_parts(
+                        need_list,
+                        needs_config,
+                        element,
+                        location=node,
+                        origin_docname=current_needbar["docname"],
                     )
-                    line_number.append(float(result))
+                    if scope_ids is not None:
+                        found = [
+                            need for need in found if need["id_complete"] in scope_ids
+                        ]
+                    line_number.append(float(len(found)))
             local_data_number.append(line_number)
 
         # 6. calculate index according to configuration and content size

--- a/sphinx_needs/directives/needpie.py
+++ b/sphinx_needs/directives/needpie.py
@@ -230,14 +230,13 @@ def process_needpie(
                     f"arg{index + 1}": arg for index, arg in enumerate(args)
                 }
 
-                # a filter-func receives only the needs in the scope;
-                # its own numbers are whatever it returns
+                # a filter-func receives only the needs in the scope, and receives
+                # them as the same view an unscoped chart hands it; its own numbers
+                # are whatever it returns
                 ff_needs = (
                     need_list
                     if scope_ids is None
-                    else [
-                        need for need in need_list if need["id_complete"] in scope_ids
-                    ]
+                    else need_list.filter_id_complete(scope_ids)
                 )
 
                 sizes = []

--- a/sphinx_needs/directives/needpie.py
+++ b/sphinx_needs/directives/needpie.py
@@ -12,7 +12,11 @@ from sphinx_needs.data import NeedsPieType, SphinxNeedsData
 from sphinx_needs.debug import measure_time
 from sphinx_needs.directives.utils import no_needs_found_paragraph
 from sphinx_needs.exceptions import NeedsInvalidFilter
-from sphinx_needs.filter_common import FilterBase, filter_needs_parts
+from sphinx_needs.filter_common import (
+    FilterBase,
+    filter_needs_parts,
+    filter_scope_ids,
+)
 from sphinx_needs.logging import get_logger, log_warning
 from sphinx_needs.utils import (
     add_doc,
@@ -50,13 +54,19 @@ class NeedpieDirective(FilterBase):
         "colors": directives.unchanged_required,
         "text_color": directives.unchanged_required,
         "shadow": directives.flag,
+        "status": FilterBase.base_option_spec["status"],
+        "tags": FilterBase.base_option_spec["tags"],
+        "types": FilterBase.base_option_spec["types"],
+        "filter": FilterBase.base_option_spec["filter"],
         "filter-func": FilterBase.base_option_spec["filter-func"],
         "filter_warning": FilterBase.base_option_spec["filter_warning"],
         # ubCode compatibility: accepted and ignored by Sphinx-Needs.
         "cypher": directives.unchanged,
     }
 
-    # Update the options_spec only with value filter-func defined in the FilterBase class
+    # This replaces FilterBase's option_spec rather than extending it, since a chart
+    # takes only some of the filter options: the four selection options are its scope,
+    # and `sort_by` / `export_id` / `show_filters` have nothing to act on in a chart.
 
     def run(self) -> Sequence[nodes.Node]:
         env = self.env
@@ -86,10 +96,16 @@ class NeedpieDirective(FilterBase):
 
         shadow = "shadow" in self.options
 
+        filter_attributes = self.collect_filter_attributes()
+
         attributes: NeedsPieType = {
             "docname": env.docname,
             "lineno": self.lineno,
             "target_id": targetid,
+            "status": filter_attributes["status"],
+            "tags": filter_attributes["tags"],
+            "types": filter_attributes["types"],
+            "filter": filter_attributes["filter"],
             "title": title,
             "content": content,
             "legend": legend,
@@ -99,8 +115,8 @@ class NeedpieDirective(FilterBase):
             "colors": colors,
             "shadow": shadow,
             "text_color": text_color,
-            "filter_func": self.collect_filter_attributes()["filter_func"],
-            "filter_warning": self.collect_filter_attributes()["filter_warning"],
+            "filter_func": filter_attributes["filter_func"],
+            "filter_warning": filter_attributes["filter_warning"],
         }
         pie_node = Needpie("", **attributes)
         self.set_source_info(pie_node)
@@ -158,6 +174,19 @@ def process_needpie(
 
         content = current_needpie["content"]
 
+        # the selection options are the scope: the needs each content line is
+        # counted over, resolved once for the whole chart (None if unscoped)
+        scope_ids = filter_scope_ids(
+            needs_data.get_needs_view(),
+            needs_config,
+            status=current_needpie["status"],
+            tags=current_needpie["tags"],
+            types=current_needpie["types"],
+            filter=current_needpie["filter"],
+            location=node,
+            origin_docname=current_needpie["docname"],
+        )
+
         sizes = []
         # adds parts to need_list
         need_list = needs_data.get_needs_view().to_list_with_parts()
@@ -166,16 +195,18 @@ def process_needpie(
                 if line.isdigit():
                     sizes.append(abs(float(line)))
                 else:
-                    result = len(
-                        filter_needs_parts(
-                            need_list,
-                            needs_config,
-                            line,
-                            location=node,
-                            origin_docname=current_needpie["docname"],
-                        )
+                    found = filter_needs_parts(
+                        need_list,
+                        needs_config,
+                        line,
+                        location=node,
+                        origin_docname=current_needpie["docname"],
                     )
-                    sizes.append(result)
+                    if scope_ids is not None:
+                        found = [
+                            need for need in found if need["id_complete"] in scope_ids
+                        ]
+                    sizes.append(len(found))
         elif current_needpie["filter_func"] and not content:
             # check and get filter_func
             try:
@@ -199,8 +230,18 @@ def process_needpie(
                     f"arg{index + 1}": arg for index, arg in enumerate(args)
                 }
 
+                # a filter-func receives only the needs in the scope;
+                # its own numbers are whatever it returns
+                ff_needs = (
+                    need_list
+                    if scope_ids is None
+                    else [
+                        need for need in need_list if need["id_complete"] in scope_ids
+                    ]
+                )
+
                 sizes = []
-                ff_result.func(needs=need_list, results=sizes, **args_context)
+                ff_result.func(needs=ff_needs, results=sizes, **args_context)
 
                 # check items in sizes
                 if not isinstance(sizes, list):

--- a/sphinx_needs/filter_common.py
+++ b/sphinx_needs/filter_common.py
@@ -298,11 +298,14 @@ def filter_scope_ids(
     and a literal numeric line is not affected at all.
 
     The scope is the same set of needs that the same four options select on a
-    need-listing directive such as ``needlist``: the options are ANDed with each
-    other, each one matches any-of its own values, ``:types:`` matches the
-    directive name or the human-readable type title, and ``:filter:`` is
-    evaluated last, over needs *and* parts. Parts follow their need for
-    ``:status:``, ``:tags:`` and ``:types:``, exactly as they do there.
+    need-listing directive such as ``needlist``: each option narrows the view in
+    turn, exactly as ``process_filters`` narrows it there, each one matching
+    any-of its own values; ``:types:`` matches the directive name or the
+    human-readable type title; and ``:filter:`` is evaluated last, over needs
+    *and* parts. Parts follow their need for ``:status:``, ``:tags:`` and
+    ``:types:``, exactly as they do there -- including that the ``id`` fast path
+    admits sibling parts once the view has been narrowed, which is inherited
+    behaviour rather than a property of the scope.
 
     :param needs_view: all needs of the project, unfiltered.
     :param config: used to evaluate the ``filter`` expression.

--- a/sphinx_needs/filter_common.py
+++ b/sphinx_needs/filter_common.py
@@ -335,15 +335,18 @@ def filter_scope_ids(
     if types:
         filtered_needs = filtered_needs.filter_types(types, or_type_names=True)
 
-    members: Iterable[NeedItem | NeedPartItem] = filtered_needs.to_list_with_parts()
-    if filter:
-        members = filter_needs_parts(
-            filtered_needs.to_list_with_parts(),
+    parts = filtered_needs.to_list_with_parts()
+    members: Iterable[NeedItem | NeedPartItem] = (
+        filter_needs_parts(
+            parts,
             config,
             filter,
             location=location,
             origin_docname=origin_docname,
         )
+        if filter
+        else parts
+    )
 
     return frozenset(need["id_complete"] for need in members)
 

--- a/sphinx_needs/filter_common.py
+++ b/sphinx_needs/filter_common.py
@@ -275,6 +275,79 @@ def process_filters(
     return found_needs
 
 
+def filter_scope_ids(
+    needs_view: NeedsView,
+    config: NeedsSphinxConfig,
+    /,
+    *,
+    status: list[str],
+    tags: list[str],
+    types: list[str],
+    filter: str | None,
+    location: nodes.Element,
+    origin_docname: str,
+) -> frozenset[str] | None:
+    """Resolve the selection options of a chart directive into a scope of needs.
+
+    ``needpie`` and ``needbar`` count one filter per content line or grid cell,
+    rather than the single filter the need-listing directives take.
+    The four selection options therefore do not select what such a chart *shows*;
+    they select the needs (and parts) it counts over, once for the whole chart.
+    Each content line is then counted as ``line-result`` intersected with this scope,
+    so a line can only ever count needs that are in the scope,
+    and a literal numeric line is not affected at all.
+
+    The scope is the same set of needs that the same four options select on a
+    need-listing directive such as ``needlist``: the options are ANDed with each
+    other, each one matches any-of its own values, ``:types:`` matches the
+    directive name or the human-readable type title, and ``:filter:`` is
+    evaluated last, over needs *and* parts. Parts follow their need for
+    ``:status:``, ``:tags:`` and ``:types:``, exactly as they do there.
+
+    :param needs_view: all needs of the project, unfiltered.
+    :param config: used to evaluate the ``filter`` expression.
+    :param status: the ``:status:`` option values, empty if the option was not given.
+    :param tags: the ``:tags:`` option values, empty if the option was not given.
+    :param types: the ``:types:`` option values, empty if the option was not given.
+    :param filter: the ``:filter:`` option value, None if the option was not given.
+    :param location: the chart node, used to locate warnings of an invalid ``filter``.
+    :param origin_docname: the document the chart is written on,
+        so that ``c.this_doc()`` can be used in ``filter``.
+
+    :return: the ``id_complete`` of every need and part in the scope,
+        or None if no selection option was given.
+        None means "no scope", which is not the same as an empty scope:
+        an unscoped chart counts its lines over the whole project.
+    """
+    if not (status or tags or types or filter):
+        # no selection option given: the chart counts over the whole project,
+        # exactly as it did before these options existed
+        return None
+
+    # the same narrowing calls, in the same order, that process_filters applies
+    # for a need-listing directive, so that the scope of a chart and the result
+    # of a needlist with the same options hold the same needs
+    filtered_needs = needs_view
+    if status:
+        filtered_needs = filtered_needs.filter_statuses(status)
+    if tags:
+        filtered_needs = filtered_needs.filter_has_tag(tags)
+    if types:
+        filtered_needs = filtered_needs.filter_types(types, or_type_names=True)
+
+    members: Iterable[NeedItem | NeedPartItem] = filtered_needs.to_list_with_parts()
+    if filter:
+        members = filter_needs_parts(
+            filtered_needs.to_list_with_parts(),
+            config,
+            filter,
+            location=location,
+            origin_docname=origin_docname,
+        )
+
+    return frozenset(need["id_complete"] for need in members)
+
+
 def resolve_max_items(max_items: int | None, config: NeedsSphinxConfig) -> int:
     """Resolve the effective item limit of a view directive.
 

--- a/sphinx_needs/utils.py
+++ b/sphinx_needs/utils.py
@@ -317,7 +317,9 @@ class FilterFunc(Protocol):
     def __call__(
         self,
         *,
-        needs: NeedsAndPartsListView,
+        # a needpie that carries selection options passes the needs of its scope
+        # as a plain list, so this is only ever iterated, never narrowed further
+        needs: NeedsAndPartsListView | list[NeedItem | NeedPartItem],
         results: list[Any],
         **kwargs: str,
     ) -> None: ...

--- a/sphinx_needs/utils.py
+++ b/sphinx_needs/utils.py
@@ -317,9 +317,7 @@ class FilterFunc(Protocol):
     def __call__(
         self,
         *,
-        # a needpie that carries selection options passes the needs of its scope
-        # as a plain list, so this is only ever iterated, never narrowed further
-        needs: NeedsAndPartsListView | list[NeedItem | NeedPartItem],
+        needs: NeedsAndPartsListView,
         results: list[Any],
         **kwargs: str,
     ) -> None: ...

--- a/sphinx_needs/views.py
+++ b/sphinx_needs/views.py
@@ -362,6 +362,21 @@ class NeedsAndPartsListView:
             )
         return self._copy_filtered(selected_ids)
 
+    def filter_id_complete(self, values: Iterable[str]) -> NeedsAndPartsListView:
+        """Create new view with only the needs/parts whose ``id_complete`` is in ``values``.
+
+        This selection is exact, which ``filter_ids`` is not:
+        a part is selected on its own, without its need and without its sibling parts,
+        and a need is selected without its parts.
+        Values that are not in the view are ignored.
+        """
+        value_set = set(values)
+        return self._copy_filtered(
+            (item["id_parent"], item["id"]) if item["is_part"] else (item["id"], None)
+            for item in self
+            if item["id_complete"] in value_set
+        )
+
     def filter_is_external(self, value: bool) -> NeedsAndPartsListView:
         """Create new view with only needs/parts where ``is_external`` field is true/false."""
         return self._copy_filtered(self._indexes.indexes.is_external.get(value, []))

--- a/tests/doc_test/doc_chart_scope/chart_scope_func.py
+++ b/tests/doc_test/doc_chart_scope/chart_scope_func.py
@@ -1,0 +1,12 @@
+"""A ``filter-func`` that reports how many needs it was handed.
+
+A scope restricts the *input* of a filter function, not its output, so the first
+returned value is the size of the ``needs`` the function received. It is what a
+test can assert the scope on, since the numbers of a filter-func pie are
+whatever the function returns.
+"""
+
+
+def sizes(needs, results):
+    results.append(len(list(needs)))
+    results.append(1)

--- a/tests/doc_test/doc_chart_scope/chart_scope_func.py
+++ b/tests/doc_test/doc_chart_scope/chart_scope_func.py
@@ -10,3 +10,16 @@ whatever the function returns.
 def sizes(needs, results):
     results.append(len(list(needs)))
     results.append(1)
+
+
+def open_reqs(needs, results):
+    """A ``filter-func`` that narrows the needs it was handed, rather than iterating.
+
+    ``needs`` is a view, and a view can be narrowed further -- which is what
+    ``docs/api.rst`` promises by publishing the views as injected into filters.
+    A scoped chart has to hand over the same kind of object as an unscoped one,
+    so this function must work with and without a scope; under ``:status: open``
+    it reports the open requirements.
+    """
+    results.append(len(needs.filter_types(["req"])))
+    results.append(1)

--- a/tests/doc_test/doc_chart_scope/conf.py
+++ b/tests/doc_test/doc_chart_scope/conf.py
@@ -1,0 +1,8 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+extensions = ["sphinx_needs"]
+
+needs_id_regex = "^[A-Za-z0-9_]"

--- a/tests/doc_test/doc_chart_scope/index.rst
+++ b/tests/doc_test/doc_chart_scope/index.rst
@@ -145,6 +145,11 @@ A scope on a filter function
    :status: open
    :filter-func: chart_scope_func.sizes
 
+.. needpie:: pie filter func narrowing
+   :labels: open reqs, one
+   :status: open
+   :filter-func: chart_scope_func.open_reqs
+
 Scoped bars
 -----------
 

--- a/tests/doc_test/doc_chart_scope/index.rst
+++ b/tests/doc_test/doc_chart_scope/index.rst
@@ -1,0 +1,192 @@
+TEST DOCUMENT CHART SCOPE
+=========================
+
+.. req:: One
+   :id: REQ_1
+   :status: open
+   :tags: a
+
+.. req:: Two
+   :id: REQ_2
+   :status: open
+   :tags: b
+
+.. req:: Three
+   :id: REQ_3
+   :status: closed
+   :tags: a
+
+.. spec:: S1
+   :id: SPEC_1
+   :status: open
+   :tags: a
+
+.. spec:: S2
+   :id: SPEC_2
+   :status: closed
+
+.. test:: T1
+   :id: TEST_1
+   :status: open
+   :tags: a
+
+   Body with :need_part:`(P1) part one` inside.
+
+Scoped pies
+-----------
+
+.. needpie:: pie unscoped
+   :labels: s, t, a, lit
+
+   status == 'open'
+   type == 'req'
+   'a' in tags
+   3
+
+.. needpie:: pie status
+   :labels: s, t, a, lit
+   :status: open
+
+   status == 'open'
+   type == 'req'
+   'a' in tags
+   3
+
+.. needpie:: pie tags
+   :labels: s, t, a, lit
+   :tags: a
+
+   status == 'open'
+   type == 'req'
+   'a' in tags
+   3
+
+.. needpie:: pie types
+   :labels: s, t, a, lit
+   :types: req
+
+   status == 'open'
+   type == 'req'
+   'a' in tags
+   3
+
+.. needpie:: pie types by title
+   :labels: s, t, a, lit
+   :types: Requirement
+
+   status == 'open'
+   type == 'req'
+   'a' in tags
+   3
+
+.. needpie:: pie status and tags
+   :labels: s, t, a, lit
+   :status: open
+   :tags: a
+
+   status == 'open'
+   type == 'req'
+   'a' in tags
+   3
+
+.. needpie:: pie filter
+   :labels: s, t, a, lit
+   :filter: type == 'req'
+
+   status == 'open'
+   type == 'req'
+   'a' in tags
+   3
+
+.. needpie:: pie status and filter
+   :labels: s, t, a, lit
+   :status: open
+   :filter: type == 'req'
+
+   status == 'open'
+   type == 'req'
+   'a' in tags
+   3
+
+.. needpie:: pie scope selects nothing
+   :labels: s, t, a, lit
+   :status: nonexistent
+
+   status == 'open'
+   type == 'req'
+   'a' in tags
+   3
+
+Empty states
+------------
+
+.. needpie:: pie all filters and no scope members
+   :labels: s, t, a
+   :status: nonexistent
+
+   status == 'open'
+   type == 'req'
+   'a' in tags
+
+.. needpie:: pie all filters and no scope members warned
+   :labels: s, t, a
+   :status: nonexistent
+   :filter_warning: nothing is in this scope
+
+   status == 'open'
+   type == 'req'
+   'a' in tags
+
+A scope on a filter function
+----------------------------
+
+.. needpie:: pie filter func
+   :labels: seen, one
+   :status: open
+   :filter-func: chart_scope_func.sizes
+
+Scoped bars
+-----------
+
+.. needbar:: bar unscoped
+   :xlabels: sA, tB, aC
+   :ylabels: row
+   :show_sum:
+
+   status == 'open', type == 'req', 'a' in tags
+
+.. needbar:: bar status
+   :xlabels: sA, tB, aC
+   :ylabels: row
+   :show_sum:
+   :status: open
+
+   status == 'open', type == 'req', 'a' in tags
+
+.. needbar:: bar filter
+   :xlabels: sA, tB, aC
+   :ylabels: row
+   :show_sum:
+   :filter: type == 'req'
+
+   status == 'open', type == 'req', 'a' in tags
+
+.. needbar:: bar scope selects nothing
+   :xlabels: sA, tB, aC
+   :ylabels: row
+   :show_sum:
+   :status: nonexistent
+
+   status == 'open', type == 'req', 'a' in tags
+
+.. needbar:: bar filter with a comma
+   :xlabels: sA, tB, aC
+   :ylabels: row
+   :show_sum:
+   :filter: status in ['closed', 'nonexistent']
+
+   status == 'open', type == 'req', 'a' in tags
+
+.. toctree::
+
+   invalid

--- a/tests/doc_test/doc_chart_scope/invalid.rst
+++ b/tests/doc_test/doc_chart_scope/invalid.rst
@@ -1,0 +1,15 @@
+An invalid scope filter
+=======================
+
+A scope ``:filter:`` that cannot be evaluated is warned by the filter engine and
+selects nothing, so every filter line counts zero. The literal line is not
+counted over the scope, so the chart is still drawn.
+
+.. needpie:: pie invalid scope filter
+   :labels: s, t, a, lit
+   :filter: xxx
+
+   status == 'open'
+   type == 'req'
+   'a' in tags
+   3

--- a/tests/doc_test/doc_filter_this_doc/index.rst
+++ b/tests/doc_test/doc_filter_this_doc/index.rst
@@ -21,6 +21,12 @@ index_ratio_b-:need_count:`True ? c.this_doc()`
 
    c.this_doc()
 
+.. needpie:: Index scoped pie
+   :filter: c.this_doc()
+
+   type == 'story'
+   1
+
 .. toctree::
 
    page

--- a/tests/doc_test/doc_filter_this_doc/page.rst
+++ b/tests/doc_test/doc_filter_this_doc/page.rst
@@ -9,3 +9,9 @@ page_count-:need_count:`c.this_doc()`
 .. needpie:: Page pie
 
    c.this_doc()
+
+.. needpie:: Page scoped pie
+   :filter: c.this_doc()
+
+   type == 'story'
+   2

--- a/tests/doc_test/doc_ubcode_compat/index.rst
+++ b/tests/doc_test/doc_ubcode_compat/index.rst
@@ -32,14 +32,14 @@ TEST DOCUMENT UBCODE COMPAT
    :height: 300
 
 .. needpie::
-   :cypher: MATCH (n:Need) WHERE n.type = 'req' RETURN n
+   :cypher: n.type = 'req'
    :types: req
 
    type == 'req'
    type == 'spec'
 
 .. needbar::
-   :cypher: MATCH (n:Need) WHERE n.type = 'req' RETURN n
+   :cypher: n.type = 'req'
    :types: req
 
    type == 'req', type == 'spec'

--- a/tests/doc_test/doc_ubcode_compat/index.rst
+++ b/tests/doc_test/doc_ubcode_compat/index.rst
@@ -32,12 +32,14 @@ TEST DOCUMENT UBCODE COMPAT
    :height: 300
 
 .. needpie::
-   :cypher: MATCH (n:Need) RETURN n
+   :cypher: MATCH (n:Need) WHERE n.type = 'req' RETURN n
+   :types: req
 
    type == 'req'
    type == 'spec'
 
 .. needbar::
-   :cypher: MATCH (n:Need) RETURN n
+   :cypher: MATCH (n:Need) WHERE n.type = 'req' RETURN n
+   :types: req
 
    type == 'req', type == 'spec'

--- a/tests/doc_test/doc_ubcode_compat/index.rst
+++ b/tests/doc_test/doc_ubcode_compat/index.rst
@@ -10,17 +10,17 @@ TEST DOCUMENT UBCODE COMPAT
 
 .. needlist::
    :types: req
-   :cypher: MATCH (n:Need) RETURN n
+   :cypher: MATCH (n:req) RETURN n
    :max_items: 10
 
 .. needtable::
    :types: req
-   :cypher: MATCH (n:Need) RETURN n
+   :cypher: MATCH (n:req) RETURN n
    :max_items: 10
 
 .. needflow::
    :types: req
-   :cypher: MATCH (n:Need) RETURN n
+   :cypher: MATCH (n:req) RETURN n
    :max_items: 10
    :width: 400
    :height: 300

--- a/tests/test_chart_scope.py
+++ b/tests/test_chart_scope.py
@@ -112,15 +112,20 @@ def test_scope_intersects_every_content_line(test_app: SphinxTestApp):
 
     images = chart_images(Path(app.outdir, "index.html").read_text())
     # the two empty-state pies write no image, so they are not in here, and the
-    # filter-func pie has its own test
-    assert set(images) == set(PIE_ORACLE) | set(BAR_ORACLE) | {"pie filter func"}
+    # two filter-func pies have their own tests
+    assert set(images) == set(PIE_ORACLE) | set(BAR_ORACLE) | {
+        "pie filter func",
+        "pie filter func narrowing",
+    }
 
     def svg(title: str) -> str:
         return Path(app.outdir, "_images", images[title]).read_text()
 
     assert {title: pie_slice_counts(svg(title)) for title in PIE_ORACLE} == PIE_ORACLE
+    # the whole list of sum labels, so a chart drawing a row the oracle does not
+    # know about is a failure rather than a truncation
     assert {
-        title: bar_sum_labels(svg(title), title, 3) for title in BAR_ORACLE
+        title: bar_sum_labels(svg(title), title) for title in BAR_ORACLE
     } == BAR_ORACLE
 
 
@@ -182,6 +187,25 @@ def test_scope_restricts_the_input_of_a_filter_func(test_app: SphinxTestApp):
     images = chart_images(Path(app.outdir, "index.html").read_text())
     svg = Path(app.outdir, "_images", images["pie filter func"]).read_text()
     assert pie_slice_counts(svg) == [5, 1]
+
+
+@CHART_SCOPE
+def test_a_scoped_filter_func_receives_a_view(test_app: SphinxTestApp):
+    """The scoped needs are the same kind of object as the unscoped ones.
+
+    ``docs/api.rst`` publishes the need views as "injected into filters", so a
+    filter function may narrow what it is handed instead of iterating it. Handing
+    a scoped chart's function a plain list would end the whole build with
+    ``'list' object has no attribute 'filter_types'`` -- no document, no line, no
+    directive named -- so the fixture's second function calls a view method, and
+    reports the two open requirements of the corpus.
+    """
+    app = test_app
+    app.build()
+
+    images = chart_images(Path(app.outdir, "index.html").read_text())
+    svg = Path(app.outdir, "_images", images["pie filter func narrowing"]).read_text()
+    assert pie_slice_counts(svg) == [2, 1]
 
 
 @CHART_SCOPE

--- a/tests/test_chart_scope.py
+++ b/tests/test_chart_scope.py
@@ -1,0 +1,259 @@
+"""Tests for the selection options of ``needpie`` and ``needbar``.
+
+``:status:``, ``:tags:``, ``:types:`` and ``:filter:`` do not select what a chart
+shows -- a chart shows whatever its content says -- they select the needs it
+counts over. The scope is resolved once per chart and every content line is then
+counted as its own result intersected with that scope, so the numbers of a scoped
+chart are the numbers of the unscoped chart, restricted to the scope.
+
+The oracle these tests assert is the corpus of ``doc_test/doc_chart_scope``:
+six needs of three types with two statuses and the tags ``a``/``b``, one of which
+carries the part ``TEST_1.P1``, so that seven objects can be counted.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+from docutils import nodes
+from sphinx.testing.util import SphinxTestApp
+from sphinx.util.console import strip_colors
+
+from sphinx_needs.config import NeedsSphinxConfig
+from sphinx_needs.data import NeedsFilteredBaseType, SphinxNeedsData
+from sphinx_needs.filter_common import filter_scope_ids, process_filters
+from tests.util import bar_sum_labels, chart_images, pie_slice_counts
+
+CHART_SCOPE = pytest.mark.parametrize(
+    "test_app",
+    [
+        {
+            "buildername": "html",
+            "srcdir": "doc_test/doc_chart_scope",
+            # the fixture needs no diagrams, so the suite-wide plantuml override
+            # would only add an "unknown config value" warning to assert around
+            "no_plantuml": True,
+        }
+    ],
+    indirect=True,
+)
+
+INVALID_FILTER_WARNING = (
+    "<srcdir>/invalid.rst:8: WARNING: Filter 'xxx' not valid. "
+    "Error: name 'xxx' is not defined. [needs.filter]"
+)
+"""The only warning the fixture is expected to emit, from its one invalid scope."""
+
+PIE_ORACLE = {
+    # every pie of the fixture counts the same four content lines:
+    #   status == 'open' / type == 'req' / 'a' in tags / the literal 3
+    "pie unscoped": [5, 3, 5, 3],
+    "pie status": [5, 2, 4, 3],
+    "pie tags": [4, 2, 5, 3],
+    "pie types": [2, 3, 2, 3],
+    # ``:types:`` matches the human-readable type title as well as the directive
+    # name, so this pie must count exactly what ``:types: req`` counts
+    "pie types by title": [2, 3, 2, 3],
+    "pie status and tags": [4, 1, 4, 3],
+    "pie filter": [2, 3, 2, 3],
+    "pie status and filter": [2, 2, 1, 3],
+    # a scope that selects nothing zeroes every filter line, but a literal line
+    # is not counted over the scope and so is left alone
+    "pie scope selects nothing": [0, 0, 0, 3],
+}
+
+BAR_ORACLE = {
+    # every bar of the fixture counts one row of three cells:
+    #   status == 'open' / type == 'req' / 'a' in tags
+    "bar unscoped": ["5", "3", "5"],
+    "bar status": ["5", "2", "4"],
+    "bar filter": ["2", "3", "2"],
+    # unlike a pie, a bar chart has no empty state: it draws all zeros
+    "bar scope selects nothing": ["0", "0", "0"],
+    # a comma in the option value is not a cell separator, so this filter
+    # arrives whole and selects the two closed needs
+    "bar filter with a comma": ["0", "1", "1"],
+}
+
+SCOPES: list[dict[str, object]] = [
+    {"status": ["open"], "tags": [], "types": [], "filter": None},
+    {"status": [], "tags": ["a"], "types": [], "filter": None},
+    {"status": [], "tags": [], "types": ["req"], "filter": None},
+    {"status": [], "tags": [], "types": ["Requirement"], "filter": None},
+    {"status": ["open"], "tags": ["a"], "types": [], "filter": None},
+    {"status": [], "tags": [], "types": [], "filter": "type == 'req'"},
+    {"status": ["open"], "tags": [], "types": [], "filter": "type == 'req'"},
+    {"status": ["nonexistent"], "tags": [], "types": [], "filter": None},
+]
+"""The scopes of the oracle, as the four option values a directive collects."""
+
+
+def _warnings(app: SphinxTestApp) -> list[str]:
+    return (
+        strip_colors(app._warning.getvalue())
+        .replace(str(app.srcdir) + os.path.sep, "<srcdir>/")
+        .splitlines()
+    )
+
+
+@CHART_SCOPE
+def test_scope_intersects_every_content_line(test_app: SphinxTestApp):
+    """A scoped chart counts each content line over the scope only.
+
+    This is the whole oracle: nine pies and five bars whose content is identical
+    and whose selection options are not, so every number that moves is the scope
+    at work and nothing else.
+    """
+    app = test_app
+    app.build()
+    assert _warnings(app) == [INVALID_FILTER_WARNING]
+
+    images = chart_images(Path(app.outdir, "index.html").read_text())
+    # the two empty-state pies write no image, so they are not in here, and the
+    # filter-func pie has its own test
+    assert set(images) == set(PIE_ORACLE) | set(BAR_ORACLE) | {"pie filter func"}
+
+    def svg(title: str) -> str:
+        return Path(app.outdir, "_images", images[title]).read_text()
+
+    assert {title: pie_slice_counts(svg(title)) for title in PIE_ORACLE} == PIE_ORACLE
+    assert {
+        title: bar_sum_labels(svg(title), title, 3) for title in BAR_ORACLE
+    } == BAR_ORACLE
+
+
+@CHART_SCOPE
+def test_scope_selecting_nothing_keeps_each_directives_empty_state(
+    test_app: SphinxTestApp,
+):
+    """A scope that selects nothing does not introduce a new empty state.
+
+    A pie of only filter lines then counts nothing and is replaced by the "no
+    needs" paragraph it already used for a filter that matches nothing, including
+    the ``:filter_warning:`` text. A pie that also has a literal line still has a
+    value and is still drawn, and a bar chart, which has no such paragraph, draws
+    all zeros -- see ``BAR_ORACLE``.
+    """
+    app = test_app
+    app.build()
+
+    html = Path(app.outdir, "index.html").read_text()
+    assert html.count('<p class="needs_filter_warning"') == 2
+    assert "No needs passed the filters" in html
+    assert "nothing is in this scope" in html
+
+    images = chart_images(html)
+    assert "pie all filters and no scope members" not in images
+    assert "pie all filters and no scope members warned" not in images
+    assert "pie scope selects nothing" in images
+
+
+@CHART_SCOPE
+def test_invalid_scope_filter_warns_once_and_selects_nothing(test_app: SphinxTestApp):
+    """An unevaluable scope ``:filter:`` is warned by the filter engine.
+
+    It is the same warning the same expression gives on a content line, and it is
+    given once for the chart rather than once per line, because the scope is
+    resolved once. The scope is then empty, so every filter line counts zero.
+    """
+    app = test_app
+    app.build()
+    assert _warnings(app) == [INVALID_FILTER_WARNING]
+
+    images = chart_images(Path(app.outdir, "invalid.html").read_text())
+    svg = Path(app.outdir, "_images", images["pie invalid scope filter"]).read_text()
+    assert pie_slice_counts(svg) == [0, 0, 0, 3]
+
+
+@CHART_SCOPE
+def test_scope_restricts_the_input_of_a_filter_func(test_app: SphinxTestApp):
+    """A ``:filter-func:`` is handed the needs of the scope, not the project.
+
+    The scope restricts what the function sees, not what it returns: the numbers
+    of the chart are whatever the function appends. The fixture's function returns
+    the size of the ``needs`` it was given, which is 5 for ``:status: open`` and
+    would be 7 -- the whole corpus, parts included -- without the scope.
+    """
+    app = test_app
+    app.build()
+
+    images = chart_images(Path(app.outdir, "index.html").read_text())
+    svg = Path(app.outdir, "_images", images["pie filter func"]).read_text()
+    assert pie_slice_counts(svg) == [5, 1]
+
+
+@CHART_SCOPE
+def test_scope_membership_equals_the_filter_options_of_a_view_directive(
+    test_app: SphinxTestApp,
+):
+    """The scope holds exactly what the same options select on a view directive.
+
+    ``filter_scope_ids`` does not call ``process_filters`` -- a chart has no
+    single filter to give it, and its content is not filter code -- so the two
+    can drift apart. This pins them together for every scope of the oracle.
+    """
+    app = test_app
+    app.build()
+
+    data = SphinxNeedsData(app.env)
+    config = NeedsSphinxConfig(app.env.config)
+    location = nodes.paragraph()
+
+    for scope in SCOPES:
+        scope_ids = filter_scope_ids(
+            data.get_needs_view(),
+            config,
+            status=scope["status"],
+            tags=scope["tags"],
+            types=scope["types"],
+            filter=scope["filter"],
+            location=location,
+            origin_docname="index",
+        )
+        filter_data: NeedsFilteredBaseType = {
+            "docname": "index",
+            "lineno": 1,
+            "target_id": "equivalence",
+            "status": scope["status"],
+            "tags": scope["tags"],
+            "types": scope["types"],
+            "filter": scope["filter"],
+            "sort_by": None,
+            # a chart's content is one filter per line, never filter code, so the
+            # comparison is against the option-only branch of process_filters
+            "filter_code": [],
+            "filter_func": None,
+            "filter_warning": None,
+        }
+        found = process_filters(
+            app, data.get_needs_view(), filter_data, "needpie", location
+        )
+        assert scope_ids == frozenset(need["id_complete"] for need in found), scope
+
+
+@CHART_SCOPE
+def test_no_selection_option_means_no_scope(test_app: SphinxTestApp):
+    """No selection option is not an empty scope, it is no scope at all.
+
+    An empty scope would zero every filter line; no scope must leave a chart
+    counting over the whole project, exactly as it did before the options
+    existed. ``None`` is what carries that difference.
+    """
+    app = test_app
+    app.build()
+
+    assert (
+        filter_scope_ids(
+            SphinxNeedsData(app.env).get_needs_view(),
+            NeedsSphinxConfig(app.env.config),
+            status=[],
+            tags=[],
+            types=[],
+            filter=None,
+            location=nodes.paragraph(),
+            origin_docname="index",
+        )
+        is None
+    )

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -14,6 +14,7 @@ from sphinx_needs.need_item import (
     NeedsContent,
 )
 from sphinx_needs.views import NeedsView
+from tests.util import chart_images, pie_slice_counts
 
 
 @pytest.mark.parametrize(
@@ -138,6 +139,9 @@ def test_this_doc_in_charts_and_need_count(test_app):
 
     These call the filter engine directly and used to omit the origin document,
     so the filter aborted with a ``needs.filter`` warning and counted nothing.
+
+    A chart's ``:filter:`` scope calls the engine once more, from a third place,
+    and so has to name the origin document as well.
     """
     app = test_app
     app.build()
@@ -158,10 +162,20 @@ def test_this_doc_in_charts_and_need_count(test_app):
     assert "No needs passed the filters" not in html
     assert '<img alt="Index bar"' in html
 
+    # a scope ``:filter:`` of c.this_doc() restricts the chart to its own page,
+    # so the first slice counts the page's two story needs, not the project's three
+    images = chart_images(html)
+    scoped_pie = Path(app.outdir, "_images", images["Index scoped pie"]).read_text()
+    assert pie_slice_counts(scoped_pie) == [2, 1]
+
     html_page = Path(app.outdir, "page.html").read_text()
     assert "page_count-1" in html_page
     assert '<img alt="Page pie"' in html_page
     assert "No needs passed the filters" not in html_page
+
+    page_images = chart_images(html_page)
+    scoped_pie = Path(app.outdir, "_images", page_images["Page scoped pie"]).read_text()
+    assert pie_slice_counts(scoped_pie) == [1, 2]
 
 
 def _capture_diagrams(app) -> dict[str, list[str]]:

--- a/tests/test_ubcode_compat.py
+++ b/tests/test_ubcode_compat.py
@@ -10,6 +10,10 @@ larger than the number of needs must leave the output untouched. The
 ``needpie`` and ``needbar`` blocks are the exception: neither directive has
 ``max_items``, so a stray one there would be exactly the ``unknown option``
 error these tests guard against.
+
+Those two blocks are also this repository's worked example of the portable
+pairing: each carries a ``:cypher:`` query beside the same scope written as
+``:types:``, which is the form that counts the same needs in both tools.
 """
 
 from pathlib import Path

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -140,3 +140,23 @@ def test_filter_ids_is_not_id_complete():
         "TEST_1.P1",
         "TEST_1.P2",
     ]
+
+
+def test_filter_id_complete_keeps_the_order_of_the_view():
+    """The result iterates in the view's own order, not in the order of ``values``.
+
+    A ``:filter-func:`` used to be handed a plain list built by iterating the
+    unscoped view, so its needs arrived in document order; the view it is handed
+    now must iterate the same way, or a function that relies on that order (the
+    first need, a running total) changes its answer when a scope is added.
+    """
+    view = _parts_view()
+    selected = view.filter_id_complete(["TEST_1.P2", "REQ_1", "TEST_1"])
+    assert [item["id_complete"] for item in selected] == [
+        "REQ_1",
+        "TEST_1",
+        "TEST_1.P2",
+    ]
+    assert [item["id_complete"] for item in selected] == [
+        item["id_complete"] for item in view if item["id_complete"] != "TEST_1.P1"
+    ]

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,0 +1,142 @@
+"""Unit tests for the read-only need views of ``sphinx_needs.views``.
+
+These views are part of the published Python API (``docs/api.rst``) and are the
+objects a filter string or a filter function is handed, so their narrowing
+methods are exercised here directly, without a Sphinx build.
+"""
+
+from __future__ import annotations
+
+from sphinx_needs.need_item import NeedItem, NeedPartData, NeedsContent
+from sphinx_needs.views import NeedsAndPartsListView, NeedsView
+
+CORE_BASE = {
+    "id": "abc",
+    "type": "type",
+    "type_name": "type title",
+    "type_prefix": "type prefix",
+    "type_color": "#000000",
+    "type_style": "node",
+    "status": None,
+    "tags": [],
+    "constraints": (),
+    "title": "title",
+    "collapse": False,
+    "arch": {},
+    "style": None,
+    "layout": None,
+    "hide": False,
+    "external_css": "external_link",
+    "has_dead_links": False,
+    "has_forbidden_dead_links": False,
+    "sections": (),
+    "signature": None,
+}
+
+
+def _parts_view() -> NeedsAndPartsListView:
+    """A need without parts and a need with two, so a sibling part can be left out.
+
+    Two parts is the shape that tells an exact selection from an approximate one:
+    ``TEST_1.P1`` and ``TEST_1.P2`` share a need id, so anything that selects by
+    need id cannot address one of them alone.
+    """
+    needs = [
+        NeedItem(
+            core=CORE_BASE | {"id": "REQ_1", "type": "req", "type_name": "Requirement"},
+            extras={},
+            links={},
+            source=None,
+            content=NeedsContent(content="", doctype=".rst"),
+            parts=(),
+        ),
+        NeedItem(
+            core=CORE_BASE | {"id": "TEST_1", "type": "test", "type_name": "Test Case"},
+            extras={},
+            links={},
+            source=None,
+            content=NeedsContent(content="", doctype=".rst"),
+            parts=(
+                NeedPartData(id="P1", content="Part one"),
+                NeedPartData(id="P2", content="Part two"),
+            ),
+        ),
+    ]
+    return NeedsView._from_needs({n["id"]: n for n in needs}).to_list_with_parts()
+
+
+def _ids(view: NeedsAndPartsListView) -> list[str]:
+    return sorted(item["id_complete"] for item in view)
+
+
+def test_the_corpus_holds_the_needs_and_every_part():
+    """The premise of the tests below: parts are members in their own right."""
+    assert _ids(_parts_view()) == ["REQ_1", "TEST_1", "TEST_1.P1", "TEST_1.P2"]
+
+
+def test_filter_id_complete_selects_exactly_the_given_items():
+    """A part is selected on its own -- without its need and without its sibling.
+
+    This is what ``filter_ids`` cannot do, and it is why a chart's scope, which is
+    a set of ``id_complete`` values, needs its own method: selecting the parent
+    need or the sibling part would silently widen a scope.
+    """
+    view = _parts_view().filter_id_complete(["REQ_1", "TEST_1.P1"])
+    assert _ids(view) == ["REQ_1", "TEST_1.P1"]
+
+
+def test_filter_id_complete_can_select_a_need_without_its_parts():
+    """Selecting a need does not bring its parts along."""
+    assert _ids(_parts_view().filter_id_complete(["TEST_1"])) == ["TEST_1"]
+
+
+def test_filter_id_complete_of_nothing_is_an_empty_view():
+    """An empty selection is an empty view, not an unfiltered one.
+
+    A chart's scope relies on this: a scope that selected nothing must count
+    nothing, which is a different thing from a chart that has no scope at all.
+    """
+    view = _parts_view().filter_id_complete([])
+    assert _ids(view) == []
+    assert len(view) == 0
+    assert not view
+
+
+def test_filter_id_complete_ignores_values_that_are_not_in_the_view():
+    """Unknown ids are ignored, and so are ids the view has already filtered out."""
+    assert _ids(_parts_view().filter_id_complete(["REQ_1", "NOPE", "TEST_1.P9"])) == [
+        "REQ_1"
+    ]
+    narrowed = _parts_view().filter_types(["test"])
+    assert _ids(narrowed.filter_id_complete(["REQ_1", "TEST_1.P2"])) == ["TEST_1.P2"]
+
+
+def test_filter_id_complete_returns_a_view_that_can_be_narrowed_further():
+    """The result is a view, so every other narrowing method still applies.
+
+    A filter function is handed one of these, and the published API says so, so
+    the result of an exact selection has to keep those methods reachable.
+    """
+    view = _parts_view().filter_id_complete(["REQ_1", "TEST_1", "TEST_1.P2"])
+    assert isinstance(view, NeedsAndPartsListView)
+    assert _ids(view.filter_types(["test"])) == ["TEST_1", "TEST_1.P2"]
+    assert _ids(view.filter_types(["Requirement"], or_type_names=True)) == ["REQ_1"]
+
+
+def test_filter_ids_is_not_id_complete():
+    """Why ``filter_id_complete`` exists, pinned rather than described.
+
+    ``filter_ids`` matches a need id or a bare part id, so an ``id_complete``
+    value never matches, and a need id brings its parts along once the view has
+    been narrowed. Both behaviours are fine for its own callers and wrong for a
+    scope.
+    """
+    fresh = _parts_view()
+    assert _ids(fresh.filter_ids(["TEST_1.P1"])) == []
+    assert _ids(fresh.filter_ids(["P1"])) == ["TEST_1.P1"]
+    narrowed = _parts_view().filter_types(["test"])
+    assert _ids(narrowed.filter_ids(["TEST_1"])) == [
+        "TEST_1",
+        "TEST_1.P1",
+        "TEST_1.P2",
+    ]

--- a/tests/util.py
+++ b/tests/util.py
@@ -63,7 +63,9 @@ def chart_images(html: str) -> dict[str, str]:
     """Map the alt text of every chart image of a page to its image file name.
 
     A chart's alt text is its title, so this is how a test picks one ``needpie``
-    or ``needbar`` of a page out of the ``_images`` directory.
+    or ``needbar`` of a page out of the ``_images`` directory. A chart without a
+    title has no alt text and keys on its image path instead, so a fixture whose
+    charts must be addressed individually has to give each of them a title.
     """
     return dict(re.findall(r'<img alt="([^"]*)"[^>]*src="_images/([^"]*)"', html))
 
@@ -72,28 +74,45 @@ def pie_slice_counts(svg: str) -> list[int]:
     """The absolute value every slice of a pie chart reports, in content order.
 
     Matplotlib draws text as glyph paths, but writes the string itself as an XML
-    comment beside them, which is the only readable trace a label leaves.
+    comment beside them, which is the only readable trace a label leaves. A pie
+    writes each slice's value as its own ``(N)`` comment, from the second line of
+    the ``percent\n(absolute)`` label that ``label_calc`` builds.
 
-    A slice below 5% -- a zero one included -- has its own label hidden and is
-    listed in the legend instead, which ``needpie`` then switches on. The legend
-    holds every slice, so it is read whenever there is one.
+    A slice below 5% -- a zero one included -- has that label hidden, and the
+    directive then switches the legend on and appends ``percent (absolute)`` to
+    every legend entry. Only that enriched legend is read instead, and only when
+    it is there: a legend the author asked for with ``:legend:`` carries bare
+    labels and no counts, so the slice labels are still the complete list.
     """
-    legend = svg.find('<g id="legend_1">')
-    region = svg if legend == -1 else svg[legend:]
+    legend_at = svg.find('<g id="legend_1">')
+    if legend_at != -1:
+        enriched = [
+            int(match.group(1))
+            for comment in re.findall(r"<!-- (.*?) -->", svg[legend_at:])
+            if (match := re.search(r" \d+\.\d% \((\d+)\)$", comment))
+        ]
+        if enriched:
+            return enriched
+
     return [
         int(match.group(1))
-        for comment in re.findall(r"<!-- (.*?) -->", region)
-        if (match := re.search(r"\((\d+)\)$", comment))
+        for comment in re.findall(r"<!-- (.*?) -->", svg)
+        if (match := re.fullmatch(r"\((\d+)\)", comment))
     ]
 
 
-def bar_sum_labels(svg: str, title: str, count: int) -> list[str]:
-    """The values a ``:show_sum:`` bar chart writes into its bars, in cell order.
+def bar_sum_labels(svg: str, title: str) -> list[str]:
+    """Every value a ``:show_sum:`` bar chart writes into its bars, row by row.
 
-    The labels leave the same XML comments as any other matplotlib text. The bars
-    are drawn after both axes and the title after the bars, so the sum labels are
-    the ``count`` comments in front of the title, which is asserted as the anchor.
+    The labels leave the same XML comments as any other matplotlib text. They are
+    drawn after both axes -- so after the tick labels, which are the only other
+    numbers on the chart -- and before the title, which is the anchor this reads
+    up to. The whole list is returned, so a caller that asserts it sees every row
+    the chart drew rather than a chosen tail of them.
     """
-    comments = re.findall(r"<!-- (.*?) -->", svg)
-    assert comments[-1] == title, comments
-    return comments[-(count + 1) : -1]
+    axis_at = svg.index('<g id="matplotlib.axis_2"')
+    # the axis groups hold only line and text groups, so the next patch group is
+    # past the tick labels: the axes spines, drawn just before the bar labels
+    bars_at = svg.index('<g id="patch_', axis_at)
+    title_at = svg.index(f"<!-- {title} -->", bars_at)
+    return re.findall(r"<!-- (.*?) -->", svg[bars_at:title_at])

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,3 +1,4 @@
+import re
 from io import StringIO
 from xml.etree import ElementTree
 
@@ -56,3 +57,43 @@ def extract_needs_from_html(html):
         tables = document.findall(".//html:table", {"html": ""})
 
     return [HtmlNeed(table) for table in tables if "need" in table.get("class", "")]
+
+
+def chart_images(html: str) -> dict[str, str]:
+    """Map the alt text of every chart image of a page to its image file name.
+
+    A chart's alt text is its title, so this is how a test picks one ``needpie``
+    or ``needbar`` of a page out of the ``_images`` directory.
+    """
+    return dict(re.findall(r'<img alt="([^"]*)"[^>]*src="_images/([^"]*)"', html))
+
+
+def pie_slice_counts(svg: str) -> list[int]:
+    """The absolute value every slice of a pie chart reports, in content order.
+
+    Matplotlib draws text as glyph paths, but writes the string itself as an XML
+    comment beside them, which is the only readable trace a label leaves.
+
+    A slice below 5% -- a zero one included -- has its own label hidden and is
+    listed in the legend instead, which ``needpie`` then switches on. The legend
+    holds every slice, so it is read whenever there is one.
+    """
+    legend = svg.find('<g id="legend_1">')
+    region = svg if legend == -1 else svg[legend:]
+    return [
+        int(match.group(1))
+        for comment in re.findall(r"<!-- (.*?) -->", region)
+        if (match := re.search(r"\((\d+)\)$", comment))
+    ]
+
+
+def bar_sum_labels(svg: str, title: str, count: int) -> list[str]:
+    """The values a ``:show_sum:`` bar chart writes into its bars, in cell order.
+
+    The labels leave the same XML comments as any other matplotlib text. The bars
+    are drawn after both axes and the title after the bars, so the sum labels are
+    the ``count`` comments in front of the title, which is asserted as the anchor.
+    """
+    comments = re.findall(r"<!-- (.*?) -->", svg)
+    assert comments[-1] == title, comments
+    return comments[-(count + 1) : -1]


### PR DESCRIPTION
`needpie` and `needbar` now accept `:filter:`, `:status:`, `:tags:` and `:types:`. On a chart these options are a
**scope**: the set of needs the chart counts over, resolved once for the whole chart, with every content line or grid
cell then counted within it. A static number is never affected, and a chart without any of the options counts over
the whole project exactly as before.

```rst
.. needpie:: Open requirements by tag
   :status: open
   :types: req
   :labels: safety, other

   "safety" in tags
   "safety" not in tags
```

Each slice now counts only open requirements instead of every need in the project. The same options apply to every
cell of a `needbar`, and a `:filter:` given as an option is not split by the cell `:separator:`, so
`:filter: status in ['open', 'closed']` works as written.

The scope holds exactly what the same four options select on a `needlist` — ANDed, any-of within each option,
`:types:` matching the directive name or the type title, `:filter:` evaluated last over needs and parts — and a test
pins that equality. With the ubCode-only `cypher` option this completes the portable pairing: ubCode reads the query,
a Sphinx build ignores it and reads these options, so writing both makes the two tools count over the same needs.

Behaviour worth knowing, each pinned by a test:

- A `:filter-func:` on `needpie` receives the scoped needs, as the same view type as before (a new public
  `NeedsAndPartsListView.filter_id_complete` selects exactly by `id_complete`).
- A scope that selects nothing keeps each directive's existing empty state: a pie of only filter lines shows its
  `:filter_warning:` text, a bar chart draws all zeros.
- An invalid scope `:filter:` warns once per chart (`needs.filter`) and selects nothing. A scope restricts what a
  line counts, not what its filter can see: the `needs` variable inside a content line is unchanged.
- `c.this_doc()` works in a scope `:filter:`.

Not added: `sort_by`, `export_id` and `show_filters`; `filter-func` and `filter_warning` stay unavailable on
`needbar`. Known gaps: `needs_filter_max_time` and `needs_debug_filters` do not cover a chart's scope, and a syntax
error in a scope filter ends the build like any other filter string (#1772).

Docs: both directive pages gain a `common filters` section with a paired example, `docs/filter.rst` lists `needbar`
and rewrites the ubCode compatibility note for both charts, and the changelog gains an entry (with #1818's amended so
the two agree). Companion ubCode PR: https://github.com/useblocks/ubcode/pull/3262.