### PR TITLE
🔧 Keep dependabot off the typing floor's stubs, and fence the floor against drift

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,17 @@ updates:
         update-types:
           - version-update:semver-major
           - version-update:semver-minor
+      # the `typing` dependency group pins the oldest supported docutils series and the stubs
+      # that describe it, so the type checker runs against the floor; a newer series would
+      # type-check against an API the floor does not have. Both move by hand, with the floor.
+      - dependency-name: docutils
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor
+      - dependency-name: types-docutils
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor
     groups:
       # a dependency joins the first group whose pattern matches, so `ty` is listed first:
       # its 0.0.x releases are patch bumps that can change diagnostics, and each one should

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,12 +31,11 @@ updates:
           - version-update:semver-major
           - version-update:semver-minor
       # the `typing` dependency group pins the oldest supported docutils series and the stubs
-      # that describe it, so the type checker runs against the floor; a newer series would
-      # type-check against an API the floor does not have. Both move by hand, with the floor.
-      - dependency-name: docutils
-        update-types:
-          - version-update:semver-major
-          - version-update:semver-minor
+      # that describe it, so the type checker runs against the floor. The stubs have no other
+      # job, so their series moves by hand, with the floor (`check_typing_floor.py` fails
+      # Lint when the two drift apart). docutils itself is deliberately NOT listed: the main
+      # environment should keep taking new docutils series as sphinx allows them, and the
+      # occasional proposal to widen the floor line is closed by hand.
       - dependency-name: types-docutils
         update-types:
           - version-update:semver-major

--- a/.github/scripts/check_typing_floor.py
+++ b/.github/scripts/check_typing_floor.py
@@ -1,0 +1,95 @@
+"""Check that the type-checking floor environment is the floor it claims to be.
+
+Run inside `.venvs/typing`, the environment the `typing` dependency group installs. Two
+things can drift there, and both would leave ty checking against an API the floor does not
+have, silently and green:
+
+- the stubs and the library they describe: `types-docutils` must be the same series
+  (`major.minor`) as the installed `docutils`. Dependabot cannot know the two are coupled,
+  and once proposed moving the stubs three series ahead of the library.
+- the floor and the matrix: the installed `docutils` must be the lowest series the
+  installed `sphinx` accepts. When the oldest sphinx leaves the matrix, the `typing` group
+  has to move with it; this is where forgetting that is caught.
+
+Usage: python .github/scripts/check_typing_floor.py
+"""
+
+import sys
+from importlib.metadata import PackageNotFoundError, requires, version
+
+from packaging.requirements import Requirement
+from packaging.version import Version
+
+
+def series(text):
+    parsed = Version(text)
+    return f"{parsed.major}.{parsed.minor}"
+
+
+def docutils_floor_of_sphinx():
+    """The lowest docutils series the installed sphinx accepts, or None if not declared."""
+    for requirement in requires("sphinx") or []:
+        parsed = Requirement(requirement)
+        if parsed.name.lower() != "docutils":
+            continue
+        # sphinx declares docutils unconditionally; skip an extra-only declaration if
+        # one ever appears, since the floor environment installs no sphinx extras
+        if parsed.marker is not None and not parsed.marker.evaluate({"extra": ""}):
+            continue
+        lower = [
+            Version(spec.version)
+            for spec in parsed.specifier
+            if spec.operator in (">=", "==", "~=")
+        ]
+        return series(str(min(lower))) if lower else None
+    return None
+
+
+def check():
+    try:
+        docutils_version = version("docutils")
+        stubs_version = version("types-docutils")
+        sphinx_version = version("sphinx")
+    except PackageNotFoundError as exc:
+        print(
+            f"::error::{exc.name} is not installed here; this check runs inside "
+            "`.venvs/typing`, which `uv run poe typecheck` creates"
+        )
+        return 2
+
+    ok = True
+    if series(stubs_version) != series(docutils_version):
+        print(
+            f"::error::types-docutils {stubs_version} describes docutils "
+            f"{series(stubs_version)}, but docutils {docutils_version} is installed: "
+            "move both entries of the `typing` group together"
+        )
+        ok = False
+
+    floor = docutils_floor_of_sphinx()
+    if floor is None:
+        print(
+            f"::error::sphinx {sphinx_version} declares no docutils requirement to read"
+        )
+        return 2
+    if series(docutils_version) != floor:
+        print(
+            f"::error::sphinx {sphinx_version} accepts docutils from {floor}, but the "
+            f"`typing` group installs docutils {docutils_version}: the floor moved, so "
+            "move the group with it"
+        )
+        ok = False
+
+    if ok:
+        print(
+            f"typing floor: sphinx {sphinx_version} (accepts docutils from {floor}), "
+            f"docutils {docutils_version}, types-docutils {stubs_version}"
+        )
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 1:
+        print("usage: check_typing_floor.py (no arguments; run inside .venvs/typing)")
+        sys.exit(2)
+    sys.exit(check())

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,6 +30,13 @@ jobs:
         # the `sphinx-7` and `typing` groups both cap sphinx at the 7.4 series; both are in
         # the conflict set so that a plain `uv sync` is not capped by either
         run: uv run --frozen python -c "import sphinx; assert sphinx.version_info[0] >= 9, sphinx.__version__"
+      - name: Check the typing floor is the floor it claims to be
+        # .venvs/typing exists because the `ty` hook ran the typecheck task above; the
+        # stubs must match the installed docutils, and that docutils must be the lowest
+        # series the floor sphinx accepts
+        env:
+          UV_PROJECT_ENVIRONMENT: .venvs/typing
+        run: uv run --frozen --no-sync --no-group dev --group typing python .github/scripts/check_typing_floor.py
 
   # ubc:
   #   name: ubc


### PR DESCRIPTION
The `typing` dependency group pins the oldest supported docutils series and the stubs that describe it, on purpose, the way the `sphinx-7/8/9` groups pin one sphinx series each. Dependabot cannot know that: #1836 widened `types-docutils~=0.20.0` to `>=0.20,<0.24` and installed the 0.23 stubs against docutils 0.20.1, and Lint went red on the diagnostics the mismatched stubs produce.

Two changes:

- **Only `types-docutils` joins the ignore list** (major and minor). The stubs have no job but to match the floor's docutils, so their series moves by hand, with the floor. docutils itself is deliberately not ignored: an ignore is per dependency across the whole lock, and it would also have hidden the lock-only bumps the main environment should keep taking as sphinx allows them (it can take 0.22.4 today). The price is a rare proposal to widen the floor line, roughly once a year given docutils' release cadence, which fails Lint and is closed by hand; it doubles as the reminder that docutils moved.
- **A fence, so the bottom pin never needs a manual review.** `check_typing_floor.py` runs in Lint inside `.venvs/typing`: the installed `types-docutils` must be the same series as the installed `docutils`, and that docutils must be the lowest series the installed sphinx accepts. Dropping the oldest sphinx from the matrix without moving the `typing` group, or the stubs drifting from the library, goes red naming both. Proven locally: the #1836 shape (stubs 0.23 against docutils 0.20) and docutils 0.21 in the floor environment each fail with the expected message; the locked environment passes.

#1836 is closed in favour of this.
