### PR TITLE
🔧 Exempt third-party node classes from the test-suite parent check, so the benchmark runs again

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -273,11 +273,21 @@ def plantuml_command(sphinx_test_tempdir) -> str:
     )
 
 
+# node classes from extensions outside sphinx-needs are exempt from the parent check:
+# sphinx-design installs its tab nodes by assigning ``children`` directly, so they never get
+# a parent (#1757), and the invariant guarded here (#1564) is about sphinx-needs' own nodes
+_PARENT_CHECK_EXEMPT_MODULES = ("sphinx_design.",)
+
+
 def _check_parent_child(app: Sphinx, doctree: document, docname: str):
     for idx, node in enumerate(doctree.findall()):
         if idx == 0:
             continue
-        assert node.parent is not None
+        if type(node).__module__.startswith(_PARENT_CHECK_EXEMPT_MODULES):
+            continue
+        assert node.parent is not None, (
+            f"{docname}: <{type(node).__name__}> has no parent"
+        )
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
Closes #1757.

The `doctree-resolved` check that #1564 added to `tests/conftest.py` asserts that every node in a resolved doctree has a parent. sphinx-design installs its tab nodes by assigning `children` directly, so `sd_tab_input` and `sd_tab_label` never get one, and the one `tab-set` in the documentation (`directives/needuml`) has failed `test_official_time` on every master push since 2026-07-01. That is why the benchmark workflow has been red for two months while the main CI stayed green: the official docs are only built by the benchmark.

This takes option 2 from the issue: node classes from `sphinx_design` are exempt, the invariant is unchanged for every other node, and the assertion now names the document and node class when it fires. One file, eleven lines.

Verified locally with the workflow's own commands (it only runs on pushes to master, so the first real run is the merge):

- before: `test_official_time` fails with `assert None is not None` on `<sd_tab_input>`, as in the issue;
- after: `pytest -k _time tests/benchmarks` → 2 passed; `pytest -k _memory tests/benchmarks` → 1 passed; a smoke subset of the normal suite (29 tests, which the check also guards) passes; all hooks green.

Not done here: the upstream fix in sphinx-design (option 1), which would also help sphinxcontrib-spelling users; the issue notes no report exists there yet.
