### PR TITLE
🚀 Release v8.5.0

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -16,7 +16,7 @@ on:
     paths: ['docker/**']
 
 env:
-  NEEDS_VERSION: 8.4.0
+  NEEDS_VERSION: 8.5.0
   DEPLOY_IMAGE: ${{ github.event_name != 'pull_request' }}
 
 jobs:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,12 +4,25 @@
 Changelog
 =========
 
-.. _`release:unreleased`:
+.. _`release:8.5.0`:
 
-Unreleased
-----------
+8.5.0
+-----
 
-:Released: Unreleased
+:Released: 03.09.2026
+:Full Changelog: `v8.4.0...v8.5.0 <https://github.com/useblocks/sphinx-needs/compare/8.4.0...8.5.0>`__
+
+This release is about **charts**, and about the tooling behind the project. :ref:`needpie`
+and :ref:`needbar` gain a scope — the same ``:filter:``, ``:status:``, ``:tags:`` and
+``:types:`` options a view directive takes — and accept the ``cypher`` option a chart
+authored for `ubCode`_ carries, so one document builds in both tools. Schema validation
+errors now name the keyword that failed and report a ``$ref`` at its definition, which
+changes their text. The bug fixes continue the previous release's theme: a :ref:`needuml`,
+:ref:`needarch` or :ref:`needextract` input that used to end the build with a traceback,
+and a malformed :ref:`needs_warnings` filter, are now located warnings — and, for a project
+that builds with ``-W``, can turn a green build red until the reported mistake is fixed or
+suppressed. Under the hood the development toolchain moves to a committed ``uv.lock``,
+``poe`` tasks and ``ty``; none of that touches the published package.
 
 Improvements
 ............

--- a/sphinx_needs/__init__.py
+++ b/sphinx_needs/__init__.py
@@ -1,6 +1,6 @@
 """Sphinx needs extension for managing needs/requirements and specifications"""
 
-__version__ = "8.4.0"
+__version__ = "8.5.0"
 
 
 def setup(app):


### PR DESCRIPTION
Minor release: two chart features (#1831, #1818), a changed-output improvement to schema validation messages (#1819), three bug-fix sets that turn build-ending tracebacks into warnings (#1800, #1795, #1830), and the toolchain moves (#1823, #1830). Nothing breaking, so 8.5.0.

Same three files as v8.4.0: `__version__`, the docker workflow's `NEEDS_VERSION`, and the changelog header (label, heading, release date, compare link, and a summary paragraph in the style of the previous releases).
