### PR TITLE
🔧 Label issues and pull requests by package: path-based for PRs, a form dropdown for issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,62 @@
+name: Bug report
+description: A build, an output or a warning is wrong
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report. A minimal example and the exact versions are what turn
+        "cannot reproduce" into a fix, so the fields asking for them are required.
+  - type: dropdown
+    id: package
+    attributes:
+      label: Package
+      description: >-
+        Which distribution in this repository is affected? Pick "the repository" for workflows, CI, release, docker or tooling.
+      multiple: true
+      options:
+        - sphinx-needs
+        - the repository (workflows, CI, release, docker, tooling)
+    validations:
+      required: true
+  - type: textarea
+    id: what
+    attributes:
+      label: What happens
+      description: What you did, what you expected, and what happened instead.
+    validations:
+      required: true
+  - type: textarea
+    id: example
+    attributes:
+      label: Minimal example
+      description: >-
+        The smallest conf.py and source that reproduce it. A link to a repository or a zip is fine too.
+      render: rst
+    validations:
+      required: true
+  - type: textarea
+    id: output
+    attributes:
+      label: Build output
+      description: The warning, traceback or wrong output, as text.
+      render: text
+  - type: input
+    id: version-needs
+    attributes:
+      label: sphinx-needs version
+      placeholder: "8.5.0"
+    validations:
+      required: true
+  - type: input
+    id: version-sphinx
+    attributes:
+      label: Sphinx and Python versions
+      placeholder: "sphinx 9.1.0, python 3.13"
+    validations:
+      required: true
+  - type: input
+    id: builder
+    attributes:
+      label: Builder and theme
+      placeholder: "html with furo; latexpdf; needs"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Question or discussion
+    url: https://github.com/useblocks/sphinx-needs/discussions
+    about: Ask how to do something, or discuss an idea before it becomes an issue.
+  - name: Documentation
+    url: https://sphinx-needs.readthedocs.io
+    about: The reference for every directive, role and configuration option.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,36 @@
+name: Feature request
+description: Propose new behaviour, an option, or a change to how something works
+labels: ["enhancement"]
+body:
+  - type: dropdown
+    id: package
+    attributes:
+      label: Package
+      description: >-
+        Which distribution in this repository would change? Pick "the repository" for workflows, CI, release, docker or tooling.
+      multiple: true
+      options:
+        - sphinx-needs
+        - the repository (workflows, CI, release, docker, tooling)
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: The problem
+      description: What you are trying to do, and what stops you today.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behaviour
+      description: >-
+        How it would look to a user: directive options, configuration, output. A sketch of the source and the result you expect is ideal.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other ways to get there, and why they fall short.

--- a/.github/issue-labeler.yml
+++ b/.github/issue-labeler.yml
@@ -1,0 +1,10 @@
+# Labels issues from the "Package" dropdown of the issue forms
+# (.github/workflows/label-issues.yaml). A form renders the dropdown as a
+# "### Package" heading followed by the chosen options, comma-separated, so each
+# pattern looks for its option between that heading and the next one. Issues created
+# without a form (the API, `gh issue create`) have no such heading and get nothing
+# from here -- pass the label yourself, as AGENTS.md says.
+'pkg: sphinx-needs':
+  - '### Package[^#]*\bsphinx-needs\b'
+'pkg: workspace':
+  - '### Package[^#]*\bthe repository\b'

--- a/.github/issue-labeler.yml
+++ b/.github/issue-labeler.yml
@@ -3,8 +3,9 @@
 # "### Package" heading followed by the chosen options, comma-separated, so each
 # pattern looks for its option between that heading and the next one. Issues created
 # without a form (the API, `gh issue create`) have no such heading and get nothing
-# from here -- pass the label yourself, as AGENTS.md says.
+# from here -- pass the label yourself, as AGENTS.md says. The `/.../i` form makes the
+# patterns case-insensitive, like the workflow's `contains()` gate, so the two agree.
 'pkg: sphinx-needs':
-  - '### Package[^#]*\bsphinx-needs\b'
+  - '/### Package[^#]*\bsphinx-needs\b/i'
 'pkg: workspace':
-  - '### Package[^#]*\bthe repository\b'
+  - '/### Package[^#]*\bthe repository\b/i'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,26 @@
+# Labels pull requests by the paths they touch (.github/workflows/label-prs.yaml):
+# one entry per distribution under packages/, plus one for the repository itself.
+# uv.lock is deliberately absent from the repository entry -- a member's dependency
+# change relocks it, and that is not a repository concern.
+'pkg: sphinx-needs':
+  - changed-files:
+      - any-glob-to-any-file: 'packages/sphinx-needs/**'
+'pkg: workspace':
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/**'
+          - '.claude/**'
+          - 'docker/**'
+          - 'scripts/**'
+          - 'pyproject.toml'
+          - '.pre-commit-config.yaml'
+          - '.readthedocs.yml'
+          - '.gitattributes'
+          - '.gitignore'
+          - '.yamlfmt'
+          - 'codecov.yml'
+          - 'context7.json'
+          - 'AGENTS.md'
+          - 'CLAUDE.md'
+          - 'README.md'
+          - 'LICENSE'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,7 +1,9 @@
 # Labels pull requests by the paths they touch (.github/workflows/label-prs.yaml):
 # one entry per distribution under packages/, plus one for the repository itself.
 # uv.lock is deliberately absent from the repository entry -- a member's dependency
-# change relocks it, and that is not a repository concern.
+# change relocks it, and that is not a repository concern -- so a lock-only pull request
+# gets no label and is labelled by hand. The repository entry is an allow-list with no
+# test behind it: a new root-level file or directory needs a line here.
 'pkg: sphinx-needs':
   - changed-files:
       - any-glob-to-any-file: 'packages/sphinx-needs/**'

--- a/.github/workflows/label-issues.yaml
+++ b/.github/workflows/label-issues.yaml
@@ -3,7 +3,10 @@ name: Label issues
 # Reads the "Package" dropdown that the issue forms render into the body and applies
 # the matching `pkg:` labels (.github/issue-labeler.yml). Runs on edits too, so a
 # changed answer moves the label; `sync-labels` only touches the labels named in that
-# file, so anything else on the issue is left alone.
+# file, so anything else on the issue is left alone. The job is gated on the body
+# actually containing the form's heading: an issue created without a form (the API,
+# `gh issue create`, a blank web issue, everything that predates the forms) carries a
+# hand-applied label, and without the gate `sync-labels` would strip it on the first edit.
 on:
   issues:
     types: [opened, edited]
@@ -14,11 +17,15 @@ permissions:
 
 jobs:
   label:
+    if: contains(github.event.issue.body, '### Package')
     runs-on: ubuntu-latest
     steps:
       - uses: github/issue-labeler@v3.5
         with:
           configuration-path: .github/issue-labeler.yml
+          # required by the action and without a default: the step throws before doing
+          # anything if it is missing
+          enable-versioned-regex: 0
           include-title: 0
           sync-labels: 1
           repo-token: ${{ github.token }}

--- a/.github/workflows/label-issues.yaml
+++ b/.github/workflows/label-issues.yaml
@@ -17,7 +17,8 @@ permissions:
 
 jobs:
   label:
-    if: contains(github.event.issue.body, '### Package')
+    # quoted: an unquoted scalar containing `#` survives only because a `'` precedes it
+    if: "contains(github.event.issue.body, '### Package')"
     runs-on: ubuntu-latest
     steps:
       - uses: github/issue-labeler@v3.5

--- a/.github/workflows/label-issues.yaml
+++ b/.github/workflows/label-issues.yaml
@@ -1,0 +1,24 @@
+name: Label issues
+
+# Reads the "Package" dropdown that the issue forms render into the body and applies
+# the matching `pkg:` labels (.github/issue-labeler.yml). Runs on edits too, so a
+# changed answer moves the label; `sync-labels` only touches the labels named in that
+# file, so anything else on the issue is left alone.
+on:
+  issues:
+    types: [opened, edited]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: github/issue-labeler@v3.5
+        with:
+          configuration-path: .github/issue-labeler.yml
+          include-title: 0
+          sync-labels: 1
+          repo-token: ${{ github.token }}

--- a/.github/workflows/label-prs.yaml
+++ b/.github/workflows/label-prs.yaml
@@ -2,9 +2,12 @@ name: Label pull requests
 
 # `pull_request_target` rather than `pull_request`: a pull request from a fork gets a
 # read-only token under `pull_request`, so labelling it would fail. Under
-# `pull_request_target` the workflow file and the token come from the base branch and
-# nothing from the pull request is checked out or executed -- the action only reads the
-# list of changed files and applies labels from .github/labeler.yml.
+# `pull_request_target` the workflow file and the token come from the default branch of
+# this repository and nothing from the pull request is checked out or executed -- the
+# action only reads the list of changed files and applies labels from .github/labeler.yml.
+# Labels are only ever added, never synced away: a pull request branched before the
+# workspace move still diffs against old-layout paths until it is rebased, and syncing
+# would strip its label (or replace it with the wrong one) on its next push.
 on:
   pull_request_target:
     types: [opened, synchronize, reopened]
@@ -20,5 +23,3 @@ jobs:
       - uses: actions/labeler@v7
         with:
           configuration-path: .github/labeler.yml
-          # a push that stops touching a path removes that path's label again
-          sync-labels: true

--- a/.github/workflows/label-prs.yaml
+++ b/.github/workflows/label-prs.yaml
@@ -1,0 +1,24 @@
+name: Label pull requests
+
+# `pull_request_target` rather than `pull_request`: a pull request from a fork gets a
+# read-only token under `pull_request`, so labelling it would fail. Under
+# `pull_request_target` the workflow file and the token come from the base branch and
+# nothing from the pull request is checked out or executed -- the action only reads the
+# list of changed files and applies labels from .github/labeler.yml.
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v7
+        with:
+          configuration-path: .github/labeler.yml
+          # a push that stops touching a path removes that path's label again
+          sync-labels: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,3 +150,15 @@ move's pull request.
 3. **Documentation**: update the docs if behaviour changes or options are added
 4. **Changelog**: update `packages/sphinx-needs/docs/changelog.rst`
 5. **Code quality**: `uv run poe lint` and `uv run poe typecheck-needs` pass
+
+## Issues and labels
+
+Every issue and pull request carries one `pkg:` label naming what it concerns:
+`pkg: <distribution>` (today `pkg: sphinx-needs`) or `pkg: workspace` for the repository
+itself — workflows, CI, release, docker, tooling, the workspace root. Pull requests get
+theirs automatically from the paths they touch (`.github/labeler.yml`); the issue forms
+set it from their "Package" dropdown (`.github/issue-labeler.yml`). **An issue created
+without a form — `gh issue create`, the API — gets no label from anywhere, so pass it
+yourself**, together with the kind (`bug`, `enhancement`, `documentation`):
+`gh issue create --label 'pkg: sphinx-needs' --label bug --title … --body-file …`.
+Templates never constrain the API; they only shape the web "New issue" page.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,12 +153,14 @@ move's pull request.
 
 ## Issues and labels
 
-Every issue and pull request carries one `pkg:` label naming what it concerns:
+Every issue and pull request carries one or more `pkg:` labels naming what it concerns:
 `pkg: <distribution>` (today `pkg: sphinx-needs`) or `pkg: workspace` for the repository
 itself — workflows, CI, release, docker, tooling, the workspace root. Pull requests get
 theirs automatically from the paths they touch (`.github/labeler.yml`); the issue forms
 set it from their "Package" dropdown (`.github/issue-labeler.yml`). **An issue created
-without a form — `gh issue create`, the API — gets no label from anywhere, so pass it
-yourself**, together with the kind (`bug`, `enhancement`, `documentation`):
-`gh issue create --label 'pkg: sphinx-needs' --label bug --title … --body-file …`.
-Templates never constrain the API; they only shape the web "New issue" page.
+without a form — `gh issue create`, the API, a blank web issue — gets no label from
+anywhere, so pass it yourself**, together with the kind (`bug`, `enhancement`,
+`documentation`): `gh issue create --label 'pkg: sphinx-needs' --label bug --title …
+--body-file …`. Templates never constrain the API; they only shape the web "New issue"
+page and the interactive `gh issue create` prompt. Triage adds the label to whatever
+arrives without one.


### PR DESCRIPTION
The repository is now a workspace that will hold several distributions (#1803), so every
issue and pull request needs to say which one it concerns. The two labels exist and every
open item already carries one (`pkg: sphinx-needs` on 206 issues and 33 PRs,
`pkg: workspace` on the 6 issues and 2 PRs about the repository itself). This makes the
labelling automatic from here on.

### Pull requests: by path

`.github/labeler.yml` + `.github/workflows/label-prs.yaml` (`actions/labeler`): a pull
request touching `packages/sphinx-needs/**` gets `pkg: sphinx-needs`; one touching the
repository's own files (`.github/`, `docker/`, `scripts/`, the root `pyproject.toml`, hooks,
Read the Docs, the agent files, …) gets `pkg: workspace`; both when it touches both.
`uv.lock` is deliberately not on the repository list: a member's dependency change relocks
it, and that is not a repository concern, so a lock-only pull request is labelled by hand.
Labels are only added, never synced away: the ~31 open pull requests branched before the
workspace move still diff against old-layout paths until they are rebased, and syncing would
strip their label or replace it with the wrong one on their next push. The trigger is
`pull_request_target` so pull requests from forks can be labelled too; the workflow runs from
the default branch and nothing from the pull request is checked out or run.

### Issues: from a form

Two issue forms replace the (absent) templates, each with a **Package** dropdown
(multi-select) and its kind label as the form's default:

- **Bug report** (`bug`): what happens, a minimal example (required), build output, the
  sphinx-needs / Sphinx / Python versions (required), builder and theme.
- **Feature request** (`enhancement`): the problem, the proposed behaviour, alternatives.

`config.yml` keeps blank issues enabled and routes questions to Discussions and the docs.
`.github/issue-labeler.yml` + `label-issues.yaml` (`github/issue-labeler`) turn the
dropdown into the `pkg:` labels on open and on edit, syncing only the `pkg:` set. The job is
gated on the body carrying the form's `### Package` heading, so the 212 issues labelled by
hand today, and anything created without a form, are never touched by it.

The regexes were exercised locally against the bodies the forms render (one package, the
repository, both, and an API-created issue with no headings): each case yields exactly the
expected labels, including a body whose later sections mention "sphinx-needs" in prose. An
adversarial review then ran the action's own shipped code with the workflow's exact inputs,
which caught a missing required input (`enable-versioned-regex`) the regex check could not
see, and measured the two label-sync hazards above against the live backlog; the second
commit is those fixes.

### Issues created without a form

The API and a non-interactive `gh issue create` bypass templates entirely (they only shape
the web "New issue" page and the interactive `gh issue create` prompt), so such an issue
gets no `pkg:` label from anywhere. `AGENTS.md` gains an
"Issues and labels" section saying to pass it, together with the kind label; a blank web
issue is the same case, and triage adds the label to whatever arrives without one.

### What cannot be verified before merge

Both workflows run from the default branch (`pull_request_target` takes the workflow from
the default branch of the base repository; `issues` events only fire on the default branch), so neither can label anything
on this pull request. First check after merge: open a bug report through the form with
both packages selected and confirm the three labels arrive, then close it; the next pull
request that touches a package path confirms the other.

When a distribution is imported, its label is created and one line is added to each of
`labeler.yml` and `issue-labeler.yml`, and one option to each form's dropdown.
