### PR TITLE
🔧 House the workspace tooling in a virtual member that is never released

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -14,6 +14,7 @@
           - '.claude/**'
           - 'docker/**'
           - 'scripts/**'
+          - 'tools/**'
           - 'pyproject.toml'
           - '.pre-commit-config.yaml'
           - '.readthedocs.yml'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
         # (see the script's docstring). The local prek hook runs the same script against
         # the synced environment, so `uv run poe lint` covers it too
         run: >
-          uv run --no-project --with packaging python .github/scripts/check_workspace.py
+          uv run --no-project --with packaging python tools/src/sn_tools/check_workspace.py
       - run: uv run --frozen prek run --all-files --show-diff-on-failure
         env:
           PREK_COLOR: always
@@ -92,15 +92,12 @@ jobs:
         env:
           UV_PROJECT_ENVIRONMENT: .venvs/typing
         run: uv run --frozen --no-sync --no-group dev --group typing python .github/scripts/check_typing_floor.py
-      - name: Test the repository's own scripts
-        # `.github/scripts/` holds the release fences: the one that decides whether a tag
-        # may publish, and the one that rewrites floors. They are not in any package, so
-        # this is the only job that runs their tests. They are in the root `testpaths`, so
-        # a bare `pytest` at the root runs them too -- but every matrix cell names the
-        # package's `tests` path explicitly and so never collects them. The directory is
-        # `selftests/` rather than `tests/` so that no importable `tests` exists outside a
-        # package
-        run: uv run --frozen --no-sync pytest .github/scripts/selftests -q
+      - name: Test the repository's own tooling
+        # `tools/` holds the release fences: the one that decides whether a tag may publish,
+        # and the one that rewrites floors. Nothing else in CI exercises them, and they are
+        # in the root `testpaths`, so a bare `pytest` at the root runs them too -- but every
+        # matrix cell names the package's `tests` path explicitly and so never collects them
+        run: uv run --frozen --no-sync pytest tools/tests -q
 
   # ubc:
   #   name: ubc

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -58,7 +58,7 @@ jobs:
       # skipping either check, so a rehearsal exercises `git merge-base` and the
       # `fetch-depth: 0` above rather than leaving them for the first real tag.
       - id: plan
-        run: uv run --no-project --with packaging python .github/scripts/release_plan.py --tag "$TAG" --github-output ${{ github.event_name == 'workflow_dispatch' && '--rehearsal' || '' }}
+        run: uv run --no-project --with packaging python tools/src/sn_tools/release_plan.py --tag "$TAG" --github-output ${{ github.event_name == 'workflow_dispatch' && '--rehearsal' || '' }}
 
   build:
     name: Build and gate
@@ -90,7 +90,7 @@ jobs:
           cache-python: true
       - name: Check the workspace manifests agree with each other
         run: >
-          uv run --no-project --with packaging python .github/scripts/check_workspace.py
+          uv run --no-project --with packaging python tools/src/sn_tools/check_workspace.py
       - name: Build
         # `--package`, and `-o` into a per-distribution directory: `uv publish`'s default
         # glob is `dist/*`, which in a workspace would publish every artefact in it.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
         # `--no-project --with packaging`, so that a mistake in the manifests is named
         # rather than reported as a failed sync; here the synced environment already
         # exists, so the hook uses it and stays fast
-        entry: uv run --frozen --no-sync python .github/scripts/check_workspace.py
+        entry: uv run --frozen --no-sync python tools/src/sn_tools/check_workspace.py
         pass_filenames: false
         files: ^(pyproject\.toml|packages/[^/]+/pyproject\.toml|packages/[^/]+/src/[^/]+/__init__\.py)$
       - id: ty

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,8 +53,7 @@ sphinx-needs-workspace-tools` is refused ("is missing a `build-system`"), the lo
 installing it (`import sn_tools` fails, which is correct — the tooling is run by path). So
 nothing in this repository's workflows can build it.
 
-**It is not a build prohibition**, and anything written here that says otherwise is wrong:
-`uv build tools/` (likewise `cd tools && uv build`) does not go through the selector at all
+**It is not a build prohibition**: `uv build tools/` (likewise `cd tools && uv build`) does not go through the selector at all
 — with no `[build-system]`, PEP 517 says the default backend applies, uv runs
 `setuptools.build_meta:__legacy__`, and a real sdist and wheel come out. Two things make the
 member unreleasable, and neither is `package = false`:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,10 +2,11 @@
 
 Guidance for AI coding agents working on this repository. It is a
 [uv workspace](https://docs.astral.sh/uv/concepts/projects/workspaces/). Each distribution
-lives under `packages/<distribution-name>/`. The root is a project named
-`sphinx-needs-workspace` that is **never built and never published** (`[tool.uv] package =
-false`, no `[build-system]`): it exists to depend on every member, to own the dependency
-groups they share, and to hold repository-level policy. **Assume the working directory is the
+lives under `packages/<distribution-name>/`, and the repository's own tooling is a further,
+virtual member in `tools/`. The root is a project named `sphinx-needs-workspace` that is
+**never built and never published** (`[tool.uv] package = false`, no `[build-system]`): it
+exists to depend on every member, to own the dependency groups they share, and to hold
+repository-level policy. **Assume the working directory is the
 repository root**; every command below is written for it.
 
 Each package has its own `AGENTS.md` with the detail for that package — start with
@@ -27,9 +28,31 @@ the shim.
 | lint, format, type-check, pytest and task configuration | the root `pyproject.toml` |
 | the lock | the root `uv.lock` — one lock for the whole workspace |
 | hooks | the root `.pre-commit-config.yaml` — one config; anything triggered by `uv.lock` has to live here |
-| CI, scripts | `.github/` |
+| the repository's own tooling | `tools/` — the workspace fences and the release plan |
+| CI | `.github/workflows/`, and `.github/scripts/` for the three checks that must run *inside* a CI environment |
 | the docker image | `docker/` — a repository-level deliverable, like the workflows |
 | Read the Docs | `.readthedocs.yml`, and it stays at the root under that exact name: the configuration path applies to every version, so moving it makes older tags unbuildable |
+
+**`tools/` is the workspace's tooling — a virtual member, never built and never
+published, whose manifest declares the tooling's dependencies; `.github/scripts/` keeps
+only the checks that must execute inside a specific CI environment.** The distinction is
+what each script *inspects*. `tools/src/sn_tools/` holds the ones that read the manifests
+before any environment exists — `check_workspace.py`, `release_plan.py`,
+`propagate_floors.py` — and they are run by path, never imported
+(`uv run --no-project --with packaging python tools/src/sn_tools/<script>.py` in CI, so a
+manifest mistake is named rather than reported as a failed sync). `.github/scripts/` keeps
+`check_sphinx_cell.py` (it imports the cell's own sphinx), `check_typing_floor.py` (it runs
+inside `.venvs/typing`) and `extract_benchmark_data.py` (it runs inside the benchmark job) —
+none of which could move without dragging a member into every matrix cell. `scripts/smoke_needs.py`
+stays too: its whole point is to run outside every project environment.
+
+The member is `[tool.uv] package = false`, which is this workspace's `publish = false` and
+is stronger than declaring an intent: `uv build --all-packages` skips it,
+`uv build --package sphinx-needs-workspace-tools` is refused for having no `build-system`,
+and the lock records `source = { virtual = "tools" }`. So no uv command can produce a
+distribution of it, `uv sync` installs its *dependencies* without installing it (`import
+sn_tools` fails, which is correct — the tooling is run by path), and
+`tools/src/sn_tools/release_plan.py` refuses a tag that names it.
 
 ## Commands
 
@@ -42,6 +65,7 @@ uv run poe typecheck-needs            # ty, against the oldest supported sphinx
 uv run poe docs-needs                 # the furo docs build
 uv run poe smoke-needs                # build the wheel and test the built package
 uv run poe check-workspace            # the manifests agree with each other (Lint runs it)
+uv run --frozen --no-sync pytest tools/tests -q   # the tooling's own tests
 UV_PYTHON=3.12 uv run --no-sync poe test-needs-sphinx8   # one CI matrix cell
 ```
 
@@ -172,7 +196,7 @@ workflow holds no API token, and every one of its checks fails closed.
 1. **Release pull request**, from `master` with a clean tree:
    ```bash
    uv version --package <dist> --bump {patch|minor|major} --no-sync
-   python .github/scripts/propagate_floors.py <dist>   # only if a member depends on <dist>
+   python tools/src/sn_tools/propagate_floors.py <dist>   # only if a member depends on <dist>
    uv lock
    ```
    `--no-sync` is not optional. `--frozen` leaves `uv.lock` claiming the old version, and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,9 +33,9 @@ the shim.
 | the docker image | `docker/` — a repository-level deliverable, like the workflows |
 | Read the Docs | `.readthedocs.yml`, and it stays at the root under that exact name: the configuration path applies to every version, so moving it makes older tags unbuildable |
 
-**`tools/` is the workspace's tooling — a virtual member, never built and never
-published, whose manifest declares the tooling's dependencies; `.github/scripts/` keeps
-only the checks that must execute inside a specific CI environment.** The distinction is
+**`tools/` is the workspace's tooling — a virtual member, never released, whose manifest
+declares the tooling's dependencies; `.github/scripts/` keeps only the checks that must
+execute inside a specific CI environment.** The distinction is
 what each script *inspects*. `tools/src/sn_tools/` holds the ones that read the manifests
 before any environment exists — `check_workspace.py`, `release_plan.py`,
 `propagate_floors.py` — and they are run by path, never imported
@@ -46,13 +46,22 @@ inside `.venvs/typing`) and `extract_benchmark_data.py` (it runs inside the benc
 none of which could move without dragging a member into every matrix cell. `scripts/smoke_needs.py`
 stays too: its whole point is to run outside every project environment.
 
-The member is `[tool.uv] package = false`, which is this workspace's `publish = false` and
-is stronger than declaring an intent: `uv build --all-packages` skips it,
-`uv build --package sphinx-needs-workspace-tools` is refused for having no `build-system`,
-and the lock records `source = { virtual = "tools" }`. So no uv command can produce a
-distribution of it, `uv sync` installs its *dependencies* without installing it (`import
-sn_tools` fails, which is correct — the tooling is run by path), and
-`tools/src/sn_tools/release_plan.py` refuses a tag that names it.
+The member is `[tool.uv] package = false`. That makes it **invisible to uv's workspace
+selectors**: `uv build --all-packages` skips it, `uv build --package
+sphinx-needs-workspace-tools` is refused ("is missing a `build-system`"), the lock records
+`source = { virtual = "tools" }`, and `uv sync` installs its *dependencies* without
+installing it (`import sn_tools` fails, which is correct — the tooling is run by path). So
+nothing in this repository's workflows can build it.
+
+**It is not a build prohibition**, and anything written here that says otherwise is wrong:
+`uv build tools/` (likewise `cd tools && uv build`) does not go through the selector at all
+— with no `[build-system]`, PEP 517 says the default backend applies, uv runs
+`setuptools.build_meta:__legacy__`, and a real sdist and wheel come out. Two things make the
+member unreleasable, and neither is `package = false`:
+`tools/src/sn_tools/release_plan.py` refuses a tag that names a virtual member — and since a
+tag is the only thing that starts the release workflow, that is the fence, not a
+belt-and-braces extra — and the manifest carries `Private :: Do Not Upload`, which PyPI
+rejects on upload, for the by-hand path.
 
 ## Commands
 

--- a/packages/sphinx-needs/pyproject.toml
+++ b/packages/sphinx-needs/pyproject.toml
@@ -9,7 +9,7 @@ name = "sphinx-needs"
 # agreement check, the floor propagation, the workspace fence -- needs the number without
 # running the build backend. It is duplicated once, as `__version__` in
 # `src/sphinx_needs/__init__.py` (which is stamped into every generated `needs.json`, so it
-# cannot become an `importlib.metadata` lookup); `.github/scripts/check_workspace.py` is
+# cannot become an `importlib.metadata` lookup); `tools/src/sn_tools/check_workspace.py` is
 # what keeps the two equal.
 version = "8.5.0"
 # `description` stays dynamic: flit_core reads the module docstring by AST, so a static

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,9 @@
 # The workspace root. It builds and publishes nothing of its own: every distribution lives
 # under `packages/<dist-name>/`, and the directory name is the distribution name. Today there
 # is exactly one, `packages/sphinx-needs`; `tools/` is a second member, virtual, which this
-# repository's own fences and release plan live in and which nothing can ever build or
-# publish. What the root owns is repository-level policy --
+# repository's own fences and release plan live in and which is never released (see
+# `tools/pyproject.toml` for what `[tool.uv] package = false` does and, just as important,
+# what it does not). What the root owns is repository-level policy --
 # the lock, the dependency groups shared by every member, and the lint, type-check, pytest
 # and task configuration.
 
@@ -45,8 +46,9 @@ sphinx-needs = { workspace = true }
 sphinx-needs-workspace-tools = { workspace = true }
 
 # `packages/*` is the published distributions; `tools` is the repository's own tooling and
-# is never built or published (see `tools/pyproject.toml`). Both are members so that one
-# lock, one `uv sync` and one set of fences cover everything in the tree.
+# is never released (see `tools/pyproject.toml` for what makes that true, and for what
+# `[tool.uv] package = false` does NOT do). Both are members so that one lock, one
+# `uv sync` and one set of fences cover everything in the tree.
 [tool.uv.workspace]
 members = ["packages/*", "tools"]
 
@@ -61,8 +63,9 @@ members = ["packages/*", "tools"]
 # nothing to collide with. What does NOT belong here is a dependency of the repository's own
 # tooling: `tools/pyproject.toml` declares those, and the root depends on that member, so
 # `packaging` and `tomlkit` reach every environment -- including `.venvs/typing`, where ty
-# has to resolve the tooling's imports -- without a line in any group. A package gets a prefixed group of its own only once it genuinely
-# needs a different pin from the workspace's.
+# has to resolve the tooling's imports -- without a line in any group. A package gets a
+# prefixed group of its own only once it genuinely needs a different pin from the
+# workspace's.
 [dependency-groups]
 dev = [
   "prek>=0.5.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,8 @@
 # The workspace root. It builds and publishes nothing of its own: every distribution lives
 # under `packages/<dist-name>/`, and the directory name is the distribution name. Today there
-# is exactly one, `packages/sphinx-needs`. What the root owns is repository-level policy --
+# is exactly one, `packages/sphinx-needs`; `tools/` is a second member, virtual, which this
+# repository's own fences and release plan live in and which nothing can ever build or
+# publish. What the root owns is repository-level policy --
 # the lock, the dependency groups shared by every member, and the lint, type-check, pytest
 # and task configuration.
 
@@ -18,8 +20,11 @@ version = "0"
 requires-python = ">=3.11,<4"
 # EVERY workspace member is listed here. A `[project]` at the root makes `uv sync` sync this
 # project rather than every member, so this list is what keeps a bare `uv sync` installing
-# them -- without it the suite has no `sphinx_needs` to import.
-dependencies = ["sphinx-needs"]
+# them -- without it the suite has no `sphinx_needs` to import. The tooling member is
+# virtual (`[tool.uv] package = false`), so what this line installs for it is its
+# DEPENDENCIES, not the member: that is how `packaging` and `tomlkit` reach every
+# environment from one declaration in `tools/pyproject.toml`.
+dependencies = ["sphinx-needs", "sphinx-needs-workspace-tools"]
 
 # Pass-throughs to the members' published extras, and the reason they have to exist: uv
 # resolves `--extra` (and poe's `extra =`) against the PROJECT, which is now this root, so
@@ -37,9 +42,13 @@ theme-rtd = ["sphinx-needs[theme-rtd]"]
 
 [tool.uv.sources]
 sphinx-needs = { workspace = true }
+sphinx-needs-workspace-tools = { workspace = true }
 
+# `packages/*` is the published distributions; `tools` is the repository's own tooling and
+# is never built or published (see `tools/pyproject.toml`). Both are members so that one
+# lock, one `uv sync` and one set of fences cover everything in the tree.
 [tool.uv.workspace]
-members = ["packages/*"]
+members = ["packages/*", "tools"]
 
 # EVERY dependency group in this workspace is declared here, at the root, under its
 # pre-move name. Groups cannot be composed across the root/member boundary in either
@@ -49,18 +58,16 @@ members = ["packages/*"]
 # includes `test`, so `uv sync` with no arguments is already a working test environment.
 # There is no `needs-` prefix on any of them: a prefix would only be needed to stop two
 # members' groups colliding under a bare `--group` name, and declared once here there is
-# nothing to collide with. A package gets a prefixed group of its own only once it genuinely
+# nothing to collide with. What does NOT belong here is a dependency of the repository's own
+# tooling: `tools/pyproject.toml` declares those, and the root depends on that member, so
+# `packaging` and `tomlkit` reach every environment -- including `.venvs/typing`, where ty
+# has to resolve the tooling's imports -- without a line in any group. A package gets a prefixed group of its own only once it genuinely
 # needs a different pin from the workspace's.
 [dependency-groups]
 dev = [
   "prek>=0.5.1",
   "poethepoet~=0.48",
   "uv>=0.12.9",
-  # the only dependency any repository script has beyond `packaging` (which sphinx already
-  # pulls in everywhere): `.github/scripts/propagate_floors.py` round-trips a member's
-  # manifest through it so a floor bump is a one-line diff with the comments intact.
-  # A 49 KB wheel with no dependencies of its own
-  "tomlkit>=0.13",
   { include-group = "test" },
   { include-group = "js" },
 ]
@@ -103,11 +110,6 @@ typing = [
   "types-docutils~=0.20.0",
   "types-requests",
   "ty~=0.0.77",
-  # not a floor of anything: `[tool.ty.src] include` now covers `.github/scripts`, and ty
-  # resolves the imports of what it checks against THIS environment, so `propagate_floors.py`
-  # needs tomlkit here as well as in `dev`. It has no dependencies, so the floor this
-  # environment exists to pin is unaffected (`check_typing_floor.py` still passes)
-  "tomlkit>=0.13",
 ]
 
 [tool.uv]
@@ -138,7 +140,7 @@ conflicts = [
 # carry a `tests/test_utils.py`.
 [tool.pytest.ini_options]
 addopts = "--import-mode=importlib"
-testpaths = ["packages/sphinx-needs/tests", ".github/scripts/selftests"]
+testpaths = ["packages/sphinx-needs/tests", "tools/tests"]
 # The package tasks run from the package with `--ignore=performance` rather than a path, so
 # the walk covers the whole package -- including whatever a docs build left in `docs/_build`,
 # which pytest's default list does NOT skip (it skips `build`, not `_build`). Setting this key
@@ -217,20 +219,23 @@ exclude = ["*.md"]
 # excluding the package under it, leaves the CI canary green because a CLI path still selects
 # the files -- what breaks then is only the editor's view.
 [tool.ty.src]
-# The repository's own tooling is checked too. It is not in any package and is run by CI
-# with `uv run --no-project --with packaging`, so nothing else would ever look at it -- and
-# `.github/scripts/release_plan.py` is the script whose failure mode is a bad release
+# The repository's own tooling is checked too -- `tools/src` for the fences and the release
+# plan, `.github/scripts` for the three checks that must run inside a specific CI
+# environment, and `scripts` for the smoke test. None of it is imported by the suite, so
+# nothing else would ever look at it, and `tools/src/sn_tools/release_plan.py` is the script
+# whose failure mode is a bad release
 include = [
   "packages/sphinx-needs/src/sphinx_needs",
+  "tools/src",
   ".github/scripts",
   "scripts",
 ]
 # the scripts' own tests are not checked, for the same reason the package's are not: pytest
 # is deliberately absent from the `typing` environment, which pins the oldest supported
 # sphinx and docutils and nothing else it does not need. What the tests assert is asserted
-# by running them. (They live in `selftests/`, not `tests/`: nothing outside a package may
-# be a directory called `tests`, or it competes with a package's own for the name)
-exclude = [".github/scripts/selftests"]
+# by running them. `tools/tests` is a directory called `tests`, which is safe only because
+# nothing ever puts `tools/` itself on `sys.path` -- its conftest inserts `tools/src`
+exclude = ["tools/tests"]
 
 [tool.ty.environment]
 python-version = "3.11"
@@ -355,7 +360,7 @@ help = "Type-check sphinx_needs with ty against the oldest supported sphinx (the
 # but it is NOT a fence on `src.include` above: ty intersects the two, so a stale `include`
 # makes this check zero files and exit 0. The canary step in ci.yaml's Lint job is what
 # guards that.
-cmd = "ty check packages/sphinx-needs/src/sphinx_needs .github/scripts scripts --python .venvs/typing"
+cmd = "ty check packages/sphinx-needs/src/sphinx_needs tools/src .github/scripts scripts --python .venvs/typing"
 executor = { type = "uv", frozen = true, no-group = "dev", group = ["typing"] }
 env = { UV_PROJECT_ENVIRONMENT = ".venvs/typing" }
 
@@ -372,7 +377,7 @@ help = "Check the workspace manifests agree with each other (the fence CI's Lint
 # `uv run --no-project --with packaging`, deliberately -- a check on the manifests must not
 # need an environment built from those manifests -- but locally the prek hook and this task
 # use the synced one, because it is already there
-cmd = "python .github/scripts/check_workspace.py"
+cmd = "python tools/src/sn_tools/check_workspace.py"
 
 # --- The built package ---
 # These two are named for the distribution they act on rather than for the repository, so

--- a/tools/pyproject.toml
+++ b/tools/pyproject.toml
@@ -1,23 +1,39 @@
 # The workspace's tooling: the manifest fences and the release plan. It is a member so that
 # its dependencies are declared in one place and installed everywhere the tooling runs,
 # rather than being borrowed from whatever a test dependency happened to pull in -- and it
-# is a VIRTUAL member so that it can never be released.
+# is a VIRTUAL member so that it is never released.
 #
-# `[tool.uv] package = false` is this workspace's `publish = false`, and it is stronger than
-# Cargo's, because the artefact cannot be produced at all. Measured on uv 0.12.9:
+# `[tool.uv] package = false` makes the member invisible to uv's workspace SELECTORS.
+# Measured on uv 0.12.9:
 #
 #   * `uv build --all-packages` skips it -- only the publishable members are built;
-#   * `uv build --package sphinx-needs-workspace-tools` is REFUSED ("does not have a
-#     `build-system`"), so there is no way to produce a distribution of it by hand either;
+#   * `uv build --package sphinx-needs-workspace-tools` is refused, verbatim: "Package
+#     `sphinx-needs-workspace-tools` is missing a `build-system`";
 #   * `uv lock` records it as `source = { virtual = "tools" }`, and `uv sync` installs its
 #     DEPENDENCIES without installing it -- `import sn_tools` fails in `.venv`, which is
 #     correct: the tooling is run by path, from the repository, never imported by the suite;
 #   * `uv version --package sphinx-needs-workspace-tools` still works, so the fences that
 #     read every member's version have something to read.
 #
-# `tools/src/sn_tools/release_plan.py`'s own rule closes the loop: a tag naming a virtual
-# member is refused before anything is built, and a publishable member that declares a
-# runtime dependency on one is refused too, because that wheel could never be installed.
+# So nothing in this repository's workflows can build it. It is NOT a build prohibition, and
+# an earlier version of this comment wrongly said it was: `uv build tools/` (likewise
+# `cd tools && uv build`, `uv build --directory tools`) does not go through the selector at
+# all -- with no `[build-system]`, PEP 517 says the default backend applies, uv runs
+# `setuptools.build_meta:__legacy__`, and a complete sdist and wheel come out.
+#
+# Which is why the two fences below are load-bearing rather than decorative:
+#
+#   1. `tools/src/sn_tools/release_plan.py` refuses a tag that names a virtual member,
+#      before anything is built -- and since a tag is the only thing that starts the release
+#      workflow, that is what makes a release impossible. It also refuses a publishable
+#      member that declares a runtime dependency on one, because that wheel could never be
+#      installed. Do not delete those rules as redundant; they are the fence.
+#   2. `Private :: Do Not Upload` below, for the by-hand path: "To prevent a package from
+#      being uploaded to PyPI, use the special `Private :: Do Not Upload` classifier. PyPI
+#      will always reject packages with classifiers beginning with `Private ::`."
+#      (packaging.python.org/en/latest/guides/writing-pyproject-toml/). Measured here only
+#      as far as the metadata -- `uv build tools/` puts the classifier in METADATA; no
+#      upload has ever been attempted from this repository.
 #
 # It lives OUTSIDE `packages/`, which keeps meaning "distributions this repository
 # publishes", and it carries no `pkg:` label of its own -- `.github/labeler.yml` files it
@@ -25,7 +41,10 @@
 [project]
 name = "sphinx-needs-workspace-tools"
 version = "0"
-description = "Repository tooling: the workspace fences and the release plan. Never built, never published."
+description = "Repository tooling: the workspace fences and the release plan. Never released."
+# the second fence, for the `uv build tools/` path uv's selectors do not cover: PyPI rejects
+# any distribution whose metadata carries a classifier beginning `Private ::`
+classifiers = ["Private :: Do Not Upload"]
 # must equal the root's, and `check_workspace.py` check (3) is what says so
 requires-python = ">=3.11,<4"
 dependencies = [

--- a/tools/pyproject.toml
+++ b/tools/pyproject.toml
@@ -1,0 +1,37 @@
+# The workspace's tooling: the manifest fences and the release plan. It is a member so that
+# its dependencies are declared in one place and installed everywhere the tooling runs,
+# rather than being borrowed from whatever a test dependency happened to pull in -- and it
+# is a VIRTUAL member so that it can never be released.
+#
+# `[tool.uv] package = false` is this workspace's `publish = false`, and it is stronger than
+# Cargo's, because the artefact cannot be produced at all. Measured on uv 0.12.9:
+#
+#   * `uv build --all-packages` skips it -- only the publishable members are built;
+#   * `uv build --package sphinx-needs-workspace-tools` is REFUSED ("does not have a
+#     `build-system`"), so there is no way to produce a distribution of it by hand either;
+#   * `uv lock` records it as `source = { virtual = "tools" }`, and `uv sync` installs its
+#     DEPENDENCIES without installing it -- `import sn_tools` fails in `.venv`, which is
+#     correct: the tooling is run by path, from the repository, never imported by the suite;
+#   * `uv version --package sphinx-needs-workspace-tools` still works, so the fences that
+#     read every member's version have something to read.
+#
+# `tools/src/sn_tools/release_plan.py`'s own rule closes the loop: a tag naming a virtual
+# member is refused before anything is built, and a publishable member that declares a
+# runtime dependency on one is refused too, because that wheel could never be installed.
+#
+# It lives OUTSIDE `packages/`, which keeps meaning "distributions this repository
+# publishes", and it carries no `pkg:` label of its own -- `.github/labeler.yml` files it
+# under `pkg: workspace`, which is what it is.
+[project]
+name = "sphinx-needs-workspace-tools"
+version = "0"
+description = "Repository tooling: the workspace fences and the release plan. Never built, never published."
+# must equal the root's, and `check_workspace.py` check (3) is what says so
+requires-python = ">=3.11,<4"
+dependencies = [
+  "packaging>=24", # requirement/specifier/version parsing, in every fence
+  "tomlkit>=0.13", # round-tripping a manifest in propagate_floors.py
+]
+
+[tool.uv]
+package = false

--- a/tools/pyproject.toml
+++ b/tools/pyproject.toml
@@ -15,11 +15,11 @@
 #   * `uv version --package sphinx-needs-workspace-tools` still works, so the fences that
 #     read every member's version have something to read.
 #
-# So nothing in this repository's workflows can build it. It is NOT a build prohibition, and
-# an earlier version of this comment wrongly said it was: `uv build tools/` (likewise
-# `cd tools && uv build`, `uv build --directory tools`) does not go through the selector at
-# all -- with no `[build-system]`, PEP 517 says the default backend applies, uv runs
-# `setuptools.build_meta:__legacy__`, and a complete sdist and wheel come out.
+# So nothing in this repository's workflows can build it. It is NOT a build prohibition:
+# `uv build tools/` (likewise `cd tools && uv build`, `uv build --directory tools`) does not
+# go through the selector at all -- with no `[build-system]`, PEP 517 says the default
+# backend applies, uv runs `setuptools.build_meta:__legacy__`, and a complete sdist and
+# wheel come out.
 #
 # Which is why the two fences below are load-bearing rather than decorative:
 #
@@ -33,7 +33,9 @@
 #      will always reject packages with classifiers beginning with `Private ::`."
 #      (packaging.python.org/en/latest/guides/writing-pyproject-toml/). Measured here only
 #      as far as the metadata -- `uv build tools/` puts the classifier in METADATA; no
-#      upload has ever been attempted from this repository.
+#      upload has ever been attempted from this repository. `check_workspace.py`'s check
+#      (6) asserts this line is here, for every virtual member: it is one line that looks
+#      like decoration, so without a fence it is the line a tidy-up deletes.
 #
 # It lives OUTSIDE `packages/`, which keeps meaning "distributions this repository
 # publishes", and it carries no `pkg:` label of its own -- `.github/labeler.yml` files it

--- a/tools/src/sn_tools/__init__.py
+++ b/tools/src/sn_tools/__init__.py
@@ -1,0 +1,1 @@
+"""The workspace's own tooling: the manifest fences and the release plan."""

--- a/tools/src/sn_tools/__init__.py
+++ b/tools/src/sn_tools/__init__.py
@@ -1,1 +1,7 @@
-"""The workspace's own tooling: the manifest fences and the release plan."""
+"""The workspace's own tooling: the manifest fences and the release plan.
+
+No ``__version__`` here, deliberately: this member is never released, and
+``check_workspace.py``'s check (5) skips virtual members by rule -- it would also not
+find this package by derivation, since the distribution is `sphinx-needs-workspace-tools`
+and the module is `sn_tools`.
+"""

--- a/tools/src/sn_tools/check_workspace.py
+++ b/tools/src/sn_tools/check_workspace.py
@@ -19,7 +19,10 @@ a failure mode that no other gate in this repository can see:
    can satisfy. Worse, the specifier is not in `uv.lock` at all -- changing it gives a
    zero-line lock diff and `uv lock --check` still exits 0 -- so no amount of `--frozen`
    and no review of the lock can ever see it. "Tight" is the workspace's tracking policy:
-   `>=<the dependency's current version>,<<its next major>`. Extensions carry no
+   `>=<the dependency's current version>,<<its next major>`. A dependency on a member
+   declaring `[tool.uv] package = false` is refused outright: uv can build such a member
+   with no command, so it is never on PyPI and the wheel could not be installed at all.
+   Extensions carry no
    backwards-compatibility code, so the floor is a claim about what was actually tested,
    and the cap is what stops a future major being co-installed with a dependant written
    against the old one. `--no-policy` keeps only the honesty half.
@@ -33,13 +36,13 @@ line, so one run names every mistake rather than the first one.
 
 Usage::
 
-    python .github/scripts/check_workspace.py [--no-policy]
+    python tools/src/sn_tools/check_workspace.py [--no-policy]
 
 Run at the workspace root. Needs `packaging` and nothing else, and it reads only manifests
 and source text -- deliberately: a check on the manifests must not depend on an environment
 built from those manifests, or a manifest mistake is reported as "sync failed" instead of
 being named. In CI it runs as
-`uv run --no-project --with packaging python .github/scripts/check_workspace.py`, which
+`uv run --no-project --with packaging python tools/src/sn_tools/check_workspace.py`, which
 needs no `uv sync` at all.
 """
 
@@ -97,6 +100,16 @@ class Member:
             return Version(raw)
         except InvalidVersion:
             return None
+
+    @property
+    def virtual(self) -> bool:
+        """`[tool.uv] package = false` -- the workspace's `publish = false`.
+
+        uv can build such a member with no command (`--all-packages` skips it,
+        `--package` is refused), so it is never on PyPI and nothing may declare a runtime
+        dependency on it.
+        """
+        return self.data.get("tool", {}).get("uv", {}).get("package") is False
 
     @property
     def module(self) -> str:
@@ -290,6 +303,7 @@ def check_requires_python(
 
 def check_specifiers(members: list[Member], policy: bool, report: Report) -> None:
     """(4) intra-workspace runtime specifiers are honest, and tight."""
+    virtual = {member.key for member in members if member.virtual}
     versions: dict[str, Version] = {}
     for member in members:
         if "version" in member.dynamic:
@@ -324,6 +338,15 @@ def check_specifiers(members: list[Member], policy: bool, report: Report) -> Non
                 continue
             edges += 1
             where = f"{member.name}{f'[{extra}]' if extra else ''} -> {requirement}"
+            if target in virtual:
+                report.error(
+                    member.relative,
+                    f"{where}: `{target}` is `[tool.uv] package = false` and is therefore "
+                    "never on PyPI, so this wheel could never be installed. A virtual "
+                    "member is repository tooling; if a published package needs its code, "
+                    "the code belongs in a published package",
+                )
+                continue
             current = versions[target]
             # prereleases=True so a member sitting on a release candidate is not reported
             # as un-admitted by a floor that names that very candidate
@@ -342,7 +365,7 @@ def check_specifiers(members: list[Member], policy: bool, report: Report) -> Non
                         member.relative,
                         f"{where}: tight tracking wants `{target}{want}` (the floor is "
                         f"{target}'s current version and the cap is its next major); run "
-                        f"`python .github/scripts/propagate_floors.py {target}`",
+                        f"`python tools/src/sn_tools/propagate_floors.py {target}`",
                     )
                     continue
             report.ok(f"{where}  (workspace {target} {current})")

--- a/tools/src/sn_tools/check_workspace.py
+++ b/tools/src/sn_tools/check_workspace.py
@@ -19,20 +19,25 @@ a failure mode that no other gate in this repository can see:
    can satisfy. Worse, the specifier is not in `uv.lock` at all -- changing it gives a
    zero-line lock diff and `uv lock --check` still exits 0 -- so no amount of `--frozen`
    and no review of the lock can ever see it. "Tight" is the workspace's tracking policy:
-   `>=<the dependency's current version>,<<its next major>`. A dependency on a member
-   declaring `[tool.uv] package = false` is refused outright: such a member is never
-   released, so it is never on PyPI and the wheel could not be installed at all. The
-   tight-tracking half is asked only of a PUBLISHABLE dependant -- the cap exists to stop a
-   future major being co-installed with a wheel written against the old one, and nothing is
-   ever co-installed with a virtual member. Extensions carry no
+   `>=<the dependency's current version>,<<its next major>`. Extensions carry no
    backwards-compatibility code, so the floor is a claim about what was actually tested,
-   and the cap is what stops a future major being co-installed with a dependant written
-   against the old one. `--no-policy` keeps only the honesty half.
+   and the cap is what stops a future major of the dependency being co-installed with a
+   published wheel written against the old one. Both halves are asked of a publishable
+   member; only the honesty half is asked of a virtual one, which publishes nothing and is
+   therefore never co-installed with anything. A PUBLISHABLE member depending on a virtual
+   one is refused outright: that wheel would name a distribution which is never on PyPI.
+   `--no-policy` keeps only the honesty half.
 5. **`__version__` equals `[project] version`.** (Virtual members are skipped: nothing they
    stamp ever ships.) sphinx-needs writes `__version__` into
    every generated `needs.json`, a documented interchange format, so it cannot become an
    `importlib.metadata` lookup; the number is therefore written twice and this is what
    keeps the two equal. A module with no `__version__` is skipped, not an error.
+
+6. **every virtual member declares `Private :: Do Not Upload`.** `[tool.uv] package =
+   false` only hides a member from uv's workspace selectors; `uv build <dir>/` still
+   produces a distribution through PEP 517's default backend. That classifier is what makes
+   PyPI refuse the artefact if anyone ever tries, and being one line that looks like
+   decoration it is exactly the line a future tidy-up deletes -- so it is asserted here.
 
 Every failure is reported before the script exits, each on its own `::error file=...::`
 line, so one run names every mistake rather than the first one.
@@ -64,6 +69,10 @@ from packaging.utils import canonicalize_name
 from packaging.version import InvalidVersion, Version
 
 ROOT_MANIFEST = "pyproject.toml"
+# PyPI rejects any distribution whose metadata carries a classifier beginning `Private ::`
+# (packaging.python.org/en/latest/guides/writing-pyproject-toml/), which is the only thing
+# standing between a by-hand `uv build tools/` and an upload
+PRIVATE_CLASSIFIER = "Private :: Do Not Upload"
 
 
 class Report:
@@ -344,7 +353,10 @@ def check_specifiers(members: list[Member], policy: bool, report: Report) -> Non
                 continue
             edges += 1
             where = f"{member.name}{f'[{extra}]' if extra else ''} -> {requirement}"
-            if target in virtual:
+            # only a PUBLISHABLE dependant is refused: the objection is that the wheel
+            # would name a distribution which is never on PyPI, and a virtual member ships
+            # no wheel. uv resolves a virtual -> virtual edge happily, and so does this
+            if target in virtual and not member.virtual:
                 report.error(
                     member.relative,
                     f"{where}: `{target}` is `[tool.uv] package = false` and is therefore "
@@ -357,11 +369,16 @@ def check_specifiers(members: list[Member], policy: bool, report: Report) -> Non
             # prereleases=True so a member sitting on a release candidate is not reported
             # as un-admitted by a floor that names that very candidate
             if not requirement.specifier.contains(current, prereleases=True):
+                consequence = (
+                    "so this would publish a wheel nobody can install"
+                    if not member.virtual
+                    else "so the specifier says something untrue about the tree"
+                )
                 report.error(
                     member.relative,
                     f"{where}: the workspace builds {target} {current}, which this "
                     "specifier does not admit -- uv resolves the workspace copy regardless "
-                    "(uv#9811), so this would publish a wheel nobody can install",
+                    f"(uv#9811), {consequence}",
                 )
                 continue
             # the honesty half applies to everyone; the tight-tracking half is about
@@ -382,6 +399,29 @@ def check_specifiers(members: list[Member], policy: bool, report: Report) -> Non
             f"no intra-workspace runtime dependencies among {len(members)} member(s): "
             + (", ".join(f"{k} {v}" for k, v in sorted(versions.items())) or "-")
         )
+
+
+def check_virtual_classifier(members: list[Member], report: Report) -> None:
+    """(6) every virtual member declares `Private :: Do Not Upload`.
+
+    The classifier is the second of the two fences that keep a virtual member off PyPI (the
+    first is the release plan refusing its tag), and it is a single line that looks like
+    decoration -- which is why it is asserted rather than trusted.
+    """
+    for member in sorted(members, key=lambda m: m.key):
+        if not member.virtual:
+            continue
+        if PRIVATE_CLASSIFIER in member.project.get("classifiers", []):
+            report.ok(f"{member.relative}: declares `{PRIVATE_CLASSIFIER}`")
+        else:
+            report.error(
+                member.relative,
+                f"{member.name} is `[tool.uv] package = false` but does not declare the "
+                f'classifier "{PRIVATE_CLASSIFIER}". `package = false` only hides the '
+                "member from uv's workspace selectors -- it can still be built by hand "
+                "(`uv build <dir>/` falls through to PEP 517's default backend) -- and "
+                "that classifier is what makes PyPI refuse the artefact",
+            )
 
 
 def module_version(member: Member) -> tuple[Path, str] | None:
@@ -482,6 +522,7 @@ def main(argv: list[str] | None = None) -> int:
     check_requires_python(manifest, members, report)
     check_specifiers(members, not args.no_policy, report)
     check_module_version(root, members, report)
+    check_virtual_classifier(members, report)
     return 1 if report.failures else 0
 
 

--- a/tools/src/sn_tools/check_workspace.py
+++ b/tools/src/sn_tools/check_workspace.py
@@ -20,13 +20,16 @@ a failure mode that no other gate in this repository can see:
    zero-line lock diff and `uv lock --check` still exits 0 -- so no amount of `--frozen`
    and no review of the lock can ever see it. "Tight" is the workspace's tracking policy:
    `>=<the dependency's current version>,<<its next major>`. A dependency on a member
-   declaring `[tool.uv] package = false` is refused outright: uv can build such a member
-   with no command, so it is never on PyPI and the wheel could not be installed at all.
-   Extensions carry no
+   declaring `[tool.uv] package = false` is refused outright: such a member is never
+   released, so it is never on PyPI and the wheel could not be installed at all. The
+   tight-tracking half is asked only of a PUBLISHABLE dependant -- the cap exists to stop a
+   future major being co-installed with a wheel written against the old one, and nothing is
+   ever co-installed with a virtual member. Extensions carry no
    backwards-compatibility code, so the floor is a claim about what was actually tested,
    and the cap is what stops a future major being co-installed with a dependant written
    against the old one. `--no-policy` keeps only the honesty half.
-5. **`__version__` equals `[project] version`.** sphinx-needs writes `__version__` into
+5. **`__version__` equals `[project] version`.** (Virtual members are skipped: nothing they
+   stamp ever ships.) sphinx-needs writes `__version__` into
    every generated `needs.json`, a documented interchange format, so it cannot become an
    `importlib.metadata` lookup; the number is therefore written twice and this is what
    keeps the two equal. A module with no `__version__` is skipped, not an error.
@@ -103,11 +106,14 @@ class Member:
 
     @property
     def virtual(self) -> bool:
-        """`[tool.uv] package = false` -- the workspace's `publish = false`.
+        """`[tool.uv] package = false` -- a member this repository never releases.
 
-        uv can build such a member with no command (`--all-packages` skips it,
-        `--package` is refused), so it is never on PyPI and nothing may declare a runtime
-        dependency on it.
+        The flag hides the member from uv's workspace selectors (`--all-packages` skips
+        it, `--package` is refused), which is not the same as a build prohibition:
+        `uv build tools/` falls through to PEP 517's default backend and does produce a
+        distribution. What makes the member unreleasable is the release plan refusing a tag
+        that names it -- so nothing may declare a runtime dependency on one, because such a
+        wheel would name a distribution that is never on PyPI.
         """
         return self.data.get("tool", {}).get("uv", {}).get("package") is False
 
@@ -358,7 +364,9 @@ def check_specifiers(members: list[Member], policy: bool, report: Report) -> Non
                     "(uv#9811), so this would publish a wheel nobody can install",
                 )
                 continue
-            if policy:
+            # the honesty half applies to everyone; the tight-tracking half is about
+            # what a PUBLISHED wheel promises, and a virtual member publishes nothing
+            if policy and not member.virtual:
                 want = SpecifierSet(f">={current},<{current.major + 1}")
                 if set(requirement.specifier) != set(want):
                     report.error(
@@ -409,6 +417,12 @@ def module_version(member: Member) -> tuple[Path, str] | None:
 def check_module_version(root: Path, members: list[Member], report: Report) -> None:
     """(5) `__version__` in the module equals `[project] version`."""
     for member in sorted(members, key=lambda m: m.key):
+        if member.virtual:
+            # by rule, not by accident: nothing a virtual member stamps into a module ever
+            # ships, and its module name need not derive from its distribution name (this
+            # repository's own `sphinx-needs-workspace-tools` is imported as `sn_tools`), so
+            # the derivation below would look in the wrong place and silently find nothing
+            continue
         declared = member.project.get("version")
         if "version" in member.dynamic or not isinstance(declared, str):
             continue  # already reported by check (4)

--- a/tools/src/sn_tools/propagate_floors.py
+++ b/tools/src/sn_tools/propagate_floors.py
@@ -11,7 +11,7 @@ specifier says (uv#9811), and the specifier is not in `uv.lock` at all.
 So it is mechanical. Run it in the release **pull request**, right after
 `uv version --package X --bump ...`, and never in the release job: the job runs *after* the
 tag, so a rewrite there would not be in the tagged commit and the published wheel would
-disagree with the tree the tag names. `.github/scripts/check_workspace.py` in Lint is what
+disagree with the tree the tag names. `tools/src/sn_tools/check_workspace.py` in Lint is what
 fails if somebody forgets.
 
 tomlkit rather than tomllib plus text munging because it round-trips comments and
@@ -19,9 +19,9 @@ formatting: the diff is one line per dependant and nothing else.
 
 Usage::
 
-    python .github/scripts/propagate_floors.py sphinx-variants           # the tree's version
-    python .github/scripts/propagate_floors.py sphinx-variants --version 2.0.0
-    python .github/scripts/propagate_floors.py sphinx-variants --check   # report, write nothing
+    python tools/src/sn_tools/propagate_floors.py sphinx-variants           # the tree's version
+    python tools/src/sn_tools/propagate_floors.py sphinx-variants --version 2.0.0
+    python tools/src/sn_tools/propagate_floors.py sphinx-variants --check   # report, write nothing
 
 Run at the workspace root. Needs `tomlkit` and `packaging` (both in the root `dev` group;
 in CI, `uv run --no-project --with tomlkit --with packaging python ...`). Afterwards run

--- a/tools/src/sn_tools/propagate_floors.py
+++ b/tools/src/sn_tools/propagate_floors.py
@@ -23,8 +23,10 @@ Usage::
     python tools/src/sn_tools/propagate_floors.py sphinx-variants --version 2.0.0
     python tools/src/sn_tools/propagate_floors.py sphinx-variants --check   # report, write nothing
 
-Run at the workspace root. Needs `tomlkit` and `packaging` (both in the root `dev` group;
-in CI, `uv run --no-project --with tomlkit --with packaging python ...`). Afterwards run
+Run at the workspace root. Needs `tomlkit` and `packaging`, declared once in
+`tools/pyproject.toml` and installed into every environment through the root's dependency on
+that member; in CI, where no environment is synced, `uv run --no-project --with tomlkit
+--with packaging python ...`. Afterwards run
 `uv lock` -- usually a no-op, which is precisely why this cannot be delegated to the lock.
 """
 

--- a/tools/src/sn_tools/release_plan.py
+++ b/tools/src/sn_tools/release_plan.py
@@ -313,7 +313,11 @@ def plan(args: argparse.Namespace) -> int:
     #    ask the index -- it is a wheel that could not be installed, and it is fatal here
     #    exactly as it is in `check_workspace.py` on every pull request.
     for dependency in sorted(graph[dist]):
-        if dependency in virtual:
+        # `and dist not in virtual` is belt and braces -- rule 0 above already refused a
+        # tag naming a virtual member -- but it states the actual rule: the objection is
+        # that the WHEEL would name something never on PyPI, and only a publishable
+        # dependant has a wheel
+        if dependency in virtual and dist not in virtual:
             raise PlanError(
                 f"{found[dist]['name']} declares a runtime (or extra) dependency on "
                 f"{found[dependency]['name']}, which is a virtual member "

--- a/tools/src/sn_tools/release_plan.py
+++ b/tools/src/sn_tools/release_plan.py
@@ -11,9 +11,13 @@ is not a clear "no" is an error, never a pass.
 Given a tag `<dist>-v<version>` it asserts, in order:
 
 0. `<dist>` is a member this repository actually publishes. A member declaring
-   `[tool.uv] package = false` is VIRTUAL -- uv can build it with no command, so there is
-   nothing a tag could release -- and a runtime dependency on one is refused for the same
-   reason: the wheel would name a distribution that is never on PyPI;
+   `[tool.uv] package = false` is VIRTUAL, and this check is what makes it unreleasable.
+   The flag itself only hides the member from uv's workspace selectors (`--all-packages`
+   skips it, `--package` is refused); it is not a build prohibition, because
+   `uv build tools/` falls through to PEP 517's default backend and does produce a
+   distribution. Since a tag is the only thing that starts this workflow, refusing the tag
+   here is the fence -- do not remove it as redundant. A dependency on one is refused for a
+   related reason: the wheel would name a distribution that is never on PyPI;
 1. the tag parses, and `<dist>` is a member of this workspace;
 2. `<version>` is exactly the version that member declares -- the tag cannot publish
    something the tree does not build;
@@ -85,9 +89,11 @@ def members(root: Path) -> tuple[dict[str, dict[str, Any]], set[str]]:
     """Every workspace member's `[project]` table, and the names of the virtual ones.
 
     A member with `[tool.uv] package = false` is virtual: `uv build --all-packages` skips
-    it and `uv build --package <it>` is refused, so no uv command can produce a
-    distribution of it. That is this workspace's `publish = false`, and it is what makes
-    the rules below safe to state as errors rather than as warnings.
+    it and `uv build --package <it>` is refused, so nothing this repository's workflows run
+    can build one. That is a selector property, not a build prohibition -- `uv build
+    tools/` still produces a distribution through PEP 517's default backend -- which is why
+    the caller's rules below are the actual fence, and why they are errors rather than
+    warnings.
     """
     manifest = tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))
     globs = manifest["tool"]["uv"]["workspace"]["members"]
@@ -271,7 +277,8 @@ def plan(args: argparse.Namespace) -> int:
     if dist in virtual:
         raise PlanError(
             f"`{found[dist]['name']}` is a virtual member (`[tool.uv] package = false`): "
-            "never built, never published -- there is nothing to release"
+            "this repository never releases it, and refusing this tag is what makes that "
+            "true -- there is nothing to release"
         )
 
     # 2. the tag's version is the version this tree builds
@@ -308,7 +315,7 @@ def plan(args: argparse.Namespace) -> int:
     for dependency in sorted(graph[dist]):
         if dependency in virtual:
             raise PlanError(
-                f"{found[dist]['name']} declares a runtime dependency on "
+                f"{found[dist]['name']} declares a runtime (or extra) dependency on "
                 f"{found[dependency]['name']}, which is a virtual member "
                 "(`[tool.uv] package = false`); the published wheel could never be "
                 f"installed: `{found[dependency]['name']}` is never on PyPI"

--- a/tools/src/sn_tools/release_plan.py
+++ b/tools/src/sn_tools/release_plan.py
@@ -10,6 +10,10 @@ is not a clear "no" is an error, never a pass.
 
 Given a tag `<dist>-v<version>` it asserts, in order:
 
+0. `<dist>` is a member this repository actually publishes. A member declaring
+   `[tool.uv] package = false` is VIRTUAL -- uv can build it with no command, so there is
+   nothing a tag could release -- and a runtime dependency on one is refused for the same
+   reason: the wheel would name a distribution that is never on PyPI;
 1. the tag parses, and `<dist>` is a member of this workspace;
 2. `<version>` is exactly the version that member declares -- the tag cannot publish
    something the tree does not build;
@@ -35,13 +39,13 @@ the answer to "what do I release, and in what sequence".
 
 Usage::
 
-    python .github/scripts/release_plan.py                      # print the order
-    python .github/scripts/release_plan.py --tag sphinx-needs-v8.6.0
-    python .github/scripts/release_plan.py --tag ... --rehearsal --github-output
+    python tools/src/sn_tools/release_plan.py                      # print the order
+    python tools/src/sn_tools/release_plan.py --tag sphinx-needs-v8.6.0
+    python tools/src/sn_tools/release_plan.py --tag ... --rehearsal --github-output
 
 Run at the workspace root. Needs `packaging`; PyPI is reached with the standard library,
 and git with `git`. In CI it runs as
-`uv run --no-project --with packaging python .github/scripts/release_plan.py`, so a
+`uv run --no-project --with packaging python tools/src/sn_tools/release_plan.py`, so a
 manifest mistake is named here rather than reported as "sync failed".
 """
 
@@ -77,10 +81,18 @@ class PlanError(RuntimeError):
     """A condition that must stop the release rather than be guessed at."""
 
 
-def members(root: Path) -> dict[str, dict[str, Any]]:
+def members(root: Path) -> tuple[dict[str, dict[str, Any]], set[str]]:
+    """Every workspace member's `[project]` table, and the names of the virtual ones.
+
+    A member with `[tool.uv] package = false` is virtual: `uv build --all-packages` skips
+    it and `uv build --package <it>` is refused, so no uv command can produce a
+    distribution of it. That is this workspace's `publish = false`, and it is what makes
+    the rules below safe to state as errors rather than as warnings.
+    """
     manifest = tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))
     globs = manifest["tool"]["uv"]["workspace"]["members"]
     out: dict[str, dict[str, Any]] = {}
+    virtual: set[str] = set()
     for pattern in globs:
         for path in sorted(root.glob(f"{pattern}/pyproject.toml")):
             raw = tomllib.loads(path.read_text(encoding="utf-8"))
@@ -102,8 +114,11 @@ def members(root: Path) -> dict[str, dict[str, Any]]:
                     f"{path}: {data['name']} declares no [project] version; the tag says "
                     "which version is being released and this is what it is checked against"
                 )
-            out[canonicalize_name(data["name"])] = data
-    return out
+            key = canonicalize_name(data["name"])
+            out[key] = data
+            if raw.get("tool", {}).get("uv", {}).get("package") is False:
+                virtual.add(key)
+    return out, virtual
 
 
 def edges(project: dict[str, Any], names: set[str]) -> set[str]:
@@ -233,23 +248,31 @@ def split_tag(tag: str, known: list[str]) -> tuple[str, str]:
 
 def plan(args: argparse.Namespace) -> int:
     root: Path = args.root
-    found = members(root)
+    found, virtual = members(root)
     names = set(found)
     graph = {name: edges(data, names) for name, data in found.items()}
-    sequence = order(graph)
+    sequence = [name for name in order(graph) if name not in virtual]
 
     print("release order (dependencies first):")
     for rank, name in enumerate(sequence, 1):
         deps = ", ".join(sorted(graph[name])) or "-"
         print(f"  {rank}. {name} {found[name]['version']}   depends on: {deps}")
+    # listed, but not numbered: a virtual member has no release to order
+    for name in sorted(virtual):
+        print(f"  -- {name} {found[name]['version']}   (virtual -- never published)")
 
     if not args.tag:
         return 0
 
     failures = 0
 
-    # 1. the tag names a member
+    # 1. the tag names a member, and one this repository publishes
     dist, version = split_tag(args.tag, sorted(names))
+    if dist in virtual:
+        raise PlanError(
+            f"`{found[dist]['name']}` is a virtual member (`[tool.uv] package = false`): "
+            "never built, never published -- there is nothing to release"
+        )
 
     # 2. the tag's version is the version this tree builds
     declared = found[dist]["version"]
@@ -278,8 +301,18 @@ def plan(args: argparse.Namespace) -> int:
     else:
         print(f"OK    {dist} {version} is not on PyPI yet")
 
-    # 4. every intra-workspace runtime dependency is published at the tree's version
+    # 4. every intra-workspace runtime dependency is published at the tree's version.
+    #    A virtual dependency is never on PyPI at any version, so it is not a question to
+    #    ask the index -- it is a wheel that could not be installed, and it is fatal here
+    #    exactly as it is in `check_workspace.py` on every pull request.
     for dependency in sorted(graph[dist]):
+        if dependency in virtual:
+            raise PlanError(
+                f"{found[dist]['name']} declares a runtime dependency on "
+                f"{found[dependency]['name']}, which is a virtual member "
+                "(`[tool.uv] package = false`); the published wheel could never be "
+                f"installed: `{found[dependency]['name']}` is never on PyPI"
+            )
         needed = found[dependency]["version"]
         if on_pypi(dependency, needed):
             print(f"OK    {dependency} {needed} is on PyPI")

--- a/tools/tests/conftest.py
+++ b/tools/tests/conftest.py
@@ -1,4 +1,4 @@
-"""Scratch workspaces for the repository's own scripts (`.github/scripts/*.py`).
+"""Scratch workspaces for the repository's own tooling (`tools/src/sn_tools/`).
 
 Every test here builds a throwaway uv workspace under `tmp_path` and runs one script's
 `main()` against it. Nothing reaches the network and nothing runs `uv`: the scripts under
@@ -15,15 +15,21 @@ from typing import Any
 
 import pytest
 
-# The scripts under test are loose files, not a package, and nothing installs them. Putting
-# `.github/scripts` on `sys.path` HERE rather than in the root `[tool.pytest.ini_options]
-# pythonpath` confines the change to the sessions that collect these tests -- a bare root
-# `pytest` collects both trees and so shares one `sys.path` throughout, which is harmless
-# because the name that could collide (`tests`) no longer exists outside a package. That
-# rename is the half of this that does the work; a repository-wide `pythonpath` entry would
-# have exposed this directory's siblings by name to every pytest run rooted here, including
-# the ones that never look at these tests. Hence `selftests`, and hence this line.
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+# `tools` is a VIRTUAL member (`[tool.uv] package = false`), so nothing installs
+# `sn_tools` into any environment -- deliberately: the tooling is run by path, from the
+# repository, and is never imported by anything the suite ships. These tests therefore put
+# it on `sys.path` themselves.
+#
+# `tools/src`, NOT `tools/`. Putting `tools/` on a path root would make this very
+# directory importable as a top-level package called `tests`, competing for the name with
+# `packages/sphinx-needs/tests` in any session that collects both -- which a bare root
+# `pytest` does, because `testpaths` names them both. `tools/src` contains exactly one
+# name, `sn_tools`, which nothing else claims.
+#
+# Doing it here rather than in a repository-wide `[tool.pytest.ini_options] pythonpath`
+# also confines the change to the sessions that collect these tests: the CI matrix cells,
+# which pass the package's `tests` path explicitly, never execute this file at all.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 ROOT_TEMPLATE = """\
 [project]
@@ -56,6 +62,7 @@ def write_member(
     requires_python: str = ">=3.11,<4",
     module_version: str | None = None,
     module_name: str | None = None,
+    virtual: bool = False,
 ) -> Path:
     """One member manifest, plus (optionally) a module carrying a `__version__` literal."""
     directory.mkdir(parents=True, exist_ok=True)
@@ -76,6 +83,9 @@ def write_member(
             lines.append(f"{extra} = [{toml_list(specs)}]")
     if module_name:
         lines += ["", "[tool.flit.module]", f'name = "{module_name}"']
+    if virtual:
+        # the workspace's `publish = false`: uv can build this member with no command
+        lines += ["", "[tool.uv]", "package = false"]
     manifest = directory / "pyproject.toml"
     manifest.write_text("\n".join(lines) + "\n", encoding="utf-8")
     if module_version is not None:

--- a/tools/tests/conftest.py
+++ b/tools/tests/conftest.py
@@ -84,7 +84,8 @@ def write_member(
     if module_name:
         lines += ["", "[tool.flit.module]", f'name = "{module_name}"']
     if virtual:
-        # the workspace's `publish = false`: uv can build this member with no command
+        # a member this repository never releases: `package = false` hides it from uv's
+        # workspace selectors, and the release plan refuses a tag that names it
         lines += ["", "[tool.uv]", "package = false"]
     manifest = directory / "pyproject.toml"
     manifest.write_text("\n".join(lines) + "\n", encoding="utf-8")

--- a/tools/tests/conftest.py
+++ b/tools/tests/conftest.py
@@ -63,6 +63,7 @@ def write_member(
     module_version: str | None = None,
     module_name: str | None = None,
     virtual: bool = False,
+    private_classifier: bool = True,
 ) -> Path:
     """One member manifest, plus (optionally) a module carrying a `__version__` literal."""
     directory.mkdir(parents=True, exist_ok=True)
@@ -76,6 +77,10 @@ def write_member(
         lines.append(f'version = "{version}"')
     lines.append(f'requires-python = "{requires_python}"')
     lines.append(f"dependencies = [{toml_list(dependencies or [])}]")
+    if virtual and private_classifier:
+        # what check (6) demands of every virtual member; a test that wants it red passes
+        # `private_classifier=False`
+        lines.append('classifiers = ["Private :: Do Not Upload"]')
     if optional_dependencies:
         lines.append("")
         lines.append("[project.optional-dependencies]")

--- a/tools/tests/test_check_workspace.py
+++ b/tools/tests/test_check_workspace.py
@@ -154,8 +154,8 @@ def test_specifier_is_admitted_but_not_tight(workspace, capsys) -> None:
 def test_a_runtime_dependency_on_a_virtual_member_is_an_error(
     workspace, capsys
 ) -> None:
-    """`[tool.uv] package = false` means uv can build it with no command, so it is never on
-    PyPI and a wheel naming it could not be installed."""
+    """A virtual member is never released, so it is never on PyPI and a wheel naming it
+    could not be installed."""
     root = workspace(
         {
             "acme-core": {"version": "2.0.0", "dependencies": ["acme-tools>=0,<1"]},
@@ -188,6 +188,58 @@ def test_a_virtual_member_is_otherwise_checked_like_any_other(
         "::error file=packages/acme-tools/pyproject.toml::requires-python is >=3.12,<4"
         in out
     )
+
+
+def test_a_virtual_dependant_is_not_held_to_the_tracking_policy(
+    workspace, capsys
+) -> None:
+    """The cap stops a future major being co-installed with a published wheel; a virtual
+    member publishes none, so a loose floor outward is its own business."""
+    root = workspace(
+        {
+            "acme-core": {"version": "1.2.3"},
+            "acme-tools": {
+                "version": "0",
+                "virtual": True,
+                "dependencies": ["acme-core>=1.0"],
+            },
+        }
+    )
+    assert run(root) == 0
+    assert "OK    acme-tools -> acme-core>=1.0" in capsys.readouterr().out
+
+
+def test_a_virtual_dependant_is_still_held_to_honesty(workspace, capsys) -> None:
+    """Only the policy half is relaxed: a floor the tree cannot satisfy is still red."""
+    root = workspace(
+        {
+            "acme-core": {"version": "1.2.3"},
+            "acme-tools": {
+                "version": "0",
+                "virtual": True,
+                "dependencies": ["acme-core>=99"],
+            },
+        }
+    )
+    assert run(root) == 1
+    assert "which this specifier does not admit" in capsys.readouterr().out
+
+
+def test_check_five_skips_a_virtual_member_by_rule(workspace, capsys) -> None:
+    """Not by module-name derivation: a virtual member with a module present and a
+    mismatching `__version__` is still skipped."""
+    root = workspace(
+        {
+            "acme-tools": {
+                "version": "0",
+                "virtual": True,
+                "module_version": "9.9.9",
+            }
+        }
+    )
+    assert run(root) == 0
+    out = capsys.readouterr().out
+    assert "__version__" not in out
 
 
 def test_no_policy_accepts_a_loose_but_honest_floor(workspace, capsys) -> None:

--- a/tools/tests/test_check_workspace.py
+++ b/tools/tests/test_check_workspace.py
@@ -11,8 +11,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import check_workspace
 import pytest
+from sn_tools import check_workspace
 
 pytestmark = pytest.mark.filterwarnings("error")
 
@@ -149,6 +149,45 @@ def test_specifier_is_admitted_but_not_tight(workspace, capsys) -> None:
     out = capsys.readouterr().out
     assert "tight tracking wants `acme-core<2,>=1.2.3`" in out
     assert "propagate_floors.py acme-core" in out
+
+
+def test_a_runtime_dependency_on_a_virtual_member_is_an_error(
+    workspace, capsys
+) -> None:
+    """`[tool.uv] package = false` means uv can build it with no command, so it is never on
+    PyPI and a wheel naming it could not be installed."""
+    root = workspace(
+        {
+            "acme-core": {"version": "2.0.0", "dependencies": ["acme-tools>=0,<1"]},
+            "acme-tools": {"version": "0", "virtual": True},
+        }
+    )
+    assert run(root) == 1
+    out = capsys.readouterr().out
+    assert "`acme-tools` is `[tool.uv] package = false`" in out
+    assert "could never be installed" in out
+
+
+def test_a_virtual_member_is_otherwise_checked_like_any_other(
+    workspace, capsys
+) -> None:
+    """Only the runtime-edge rule is special: the rest applies unchanged."""
+    root = workspace(
+        {
+            "acme-core": {"version": "2.0.0"},
+            "acme-tools": {
+                "version": "0",
+                "virtual": True,
+                "requires_python": ">=3.12,<4",
+            },
+        }
+    )
+    assert run(root) == 1
+    out = capsys.readouterr().out
+    assert (
+        "::error file=packages/acme-tools/pyproject.toml::requires-python is >=3.12,<4"
+        in out
+    )
 
 
 def test_no_policy_accepts_a_loose_but_honest_floor(workspace, capsys) -> None:

--- a/tools/tests/test_check_workspace.py
+++ b/tools/tests/test_check_workspace.py
@@ -242,6 +242,71 @@ def test_check_five_skips_a_virtual_member_by_rule(workspace, capsys) -> None:
     assert "__version__" not in out
 
 
+def test_a_virtual_member_must_declare_the_private_classifier(
+    workspace, capsys
+) -> None:
+    """The classifier is the second fence; without this, it is the line a tidy-up deletes."""
+    root = workspace(
+        {"acme-tools": {"version": "0", "virtual": True, "private_classifier": False}}
+    )
+    assert run(root) == 1
+    out = capsys.readouterr().out
+    assert "::error file=packages/acme-tools/pyproject.toml::" in out
+    assert 'does not declare the classifier "Private :: Do Not Upload"' in out
+    assert "can still be built by hand" in out
+
+
+def test_a_virtual_member_with_the_classifier_is_green(workspace, capsys) -> None:
+    root = workspace({"acme-tools": {"version": "0", "virtual": True}})
+    assert run(root) == 0
+    assert "declares `Private :: Do Not Upload`" in capsys.readouterr().out
+
+
+def test_a_publishable_member_is_not_asked_for_the_classifier(
+    workspace, capsys
+) -> None:
+    root = workspace({"acme-core": {"version": "1.0.0"}})
+    assert run(root) == 0
+    assert "Private :: Do Not Upload" not in capsys.readouterr().out
+
+
+def test_a_virtual_member_may_depend_on_a_virtual_sibling(workspace, capsys) -> None:
+    """uv resolves it, and there is no wheel to be uninstallable."""
+    root = workspace(
+        {
+            "acme-tools": {
+                "version": "0",
+                "virtual": True,
+                "dependencies": ["acme-more>=0"],
+            },
+            "acme-more": {"version": "0", "virtual": True},
+        }
+    )
+    assert run(root) == 0
+    assert "OK    acme-tools -> acme-more>=0" in capsys.readouterr().out
+
+
+def test_a_virtual_dependant_gets_the_honesty_message_without_publish(
+    workspace, capsys
+) -> None:
+    """It is still an error -- uv resolves the workspace copy regardless -- but a virtual
+    member publishes no wheel, so the consequence is worded for the tree, not for PyPI."""
+    root = workspace(
+        {
+            "acme-core": {"version": "1.2.3"},
+            "acme-tools": {
+                "version": "0",
+                "virtual": True,
+                "dependencies": ["acme-core>=99"],
+            },
+        }
+    )
+    assert run(root) == 1
+    out = capsys.readouterr().out
+    assert "so the specifier says something untrue about the tree" in out
+    assert "publish a wheel nobody can install" not in out
+
+
 def test_no_policy_accepts_a_loose_but_honest_floor(workspace, capsys) -> None:
     root = workspace(
         {

--- a/tools/tests/test_propagate_floors.py
+++ b/tools/tests/test_propagate_floors.py
@@ -11,8 +11,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import propagate_floors
 import pytest
+from sn_tools import propagate_floors
 
 pytestmark = pytest.mark.filterwarnings("error")
 

--- a/tools/tests/test_release_plan.py
+++ b/tools/tests/test_release_plan.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-import release_plan
+from sn_tools import release_plan
 
 pytestmark = pytest.mark.filterwarnings("error")
 
@@ -63,6 +63,74 @@ def test_a_cycle_is_an_error(workspace, capsys) -> None:
     )
     assert run(root) == 1
     assert "cycle among workspace members: acme-a, acme-b" in capsys.readouterr().out
+
+
+# --- (0) a virtual member is never a release ---------------------------------------------
+
+
+def test_a_virtual_member_is_listed_but_not_numbered(workspace, capsys) -> None:
+    root = workspace(
+        {
+            "acme-core": {"version": "2.0.0"},
+            "acme-tools": {"version": "0", "virtual": True},
+        }
+    )
+    assert run(root) == 0
+    out = capsys.readouterr().out
+    assert "1. acme-core 2.0.0   depends on: -" in out
+    assert "-- acme-tools 0   (virtual -- never published)" in out
+    assert "2. acme-tools" not in out
+
+
+def test_a_tag_naming_a_virtual_member_is_refused(workspace, capsys, offline) -> None:
+    root = workspace(
+        {
+            "acme-core": {"version": "2.0.0"},
+            "acme-tools": {"version": "0", "virtual": True},
+        }
+    )
+    assert run(root, "--tag", "acme-tools-v0", "--rehearsal", "--no-git") == 1
+    out = capsys.readouterr().out
+    assert "`acme-tools` is a virtual member (`[tool.uv] package = false`)" in out
+    assert "there is nothing to release" in out
+
+
+def test_a_runtime_dependency_on_a_virtual_member_is_refused(
+    workspace, capsys, offline
+) -> None:
+    """The wheel would name a distribution that is never on PyPI."""
+    published(offline, {("acme-core", "2.0.0"): False})
+    root = workspace(
+        {
+            "acme-core": {"version": "2.0.0", "dependencies": ["acme-tools>=0"]},
+            "acme-tools": {"version": "0", "virtual": True},
+        }
+    )
+    assert run(root, "--tag", "acme-core-v2.0.0", "--rehearsal", "--no-git") == 1
+    out = capsys.readouterr().out
+    assert "acme-core declares a runtime dependency on acme-tools" in out
+    assert "`acme-tools` is never on PyPI" in out
+
+
+def test_pypi_is_never_asked_about_a_virtual_member(workspace, offline) -> None:
+    """Check 4 must not turn a virtual dependency into a 404 lookup."""
+    asked: list[str] = []
+
+    def fake(name: str, version: str) -> bool:
+        asked.append(name)
+        return False
+
+    offline.setattr(release_plan, "on_pypi", fake)
+    root = workspace(
+        {
+            "acme-core": {"version": "2.0.0", "dependencies": ["acme-tools>=0"]},
+            "acme-tools": {"version": "0", "virtual": True},
+        }
+    )
+    assert run(root, "--tag", "acme-core-v2.0.0", "--rehearsal", "--no-git") == 1
+    # check 3 asked about the release candidate; check 4 refused the virtual edge before
+    # it could turn it into a lookup that is guaranteed to 404
+    assert asked == ["acme-core"]
 
 
 # --- (1) the tag names a member ----------------------------------------------------------

--- a/tools/tests/test_release_plan.py
+++ b/tools/tests/test_release_plan.py
@@ -130,6 +130,30 @@ def test_an_extra_only_edge_to_a_virtual_member_is_refused(
     assert "runtime (or extra) dependency" in capsys.readouterr().out
 
 
+def test_a_virtual_to_virtual_edge_does_not_block_a_release(
+    workspace, capsys, offline
+) -> None:
+    """The refusal is about a wheel naming something never on PyPI; a virtual dependant
+    ships no wheel, so its edge onto a virtual sibling is nobody's problem."""
+    published(offline, {("acme-core", "2.0.0"): False})
+    root = workspace(
+        {
+            "acme-core": {"version": "2.0.0"},
+            "acme-tools": {
+                "version": "0",
+                "virtual": True,
+                "dependencies": ["acme-more>=0"],
+            },
+            "acme-more": {"version": "0", "virtual": True},
+        }
+    )
+    assert run(root, "--tag", "acme-core-v2.0.0", "--rehearsal", "--no-git") == 0
+    out = capsys.readouterr().out
+    assert "-- acme-more 0   (virtual -- never published)" in out
+    assert "-- acme-tools 0   (virtual -- never published)" in out
+    assert "::error" not in out
+
+
 def test_pypi_is_never_asked_about_a_virtual_member(workspace, offline) -> None:
     """Check 4 must not turn a virtual dependency into a 404 lookup."""
     asked: list[str] = []

--- a/tools/tests/test_release_plan.py
+++ b/tools/tests/test_release_plan.py
@@ -108,8 +108,26 @@ def test_a_runtime_dependency_on_a_virtual_member_is_refused(
     )
     assert run(root, "--tag", "acme-core-v2.0.0", "--rehearsal", "--no-git") == 1
     out = capsys.readouterr().out
-    assert "acme-core declares a runtime dependency on acme-tools" in out
+    assert "acme-core declares a runtime (or extra) dependency on acme-tools" in out
     assert "`acme-tools` is never on PyPI" in out
+
+
+def test_an_extra_only_edge_to_a_virtual_member_is_refused(
+    workspace, capsys, offline
+) -> None:
+    """`edges()` folds extras into the graph, so the message must not say "runtime" flatly."""
+    published(offline, {("acme-core", "2.0.0"): False})
+    root = workspace(
+        {
+            "acme-core": {
+                "version": "2.0.0",
+                "optional_dependencies": {"dev": ["acme-tools>=0"]},
+            },
+            "acme-tools": {"version": "0", "virtual": True},
+        }
+    )
+    assert run(root, "--tag", "acme-core-v2.0.0", "--rehearsal", "--no-git") == 1
+    assert "runtime (or extra) dependency" in capsys.readouterr().out
 
 
 def test_pypi_is_never_asked_about_a_virtual_member(workspace, offline) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -16,6 +16,7 @@ conflicts = [[
 members = [
     "sphinx-needs",
     "sphinx-needs-workspace",
+    "sphinx-needs-workspace-tools",
 ]
 
 [[package]]
@@ -2399,6 +2400,7 @@ version = "0"
 source = { virtual = "." }
 dependencies = [
     { name = "sphinx-needs" },
+    { name = "sphinx-needs-workspace-tools" },
 ]
 
 [package.optional-dependencies]
@@ -2456,7 +2458,6 @@ dev = [
     { name = "responses" },
     { name = "sphinxcontrib-plantuml" },
     { name = "syrupy" },
-    { name = "tomlkit" },
     { name = "uv" },
 ]
 js = [
@@ -2489,7 +2490,6 @@ test = [
 typing = [
     { name = "docutils", version = "0.20.1", source = { registry = "https://pypi.org/simple" } },
     { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" } },
-    { name = "tomlkit" },
     { name = "ty" },
     { name = "types-docutils" },
     { name = "types-requests" },
@@ -2504,6 +2504,7 @@ requires-dist = [
     { name = "sphinx-needs", extras = ["theme-im"], marker = "extra == 'theme-im'", editable = "packages/sphinx-needs" },
     { name = "sphinx-needs", extras = ["theme-pds"], marker = "extra == 'theme-pds'", editable = "packages/sphinx-needs" },
     { name = "sphinx-needs", extras = ["theme-rtd"], marker = "extra == 'theme-rtd'", editable = "packages/sphinx-needs" },
+    { name = "sphinx-needs-workspace-tools", virtual = "tools" },
 ]
 provides-extras = ["plotting", "docs", "theme-im", "theme-furo", "theme-pds", "theme-rtd"]
 
@@ -2540,7 +2541,6 @@ dev = [
     { name = "responses", specifier = ">=0.22,<0.27" },
     { name = "sphinxcontrib-plantuml", specifier = "~=0.0" },
     { name = "syrupy", specifier = ">=4,<7" },
-    { name = "tomlkit", specifier = ">=0.13" },
     { name = "uv", specifier = ">=0.12.9" },
 ]
 js = [{ name = "pytest-playwright", specifier = "~=0.9" }]
@@ -2564,10 +2564,24 @@ test = [
 typing = [
     { name = "docutils", specifier = "~=0.20.0" },
     { name = "sphinx", specifier = "~=7.4" },
-    { name = "tomlkit", specifier = ">=0.13" },
     { name = "ty", specifier = "~=0.0.77" },
     { name = "types-docutils", specifier = "~=0.20.0" },
     { name = "types-requests" },
+]
+
+[[package]]
+name = "sphinx-needs-workspace-tools"
+version = "0"
+source = { virtual = "tools" }
+dependencies = [
+    { name = "packaging" },
+    { name = "tomlkit" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "packaging", specifier = ">=24" },
+    { name = "tomlkit", specifier = ">=0.13" },
 ]
 
 [[package]]


### PR DESCRIPTION
**Stacked on #1846**, as a single commit on `ci/release-workflow` with no merge commits. It exists to be compared with #1846's layout, not to be merged by default: merge #1846 then this, retarget this to `master` and merge it alone, or close it if the layout in #1846 is judged better.

**The question.** #1846 puts the release fences in `.github/scripts/`. The recon behind them considered a workspace member for the tooling and rejected it, mainly because *a member is a release candidate*: the plan job would accept `sphinx-needs-workspace-tools-v0` as a tag. Chris asked whether uv has Cargo's `publish = false`.

**It has the selector half of it.** `[tool.uv] package = false` makes a member *virtual*. Measured on uv 0.12.9, on this very member:

- `uv build --all-packages` builds only `sphinx-needs`; the virtual member is skipped.
- `uv build --package sphinx-needs-workspace-tools` exits 2: *"is missing a `build-system`"*.
- `uv.lock` records `source = { virtual = "tools" }`.
- `uv sync` installs its **dependencies** without installing it, so `import sn_tools` fails in `.venv`, which is right: the tooling is run by path and never imported by anything shipped.

It is **not a build prohibition**, and the review caught the arc claiming that it was: `uv build tools/` (the source-path form) falls through to PEP 517's default backend and produces a real sdist and wheel that `uv publish --dry-run` accepts. Nothing in this repository's workflows can reach that form, because the `build` job only ever runs `uv build --package "$DIST"` after `plan` has validated the tag. So what makes the member unreleasable is not uv but two fences this PR adds: the plan job's rule below, and the `Private :: Do Not Upload` classifier in its manifest, which PyPI rejects on upload.

### What changes

**Moved** (`git mv`, so `git log --follow` and `git blame` keep working): `check_workspace.py`, `release_plan.py` and `propagate_floors.py` to `tools/src/sn_tools/`; their tests to `tools/tests/`. `tools/` sits **outside `packages/`**, which keeps meaning "the distributions this repository publishes", and carries no `pkg:` label of its own.

**Stayed, with the rule now written in `AGENTS.md`:** what decides where a script lives is whether it must execute *inside* a particular environment. `check_sphinx_cell.py` imports the cell's own sphinx, `check_typing_floor.py` runs inside `.venvs/typing`, `extract_benchmark_data.py` runs inside the benchmark job; none could move without installing a member into every matrix cell. `scripts/smoke_needs.py` stays for the mirror-image reason: it exists to run *outside* every project environment.

**The plan job's new rule**, each part with a red proof in the branch: a tag naming a virtual member is refused before anything is built; the release order lists virtual members on their own unnumbered line, so "the order is A → B" never names something that cannot be released; a publishable member declaring a runtime or extra dependency on a virtual one is refused, because that wheel would name a distribution that is never on PyPI; and check 4 never turns such a dependency into an index lookup guaranteed to 404. `check_workspace.py` reports the same edge on every pull request, so the release job is not the first place anyone hears of it, and it also asserts that every virtual member carries the `Private :: Do Not Upload` classifier, so the second fence has a red proof too. A virtual member's own edges are held to the honesty check but not to the tight-tracking policy, and a virtual member may depend on another: nothing it declares ever ships.

**Invocation is unchanged in kind.** CI still runs the fences by path with `--no-project --with packaging`, so a manifest mistake is still *named* rather than reported as a failed `uv sync`. A virtual member has no console scripts, so none were added.

### The comparison

| | #1846: `.github/scripts/` | this PR: virtual member `tools/` |
|---|---|---|
| dependency contract | `packaging` borrowed from whatever sphinx pulls in; `tomlkit` declared twice, in the `dev` and `typing` groups | declared once, in `tools/pyproject.toml`; reaches every environment through the root's dependency on the member |
| where the tests live | `.github/scripts/selftests/`, named to avoid a second importable `tests`; root `pythonpath` removed for the same reason | `tools/tests/` beside the code; its `conftest.py` puts `tools/src` (never `tools/`) on `sys.path` |
| what every environment installs | nothing extra | `packaging` and `tomlkit` in every environment, matrix cells included (about 50 KB, no transitive dependencies) |
| what the plan job knows | every member is releasable | virtual members are listed apart and refused; a runtime or extra edge onto one is an error in the plan and in the fence; this rule, not uv, is what makes the member unreleasable |
| what the fence's tracking policy covers | every intra-workspace edge | edges from publishable members; a virtual member may floor a sibling loosely, since it is never co-installed with anything |
| conventions for where a script lives | one: `.github/scripts/` | two, with the rule stated in `AGENTS.md`: `tools/` for the workspace's tooling, `.github/scripts/` for checks bound to a CI environment |
| members in every "for each member" output | one | two (`uv tree`, the fence's OK lines, the release order) |

One detail worth a reviewer's eye: `tools/tests/conftest.py` inserts `tools/src` on `sys.path`, never `tools/`. The directory is called `tests`, and putting its parent on a path root would make it a top-level package competing with the sphinx-needs suite's own for that name, the failure mode #1846's last round removed. `tools/src` contains exactly one name, `sn_tools`.

### Rehearsal

[Run 33932496976](https://github.com/useblocks/sphinx-needs/actions/runs/33932496976), dispatched from this branch, is green: `plan` prints the release order with the virtual member on its own line,

```
  1. sphinx-needs 8.5.0   depends on: -
  -- sphinx-needs-workspace-tools 0   (virtual -- never published)
```

then `build` runs the fence from its new path, builds the wheel, resolves it against PyPI alone and runs the compat cell (1740 passed); `publish` and `release` are skipped.
