### PR TITLE
🔧 Add a release planner and a fast import check, so the release order is known before the tag

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -135,14 +135,16 @@ jobs:
           # `[tool.flit.module] name`, so a second member that sets it needs this step
           # taught the same thing
           module=${DIST//-/_}
+          # Import every module of the wheel BEFORE the suite. A name that is missing from
+          # a dependency AS PUBLISHED is then reported in seconds, by name, instead of
+          # somewhere inside a six-minute pytest run -- and `--expect-prefix` subsumes the
+          # assertion this step used to make inline: the import must come from the wheel,
+          # not from the checkout one directory up, which is what smoke_needs.py asserts
+          # too. The walk is stdlib only, so it runs under this scratch interpreter, which
+          # has the wheel's dependencies and nothing else. Run from the repository root,
+          # before the `cd` below, so the script is where it says it is
+          /tmp/compat/bin/python tools/src/sn_tools/import_check.py --walk "$module" --expect-prefix /tmp/compat
           cd "packages/$DIST"
-          # the import must come from the wheel, not from the checkout one directory up --
-          # the same assertion smoke_needs.py makes, and for the same reason
-          /tmp/compat/bin/python -c "
-          import importlib, sys
-          m = importlib.import_module('$module')
-          print(m.__file__)
-          sys.exit(0 if '/tmp/compat/' in m.__file__ else 1)"
           # serial: plantuml is load-sensitive and `-n auto` races on the shared jar copy.
           # `-o addopts=` drops the root config's `--import-mode=importlib` so it can be
           # given explicitly here, which is what lets the tests import the installed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,9 +38,11 @@ declares the tooling's dependencies; `.github/scripts/` keeps only the checks th
 execute inside a specific CI environment.** The distinction is
 what each script *inspects*. `tools/src/sn_tools/` holds the ones that read the manifests
 before any environment exists — `check_workspace.py`, `release_plan.py`,
-`propagate_floors.py` — and they are run by path, never imported
-(`uv run --no-project --with packaging python tools/src/sn_tools/<script>.py` in CI, so a
-manifest mistake is named rather than reported as a failed sync). `.github/scripts/` keeps
+`propagate_floors.py` — plus `import_check.py`, which builds a member's wheel and imports
+it in a throwaway environment outside every project one. They are run by path, never
+imported (`uv run --no-project --with packaging python tools/src/sn_tools/<script>.py` in
+CI for the three manifest readers, so a manifest mistake is named rather than reported as a
+failed sync). `.github/scripts/` keeps
 `check_sphinx_cell.py` (it imports the cell's own sphinx), `check_typing_floor.py` (it runs
 inside `.venvs/typing`) and `extract_benchmark_data.py` (it runs inside the benchmark job) —
 none of which could move without dragging a member into every matrix cell. `scripts/smoke_needs.py`
@@ -73,6 +75,8 @@ uv run poe typecheck-needs            # ty, against the oldest supported sphinx
 uv run poe docs-needs                 # the furo docs build
 uv run poe smoke-needs                # build the wheel and test the built package
 uv run poe check-workspace            # the manifests agree with each other (Lint runs it)
+uv run poe release-plan               # what is pending, in what order (advice; exits 0)
+uv run poe import-check-needs         # import the wheel against PyPI-resolved dependencies
 uv run --frozen --no-sync pytest tools/tests -q   # the tooling's own tests
 UV_PYTHON=3.12 uv run --no-sync poe test-needs-sphinx8   # one CI matrix cell
 ```
@@ -201,6 +205,16 @@ Every distribution under `packages/` releases independently. One workflow,
 `<dist>-v<version>`. It publishes with PyPI trusted publishing (OIDC), so the
 workflow holds no API token, and every one of its checks fails closed.
 
+0. **What is pending, and in what order**: `uv run poe release-plan`. Per publishable
+   member it prints the last release tag, what PyPI has, the commits since that tag that
+   touched the member's *shipped* code, and — for each dependant — the version the compat
+   cell would install from PyPI; then a suggested sequence with the commands. It is advice
+   and exits 0 whatever it finds; the fences are still the plan job and the compat cell.
+   For a member with an intra-workspace dependency,
+   `python tools/src/sn_tools/import_check.py <dist>` (for sphinx-needs,
+   `uv run poe import-check-needs`) installs its freshly built wheel with `--no-sources`,
+   so every sibling comes from PyPI *as published*, and imports every module of it — a
+   missing symbol named in seconds rather than six minutes into a red compat cell.
 1. **Release pull request**, from `master` with a clean tree:
    ```bash
    uv version --package <dist> --bump {patch|minor|major} --no-sync

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,8 +41,9 @@ before any environment exists — `check_workspace.py`, `release_plan.py`,
 `propagate_floors.py` — plus `import_check.py`, which builds a member's wheel and imports
 it in a throwaway environment outside every project one. They are run by path, never
 imported (`uv run --no-project --with packaging python tools/src/sn_tools/<script>.py` in
-CI for the three manifest readers, so a manifest mistake is named rather than reported as a
-failed sync). `.github/scripts/` keeps
+CI for the two CI runs that way — `check_workspace.py` and `release_plan.py` — so a manifest
+mistake is named rather than reported as a failed sync; `propagate_floors.py` is the release
+engineer's, and CI never runs it). `.github/scripts/` keeps
 `check_sphinx_cell.py` (it imports the cell's own sphinx), `check_typing_floor.py` (it runs
 inside `.venvs/typing`) and `extract_benchmark_data.py` (it runs inside the benchmark job) —
 none of which could move without dragging a member into every matrix cell. `scripts/smoke_needs.py`
@@ -207,18 +208,21 @@ workflow holds no API token, and every one of its checks fails closed.
 
 0. **What is pending, and in what order**: `uv run poe release-plan`. Per publishable
    member it prints the last release tag, what PyPI has, the commits since that tag that
-   touched the member's *shipped* code, and — for each dependant — the version the compat
-   cell would install from PyPI; then a suggested sequence with the commands. It is advice
-   and exits 0 whatever it finds; the fences are still the plan job and the compat cell.
-   For a member with an intra-workspace dependency,
-   `python tools/src/sn_tools/import_check.py <dist>` (for sphinx-needs,
-   `uv run poe import-check-needs`) installs its freshly built wheel with `--no-sources`,
-   so every sibling comes from PyPI *as published*, and imports every module of it — a
-   missing symbol named in seconds rather than six minutes into a red compat cell.
+   touched the member's *shipped* code, and — for each dependant — which gate would stop a
+   release of it, or the version the compat cell would install from PyPI. Then a suggested
+   sequence with the commands. It is advice and exits 0 whatever it finds; the fences are
+   still the plan job and the compat cell. For a member with an intra-workspace dependency,
+   `uv run python tools/src/sn_tools/import_check.py <dist>` (for sphinx-needs,
+   `uv run poe import-check-needs`) installs its freshly built wheel into a throwaway
+   environment *outside* this project — so uv resolves the wheel's own dependencies from
+   PyPI and every sibling arrives *as published* — and imports every module of it, with
+   `--expect-prefix` asserting the imports come from that environment rather than the
+   checkout. A missing symbol is named in seconds rather than six minutes into a red compat
+   cell.
 1. **Release pull request**, from `master` with a clean tree:
    ```bash
    uv version --package <dist> --bump {patch|minor|major} --no-sync
-   python tools/src/sn_tools/propagate_floors.py <dist>   # only if a member depends on <dist>
+   uv run python tools/src/sn_tools/propagate_floors.py <dist>   # only if a member depends on <dist>
    uv lock
    ```
    `--no-sync` is not optional. `--frozen` leaves `uv.lock` claiming the old version, and

--- a/packages/sphinx-needs/docs/contributing.rst
+++ b/packages/sphinx-needs/docs/contributing.rst
@@ -214,12 +214,16 @@ Before either step, ask what is pending::
 
 That prints, for every distribution the workspace publishes, its last release tag, what
 PyPI has, the commits since that tag that touched the code it *ships*, and — where one
-package depends on another — the version the release workflow's compatibility check would
-install from PyPI, followed by a suggested order with the commands. It is advice, not a
-gate: it exits 0 whatever it finds. ``uv run poe import-check-needs`` is the companion
-question for a package that depends on another one in this workspace: it builds the wheel,
-installs it with ``--no-sources`` so every sibling comes from PyPI as published, and
-imports every module — which answers "is a name missing?" in seconds.
+package depends on another — which check would stop a release of the dependant, or the
+version the release workflow's compatibility check would install from PyPI. Then a
+suggested order, with the commands. It is advice, not a gate: it exits 0 whatever it finds.
+
+``uv run python tools/src/sn_tools/import_check.py <dist>`` (for sphinx-needs,
+``uv run poe import-check-needs``) is the companion question for a package that depends on
+another one in this workspace. It builds that package's wheel and installs it into a
+throwaway environment *outside* this project, so uv resolves the wheel's own dependencies
+from PyPI and every sibling arrives as published, then imports every module of it — which
+answers "is a name missing?" in seconds, where the compatibility check takes minutes.
 
 A release is two steps, a pull request and a tag.
 

--- a/packages/sphinx-needs/docs/contributing.rst
+++ b/packages/sphinx-needs/docs/contributing.rst
@@ -208,6 +208,19 @@ the tag says which: it must read ``<distribution>-v<version>``, so ``sphinx-need
 No other tag triggers it, and a tag that names no distribution in the workspace is refused
 before anything is built.
 
+Before either step, ask what is pending::
+
+    uv run poe release-plan
+
+That prints, for every distribution the workspace publishes, its last release tag, what
+PyPI has, the commits since that tag that touched the code it *ships*, and — where one
+package depends on another — the version the release workflow's compatibility check would
+install from PyPI, followed by a suggested order with the commands. It is advice, not a
+gate: it exits 0 whatever it finds. ``uv run poe import-check-needs`` is the companion
+question for a package that depends on another one in this workspace: it builds the wheel,
+installs it with ``--no-sources`` so every sibling comes from PyPI as published, and
+imports every module — which answers "is a name missing?" in seconds.
+
 A release is two steps, a pull request and a tag.
 
 The pull request bumps the version and stamps the changelog. From ``master``, with a clean

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -382,6 +382,12 @@ help = "Check the workspace manifests agree with each other (the fence CI's Lint
 # use the synced one, because it is already there
 cmd = "python tools/src/sn_tools/check_workspace.py"
 
+[tool.poe.tasks.release-plan]
+help = "What is pending, in what order, and what the compat cell would test it against"
+# a bare name: like `check-workspace` it acts on the whole workspace, not on one package.
+# Advice, never a gate -- it exits 0 whatever it finds. Step 0 of the release recipe
+cmd = "python tools/src/sn_tools/release_plan.py"
+
 # --- The built package ---
 # These two are named for the distribution they act on rather than for the repository, so
 # the names stay correct if a second distribution is ever built here. Every other task in
@@ -402,6 +408,13 @@ help = "Install the built sphinx-needs wheel out of this project and build a doc
 # builds the wheel itself -- a stale one left in dist/ would be a silent pass -- so this
 # does not depend on `build-needs` having been run first
 cmd = "python scripts/smoke_needs.py packages/sphinx-needs"
+
+[tool.poe.tasks.import-check-needs]
+help = "Import every sphinx-needs module from its built wheel, with dependencies as PUBLISHED"
+# named for the package it acts on, like `smoke-needs`: it builds one distribution's wheel.
+# `--no-sources` on the install is what makes it mean anything -- uv then takes every
+# intra-workspace dependency from PyPI instead of the checkout
+cmd = "python tools/src/sn_tools/import_check.py sphinx-needs"
 
 # --- Documentation ---
 # One task per theme, because the theme selects a different *extra* and executor options

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -412,8 +412,11 @@ cmd = "python scripts/smoke_needs.py packages/sphinx-needs"
 [tool.poe.tasks.import-check-needs]
 help = "Import every sphinx-needs module from its built wheel, with dependencies as PUBLISHED"
 # named for the package it acts on, like `smoke-needs`: it builds one distribution's wheel.
-# `--no-sources` on the install is what makes it mean anything -- uv then takes every
-# intra-workspace dependency from PyPI instead of the checkout
+# The wheel goes into an environment OUTSIDE this project, so uv reads its `Requires-Dist`
+# and resolves it from the index and every sibling arrives as published; `--no-sources` is
+# passed for the recipe and the intent (measured on uv 0.12.9, it is inert for a wheel
+# install). What stops the checkout being imported instead is that environment plus the
+# walk's `--expect-prefix`
 cmd = "python tools/src/sn_tools/import_check.py sphinx-needs"
 
 # --- Documentation ---

--- a/scripts/smoke_needs.py
+++ b/scripts/smoke_needs.py
@@ -12,8 +12,11 @@ invisible to all of them (issue #1829).  This script closes that gap:
    trees are in the sdist only because ``[tool.flit.sdist] include`` says so -- and the
    failure mode of losing them is an 11x smaller tarball, no warning and exit 0;
 3. create a throwaway virtual environment *outside* the project;
-4. install the wheel into it with ``--no-sources``, so uv resolves from the index instead
-   of silently substituting the local source tree;
+4. install the wheel into it with ``uv pip install``, which reads the wheel's own
+   ``Requires-Dist`` and resolves it from the index (measured on uv 0.12.9: ``uv pip
+   install <wheel>`` does that with or without ``--no-sources`` -- the flag governs
+   requirements uv reads from a *pyproject*, so it is passed here for the recipe and the
+   intent, not as the mechanism);
 5. assert ``sphinx_needs.__file__`` is inside that environment -- without this the whole
    run can pass while testing the checkout again;
 6. assert the wheel carries every file git tracks under the module directory -- the
@@ -322,8 +325,12 @@ def main() -> int:
             / ("Scripts" if sys.platform == "win32" else "bin")
             / ("python.exe" if sys.platform == "win32" else "python")
         )
-        # `--no-sources` is load-bearing: without it uv honours `tool.uv.sources` and
-        # installs the local source tree even into an environment outside the workspace
+        # `--no-sources` states the intent and keeps this identical to the release
+        # workflow's install, but it is not what stops the source tree being installed:
+        # measured on uv 0.12.9, `uv pip install <wheel>` resolves the wheel's
+        # `Requires-Dist` from the index either way (`[tool.uv.sources]` applies to
+        # requirements read from a pyproject). The assertion below -- the import comes from
+        # this environment -- is what actually catches a checkout being tested instead
         run(
             [
                 "uv",

--- a/tools/src/sn_tools/import_check.py
+++ b/tools/src/sn_tools/import_check.py
@@ -7,12 +7,20 @@ release workflow's compat cell -- which answers it by running the whole suite, s
 into a release job that has already built and gated the wheel. A missing symbol does not
 need six minutes; it needs one import.
 
-**`--no-sources` is the whole trick.** Installing the wheel with it makes uv resolve every
-intra-workspace dependency from the index instead of substituting the checkout, so the
-scratch environment holds this member as built and its siblings exactly as released. Then
-importing every module of the member is a complete answer to "is any name it uses missing
-from what is published". It is not a complete answer to "does it still work" -- a behaviour
-change imports perfectly -- and the compat cell stays the guard for that.
+**What makes the answer trustworthy is the throwaway environment, plus `--expect-prefix`.**
+The wheel is installed with `uv pip install` into an environment OUTSIDE the project, so uv
+reads the wheel's own `Requires-Dist` and resolves it from the index -- `uv pip` applies
+`[tool.uv.sources]` only to requirements it reads from a pyproject (measured on uv 0.12.9:
+with and without `--no-sources`, `uv pip install <wheel>` resolves a sibling from the
+registry identically; the flag IS load-bearing for `uv pip install -r pyproject.toml`). So
+the siblings arrive as published. `--no-sources` is passed anyway, and kept: it states the
+intent, it is correct defence in depth, and it makes this recipe the release build's and the
+compat cell's character for character. What would silently make the check prove nothing is
+importing the checkout instead of the wheel, and `--expect-prefix` is what refuses that.
+
+Importing every module of the member is then a complete answer to "is any name it uses
+missing from what is published". It is not a complete answer to "does it still work" -- a
+behaviour change imports perfectly -- and the compat cell stays the guard for that.
 
 Two layers, one file:
 
@@ -33,11 +41,14 @@ names the missing symbol before the suite starts.
 
 Usage::
 
-    python tools/src/sn_tools/import_check.py sphinx-needs        # or: uv run poe import-check-needs
-    python tools/src/sn_tools/import_check.py sphinx-needs --keep
-    python tools/src/sn_tools/import_check.py --walk sphinx_needs --expect-prefix /tmp/compat
+    uv run python tools/src/sn_tools/import_check.py sphinx-needs   # or: uv run poe import-check-needs
+    uv run python tools/src/sn_tools/import_check.py sphinx-needs --keep
+    /tmp/compat/bin/python tools/src/sn_tools/import_check.py --walk sphinx_needs --expect-prefix /tmp/compat
 
-Run at the workspace root. The outer layer needs `uv`; the inner needs nothing.
+Run at the workspace root. `uv run python …` rather than a bare `python`: this file needs
+`tomllib`, so whatever is on PATH has to be 3.11 or newer, and `uv run` guarantees it. The
+outer layer needs `uv`; the inner needs nothing but the interpreter it is handed, which is
+why the compat cell can run it with `/tmp/compat/bin/python`.
 """
 
 from __future__ import annotations
@@ -77,25 +88,75 @@ def innermost(exc: BaseException) -> str:
     return f"{where}: {frame.line.strip()}" if frame.line else where
 
 
+def submodule_names(
+    top: Any, module: str, unwalkable: list[str]
+) -> tuple[list[str], SystemExit | None]:
+    """Every submodule `pkgutil` can find under `top`, and the walk's own fatal exit.
+
+    `pkgutil.walk_packages` IMPORTS each package it finds, to read its `__path__` and
+    recurse, and its own `except ImportError` / `except Exception` do not cover
+    `SystemExit`. So a package whose `__init__` calls `sys.exit()` kills the generator, and
+    with it the whole walk -- silently, with the process taking that module's exit code. It
+    is caught here and handed back so the caller can report it: the per-module loop below
+    will import the same package again and file the real failure, and the walk it cut short
+    is named.
+    """
+    names: list[str] = []
+    walker = pkgutil.walk_packages(
+        getattr(top, "__path__", []), prefix=f"{module}.", onerror=unwalkable.append
+    )
+    while True:
+        try:
+            info = next(walker)
+        except StopIteration:
+            return names, None
+        except SystemExit as exc:
+            return names, exc
+        names.append(info.name)
+
+
+def is_entry_point(name: str) -> bool:
+    """`<anything>.__main__` -- a CLI entry point, not import surface.
+
+    Importing one runs it, against the WALKER's argv, and a `sys.exit()` outside an
+    `if __name__ == "__main__"` guard then ends the walk. `python -m <pkg>` is what that
+    file is for; the wheel's import surface is everything else.
+    """
+    return name.rpartition(".")[2] == "__main__"
+
+
 def walk(module: str, expect_prefix: str | None) -> int:
     """Import `module` and every submodule under it, reporting every failure.
 
     Deliberately not fail-fast: the reader wants every missing symbol at once, because the
-    next run costs another wheel build and another environment. Only `Exception` is caught
-    -- a `KeyboardInterrupt` or a `SystemExit` raised by a module at import time must still
-    stop the walk rather than be filed as one module's problem.
+    next run costs another wheel build and another environment.
+
+    `SystemExit` is caught BY NAME, everywhere a module is imported. R4's rule is "never
+    `BaseException`", and naming it satisfies that while closing a fail-open that made this
+    gate worthless: `SystemExit` is not an `Exception`, so before this it escaped the
+    per-module handler, escaped `walk()` and escaped `main()` -- and the process exited
+    with the module's own code, printing nothing at all. `sys.exit(0)` in one module made
+    the release workflow's compat-cell step go GREEN having imported nothing.
+    `KeyboardInterrupt` still propagates, which is what a caught interrupt should do.
+
+    Every path out of this function prints at least one line. That is the invariant: the
+    only thing a reader would notice about a silent pass is the absence of the `OK` line.
     """
     started = time.monotonic()
+    prefix = Path(expect_prefix).resolve() if expect_prefix is not None else None
     try:
         top = importlib.import_module(module)
+    except SystemExit as exc:
+        print(f"FAIL  {module}: SystemExit: {exc.code}")
+        print(f"        {innermost(exc)}")
+        return 1
     except Exception as exc:
         print(f"FAIL  {module}: {type(exc).__name__}: {exc}")
         print(f"        {innermost(exc)}")
         return 1
 
     location = getattr(top, "__file__", None)
-    if expect_prefix is not None:
-        prefix = Path(expect_prefix).resolve()
+    if prefix is not None:
         if location is None:
             print(
                 f"FAIL  {module} has no __file__, so it cannot be shown to come from {prefix}"
@@ -111,30 +172,63 @@ def walk(module: str, expect_prefix: str | None) -> int:
             return 1
         print(f"      {module} imported from {location}")
 
-    names = [module]
     unwalkable: list[str] = []
-    for info in pkgutil.walk_packages(
-        getattr(top, "__path__", []), prefix=f"{module}.", onerror=unwalkable.append
-    ):
-        names.append(info.name)
+    found, cut_short = submodule_names(top, module, unwalkable)
+    skipped = [name for name in found if is_entry_point(name)]
+    names = [module] + [name for name in found if not is_entry_point(name)]
 
     failures: list[tuple[str, str, str]] = []
+    homeless: list[str] = []
     for name in names:
         try:
-            importlib.import_module(name)
+            imported = importlib.import_module(name)
+        except SystemExit as exc:
+            failures.append((name, f"SystemExit: {exc.code}", innermost(exc)))
+            continue
         except Exception as exc:
             failures.append((name, f"{type(exc).__name__}: {exc}", innermost(exc)))
+            continue
+        # the prefix is asserted for EVERY module, not only the top one: a package can
+        # perfectly well pull a submodule in from somewhere else on the path
+        if prefix is None or name == module:
+            continue
+        where = getattr(imported, "__file__", None)
+        if where is None:
+            homeless.append(name)
+        elif not Path(where).resolve().is_relative_to(prefix):
+            failures.append(
+                (name, f"imported from {where}, which is not under {prefix}", "")
+            )
     elapsed = time.monotonic() - started
 
     for name, summary, frame in failures:
         print(f"FAIL  {name}: {summary}")
-        print(f"        {frame}")
+        if frame:
+            print(f"        {frame}")
+    for name in homeless:
+        print(
+            f"      {name} has no __file__ (a namespace package?); prefix not checked"
+        )
     for name in unwalkable:
         print(f"      {name} did not import, so anything under it was never walked")
+    if cut_short is not None:
+        print(
+            f"      the walk itself was cut short by SystemExit: {cut_short.code} -- "
+            "anything after that package was never listed"
+        )
+    if skipped:
+        print(
+            f"      skipped {len(skipped)} entry point(s) (__main__): {', '.join(skipped)}"
+        )
     if failures:
+        blocked = (
+            f"; {len(unwalkable)} package(s) did not import, so their contents were never walked"
+            if unwalkable
+            else ""
+        )
         print(
             f"FAIL  {len(failures)} of {len(names)} modules failed to import in "
-            f"{elapsed:.1f}s ({len(names) - len(failures)} imported)"
+            f"{elapsed:.1f}s ({len(names) - len(failures)} imported{blocked})"
         )
         return 1
     print(f"OK    {len(names)} modules imported in {elapsed:.1f}s")
@@ -244,8 +338,12 @@ def check(dist: str, wheel_arg: str | None, python: str | None, keep: bool) -> i
             ["uv", "venv", *(["--python", python] if python else []), venv],
             cwd=REPO_ROOT,
         )
-        # `--no-sources` is THE flag. Without it uv honours `[tool.uv.sources]` and installs
-        # the sibling member from the checkout, and the check silently proves nothing
+        # `--no-sources` here is the recipe, not the mechanism: measured on uv 0.12.9, a
+        # wheel's `Requires-Dist` is resolved from the index with or without it (the flag
+        # governs requirements uv reads from a pyproject). It is kept so this command is
+        # the compat cell's character for character, and because it states the intent.
+        # What stops the checkout being imported instead is the environment plus
+        # `--expect-prefix` on the walk below
         run(
             ["uv", "pip", "install", "--python", venv, "--no-sources", wheel],
             cwd=REPO_ROOT,

--- a/tools/src/sn_tools/import_check.py
+++ b/tools/src/sn_tools/import_check.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Import every module of a member's built wheel against its dependencies AS PUBLISHED.
+
+The question this answers is "does `sphinx-codelinks` still import against the
+`sphinx-needs` that is actually on PyPI?", and today the only thing that answers it is the
+release workflow's compat cell -- which answers it by running the whole suite, six minutes
+into a release job that has already built and gated the wheel. A missing symbol does not
+need six minutes; it needs one import.
+
+**`--no-sources` is the whole trick.** Installing the wheel with it makes uv resolve every
+intra-workspace dependency from the index instead of substituting the checkout, so the
+scratch environment holds this member as built and its siblings exactly as released. Then
+importing every module of the member is a complete answer to "is any name it uses missing
+from what is published". It is not a complete answer to "does it still work" -- a behaviour
+change imports perfectly -- and the compat cell stays the guard for that.
+
+Two layers, one file:
+
+* **outer** (`import_check.py <dist>`): build the wheel with character-for-character the
+  release command, make a throwaway environment, install the wheel into it with
+  `--no-sources`, and run the inner layer with that environment's interpreter;
+* **inner** (`import_check.py --walk <module> [--expect-prefix <dir>]`): import the module
+  and every submodule `pkgutil` can find, reporting all failures rather than the first.
+
+They live in one file so the outer can invoke the inner by path with a different
+interpreter, and the inner is **stdlib only** -- it runs under the scratch interpreter,
+which has the wheel's dependencies and nothing else. `--expect-prefix` is what makes the
+walk mean anything: without it the interpreter could be importing the checkout one
+directory up, and every module would import beautifully. It is the assertion
+`scripts/smoke_needs.py` makes, and the one the release workflow's compat cell used to make
+inline with `python -c`; the compat cell now runs this walk instead, so a red release job
+names the missing symbol before the suite starts.
+
+Usage::
+
+    python tools/src/sn_tools/import_check.py sphinx-needs        # or: uv run poe import-check-needs
+    python tools/src/sn_tools/import_check.py sphinx-needs --keep
+    python tools/src/sn_tools/import_check.py --walk sphinx_needs --expect-prefix /tmp/compat
+
+Run at the workspace root. The outer layer needs `uv`; the inner needs nothing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import pkgutil
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import tomllib
+import traceback
+from pathlib import Path
+from typing import Any
+
+# tools/src/sn_tools/import_check.py -> tools/src/sn_tools -> tools/src -> tools -> root
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+class CheckError(RuntimeError):
+    """A step of the outer layer that cannot be recovered from."""
+
+
+# --- the inner layer: stdlib only, runs under the scratch interpreter ---------------------
+
+
+def innermost(exc: BaseException) -> str:
+    """The last frame of the traceback -- the line that actually failed."""
+    frames = traceback.extract_tb(exc.__traceback__)
+    if not frames:
+        return "(no traceback)"
+    frame = frames[-1]
+    where = f"{frame.filename}:{frame.lineno} in {frame.name}"
+    return f"{where}: {frame.line.strip()}" if frame.line else where
+
+
+def walk(module: str, expect_prefix: str | None) -> int:
+    """Import `module` and every submodule under it, reporting every failure.
+
+    Deliberately not fail-fast: the reader wants every missing symbol at once, because the
+    next run costs another wheel build and another environment. Only `Exception` is caught
+    -- a `KeyboardInterrupt` or a `SystemExit` raised by a module at import time must still
+    stop the walk rather than be filed as one module's problem.
+    """
+    started = time.monotonic()
+    try:
+        top = importlib.import_module(module)
+    except Exception as exc:
+        print(f"FAIL  {module}: {type(exc).__name__}: {exc}")
+        print(f"        {innermost(exc)}")
+        return 1
+
+    location = getattr(top, "__file__", None)
+    if expect_prefix is not None:
+        prefix = Path(expect_prefix).resolve()
+        if location is None:
+            print(
+                f"FAIL  {module} has no __file__, so it cannot be shown to come from {prefix}"
+            )
+            return 1
+        if not Path(location).resolve().is_relative_to(prefix):
+            print(
+                f"FAIL  {module} was imported from {location}, which is not under {prefix}"
+            )
+            print(
+                "        the walk is meant to test the installed wheel; this is another copy"
+            )
+            return 1
+        print(f"      {module} imported from {location}")
+
+    names = [module]
+    unwalkable: list[str] = []
+    for info in pkgutil.walk_packages(
+        getattr(top, "__path__", []), prefix=f"{module}.", onerror=unwalkable.append
+    ):
+        names.append(info.name)
+
+    failures: list[tuple[str, str, str]] = []
+    for name in names:
+        try:
+            importlib.import_module(name)
+        except Exception as exc:
+            failures.append((name, f"{type(exc).__name__}: {exc}", innermost(exc)))
+    elapsed = time.monotonic() - started
+
+    for name, summary, frame in failures:
+        print(f"FAIL  {name}: {summary}")
+        print(f"        {frame}")
+    for name in unwalkable:
+        print(f"      {name} did not import, so anything under it was never walked")
+    if failures:
+        print(
+            f"FAIL  {len(failures)} of {len(names)} modules failed to import in "
+            f"{elapsed:.1f}s ({len(names) - len(failures)} imported)"
+        )
+        return 1
+    print(f"OK    {len(names)} modules imported in {elapsed:.1f}s")
+    return 0
+
+
+# --- the outer layer: build the wheel, install it from the index, run the inner -----------
+
+
+def canonical(name: str) -> str:
+    """PEP 503 name normalisation.
+
+    Not `packaging.utils.canonicalize_name`, because this file is one file: the inner layer
+    above runs under an interpreter that has only the wheel's dependencies, and a top-level
+    import of `packaging` would break it there.
+    """
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def module_name(manifest: dict[str, Any], dist: str) -> str:
+    """The top-level module: `[tool.flit.module] name`, else the dist name, `-` -> `_`.
+
+    Three lines duplicated from `check_workspace.Member.module` on purpose. These scripts
+    are run BY PATH and never imported, so an `import check_workspace` here and the tests'
+    `sn_tools.check_workspace` would be two module objects for one file. Keep the two rules
+    in step; the release workflow's compat cell carries the same rule a third time.
+    """
+    name = manifest.get("tool", {}).get("flit", {}).get("module", {}).get("name")
+    return name if isinstance(name, str) else dist.replace("-", "_")
+
+
+def find_member(dist: str) -> tuple[Path, dict[str, Any]]:
+    """The directory and manifest of the workspace member named `dist`."""
+    root = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    globs = root["tool"]["uv"]["workspace"]["members"]
+    wanted = canonical(dist)
+    known: list[str] = []
+    for pattern in globs:
+        for path in sorted(REPO_ROOT.glob(f"{pattern}/pyproject.toml")):
+            manifest = tomllib.loads(path.read_text(encoding="utf-8"))
+            name = manifest.get("project", {}).get("name")
+            if not isinstance(name, str):
+                continue
+            known.append(name)
+            if canonical(name) != wanted:
+                continue
+            if manifest.get("tool", {}).get("uv", {}).get("package") is False:
+                raise CheckError(
+                    f"`{name}` is a virtual member (`[tool.uv] package = false`): this "
+                    "repository never publishes it, `uv build --package` is refused for "
+                    "it, and there is no released wheel for anything to import"
+                )
+            return path.parent, manifest
+    raise CheckError(
+        f"`{dist}` is not a member of this workspace "
+        f"(known: {', '.join(sorted(known)) or 'none'})"
+    )
+
+
+def run(cmd: list[str | Path], **kwargs: Any) -> None:
+    """Run a command, echoing it first (`scripts/smoke_needs.py`'s style), and raise if it
+    fails. Output is inherited rather than captured: a `uv build` or a resolution failure is
+    the answer the reader came for."""
+    print("$", " ".join(str(part) for part in cmd), flush=True)
+    proc = subprocess.run([str(part) for part in cmd], **kwargs)
+    if proc.returncode != 0:
+        raise CheckError(f"`{cmd[0]}` failed with exit code {proc.returncode}")
+
+
+def interpreter_in(venv: Path) -> Path:
+    for candidate in (venv / "bin" / "python", venv / "Scripts" / "python.exe"):
+        if candidate.exists():
+            return candidate
+    raise CheckError(
+        f"no interpreter in {venv} (looked for bin/python, Scripts/python.exe)"
+    )
+
+
+def check(dist: str, wheel_arg: str | None, python: str | None, keep: bool) -> int:
+    """Build, install from the index, walk. Returns the inner layer's exit status."""
+    started = time.monotonic()
+    directory, manifest = find_member(dist)
+    module = module_name(manifest, dist)
+    print(f"{dist} -> module {module} ({directory.relative_to(REPO_ROOT).as_posix()})")
+    tmp = Path(tempfile.mkdtemp(prefix=f"import-check-{dist}-"))
+    try:
+        if wheel_arg:
+            wheel = Path(wheel_arg).resolve()
+            if not wheel.is_file():
+                raise CheckError(f"no such wheel: {wheel}")
+        else:
+            out_dir = tmp / "dist"
+            # character for character the command `release.yaml` and `poe build-needs`
+            # run: a check that built the artefact differently would not be checking it
+            run(
+                ["uv", "build", "--package", dist, "--no-sources", "-o", out_dir],
+                cwd=REPO_ROOT,
+            )
+            wheels = sorted(out_dir.glob("*.whl"))
+            if len(wheels) != 1:
+                raise CheckError(f"expected one wheel in {out_dir}, found {wheels}")
+            wheel = wheels[0]
+        venv = tmp / "venv"
+        # no `--python` by default: the root `.python-version` decides, which is exactly
+        # what the compat cell does. `cwd=REPO_ROOT` is what lets uv see that file
+        run(
+            ["uv", "venv", *(["--python", python] if python else []), venv],
+            cwd=REPO_ROOT,
+        )
+        # `--no-sources` is THE flag. Without it uv honours `[tool.uv.sources]` and installs
+        # the sibling member from the checkout, and the check silently proves nothing
+        run(
+            ["uv", "pip", "install", "--python", venv, "--no-sources", wheel],
+            cwd=REPO_ROOT,
+        )
+        interpreter = interpreter_in(venv)
+        inner = [
+            interpreter,
+            Path(__file__).resolve(),
+            "--walk",
+            module,
+            "--expect-prefix",
+            venv,
+        ]
+        print("$", " ".join(str(part) for part in inner), flush=True)
+        code = subprocess.run([str(part) for part in inner], cwd=REPO_ROOT).returncode
+    finally:
+        if keep:
+            print(f"kept {tmp}")
+        else:
+            shutil.rmtree(tmp, ignore_errors=True)
+    print(f"import check finished in {time.monotonic() - started:.1f}s")
+    return code
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Import every module of a member's built wheel against its dependencies as "
+            "PUBLISHED. With --walk it is the inner layer instead: import one module tree "
+            "under the current interpreter."
+        ),
+    )
+    parser.add_argument(
+        "dist", nargs="?", help="the distribution to check, e.g. sphinx-needs"
+    )
+    parser.add_argument(
+        "--walk",
+        metavar="MODULE",
+        help="INNER: import this module and every submodule under it, in THIS interpreter",
+    )
+    parser.add_argument(
+        "--expect-prefix",
+        metavar="DIR",
+        help="INNER: fail unless the module was imported from under this directory",
+    )
+    parser.add_argument(
+        "--wheel", metavar="PATH", help="use this wheel instead of building one"
+    )
+    parser.add_argument(
+        "--python", metavar="X", help="interpreter for the throwaway environment"
+    )
+    parser.add_argument(
+        "--keep", action="store_true", help="keep the temporary directory"
+    )
+    args = parser.parse_args(argv)
+
+    if args.walk:
+        return walk(args.walk, args.expect_prefix)
+    if not args.dist:
+        parser.error(
+            "name a distribution (outer layer) or pass --walk MODULE (inner layer)"
+        )
+    try:
+        return check(args.dist, args.wheel, args.python, args.keep)
+    except CheckError as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/src/sn_tools/import_check.py
+++ b/tools/src/sn_tools/import_check.py
@@ -100,6 +100,12 @@ def submodule_names(
     is caught here and handed back so the caller can report it: the per-module loop below
     will import the same package again and file the real failure, and the walk it cut short
     is named.
+
+    One boundary this cannot see: a package that imports cleanly but empties its own
+    `__path__` reports no submodules, so `pkgutil` truthfully yields none, nothing lands in
+    `unwalkable` or the cut-short exit, and a child module on disk is never imported while
+    the walk prints `OK`. Closing that would mean walking the filesystem behind the import
+    system's back; the walk trusts what a package declares.
     """
     names: list[str] = []
     walker = pkgutil.walk_packages(

--- a/tools/src/sn_tools/import_check.py
+++ b/tools/src/sn_tools/import_check.py
@@ -121,6 +121,11 @@ def is_entry_point(name: str) -> bool:
     Importing one runs it, against the WALKER's argv, and a `sys.exit()` outside an
     `if __name__ == "__main__"` guard then ends the walk. `python -m <pkg>` is what that
     file is for; the wheel's import surface is everything else.
+
+    The cost is real and deliberate: `__main__.py` IS import surface for `python -m <pkg>`,
+    so a name missing from it -- exactly the failure this whole check exists to catch -- is
+    invisible here. That is why the skip is announced on every run rather than done
+    quietly; do not read a green walk as covering a member's CLI entry point.
     """
     return name.rpartition(".")[2] == "__main__"
 
@@ -229,6 +234,26 @@ def walk(module: str, expect_prefix: str | None) -> int:
         print(
             f"FAIL  {len(failures)} of {len(names)} modules failed to import in "
             f"{elapsed:.1f}s ({len(names) - len(failures)} imported{blocked})"
+        )
+        return 1
+    # An INCOMPLETE walk is not a pass. Both of the lists above rely on the package failing
+    # again when the loop re-imports it, and an import-time failure need not be idempotent:
+    # a `sys.exit()` behind an "already configured?" test, a module that writes a cache and
+    # then fails, a plugin that registers itself on first import. Every one of those leaves
+    # a subtree unlisted and every module the loop DID reach importing cleanly -- which used
+    # to print `OK` and exit 0, with the compat cell's gate step green over an unwalked tree
+    if cut_short is not None or unwalkable:
+        reasons = []
+        if unwalkable:
+            reasons.append(
+                f"{len(unwalkable)} package(s) did not import on the walker's first pass, "
+                "so their contents were never listed"
+            )
+        if cut_short is not None:
+            reasons.append(f"the walk was cut short by SystemExit: {cut_short.code}")
+        print(
+            f"FAIL  walk incomplete: {'; '.join(reasons)} -- {len(names)} modules "
+            f"imported in {elapsed:.1f}s, and an unknown number never were"
         )
         return 1
     print(f"OK    {len(names)} modules imported in {elapsed:.1f}s")

--- a/tools/src/sn_tools/release_plan.py
+++ b/tools/src/sn_tools/release_plan.py
@@ -38,19 +38,31 @@ Given a tag `<dist>-v<version>` it asserts, in order:
 It also emits `previous_tag`, the release this one follows, for GitHub's
 `releases/generate-notes` API.
 
-With no `--tag` it just prints the topological release order, dependencies first, which is
-the answer to "what do I release, and in what sequence".
+With no `--tag` this is the **planner**, meant to be run before the release pull request
+rather than by CI. It prints the topological release order, then for every publishable
+member the last release tag, what PyPI has, the commits since that tag that touched the
+member's *shipped* code, and -- for each of its dependants -- the version of it the compat
+cell would install from PyPI; then a suggested sequence with the exact commands.
+
+**The planner is advice and never a gate: it exits 0 whatever it finds**, and 1 only when
+the data could not be gathered (a manifest it cannot read, a PyPI answer that is not a
+clean 404, a git failure). That is deliberate. The release ORDER is enforced by check 4
+above and by the compat cell running a dependant's suite against the *released* dependency;
+making "there are commits since the last tag" fatal instead would force a premature core
+release off a master carrying unfinished work every time an unrelated extension shipped a
+fix. The planner says the same thing early, in words, and lets a human decide.
 
 Usage::
 
-    python tools/src/sn_tools/release_plan.py                      # print the order
+    python tools/src/sn_tools/release_plan.py                      # the planner
     python tools/src/sn_tools/release_plan.py --tag sphinx-needs-v8.6.0
     python tools/src/sn_tools/release_plan.py --tag ... --rehearsal --github-output
 
 Run at the workspace root. Needs `packaging`; PyPI is reached with the standard library,
 and git with `git`. In CI it runs as
 `uv run --no-project --with packaging python tools/src/sn_tools/release_plan.py`, so a
-manifest mistake is named here rather than reported as "sync failed".
+manifest mistake is named here rather than reported as "sync failed" -- and always with
+`--tag`, which is why none of the planner's git or PyPI calls happen in the release job.
 """
 
 from __future__ import annotations
@@ -64,13 +76,20 @@ import tomllib
 import urllib.error
 import urllib.request
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 
 from packaging.requirements import Requirement
 from packaging.utils import canonicalize_name
 from packaging.version import InvalidVersion, Version
 
 PYPI = "https://pypi.org/pypi/{name}/{version}/json"
+# the whole-project document, which the planner reads to learn every published version at
+# once; `PYPI` above answers one exact version and is all the tag checks need
+PYPI_PROJECT = "https://pypi.org/pypi/{name}/json"
+
+# `git log --name-only` interleaves headers and file names, and a file name may contain
+# anything. Prefixing each record with a record separator makes the parse unambiguous
+COMMIT_SEP = "\x1e"
 
 # The bare `<version>` tag namespace belongs to sphinx-needs, and only to it. Every tag in
 # this repository that is not `<dist>-v<version>` predates the monorepo move, when the
@@ -85,8 +104,22 @@ class PlanError(RuntimeError):
     """A condition that must stop the release rather than be guessed at."""
 
 
-def members(root: Path) -> tuple[dict[str, dict[str, Any]], set[str]]:
-    """Every workspace member's `[project]` table, and the names of the virtual ones.
+class Workspace(NamedTuple):
+    """What `members()` reads off the manifests.
+
+    A tuple rather than a richer object so that `projects, virtual, directories =
+    members(root)` keeps reading like the two-value version it replaced. `directories` is
+    the planner's addition: it needs each member's directory to ask git which commits
+    touched the code that member ships.
+    """
+
+    projects: dict[str, dict[str, Any]]
+    virtual: set[str]
+    directories: dict[str, Path]
+
+
+def members(root: Path) -> Workspace:
+    """Every workspace member's `[project]` table, directory, and whether it is virtual.
 
     A member with `[tool.uv] package = false` is virtual: `uv build --all-packages` skips
     it and `uv build --package <it>` is refused, so nothing this repository's workflows run
@@ -99,6 +132,7 @@ def members(root: Path) -> tuple[dict[str, dict[str, Any]], set[str]]:
     globs = manifest["tool"]["uv"]["workspace"]["members"]
     out: dict[str, dict[str, Any]] = {}
     virtual: set[str] = set()
+    directories: dict[str, Path] = {}
     for pattern in globs:
         for path in sorted(root.glob(f"{pattern}/pyproject.toml")):
             raw = tomllib.loads(path.read_text(encoding="utf-8"))
@@ -122,9 +156,10 @@ def members(root: Path) -> tuple[dict[str, dict[str, Any]], set[str]]:
                 )
             key = canonicalize_name(data["name"])
             out[key] = data
+            directories[key] = path.parent
             if raw.get("tool", {}).get("uv", {}).get("package") is False:
                 virtual.add(key)
-    return out, virtual
+    return Workspace(out, virtual, directories)
 
 
 def edges(project: dict[str, Any], names: set[str]) -> set[str]:
@@ -175,6 +210,49 @@ def on_pypi(name: str, version: str) -> bool:
         ) from exc
 
 
+def published_versions(name: str) -> dict[Version, bool]:
+    """Every version PyPI has of `name`, mapped to "is this release entirely yanked?".
+
+    The planner's view of the index, and one request per member rather than one per
+    version. A 404 for the WHOLE project means the distribution has never been published,
+    which is a perfectly good state for a first release -- so it is an empty answer, not an
+    error. Every other status, and an unreachable index, is a `PlanError`: the planner
+    would otherwise print advice built on a guess about what is released, which is worse
+    than printing nothing.
+
+    Versions PyPI reports that are not PEP 440 are skipped rather than fatal -- they are
+    somebody else's history, and no release decision here can turn on one.
+    """
+    url = PYPI_PROJECT.format(name=name)
+    try:
+        with urllib.request.urlopen(url, timeout=30) as response:
+            payload = json.load(response)
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return {}
+        raise PlanError(
+            f"PyPI returned {exc.code} for {url}; refusing to advise on a guess about "
+            f"what {name} has published"
+        ) from exc
+    except urllib.error.URLError as exc:
+        raise PlanError(
+            f"cannot reach PyPI ({exc.reason}); refusing to advise on a guess about what "
+            f"{name} has published"
+        ) from exc
+    except ValueError as exc:  # json.JSONDecodeError
+        raise PlanError(f"PyPI returned unreadable JSON for {url}: {exc}") from exc
+    out: dict[Version, bool] = {}
+    for raw, files in payload.get("releases", {}).items():
+        try:
+            parsed = Version(raw)
+        except InvalidVersion:
+            continue
+        # yanked means "every file of this release is yanked", because one usable file is
+        # enough to install. A release with no files left is unusable for the same reason
+        out[parsed] = all(item.get("yanked") for item in files) if files else True
+    return out
+
+
 def git(*args: str) -> str:
     """Run git, returning stdout; a failure is a PlanError, never a silent empty answer."""
     proc = subprocess.run(["git", *args], text=True, capture_output=True, check=False)
@@ -209,17 +287,79 @@ def is_ancestor(commit: str, branch: str) -> bool:
     )
 
 
-def previous_tag(dist: str, version: str, tags: list[str]) -> str:
-    """The tag of the release immediately below `version`, or "" if there is none.
+def resolve(ref: str) -> str | None:
+    """The commit `ref` names, or None when it does not resolve. Never fatal.
+
+    Only the planner uses this, and only for context: a checkout without `origin/master`
+    (a shallow clone, a fresh worktree that has never fetched) is a fact to report, not a
+    reason to refuse advice. `is_ancestor` above is the fail-closed one, and the planner
+    calls it only after this has said the ref exists.
+    """
+    proc = subprocess.run(
+        ["git", "rev-parse", "--verify", "--quiet", f"{ref}^{{commit}}"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return proc.stdout.strip() or None
+
+
+def head_context() -> tuple[str, str]:
+    """(short sha, branch name or "detached") for HEAD, for the planner's header line."""
+    sha = git("rev-parse", "--short", "HEAD").strip()
+    branch = git("rev-parse", "--abbrev-ref", "HEAD").strip()
+    return sha, "detached" if branch == "HEAD" else branch
+
+
+def commits_since(ref: str, paths: list[str]) -> list[tuple[str, str]]:
+    """(short sha, subject) for every commit since `ref` that touched `paths`, newest first.
+
+    An empty `ref` means the member has never been tagged, and the range becomes the whole
+    history -- the caller says so in its output, because "412 unreleased commits" reads
+    like a bug otherwise.
+    """
+    span = [f"{ref}..HEAD"] if ref else ["HEAD"]
+    out: list[tuple[str, str]] = []
+    for line in git("log", "--format=%h%x09%s", *span, "--", *paths).splitlines():
+        sha, tab, subject = line.partition("\t")
+        if tab:
+            out.append((sha, subject))
+    return out
+
+
+def touched_files(ref: str, paths: list[str]) -> dict[str, set[str]]:
+    """Every commit since `ref` touching `paths`, mapped to which of those files it changed.
+
+    One `git log` for as many path sets as the caller cares about, which is what lets the
+    "this commit changed the core AND the extension" heuristic cost one process rather than
+    one per dependency edge. `--name-only` honours the pathspec, so the file lists are
+    already restricted to `paths`.
+    """
+    span = [f"{ref}..HEAD"] if ref else ["HEAD"]
+    raw = git(
+        "log", f"--format={COMMIT_SEP}%h%x09%s", "--name-only", *span, "--", *paths
+    )
+    out: dict[str, set[str]] = {}
+    for record in raw.split(COMMIT_SEP):
+        lines = [line for line in record.splitlines() if line]
+        if not lines:
+            continue
+        out[lines[0].partition("\t")[0]] = set(lines[1:])
+    return out
+
+
+def release_tags(dist: str, tags: list[str]) -> list[tuple[Version, str]]:
+    """Every tag that names a release of `dist`, as (version, tag).
 
     Considers `<dist>-v<semver>` for every member and, for sphinx-needs only, the bare
     `<semver>` tags this repository used before the monorepo move (see BARE_TAG_DIST).
+    Tags that are not PEP 440 once the prefix is off -- `v2.0.0`, `v.1.4`,
+    `depbatch-backup-...` -- are somebody's else's refs and are skipped in silence.
+
+    `previous_tag` and the planner share this one parser deliberately: "which tags are this
+    distribution's releases" must have exactly one answer.
     """
-    try:
-        current = Version(version)
-    except InvalidVersion as exc:
-        raise PlanError(f"`{version}` is not a PEP 440 version") from exc
-    candidates: list[tuple[Version, str]] = []
+    out: list[tuple[Version, str]] = []
     for tag in tags:
         raw: str | None = None
         if tag.startswith(f"{dist}-v"):
@@ -229,11 +369,19 @@ def previous_tag(dist: str, version: str, tags: list[str]) -> str:
         if raw is None:
             continue
         try:
-            parsed = Version(raw)
+            out.append((Version(raw), tag))
         except InvalidVersion:
             continue
-        if parsed < current:
-            candidates.append((parsed, tag))
+    return out
+
+
+def previous_tag(dist: str, version: str, tags: list[str]) -> str:
+    """The tag of the release immediately below `version`, or "" if there is none."""
+    try:
+        current = Version(version)
+    except InvalidVersion as exc:
+        raise PlanError(f"`{version}` is not a PEP 440 version") from exc
+    candidates = [pair for pair in release_tags(dist, tags) if pair[0] < current]
     if not candidates:
         return ""
     # max on the version, and on the tag name to break a bare/prefixed tie deterministically
@@ -252,9 +400,297 @@ def split_tag(tag: str, known: list[str]) -> tuple[str, str]:
     )
 
 
+# --- the planner: what to release, in what order, tested against what --------------------
+# Everything below runs only when no `--tag` was given. None of it is reachable from the
+# release workflow, which always passes one -- see R3 in the module docstring: the plan job
+# runs with `--no-project`, and a planner that woke up there would add PyPI and git calls to
+# the one job standing between a mistyped tag and an upload.
+
+# how many commits to list under a member before summarising the rest. A member that has
+# never been tagged has its whole history here, and a screenful is enough to recognise it
+LISTED_COMMITS = 10
+
+
+class Status(NamedTuple):
+    """One publishable member's release situation, as the planner sees it."""
+
+    name: str
+    declared: Version
+    published: dict[Version, bool]  # every version PyPI has -> is it entirely yanked?
+    latest: Version | None  # the highest version PyPI has that is not yanked
+    last_tag: str  # "" when this member has never been tagged
+    declared_tag: str  # the tag naming `declared`, if one exists locally
+    commits: list[tuple[str, str]]  # unreleased commits touching the shipped code
+    paths: list[str]  # that shipped code, repository-relative
+    verdict: int  # 1 up to date | 2 bump first | 3 ready to tag | 4 behind PyPI
+
+
+def shipped_paths(root: Path, directory: Path) -> list[str]:
+    """A member's SHIPPED code: `<dir>/src` and `<dir>/pyproject.toml`.
+
+    Documentation and tests are deliberately excluded -- a docs commit is not a reason to
+    cut a release, and counting one would make the planner cry wolf on every branch. The
+    filter is printed in the output, because "5 unreleased commits" says nothing until the
+    reader knows what "touched" was taken to mean.
+    """
+    where = directory.relative_to(root).as_posix()
+    return [f"{where}/src", f"{where}/pyproject.toml"]
+
+
+def under(path: str, roots: list[str]) -> bool:
+    """Is `path` one of `roots`, or inside one of them?"""
+    return any(path == root or path.startswith(f"{root}/") for root in roots)
+
+
+def requirement_for(project: dict[str, Any], dependency: str) -> str | None:
+    """A dependant's own requirement on `dependency`, extras included (as `edges()` is).
+
+    The manifest's own text, not a re-rendered `Requirement`: `packaging` normalises a
+    specifier set into sorted order, so `sphinx-needs>=8.5.0,<9` comes back as
+    `<9,>=8.5.0` -- correct, and not what the reader will find when they open the file.
+    """
+    specs = list(project.get("dependencies", []))
+    for extra_specs in project.get("optional-dependencies", {}).values():
+        specs.extend(extra_specs)
+    for spec in specs:
+        if canonicalize_name(Requirement(spec).name) == dependency:
+            return spec
+    return None
+
+
+def status_of(
+    name: str, project: dict[str, Any], paths: list[str], tags: list[str]
+) -> Status:
+    """Gather one member's facts and reach a verdict. Every outside call here is a seam."""
+    try:
+        declared = Version(project["version"])
+    except InvalidVersion as exc:
+        raise PlanError(
+            f"{project['name']} declares version `{project['version']}`, which is not "
+            "PEP 440; nothing in this pipeline can compare it with a tag or with PyPI"
+        ) from exc
+    releases = release_tags(name, tags)
+    last_tag = max(releases)[1] if releases else ""
+    declared_tag = next((tag for version, tag in releases if version == declared), "")
+    published = published_versions(name)
+    live = [version for version, yanked in published.items() if not yanked]
+    latest = max(live) if live else None
+    commits = commits_since(last_tag, paths)
+    # order matters: a tree BEHIND the index is an old branch, and that is the useful
+    # answer even though `declared` is (necessarily) published as well
+    if latest is not None and declared < latest:
+        verdict = 4
+    elif declared in published:
+        verdict = 2 if commits else 1
+    else:
+        verdict = 3
+    return Status(
+        name,
+        declared,
+        published,
+        latest,
+        last_tag,
+        declared_tag,
+        commits,
+        paths,
+        verdict,
+    )
+
+
+def print_commits(commits: list[tuple[str, str]], indent: str) -> None:
+    for sha, subject in commits[:LISTED_COMMITS]:
+        print(f"{indent}{sha}  {subject}")
+    if len(commits) > LISTED_COMMITS:
+        print(f"{indent}... and {len(commits) - LISTED_COMMITS} more")
+
+
+def print_status(status: Status, directory: str) -> None:
+    """One member's block: where it stands, and what to do about it."""
+    name, declared = status.name, status.declared
+    count = len(status.commits)
+    plural = "" if count == 1 else "s"
+    since = status.last_tag or "the start of history"
+    print()
+    print(f"{name} {declared}   ({directory})")
+    if status.last_tag:
+        print(f"  last release tag   {status.last_tag}")
+    else:
+        print(
+            "  last release tag   none -- never tagged, so everything below is its whole history"
+        )
+    if status.published:
+        yanked = sum(1 for value in status.published.values() if value)
+        newest = status.latest if status.latest is not None else "(every one yanked)"
+        note = f", {yanked} yanked" if yanked else ""
+        print(
+            f"  on PyPI            {len(status.published)} versions, latest {newest}{note}"
+        )
+    else:
+        print(f"  on PyPI            nothing -- {name} has never been published")
+    if status.verdict == 1:
+        print(
+            f"  up to date, nothing to release: {declared} is on PyPI and no commit since {since} touched its shipped code"
+        )
+    elif status.verdict == 2:
+        print(
+            f"  {count} unreleased commit{plural} since {since}; {declared} is already published -- bump before tagging:"
+        )
+        print(
+            f"      uv version --package {name} --bump {{patch|minor|major}} --no-sync"
+        )
+        print_commits(status.commits, "    ")
+    elif status.verdict == 3:
+        print(f"  release pending: {declared} is not on PyPI, and this tree builds it")
+        print(f"      git tag {name}-v{declared} && git push origin {name}-v{declared}")
+        print(
+            f"      rehearse first: gh workflow run release.yaml -f tag={name}-v{declared}"
+        )
+        if status.declared_tag:
+            print(
+                f"  the tag {status.declared_tag} exists but PyPI has no {declared}: that release did not complete -- re-run the workflow from the tag, do not re-tag"
+            )
+        if count:
+            print(f"  {count} commit{plural} since {since} touched its shipped code:")
+            print_commits(status.commits, "    ")
+    else:
+        print(
+            f"  this tree is BEHIND PyPI ({declared} vs {status.latest}) -- an old branch?"
+        )
+
+
+def shared_commits(core: Status, dependant: Status) -> list[tuple[str, str]]:
+    """The core's unreleased commits that ALSO touched the dependant's shipped code.
+
+    The scenario no version comparison can see: one feature commit changes the core and the
+    extension together, so the extension almost certainly relies on the core that is not
+    released yet. One `git log` covers both path sets.
+    """
+    changed = touched_files(core.last_tag, core.paths + dependant.paths)
+    subjects = dict(core.commits)
+    out: list[tuple[str, str]] = []
+    for sha, _ in core.commits:
+        files = changed.get(sha, set())
+        if any(under(item, core.paths) for item in files) and any(
+            under(item, dependant.paths) for item in files
+        ):
+            out.append((sha, subjects[sha]))
+    return out
+
+
+def print_dependant(core: Status, dependant: Status, spec: str) -> None:
+    """What a release of `dependant` would be tested against, and what that misses."""
+    live = sorted(version for version, yanked in core.published.items() if not yanked)
+    usable = sorted(Requirement(spec).specifier.filter(live))
+    tag = f"{dependant.name}-v{dependant.declared}"
+    count = len(core.commits)
+    plural = "" if count == 1 else "s"
+    print(f"    {dependant.name} {dependant.declared} needs {spec}")
+    if not usable:
+        have = f"only up to {core.latest}" if core.latest else "nothing"
+        print(
+            f"      the plan job WILL refuse `{tag}`: it needs {spec}, and PyPI has {have} -- release {core.name} first"
+        )
+    else:
+        lacks = (
+            f", which lacks {core.name}'s {count} commit{plural} since {core.last_tag or 'the start of history'}"
+            if count
+            else ""
+        )
+        print(
+            f"      the compat cell installs {core.name} from PyPI: `{tag}` would be tested against {core.name} {usable[-1]}{lacks}"
+        )
+        both = shared_commits(core, dependant)
+        if both:
+            print(
+                f"      these changed both {core.name} and {dependant.name} -- {dependant.name} very likely relies on the unreleased {core.name}; bump and release {core.name} first:"
+            )
+            print_commits(both, "        ")
+    print(
+        f"      `python tools/src/sn_tools/import_check.py {dependant.name}` installs the PUBLISHED {core.name} and imports every {dependant.name} module -- a missing symbol is named in seconds; behaviour changes still need the suite (the compat cell)"
+    )
+
+
+def print_sequence(sequence: list[str], statuses: dict[str, Status]) -> None:
+    """The topological order, filtered to what is actually pending, with the commands."""
+    pending = [name for name in sequence if statuses[name].verdict in (2, 3)]
+    settled = [name for name in sequence if statuses[name].verdict == 1]
+    behind = [name for name in sequence if statuses[name].verdict == 4]
+    print()
+    if not pending:
+        if behind:
+            print("nothing to release from this tree")
+            print(
+                f"  behind PyPI, so nothing to release from this tree: {', '.join(behind)}"
+            )
+        else:
+            print("nothing to release: every member is up to date")
+        return
+    print("suggested sequence (dependencies first):")
+    for rank, name in enumerate(pending, 1):
+        status = statuses[name]
+        if status.verdict == 2:
+            version = "<new version>"
+            print(f"  {rank}. after a bump: {name}")
+            print(
+                f"       uv version --package {name} --bump {{patch|minor|major}} --no-sync"
+            )
+        else:
+            version = str(status.declared)
+            print(f"  {rank}. {name} {version}")
+        print(f"       rehearse: gh workflow run release.yaml -f tag={name}-v{version}")
+        print(
+            f"       tag:      git tag {name}-v{version} && git push origin {name}-v{version}"
+        )
+    if settled:
+        print(f"  nothing to release: {', '.join(settled)}")
+    if behind:
+        print(
+            f"  behind PyPI, so nothing to release from this tree: {', '.join(behind)}"
+        )
+
+
+def planner(
+    root: Path, workspace: Workspace, graph: dict[str, set[str]], sequence: list[str]
+) -> None:
+    """Everything after the release order when no `--tag` was given. Prints; never gates."""
+    found, _virtual, directories = workspace
+    print()
+    print("release plan -- advice, never a gate: this exits 0 whatever it finds")
+    sha, branch = head_context()
+    print(f"  HEAD {sha} ({branch})")
+    if resolve("origin/master") is None:
+        print("  origin/master not found (no fetch?): ancestry not checked")
+    elif not is_ancestor("HEAD", "origin/master"):
+        print(
+            "  HEAD is not on origin/master -- releases are cut from master; this describes THIS tree"
+        )
+    print(
+        '  "unreleased" counts commits touching a member\'s SHIPPED code -- <member>/src and <member>/pyproject.toml. Docs and tests are deliberately not counted'
+    )
+
+    tags = list_tags()
+    statuses = {
+        name: status_of(name, found[name], shipped_paths(root, directories[name]), tags)
+        for name in sequence
+    }
+    for name in sequence:
+        print_status(statuses[name], directories[name].relative_to(root).as_posix())
+        dependants = [other for other in sequence if name in graph[other]]
+        if dependants:
+            print("  dependants:")
+        for other in dependants:
+            spec = requirement_for(found[other], name)
+            # `edges()` found the edge in the same two tables, so this cannot be None --
+            # but the planner must never traceback at a reader who wanted advice
+            if spec is not None:
+                print_dependant(statuses[name], statuses[other], spec)
+    print_sequence(sequence, statuses)
+
+
 def plan(args: argparse.Namespace) -> int:
     root: Path = args.root
-    found, virtual = members(root)
+    workspace = members(root)
+    found, virtual = workspace.projects, workspace.virtual
     names = set(found)
     graph = {name: edges(data, names) for name, data in found.items()}
     sequence = [name for name in order(graph) if name not in virtual]
@@ -268,6 +704,16 @@ def plan(args: argparse.Namespace) -> int:
         print(f"  -- {name} {found[name]['version']}   (virtual -- never published)")
 
     if not args.tag:
+        if args.no_git:
+            # the planner IS git reasoning -- which commits since the last tag touched a
+            # member's shipped code -- so the flag would not skip a check, it would empty
+            # the answer. Refusing is clearer than printing advice with the middle missing
+            raise PlanError(
+                "--no-git makes no sense without --tag: the planner's whole subject is "
+                "what git says has changed since each member's last release tag. Drop "
+                "--no-git, or pass --tag to run the release-tag checks without git"
+            )
+        planner(root, workspace, graph, sequence)
         return 0
 
     failures = 0

--- a/tools/src/sn_tools/release_plan.py
+++ b/tools/src/sn_tools/release_plan.py
@@ -242,9 +242,12 @@ def published_versions(name: str) -> dict[Version, bool]:
             f"what {name} has published"
         ) from exc
     except OSError as exc:  # URLError, and a read TimeoutError, which is not one
+        # `.reason` where there is one, so a URLError still reads `[Errno 61] Connection
+        # refused` rather than `<urlopen error [Errno 61] Connection refused>` -- which is
+        # what `on_pypi` prints two functions away, and the two should not drift
         raise PlanError(
-            f"cannot reach PyPI ({exc}); refusing to advise on a guess about what "
-            f"{name} has published"
+            f"cannot reach PyPI ({getattr(exc, 'reason', exc)}); refusing to advise on a "
+            f"guess about what {name} has published"
         ) from exc
     except ValueError as exc:  # json.JSONDecodeError
         raise PlanError(f"PyPI returned unreadable JSON for {url}: {exc}") from exc
@@ -667,32 +670,46 @@ def print_dependant(core: Status, dependant: Status, spec: str) -> None:
     print(f"    {dependant.name} {dependant.declared} needs {spec}")
     if core.declared not in core.published:
         # check (4)'s own predicate, verbatim: is the TREE's version on the index?
-        have = (
-            f"has {core.latest} as its newest live version"
-            if core.latest is not None
-            else "has nothing"
-        )
+        if core.latest is not None:
+            have = f"has {core.latest} as its newest live version"
+        elif core.published:
+            # `latest` is None but the index is not empty: every release is yanked, and
+            # "PyPI has nothing" would be a different, wronger fact
+            how_many = f"{len(core.published)} version{'' if len(core.published) == 1 else 's'}"
+            have = f"has {how_many}, all yanked"
+        else:
+            have = "has nothing"
         print(
             f"      the plan job WILL refuse `{tag}`: check 4 needs {core.name} {core.declared} on PyPI, and PyPI {have} -- release {core.name} first"
         )
-    elif core.published[core.declared]:
-        print(
-            f"      the plan job passes ({core.name} {core.declared} is on PyPI) but every file of it is yanked, so the resolver gate -- `uv pip install --dry-run` against the index -- will not pick it for a range: release a new {core.name}"
-        )
     else:
+        # the specifier is consulted BEFORE the yank, because a yanked tree version is only
+        # a problem when nothing else live satisfies the dependant: the resolver gate and the
+        # compat cell resolve a RANGE, so a live 2.0.0 answers `>=2.0.0,<3` perfectly well
+        # even while the tree's own 2.1.0 is withdrawn
         usable = sorted(Requirement(spec).specifier.filter(live))
-        if not usable:
+        withdrawn = core.published[core.declared]
+        if not usable and withdrawn:
+            print(
+                f"      the plan job passes ({core.name} {core.declared} is on PyPI) but every file of it is yanked and no other live {core.name} satisfies {spec}, so the resolver gate -- `uv pip install --dry-run` against the index -- cannot resolve it: release a new {core.name}"
+            )
+        elif not usable:
             print(
                 f"      no published {core.name} satisfies {spec}: the resolver gate fails (and Lint's check-workspace refuses a specifier that does not admit the tree's {core.declared})"
             )
         else:
+            instead = (
+                f" ({core.name} {core.declared}, this tree's version, is yanked, so the index resolves to {usable[-1]} instead)"
+                if withdrawn
+                else ""
+            )
             lacks = (
                 f", which lacks {core.name}'s {count} commit{plural} since {core.last_tag or 'the start of history'}"
                 if count
                 else ""
             )
             print(
-                f"      the compat cell installs {core.name} from PyPI: `{tag}` would be tested against {core.name} {usable[-1]}{lacks}"
+                f"      the compat cell installs {core.name} from PyPI: `{tag}` would be tested against {core.name} {usable[-1]}{instead}{lacks}"
             )
             both = shared_commits(core, dependant)
             if both:

--- a/tools/src/sn_tools/release_plan.py
+++ b/tools/src/sn_tools/release_plan.py
@@ -221,7 +221,14 @@ def published_versions(name: str) -> dict[Version, bool]:
     than printing nothing.
 
     Versions PyPI reports that are not PEP 440 are skipped rather than fatal -- they are
-    somebody else's history, and no release decision here can turn on one.
+    somebody else's history, and no release decision here can turn on one. A document that
+    is not the shape this function assumes is not skipped: it is a `PlanError`, because the
+    alternative is an `AttributeError` traceback out of the one script whose subject is
+    never guessing.
+
+    `except OSError` rather than `except URLError`: a socket read timeout raises
+    `TimeoutError`, which is an `OSError` and NOT a `URLError` -- `urlopen`'s read phase
+    does not wrap it -- so the narrower clause let a timeout through as a traceback.
     """
     url = PYPI_PROJECT.format(name=name)
     try:
@@ -234,28 +241,52 @@ def published_versions(name: str) -> dict[Version, bool]:
             f"PyPI returned {exc.code} for {url}; refusing to advise on a guess about "
             f"what {name} has published"
         ) from exc
-    except urllib.error.URLError as exc:
+    except OSError as exc:  # URLError, and a read TimeoutError, which is not one
         raise PlanError(
-            f"cannot reach PyPI ({exc.reason}); refusing to advise on a guess about what "
+            f"cannot reach PyPI ({exc}); refusing to advise on a guess about what "
             f"{name} has published"
         ) from exc
     except ValueError as exc:  # json.JSONDecodeError
         raise PlanError(f"PyPI returned unreadable JSON for {url}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise PlanError(
+            f"PyPI returned a {type(payload).__name__}, not an object, for {url}"
+        )
+    releases = payload.get("releases", {})
+    if not isinstance(releases, dict):
+        raise PlanError(
+            f"PyPI's `releases` for {url} is a {type(releases).__name__}, not an object"
+        )
     out: dict[Version, bool] = {}
-    for raw, files in payload.get("releases", {}).items():
+    for raw, files in releases.items():
         try:
             parsed = Version(raw)
         except InvalidVersion:
             continue
+        if not isinstance(files, list) or not all(
+            isinstance(item, dict) for item in files
+        ):
+            raise PlanError(
+                f"PyPI's file list for {name} {raw} is not a list of objects ({url})"
+            )
         # yanked means "every file of this release is yanked", because one usable file is
         # enough to install. A release with no files left is unusable for the same reason
         out[parsed] = all(item.get("yanked") for item in files) if files else True
     return out
 
 
-def git(*args: str) -> str:
-    """Run git, returning stdout; a failure is a PlanError, never a silent empty answer."""
-    proc = subprocess.run(["git", *args], text=True, capture_output=True, check=False)
+def git(*args: str, cwd: Path | None = None) -> str:
+    """Run git, returning stdout; a failure is a PlanError, never a silent empty answer.
+
+    `cwd` is what makes `--root` mean something to the planner: without it every git call
+    would answer about the process's working directory while the pathspecs were built for
+    another tree, which is confident misinformation rather than an error. It defaults to
+    None -- `subprocess.run`'s own default -- so the tag path, which passes no `cwd`, runs
+    byte-identically to before.
+    """
+    proc = subprocess.run(
+        ["git", *args], text=True, capture_output=True, check=False, cwd=cwd
+    )
     if proc.returncode != 0:
         raise PlanError(
             f"`git {' '.join(args)}` failed ({proc.returncode}): {proc.stderr.strip()}"
@@ -263,18 +294,23 @@ def git(*args: str) -> str:
     return proc.stdout
 
 
-def list_tags() -> list[str]:
+def list_tags(cwd: Path | None = None) -> list[str]:
     """Every tag in the checkout. The plan job's checkout has to fetch them."""
-    return [line.strip() for line in git("tag", "--list").splitlines() if line.strip()]
+    return [
+        line.strip()
+        for line in git("tag", "--list", cwd=cwd).splitlines()
+        if line.strip()
+    ]
 
 
-def is_ancestor(commit: str, branch: str) -> bool:
+def is_ancestor(commit: str, branch: str, cwd: Path | None = None) -> bool:
     """Is `commit` on `branch`? Anything other than a clean yes/no is fatal."""
     proc = subprocess.run(
         ["git", "merge-base", "--is-ancestor", commit, branch],
         capture_output=True,
         text=True,
         check=False,
+        cwd=cwd,
     )
     if proc.returncode == 0:
         return True
@@ -287,7 +323,7 @@ def is_ancestor(commit: str, branch: str) -> bool:
     )
 
 
-def resolve(ref: str) -> str | None:
+def resolve(ref: str, cwd: Path | None = None) -> str | None:
     """The commit `ref` names, or None when it does not resolve. Never fatal.
 
     Only the planner uses this, and only for context: a checkout without `origin/master`
@@ -300,18 +336,21 @@ def resolve(ref: str) -> str | None:
         capture_output=True,
         text=True,
         check=False,
+        cwd=cwd,
     )
     return proc.stdout.strip() or None
 
 
-def head_context() -> tuple[str, str]:
+def head_context(cwd: Path | None = None) -> tuple[str, str]:
     """(short sha, branch name or "detached") for HEAD, for the planner's header line."""
-    sha = git("rev-parse", "--short", "HEAD").strip()
-    branch = git("rev-parse", "--abbrev-ref", "HEAD").strip()
+    sha = git("rev-parse", "--short", "HEAD", cwd=cwd).strip()
+    branch = git("rev-parse", "--abbrev-ref", "HEAD", cwd=cwd).strip()
     return sha, "detached" if branch == "HEAD" else branch
 
 
-def commits_since(ref: str, paths: list[str]) -> list[tuple[str, str]]:
+def commits_since(
+    ref: str, paths: list[str], cwd: Path | None = None
+) -> list[tuple[str, str]]:
     """(short sha, subject) for every commit since `ref` that touched `paths`, newest first.
 
     An empty `ref` means the member has never been tagged, and the range becomes the whole
@@ -320,24 +359,41 @@ def commits_since(ref: str, paths: list[str]) -> list[tuple[str, str]]:
     """
     span = [f"{ref}..HEAD"] if ref else ["HEAD"]
     out: list[tuple[str, str]] = []
-    for line in git("log", "--format=%h%x09%s", *span, "--", *paths).splitlines():
+    for line in git(
+        "log", "--format=%h%x09%s", *span, "--", *paths, cwd=cwd
+    ).splitlines():
         sha, tab, subject = line.partition("\t")
         if tab:
             out.append((sha, subject))
     return out
 
 
-def touched_files(ref: str, paths: list[str]) -> dict[str, set[str]]:
+def touched_files(
+    ref: str, paths: list[str], cwd: Path | None = None
+) -> dict[str, set[str]]:
     """Every commit since `ref` touching `paths`, mapped to which of those files it changed.
 
     One `git log` for as many path sets as the caller cares about, which is what lets the
     "this commit changed the core AND the extension" heuristic cost one process rather than
     one per dependency edge. `--name-only` honours the pathspec, so the file lists are
     already restricted to `paths`.
+
+    `core.quotePath=false` is load-bearing: by default git C-quotes any path with a
+    non-ASCII or control character -- `"packages/core/src/x/t\303\253st.py"`, quotes and
+    all -- and `under()` would then see a name that starts with `"` and match nothing, so
+    the both-packages heuristic would silently miss such a commit. Measured.
     """
     span = [f"{ref}..HEAD"] if ref else ["HEAD"]
     raw = git(
-        "log", f"--format={COMMIT_SEP}%h%x09%s", "--name-only", *span, "--", *paths
+        "-c",
+        "core.quotePath=false",
+        "log",
+        f"--format={COMMIT_SEP}%h%x09%s",
+        "--name-only",
+        *span,
+        "--",
+        *paths,
+        cwd=cwd,
     )
     out: dict[str, set[str]] = {}
     for record in raw.split(COMMIT_SEP):
@@ -422,6 +478,7 @@ class Status(NamedTuple):
     declared_tag: str  # the tag naming `declared`, if one exists locally
     commits: list[tuple[str, str]]  # unreleased commits touching the shipped code
     paths: list[str]  # that shipped code, repository-relative
+    root: Path  # the tree those paths and every git call below are relative to
     verdict: int  # 1 up to date | 2 bump first | 3 ready to tag | 4 behind PyPI
 
 
@@ -459,7 +516,7 @@ def requirement_for(project: dict[str, Any], dependency: str) -> str | None:
 
 
 def status_of(
-    name: str, project: dict[str, Any], paths: list[str], tags: list[str]
+    name: str, project: dict[str, Any], paths: list[str], tags: list[str], root: Path
 ) -> Status:
     """Gather one member's facts and reach a verdict. Every outside call here is a seam."""
     try:
@@ -475,7 +532,7 @@ def status_of(
     published = published_versions(name)
     live = [version for version, yanked in published.items() if not yanked]
     latest = max(live) if live else None
-    commits = commits_since(last_tag, paths)
+    commits = commits_since(last_tag, paths, cwd=root)
     # order matters: a tree BEHIND the index is an old branch, and that is the useful
     # answer even though `declared` is (necessarily) published as well
     if latest is not None and declared < latest:
@@ -493,6 +550,7 @@ def status_of(
         declared_tag,
         commits,
         paths,
+        root,
         verdict,
     )
 
@@ -520,11 +578,14 @@ def print_status(status: Status, directory: str) -> None:
         )
     if status.published:
         yanked = sum(1 for value in status.published.values() if value)
-        newest = status.latest if status.latest is not None else "(every one yanked)"
-        note = f", {yanked} yanked" if yanked else ""
-        print(
-            f"  on PyPI            {len(status.published)} versions, latest {newest}{note}"
-        )
+        how_many = f"{len(status.published)} version{'' if len(status.published) == 1 else 's'}"
+        if status.latest is None:
+            print(
+                f"  on PyPI            {how_many}, latest: none -- every version yanked"
+            )
+        else:
+            note = f", {yanked} yanked" if yanked else ""
+            print(f"  on PyPI            {how_many}, latest {status.latest}{note}")
     else:
         print(f"  on PyPI            nothing -- {name} has never been published")
     if status.verdict == 1:
@@ -565,7 +626,7 @@ def shared_commits(core: Status, dependant: Status) -> list[tuple[str, str]]:
     extension together, so the extension almost certainly relies on the core that is not
     released yet. One `git log` covers both path sets.
     """
-    changed = touched_files(core.last_tag, core.paths + dependant.paths)
+    changed = touched_files(core.last_tag, core.paths + dependant.paths, cwd=core.root)
     subjects = dict(core.commits)
     out: list[tuple[str, str]] = []
     for sha, _ in core.commits:
@@ -578,35 +639,69 @@ def shared_commits(core: Status, dependant: Status) -> list[tuple[str, str]]:
 
 
 def print_dependant(core: Status, dependant: Status, spec: str) -> None:
-    """What a release of `dependant` would be tested against, and what that misses."""
+    """What a release of `dependant` would be stopped by, or tested against.
+
+    The gates are asked in the order the pipeline asks them, and each branch names the ONE
+    that fires:
+
+    1. the plan job's check (4) -- `on_pypi(<core>, <core's TREE version>)`. Note what that
+       predicate is: not "does something published satisfy the dependant's specifier" but
+       "is the version this tree builds on the index at all". Answering the second question
+       and reporting it as the first is how this line came to reassure a reader about a tag
+       the plan job then refused (and to threaten a refusal that never came, for a yanked
+       release: the per-version PyPI URL answers 200 for one, so check (4) passes);
+    2. the resolver gate and the compat cell's install, which resolve a RANGE from the
+       index and therefore skip yanked releases even though check (4) accepted one;
+    3. the compat cell itself, which is the only content-aware guard and the only thing
+       that can catch a behaviour change.
+
+    One limit worth stating: `SpecifierSet.filter` compares versions and nothing else, so a
+    release whose only artefacts are incompatible with the compat cell's interpreter -- a
+    higher `Requires-Python`, a platform-specific wheel set -- would be named here and
+    passed over by uv. Both members are pure-python `py3-none-any` today.
+    """
     live = sorted(version for version, yanked in core.published.items() if not yanked)
-    usable = sorted(Requirement(spec).specifier.filter(live))
     tag = f"{dependant.name}-v{dependant.declared}"
     count = len(core.commits)
     plural = "" if count == 1 else "s"
     print(f"    {dependant.name} {dependant.declared} needs {spec}")
-    if not usable:
-        have = f"only up to {core.latest}" if core.latest else "nothing"
+    if core.declared not in core.published:
+        # check (4)'s own predicate, verbatim: is the TREE's version on the index?
+        have = (
+            f"has {core.latest} as its newest live version"
+            if core.latest is not None
+            else "has nothing"
+        )
         print(
-            f"      the plan job WILL refuse `{tag}`: it needs {spec}, and PyPI has {have} -- release {core.name} first"
+            f"      the plan job WILL refuse `{tag}`: check 4 needs {core.name} {core.declared} on PyPI, and PyPI {have} -- release {core.name} first"
+        )
+    elif core.published[core.declared]:
+        print(
+            f"      the plan job passes ({core.name} {core.declared} is on PyPI) but every file of it is yanked, so the resolver gate -- `uv pip install --dry-run` against the index -- will not pick it for a range: release a new {core.name}"
         )
     else:
-        lacks = (
-            f", which lacks {core.name}'s {count} commit{plural} since {core.last_tag or 'the start of history'}"
-            if count
-            else ""
-        )
-        print(
-            f"      the compat cell installs {core.name} from PyPI: `{tag}` would be tested against {core.name} {usable[-1]}{lacks}"
-        )
-        both = shared_commits(core, dependant)
-        if both:
+        usable = sorted(Requirement(spec).specifier.filter(live))
+        if not usable:
             print(
-                f"      these changed both {core.name} and {dependant.name} -- {dependant.name} very likely relies on the unreleased {core.name}; bump and release {core.name} first:"
+                f"      no published {core.name} satisfies {spec}: the resolver gate fails (and Lint's check-workspace refuses a specifier that does not admit the tree's {core.declared})"
             )
-            print_commits(both, "        ")
+        else:
+            lacks = (
+                f", which lacks {core.name}'s {count} commit{plural} since {core.last_tag or 'the start of history'}"
+                if count
+                else ""
+            )
+            print(
+                f"      the compat cell installs {core.name} from PyPI: `{tag}` would be tested against {core.name} {usable[-1]}{lacks}"
+            )
+            both = shared_commits(core, dependant)
+            if both:
+                print(
+                    f"      these changed both {core.name} and {dependant.name} -- {dependant.name} very likely relies on the unreleased {core.name}; bump and release {core.name} first:"
+                )
+                print_commits(both, "        ")
     print(
-        f"      `python tools/src/sn_tools/import_check.py {dependant.name}` installs the PUBLISHED {core.name} and imports every {dependant.name} module -- a missing symbol is named in seconds; behaviour changes still need the suite (the compat cell)"
+        f"      `uv run python tools/src/sn_tools/import_check.py {dependant.name}` installs the PUBLISHED {core.name} and imports every {dependant.name} module -- a missing symbol is named in seconds; behaviour changes still need the suite (the compat cell)"
     )
 
 
@@ -617,10 +712,10 @@ def print_sequence(sequence: list[str], statuses: dict[str, Status]) -> None:
     behind = [name for name in sequence if statuses[name].verdict == 4]
     print()
     if not pending:
+        # one line, not two: the "behind" note IS the answer when nothing is pending
         if behind:
-            print("nothing to release from this tree")
             print(
-                f"  behind PyPI, so nothing to release from this tree: {', '.join(behind)}"
+                f"behind PyPI, so nothing to release from this tree: {', '.join(behind)}"
             )
         else:
             print("nothing to release: every member is up to date")
@@ -656,11 +751,11 @@ def planner(
     found, _virtual, directories = workspace
     print()
     print("release plan -- advice, never a gate: this exits 0 whatever it finds")
-    sha, branch = head_context()
+    sha, branch = head_context(cwd=root)
     print(f"  HEAD {sha} ({branch})")
-    if resolve("origin/master") is None:
+    if resolve("origin/master", cwd=root) is None:
         print("  origin/master not found (no fetch?): ancestry not checked")
-    elif not is_ancestor("HEAD", "origin/master"):
+    elif not is_ancestor("HEAD", "origin/master", cwd=root):
         print(
             "  HEAD is not on origin/master -- releases are cut from master; this describes THIS tree"
         )
@@ -668,9 +763,11 @@ def planner(
         '  "unreleased" counts commits touching a member\'s SHIPPED code -- <member>/src and <member>/pyproject.toml. Docs and tests are deliberately not counted'
     )
 
-    tags = list_tags()
+    tags = list_tags(cwd=root)
     statuses = {
-        name: status_of(name, found[name], shipped_paths(root, directories[name]), tags)
+        name: status_of(
+            name, found[name], shipped_paths(root, directories[name]), tags, root
+        )
         for name in sequence
     }
     for name in sequence:

--- a/tools/tests/test_import_check.py
+++ b/tools/tests/test_import_check.py
@@ -94,6 +94,62 @@ def test_every_failing_module_is_reported_not_just_the_first(tmp_path: Path) -> 
     assert "missing_symbol.py:1 in <module>: raise ImportError" in out
 
 
+FLAKY_PACKAGE = """\
+import pathlib
+
+marker = pathlib.Path({marker!r})
+if not marker.exists():
+    marker.write_text("seen")
+    raise {failure}
+"""
+
+
+@pytest.mark.parametrize(
+    ("failure", "expected"),
+    [
+        # the walker's own generator dies on this one, so nothing after it is even listed
+        ("SystemExit(0)", "the walk was cut short by SystemExit: 0"),
+        # this one goes through `onerror`, so the siblings are listed and the subtree is not
+        (
+            "ImportError('not yet')",
+            "1 package(s) did not import on the walker's first pass",
+        ),
+    ],
+)
+def test_an_incomplete_walk_is_never_ok(
+    tmp_path: Path, failure: str, expected: str
+) -> None:
+    """V1. An import-time failure need not be idempotent.
+
+    A `sys.exit()` behind an "already configured?" test, a module that writes a cache and
+    then fails, a plugin that registers itself on first import: the package fails while
+    `pkgutil` is walking, and succeeds when the loop re-imports it. Every module the loop
+    reached then imports cleanly, `failures` is empty -- and the walk printed `OK` and
+    exited 0 over a subtree it never listed, with the compat cell's gate step green.
+    """
+    root = scratch_package(
+        tmp_path,
+        {
+            "pkg/__init__.py": "",
+            "pkg/sub/__init__.py": FLAKY_PACKAGE.format(
+                marker=str(tmp_path / "marker"), failure=failure
+            ),
+            "pkg/sub/child.py": "VALUE = 1\n",
+            "pkg/zzz.py": "VALUE = 1\n",
+        },
+    )
+    proc = walk(root, "pkg")
+    out = proc.stdout
+    # the second import succeeds, so nothing is recorded as a per-module failure ...
+    assert "FAIL  pkg.sub:" not in out
+    assert "OK    " not in out
+    # ... and the walk is still not a pass, because it did not finish
+    assert "FAIL  walk incomplete:" in out
+    assert expected in out
+    assert "and an unknown number never were" in out
+    assert proc.returncode == 1, proc.stdout + proc.stderr
+
+
 def test_a_package_that_cannot_import_stops_its_own_subtree(tmp_path: Path) -> None:
     root = scratch_package(
         tmp_path,

--- a/tools/tests/test_import_check.py
+++ b/tools/tests/test_import_check.py
@@ -1,0 +1,306 @@
+"""`import_check.py`: the wheel-only import walk, and the environment it runs in.
+
+The **inner** layer is tested for real -- a scratch package on `PYTHONPATH`, imported by a
+subprocess with `sys.executable` -- because its entire subject is what happens at import
+time, and a mocked import would prove nothing about it.
+
+The **outer** layer is tested with `subprocess.run` monkeypatched, on its argv. It exists to
+issue four exact commands, and one flag on one of them (`--no-sources` on the install) is
+the whole reason the check means anything: without it uv substitutes the sibling member from
+the checkout and the walk passes against code that was never released. So the assertions are
+on the commands, not on their results.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+from sn_tools import import_check
+
+SCRIPT = Path(import_check.__file__).resolve()
+
+
+# --- the inner layer ----------------------------------------------------------------------
+
+
+def scratch_package(root: Path, modules: dict[str, str]) -> Path:
+    for name, body in modules.items():
+        path = root / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(textwrap.dedent(body), encoding="utf-8")
+    return root
+
+
+def walk(root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    """Run the inner layer the way the outer layer does: by path, in another process."""
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--walk", *args],
+        cwd=root,
+        text=True,
+        capture_output=True,
+        env={**os.environ, "PYTHONPATH": str(root)},
+    )
+
+
+def test_a_clean_walk_counts_every_module(tmp_path: Path) -> None:
+    root = scratch_package(
+        tmp_path,
+        {
+            "pkg/__init__.py": "",
+            "pkg/one.py": "VALUE = 1\n",
+            "pkg/sub/__init__.py": "",
+            "pkg/sub/two.py": "VALUE = 2\n",
+        },
+    )
+    proc = walk(root, "pkg")
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "OK    4 modules imported in" in proc.stdout
+
+
+def test_every_failing_module_is_reported_not_just_the_first(tmp_path: Path) -> None:
+    """The reader wants every missing symbol at once: the next run costs a wheel build."""
+    root = scratch_package(
+        tmp_path,
+        {
+            "pkg/__init__.py": "",
+            "pkg/good.py": "VALUE = 1\n",
+            "pkg/missing_symbol.py": (
+                "raise ImportError(\"cannot import name 'gone' from 'dep'\")\n"
+            ),
+            "pkg/explodes.py": "raise RuntimeError('a module-level boom')\n",
+        },
+    )
+    proc = walk(root, "pkg")
+    assert proc.returncode == 1
+    out = proc.stdout
+    assert (
+        "FAIL  pkg.missing_symbol: ImportError: cannot import name 'gone' from 'dep'"
+        in out
+    )
+    assert "FAIL  pkg.explodes: RuntimeError: a module-level boom" in out
+    assert "FAIL  2 of 4 modules failed to import" in out
+    assert "(2 imported)" in out
+    # the innermost frame, so the reader gets the line rather than only the exception
+    assert "missing_symbol.py:1 in <module>: raise ImportError" in out
+
+
+def test_a_package_that_cannot_import_stops_its_own_subtree(tmp_path: Path) -> None:
+    root = scratch_package(
+        tmp_path,
+        {
+            "pkg/__init__.py": "",
+            "pkg/broken/__init__.py": "raise RuntimeError('no')\n",
+            "pkg/broken/child.py": "VALUE = 1\n",
+            "pkg/fine.py": "VALUE = 1\n",
+        },
+    )
+    proc = walk(root, "pkg")
+    assert proc.returncode == 1
+    out = proc.stdout
+    assert "FAIL  pkg.broken: RuntimeError: no" in out
+    assert "pkg.broken did not import, so anything under it was never walked" in out
+    assert "FAIL  1 of 3 modules failed to import" in out
+
+
+def test_a_warning_at_import_time_is_not_a_failure(tmp_path: Path) -> None:
+    """Measured on the real tree: `sphinx_needs.api.exceptions` emits one on import."""
+    root = scratch_package(
+        tmp_path,
+        {
+            "pkg/__init__.py": "",
+            "pkg/noisy.py": (
+                "import warnings\nwarnings.warn('deprecated', UserWarning)\n"
+            ),
+        },
+    )
+    proc = walk(root, "pkg")
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "OK    2 modules imported" in proc.stdout
+
+
+def test_a_module_that_is_not_there_at_all(tmp_path: Path) -> None:
+    proc = walk(tmp_path, "no_such_module_anywhere")
+    assert proc.returncode == 1
+    assert "FAIL  no_such_module_anywhere: ModuleNotFoundError" in proc.stdout
+
+
+def test_expect_prefix_accepts_the_tree_it_names(tmp_path: Path) -> None:
+    root = scratch_package(tmp_path, {"pkg/__init__.py": ""})
+    proc = walk(root, "pkg", "--expect-prefix", str(root))
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "pkg imported from" in proc.stdout
+
+
+def test_expect_prefix_refuses_another_copy(tmp_path: Path) -> None:
+    """Without this the walk could import the checkout and pass against unreleased code."""
+    root = scratch_package(tmp_path, {"pkg/__init__.py": ""})
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    proc = walk(root, "pkg", "--expect-prefix", str(elsewhere))
+    assert proc.returncode == 1
+    out = proc.stdout
+    assert "which is not under" in out
+    assert "the walk is meant to test the installed wheel; this is another copy" in out
+
+
+# --- the outer layer ----------------------------------------------------------------------
+
+
+class FakeRun:
+    """Records every argv, and fakes the two side effects the outer layer depends on."""
+
+    def __init__(self, inner_returncode: int = 0, build_returncode: int = 0) -> None:
+        self.calls: list[list[str]] = []
+        self.inner_returncode = inner_returncode
+        self.build_returncode = build_returncode
+
+    def __call__(self, cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess:
+        self.calls.append(list(cmd))
+        if cmd[:2] == ["uv", "build"]:
+            if self.build_returncode:
+                return subprocess.CompletedProcess(cmd, self.build_returncode)
+            out = Path(cmd[cmd.index("-o") + 1])
+            out.mkdir(parents=True, exist_ok=True)
+            (out / "acme_core-1.0.0-py3-none-any.whl").write_bytes(b"")
+        elif cmd[:2] == ["uv", "venv"]:
+            binary = Path(cmd[-1]) / "bin" / "python"
+            binary.parent.mkdir(parents=True, exist_ok=True)
+            binary.write_text("", encoding="utf-8")
+        elif "--walk" in cmd:
+            return subprocess.CompletedProcess(cmd, self.inner_returncode)
+        return subprocess.CompletedProcess(cmd, 0)
+
+
+@pytest.fixture
+def fake_uv(monkeypatch):
+    """Point the outer layer at a scratch workspace and record what it would run."""
+
+    def build(root: Path, **kwargs: int) -> FakeRun:
+        monkeypatch.setattr(import_check, "REPO_ROOT", root)
+        fake = FakeRun(**kwargs)
+        monkeypatch.setattr(import_check.subprocess, "run", fake)
+        return fake
+
+    return build
+
+
+def test_the_commands_are_the_release_build_and_a_no_sources_install(
+    workspace, fake_uv
+) -> None:
+    root = workspace({"acme-core": {"version": "1.0.0"}})
+    fake = fake_uv(root)
+    assert import_check.main(["acme-core"]) == 0
+    build, venv, install, inner = fake.calls
+    # character for character `release.yaml`'s build step and `poe build-needs`
+    assert build[:6] == ["uv", "build", "--package", "acme-core", "--no-sources", "-o"]
+    assert build[6].endswith("/dist")
+    assert venv[:2] == ["uv", "venv"]
+    assert venv[2].endswith("/venv")
+    # THE flag: without it uv installs the sibling member from the checkout
+    assert install[:6] == ["uv", "pip", "install", "--python", venv[2], "--no-sources"]
+    assert install[6].endswith(".whl")
+    # and the walk runs under the environment's own interpreter, told where to expect it
+    assert inner[0] == str(Path(venv[2]) / "bin" / "python")
+    assert inner[1] == str(SCRIPT)
+    assert inner[2:] == ["--walk", "acme_core", "--expect-prefix", venv[2]]
+
+
+def test_the_python_flag_is_passed_to_uv_venv(workspace, fake_uv) -> None:
+    root = workspace({"acme-core": {"version": "1.0.0"}})
+    fake = fake_uv(root)
+    assert import_check.main(["acme-core", "--python", "3.11"]) == 0
+    venv = fake.calls[1]
+    assert venv[:4] == ["uv", "venv", "--python", "3.11"]
+
+
+def test_a_given_wheel_is_not_rebuilt(workspace, fake_uv, tmp_path: Path) -> None:
+    root = workspace({"acme-core": {"version": "1.0.0"}})
+    fake = fake_uv(root)
+    wheel = tmp_path / "acme_core-1.0.0-py3-none-any.whl"
+    wheel.write_bytes(b"")
+    assert import_check.main(["acme-core", "--wheel", str(wheel)]) == 0
+    assert [call[:2] for call in fake.calls[:2]] == [["uv", "venv"], ["uv", "pip"]]
+    assert not any(call[:2] == ["uv", "build"] for call in fake.calls)
+    assert str(wheel) in fake.calls[1]
+    assert fake.calls[2][1:] == [
+        str(SCRIPT),
+        "--walk",
+        "acme_core",
+        "--expect-prefix",
+        fake.calls[0][-1],
+    ]
+
+
+def test_the_module_name_honours_tool_flit_module(workspace, fake_uv) -> None:
+    """`check_workspace.Member.module`'s rule, duplicated because these run by path."""
+    root = workspace({"acme-core": {"version": "1.0.0", "module_name": "acme"}})
+    fake = fake_uv(root)
+    assert import_check.main(["acme-core"]) == 0
+    assert fake.calls[3][2:4] == ["--walk", "acme"]
+
+
+def test_the_outer_exit_status_is_the_inner_one(workspace, fake_uv) -> None:
+    root = workspace({"acme-core": {"version": "1.0.0"}})
+    fake_uv(root, inner_returncode=1)
+    assert import_check.main(["acme-core"]) == 1
+
+
+def test_a_failed_build_is_named_not_walked_around(workspace, fake_uv, capsys) -> None:
+    root = workspace({"acme-core": {"version": "1.0.0"}})
+    fake_uv(root, build_returncode=2)
+    assert import_check.main(["acme-core"]) == 1
+    assert "`uv` failed with exit code 2" in capsys.readouterr().err
+
+
+def test_a_virtual_member_has_no_wheel_to_check(workspace, fake_uv, capsys) -> None:
+    root = workspace(
+        {
+            "acme-core": {"version": "1.0.0"},
+            "acme-tools": {"version": "0", "virtual": True},
+        }
+    )
+    fake_uv(root)
+    assert import_check.main(["acme-tools"]) == 1
+    err = capsys.readouterr().err
+    assert "`acme-tools` is a virtual member (`[tool.uv] package = false`)" in err
+    assert "there is no released wheel for anything to import" in err
+
+
+def test_an_unknown_distribution_names_the_ones_there_are(
+    workspace, fake_uv, capsys
+) -> None:
+    root = workspace({"acme-core": {"version": "1.0.0"}})
+    fake_uv(root)
+    assert import_check.main(["acme-nope"]) == 1
+    err = capsys.readouterr().err
+    assert "`acme-nope` is not a member of this workspace" in err
+    assert "known: acme-core" in err
+
+
+def test_the_name_is_canonicalised(workspace, fake_uv) -> None:
+    """PEP 503: `Acme_Core` and `acme-core` are the same distribution."""
+    root = workspace({"acme-core": {"version": "1.0.0"}})
+    fake = fake_uv(root)
+    assert import_check.main(["Acme_Core"]) == 0
+    assert fake.calls[0][3] == "Acme_Core"
+
+
+def test_keep_leaves_the_directory_and_says_where(workspace, fake_uv, capsys) -> None:
+    root = workspace({"acme-core": {"version": "1.0.0"}})
+    fake_uv(root)
+    assert import_check.main(["acme-core", "--keep"]) == 0
+    kept = [
+        line
+        for line in capsys.readouterr().out.splitlines()
+        if line.startswith("kept ")
+    ]
+    assert len(kept) == 1
+    directory = Path(kept[0].removeprefix("kept "))
+    assert directory.is_dir()
+    shutil.rmtree(directory, ignore_errors=True)

--- a/tools/tests/test_import_check.py
+++ b/tools/tests/test_import_check.py
@@ -105,7 +105,12 @@ def test_a_package_that_cannot_import_stops_its_own_subtree(tmp_path: Path) -> N
     out = proc.stdout
     assert "FAIL  pkg.broken: RuntimeError: no" in out
     assert "pkg.broken did not import, so anything under it was never walked" in out
-    assert "FAIL  1 of 3 modules failed to import" in out
+    # the count understates the tree -- `pkg.broken.child` exists and was never reached --
+    # so the summary says how many packages hid contents from it
+    assert (
+        "FAIL  1 of 3 modules failed to import in 0.0s (2 imported; 1 package(s) did not "
+        "import, so their contents were never walked)" in out
+    )
 
 
 def test_a_warning_at_import_time_is_not_a_failure(tmp_path: Path) -> None:
@@ -304,3 +309,106 @@ def test_keep_leaves_the_directory_and_says_where(workspace, fake_uv, capsys) ->
     directory = Path(kept[0].removeprefix("kept "))
     assert directory.is_dir()
     shutil.rmtree(directory, ignore_errors=True)
+
+
+# --- fix round 1: `SystemExit` is a failure, and entry points are not import surface -------
+# H1. `SystemExit` is a `BaseException`, so it escaped `except Exception`, escaped `walk()`
+# and escaped `main()`: the process exited with the module's own code having printed
+# NOTHING. `sys.exit(0)` anywhere in the tree turned the compat cell's gate green.
+
+
+def test_an_entry_point_is_skipped_rather_than_run(tmp_path: Path) -> None:
+    """`__main__.py` is a CLI, not import surface: importing it runs it against the
+    walker's own argv, and its `sys.exit()` used to end the walk silently."""
+    root = scratch_package(
+        tmp_path,
+        {
+            "pkg/__init__.py": "",
+            "pkg/one.py": "VALUE = 1\n",
+            "pkg/__main__.py": "import sys\n\n\ndef main():\n    return 0\n\n\nsys.exit(main())\n",
+        },
+    )
+    proc = walk(root, "pkg")
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    out = proc.stdout
+    assert "skipped 1 entry point(s) (__main__): pkg.__main__" in out
+    assert "OK    2 modules imported in" in out
+
+
+def test_a_module_that_exits_is_a_failure_not_a_silent_pass(tmp_path: Path) -> None:
+    root = scratch_package(
+        tmp_path,
+        {
+            "pkg/__init__.py": "",
+            "pkg/good.py": "VALUE = 1\n",
+            "pkg/quits.py": "raise SystemExit(0)\n",
+        },
+    )
+    proc = walk(root, "pkg")
+    assert proc.returncode == 1, proc.stdout + proc.stderr
+    out = proc.stdout
+    assert "FAIL  pkg.quits: SystemExit: 0" in out
+    assert "quits.py:1 in <module>: raise SystemExit(0)" in out
+    assert "FAIL  1 of 3 modules failed to import" in out
+
+
+def test_a_top_level_module_that_exits_is_reported(tmp_path: Path) -> None:
+    """Every path out of the walk prints at least one line: the absence of `OK` is the only
+    thing a reader would otherwise notice about a silent pass."""
+    root = scratch_package(tmp_path, {"pkg/__init__.py": "import sys\n\nsys.exit(7)\n"})
+    proc = walk(root, "pkg")
+    assert proc.returncode == 1
+    assert "FAIL  pkg: SystemExit: 7" in proc.stdout
+
+
+def test_a_package_that_exits_during_the_walk_is_reported(tmp_path: Path) -> None:
+    """`pkgutil.walk_packages` imports each package it finds, and its own handlers do not
+    cover `SystemExit` -- so the generator died and took the whole walk with it."""
+    root = scratch_package(
+        tmp_path,
+        {
+            "pkg/__init__.py": "",
+            "pkg/aaa/__init__.py": "import sys\n\nsys.exit(3)\n",
+            "pkg/aaa/child.py": "VALUE = 1\n",
+            "pkg/zzz.py": "VALUE = 1\n",
+        },
+    )
+    proc = walk(root, "pkg")
+    assert proc.returncode == 1, proc.stdout + proc.stderr
+    out = proc.stdout
+    assert "FAIL  pkg.aaa: SystemExit: 3" in out
+    assert "the walk itself was cut short by SystemExit: 3" in out
+
+
+def test_the_prefix_is_asserted_for_every_module_not_only_the_top(
+    tmp_path: Path,
+) -> None:
+    """A package can pull a submodule in from elsewhere on the path -- here by extending
+    its own `__path__`, which is what a plugin package or a stale `.pth` does for real -- so
+    the wheel-only claim has to be checked per module, not once at the top."""
+    inside = tmp_path / "inside"
+    outside = tmp_path / "outside"
+    outside.mkdir(parents=True)
+    (outside / "stray.py").write_text("VALUE = 2\n", encoding="utf-8")
+    scratch_package(
+        inside,
+        {
+            "pkg/__init__.py": f"__path__.append({str(outside)!r})\n",
+            "pkg/local.py": "VALUE = 1\n",
+        },
+    )
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--walk", "pkg", "--expect-prefix", str(inside)],
+        cwd=tmp_path,
+        text=True,
+        capture_output=True,
+        env={**os.environ, "PYTHONPATH": str(inside)},
+    )
+    assert proc.returncode == 1, proc.stdout + proc.stderr
+    out = proc.stdout
+    # the top-level module IS under the prefix, and passes its own check
+    assert "pkg imported from" in out
+    assert f"FAIL  pkg.stray: imported from {outside}" in out
+    assert "which is not under" in out
+    # the honest submodule is untouched
+    assert "pkg.local" not in out

--- a/tools/tests/test_import_check.py
+++ b/tools/tests/test_import_check.py
@@ -5,10 +5,14 @@ subprocess with `sys.executable` -- because its entire subject is what happens a
 time, and a mocked import would prove nothing about it.
 
 The **outer** layer is tested with `subprocess.run` monkeypatched, on its argv. It exists to
-issue four exact commands, and one flag on one of them (`--no-sources` on the install) is
-the whole reason the check means anything: without it uv substitutes the sibling member from
-the checkout and the walk passes against code that was never released. So the assertions are
-on the commands, not on their results.
+issue four exact commands, so the assertions are on the commands rather than on their
+results -- and what they pin is the RECIPE: that these are, character for character, the
+release build's and the compat cell's own commands. Measured on uv 0.12.9, `--no-sources` on
+a *wheel* install changes nothing (a wheel's `Requires-Dist` resolves from the index either
+way; the flag governs requirements uv reads from a pyproject), so the argv assertion is the
+only thing that can catch its loss -- and losing it would make this check stop matching the
+pipeline it stands in for. What makes the check *mean* something is the out-of-project
+environment plus `--expect-prefix`, and those are tested against real imports above.
 """
 
 from __future__ import annotations
@@ -207,7 +211,8 @@ def test_the_commands_are_the_release_build_and_a_no_sources_install(
     assert build[6].endswith("/dist")
     assert venv[:2] == ["uv", "venv"]
     assert venv[2].endswith("/venv")
-    # THE flag: without it uv installs the sibling member from the checkout
+    # `--no-sources` pins the recipe, not a behaviour: this has to stay the same command
+    # the compat cell runs (measured -- for a wheel install the flag is inert)
     assert install[:6] == ["uv", "pip", "install", "--python", venv[2], "--no-sources"]
     assert install[6].endswith(".whl")
     # and the walk runs under the environment's own interpreter, told where to expect it

--- a/tools/tests/test_release_plan.py
+++ b/tools/tests/test_release_plan.py
@@ -16,6 +16,8 @@ assert the words.
 
 from __future__ import annotations
 
+import io
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -28,16 +30,21 @@ pytestmark = pytest.mark.filterwarnings("error")
 @pytest.fixture
 def offline(monkeypatch):
     """No network, no git, unless a test says otherwise."""
-    monkeypatch.setattr(release_plan, "list_tags", lambda: [])
-    monkeypatch.setattr(release_plan, "is_ancestor", lambda commit, branch: True)
+    monkeypatch.setattr(release_plan, "list_tags", lambda cwd=None: [])
+    monkeypatch.setattr(
+        release_plan, "is_ancestor", lambda commit, branch, cwd=None: True
+    )
     # the planner's seams. A plain `run(root)` reaches all of them, so the defaults are
     # "PyPI has nothing, git has nothing, HEAD is on origin/master" -- a workspace whose
-    # every member is unreleased, which each planner test then overrides
+    # every member is unreleased, which each planner test then overrides. Every git seam
+    # takes `cwd`, because the planner passes `--root` to git as well as to the manifests
     monkeypatch.setattr(release_plan, "published_versions", lambda name: {})
-    monkeypatch.setattr(release_plan, "commits_since", lambda ref, paths: [])
-    monkeypatch.setattr(release_plan, "touched_files", lambda ref, paths: {})
-    monkeypatch.setattr(release_plan, "head_context", lambda: ("abc1234", "master"))
-    monkeypatch.setattr(release_plan, "resolve", lambda ref: "abc1234")
+    monkeypatch.setattr(release_plan, "commits_since", lambda ref, paths, cwd=None: [])
+    monkeypatch.setattr(release_plan, "touched_files", lambda ref, paths, cwd=None: {})
+    monkeypatch.setattr(
+        release_plan, "head_context", lambda cwd=None: ("abc1234", "master")
+    )
+    monkeypatch.setattr(release_plan, "resolve", lambda ref, cwd=None: "abc1234")
     return monkeypatch
 
 
@@ -65,10 +72,67 @@ def history(monkeypatch, per_member: dict[str, list[tuple[str, str]]]) -> None:
     asked about the paths it said it would.
     """
 
-    def fake(ref: str, paths: list[str]) -> list[tuple[str, str]]:
+    def fake(
+        ref: str, paths: list[str], cwd: Path | None = None
+    ) -> list[tuple[str, str]]:
         return per_member.get(paths[0].split("/")[1], [])
 
     monkeypatch.setattr(release_plan, "commits_since", fake)
+
+
+def pypi_pair(monkeypatch, mapping: dict[str, dict[str, bool]]) -> None:
+    """BOTH PyPI seams from ONE fact table.
+
+    `published_versions` (the planner) reads the whole-project document; `on_pypi` (the tag
+    mode's check 4) reads the per-version URL, which answers 200 for a YANKED release too.
+    Driving them from one table is what lets a test run both modes over the same index and
+    assert the planner predicted what the tag mode then did -- the divergence this pairing
+    exists to catch.
+    """
+    pypi(monkeypatch, mapping)
+
+    def fake(name: str, version: str) -> bool:
+        return Version(version) in {Version(raw) for raw in mapping.get(name, {})}
+
+    monkeypatch.setattr(release_plan, "on_pypi", fake)
+
+
+def git_in(root: Path, *args: str) -> str:
+    proc = subprocess.run(
+        ["git", *args], cwd=root, text=True, capture_output=True, check=True
+    )
+    return proc.stdout.strip()
+
+
+@pytest.fixture
+def git_workspace(workspace):
+    """A scratch workspace that is also a REAL git repository.
+
+    The planner's whole subject is what git says, and `--root` has to reach git as well as
+    the manifests -- neither of which a monkeypatched seam can prove. Everything in the
+    tests that use this is real except PyPI.
+    """
+
+    def build(members: dict, **kwargs) -> Path:
+        root = workspace(members, **kwargs)
+        git_in(root, "init", "-q", "-b", "main")
+        git_in(root, "config", "user.email", "scratch@example.invalid")
+        git_in(root, "config", "user.name", "Scratch")
+        git_in(root, "config", "commit.gpgsign", "false")
+        return root
+
+    return build
+
+
+def commit(root: Path, message: str, files: dict[str, str]) -> str:
+    """Write files, commit them, and return the short sha the planner would print."""
+    for name, body in files.items():
+        path = root / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body, encoding="utf-8")
+    git_in(root, "add", "-A")
+    git_in(root, "commit", "-q", "-m", message)
+    return git_in(root, "rev-parse", "--short", "HEAD")
 
 
 def run(root: Path, *args: str) -> int:
@@ -447,7 +511,7 @@ def test_an_unusable_git_answer_is_fatal(monkeypatch, workspace, capsys) -> None
         returncode = 128
         stderr = "fatal: Not a valid object name origin/master"
 
-    monkeypatch.setattr(release_plan, "list_tags", lambda: [])
+    monkeypatch.setattr(release_plan, "list_tags", lambda cwd=None: [])
     monkeypatch.setattr(subprocess, "run", lambda *a, **k: Fake())
     published(monkeypatch, {("acme-core", "1.0.0"): False})
     root = workspace({"acme-core": {"version": "1.0.0"}})
@@ -580,7 +644,7 @@ def test_a_member_with_no_version_is_annotated_not_a_traceback(
 
 def test_up_to_date_says_nothing_to_release(workspace, capsys, offline) -> None:
     pypi(offline, {"acme-core": {"2.0.0": False}})
-    offline.setattr(release_plan, "list_tags", lambda: ["acme-core-v2.0.0"])
+    offline.setattr(release_plan, "list_tags", lambda cwd=None: ["acme-core-v2.0.0"])
     root = workspace({"acme-core": {"version": "2.0.0"}})
     assert run(root) == 0
     out = capsys.readouterr().out
@@ -593,7 +657,7 @@ def test_unreleased_commits_on_a_published_version_ask_for_a_bump(
     workspace, capsys, offline
 ) -> None:
     pypi(offline, {"acme-core": {"2.0.0": False}})
-    offline.setattr(release_plan, "list_tags", lambda: ["acme-core-v2.0.0"])
+    offline.setattr(release_plan, "list_tags", lambda cwd=None: ["acme-core-v2.0.0"])
     history(offline, {"acme-core": [("aaa1111", "a fix"), ("bbb2222", "another")]})
     root = workspace({"acme-core": {"version": "2.0.0"}})
     assert run(root) == 0
@@ -609,7 +673,7 @@ def test_a_declared_version_that_is_not_published_is_ready_to_tag(
     workspace, capsys, offline
 ) -> None:
     pypi(offline, {"acme-core": {"1.9.0": False}})
-    offline.setattr(release_plan, "list_tags", lambda: ["acme-core-v1.9.0"])
+    offline.setattr(release_plan, "list_tags", lambda cwd=None: ["acme-core-v1.9.0"])
     history(offline, {"acme-core": [("aaa1111", "the feature")]})
     root = workspace({"acme-core": {"version": "2.0.0"}})
     assert run(root) == 0
@@ -626,7 +690,9 @@ def test_a_tag_whose_release_never_completed_says_so(
     """The tag exists, PyPI does not have it: re-run the workflow, do not re-tag."""
     pypi(offline, {"acme-core": {"1.9.0": False}})
     offline.setattr(
-        release_plan, "list_tags", lambda: ["acme-core-v1.9.0", "acme-core-v2.0.0"]
+        release_plan,
+        "list_tags",
+        lambda cwd=None: ["acme-core-v1.9.0", "acme-core-v2.0.0"],
     )
     root = workspace({"acme-core": {"version": "2.0.0"}})
     assert run(root) == 0
@@ -650,7 +716,7 @@ def test_a_tree_behind_pypi_is_reported_and_still_exits_zero(
 def test_a_yanked_release_is_not_the_latest(workspace, capsys, offline) -> None:
     """A yanked 3.0.0 must not make a 2.0.0 tree look BEHIND: it cannot be installed."""
     pypi(offline, {"acme-core": {"2.0.0": False, "3.0.0": True}})
-    offline.setattr(release_plan, "list_tags", lambda: ["acme-core-v2.0.0"])
+    offline.setattr(release_plan, "list_tags", lambda cwd=None: ["acme-core-v2.0.0"])
     root = workspace({"acme-core": {"version": "2.0.0"}})
     assert run(root) == 0
     out = capsys.readouterr().out
@@ -692,10 +758,12 @@ def test_a_non_404_pypi_answer_stops_the_planner(
         raise urllib.error.HTTPError(url, status, "boom", None, None)  # ty: ignore[invalid-argument-type]
 
     offline.undo()
-    offline.setattr(release_plan, "list_tags", lambda: [])
-    offline.setattr(release_plan, "commits_since", lambda ref, paths: [])
-    offline.setattr(release_plan, "head_context", lambda: ("abc1234", "master"))
-    offline.setattr(release_plan, "resolve", lambda ref: None)
+    offline.setattr(release_plan, "list_tags", lambda cwd=None: [])
+    offline.setattr(release_plan, "commits_since", lambda ref, paths, cwd=None: [])
+    offline.setattr(
+        release_plan, "head_context", lambda cwd=None: ("abc1234", "master")
+    )
+    offline.setattr(release_plan, "resolve", lambda ref, cwd=None: None)
     offline.setattr(release_plan.urllib.request, "urlopen", raising)
     root = workspace({"acme-core": {"version": "1.0.0"}})
     assert run(root) == 1
@@ -705,7 +773,9 @@ def test_a_non_404_pypi_answer_stops_the_planner(
 
 
 def test_a_git_failure_stops_the_planner(workspace, capsys, offline) -> None:
-    def raising(ref: str, paths: list[str]) -> list[tuple[str, str]]:
+    def raising(
+        ref: str, paths: list[str], cwd: Path | None = None
+    ) -> list[tuple[str, str]]:
         raise release_plan.PlanError("`git log` failed (128): not a git repository")
 
     offline.setattr(release_plan, "commits_since", raising)
@@ -726,8 +796,10 @@ def test_no_git_is_refused_in_planner_mode(workspace, capsys, offline) -> None:
 def test_the_context_header_names_head_and_the_branch(
     workspace, capsys, offline
 ) -> None:
-    offline.setattr(release_plan, "head_context", lambda: ("deadbee", "detached"))
-    offline.setattr(release_plan, "is_ancestor", lambda commit, branch: False)
+    offline.setattr(
+        release_plan, "head_context", lambda cwd=None: ("deadbee", "detached")
+    )
+    offline.setattr(release_plan, "is_ancestor", lambda commit, branch, cwd=None: False)
     root = workspace({"acme-core": {"version": "1.0.0"}})
     assert run(root) == 0
     out = capsys.readouterr().out
@@ -739,12 +811,12 @@ def test_the_context_header_names_head_and_the_branch(
 def test_an_absent_origin_master_is_reported_not_fatal(
     workspace, capsys, offline
 ) -> None:
-    def explode(commit: str, branch: str) -> bool:
+    def explode(commit: str, branch: str, cwd: Path | None = None) -> bool:
         raise AssertionError(
             "is_ancestor must not be asked about a ref that is not there"
         )
 
-    offline.setattr(release_plan, "resolve", lambda ref: None)
+    offline.setattr(release_plan, "resolve", lambda ref, cwd=None: None)
     offline.setattr(release_plan, "is_ancestor", explode)
     root = workspace({"acme-core": {"version": "1.0.0"}})
     assert run(root) == 0
@@ -773,8 +845,9 @@ def test_the_plan_job_would_refuse_the_dependant_is_said_in_advance(
     # the manifest's own text, not `packaging`'s sorted rendering of it
     assert "acme-ext 0.1.0 needs acme-core>=2.0.0,<3" in out
     assert (
-        "the plan job WILL refuse `acme-ext-v0.1.0`: it needs acme-core>=2.0.0,<3, and "
-        "PyPI has only up to 1.9.0 -- release acme-core first" in out
+        "the plan job WILL refuse `acme-ext-v0.1.0`: check 4 needs acme-core 2.0.0 on "
+        "PyPI, and PyPI has 1.9.0 as its newest live version -- release acme-core first"
+        in out
     )
 
 
@@ -794,13 +867,14 @@ def test_a_dependant_with_nothing_published_names_that_too(
     root = workspace(DIAMOND)
     assert run(root) == 0
     assert (
-        "it needs acme-core>=2.0.0,<3, and PyPI has nothing" in capsys.readouterr().out
+        "check 4 needs acme-core 2.0.0 on PyPI, and PyPI has nothing"
+        in capsys.readouterr().out
     )
 
 
 def test_the_compat_cell_target_and_what_it_lacks(workspace, capsys, offline) -> None:
     pypi(offline, {"acme-core": {"2.0.0": False}, "acme-ext": {"0.1.0": False}})
-    offline.setattr(release_plan, "list_tags", lambda: ["acme-core-v2.0.0"])
+    offline.setattr(release_plan, "list_tags", lambda cwd=None: ["acme-core-v2.0.0"])
     history(offline, {"acme-core": [("aaa1111", "a core fix"), ("bbb2222", "another")]})
     root = workspace(DIAMOND)
     assert run(root) == 0
@@ -811,8 +885,8 @@ def test_the_compat_cell_target_and_what_it_lacks(workspace, capsys, offline) ->
         in out
     )
     assert (
-        "`python tools/src/sn_tools/import_check.py acme-ext` installs the PUBLISHED "
-        "acme-core and imports every acme-ext module" in out
+        "`uv run python tools/src/sn_tools/import_check.py acme-ext` installs the "
+        "PUBLISHED acme-core and imports every acme-ext module" in out
     )
     assert "behaviour changes still need the suite (the compat cell)" in out
 
@@ -822,7 +896,7 @@ def test_a_commit_touching_both_packages_is_singled_out(
 ) -> None:
     """Chris's scenario: one feature commit changed the core and the extension together."""
     pypi(offline, {"acme-core": {"2.0.0": False}})
-    offline.setattr(release_plan, "list_tags", lambda: ["acme-core-v2.0.0"])
+    offline.setattr(release_plan, "list_tags", lambda cwd=None: ["acme-core-v2.0.0"])
     history(
         offline,
         {"acme-core": [("5ha12ed0", "the shared feature"), ("c0e0n1y0", "a core fix")]},
@@ -830,7 +904,7 @@ def test_a_commit_touching_both_packages_is_singled_out(
     offline.setattr(
         release_plan,
         "touched_files",
-        lambda ref, paths: {
+        lambda ref, paths, cwd=None: {
             "5ha12ed0": {
                 "packages/acme-core/src/a.py",
                 "packages/acme-ext/src/b.py",
@@ -873,7 +947,7 @@ def test_an_extra_only_edge_gets_the_same_advice(workspace, capsys, offline) -> 
 def test_a_bare_tag_is_a_release_of_sphinx_needs_only(
     workspace, capsys, offline
 ) -> None:
-    offline.setattr(release_plan, "list_tags", lambda: ["8.5.0"])
+    offline.setattr(release_plan, "list_tags", lambda cwd=None: ["8.5.0"])
     root = workspace(
         {"sphinx-needs": {"version": "8.5.0"}, "acme-core": {"version": "8.5.0"}}
     )
@@ -910,7 +984,7 @@ def test_the_suggested_sequence_is_dependencies_first(
     workspace, capsys, offline
 ) -> None:
     pypi(offline, {"acme-core": {"2.0.0": False}})
-    offline.setattr(release_plan, "list_tags", lambda: ["acme-core-v2.0.0"])
+    offline.setattr(release_plan, "list_tags", lambda cwd=None: ["acme-core-v2.0.0"])
     history(offline, {"acme-core": [("aaa1111", "a core fix")]})
     root = workspace(DIAMOND)
     assert run(root) == 0
@@ -957,3 +1031,311 @@ def test_tag_mode_never_reaches_the_planner_seams(workspace, capsys, offline) ->
     out = capsys.readouterr().out
     assert "release plan -- advice" not in out
     assert '"dist": "acme-core"' in out
+
+
+# --- the planner predicts the gate that actually fires -------------------------------------
+# Fix round 1, H2. `print_dependant` used to branch on "does any published non-yanked C
+# satisfy D's specifier"; check (4) of the tag mode asks "is C's TREE version published".
+# Those are different questions, and the divergence showed up in both directions on
+# manifests `check_workspace.py` reports OK. Every test here runs BOTH modes over one index
+# and asserts they agree about the verdict.
+
+
+def both_modes(root: Path, capsys, dependant_tag: str) -> tuple[str, int]:
+    """Run the planner, then the tag mode for the dependant, over the same mocked index."""
+    assert run(root) == 0, "the planner must never gate, whatever it finds"
+    planner_output = capsys.readouterr().out
+    tag_exit = run(root, "--tag", dependant_tag, "--no-git")
+    capsys.readouterr()
+    return planner_output, tag_exit
+
+
+def test_a_gap_in_the_index_is_predicted_as_check_4_refusing(
+    workspace, capsys, offline
+) -> None:
+    """C's tree version was skipped on the index: the plan job refuses, and says so here.
+
+    The reviewer's case (a). `usable` is non-empty -- 2.2.0 satisfies `>=2.1.0,<3` -- so the
+    old code cheerfully said "would be tested against acme-core 2.2.0" about a tag the plan
+    job then refused.
+    """
+    pypi_pair(
+        offline,
+        {"acme-core": {"2.0.0": False, "2.2.0": False}},
+    )
+    root = workspace(
+        {
+            "acme-core": {"version": "2.1.0"},
+            "acme-ext": {"version": "0.1.0", "dependencies": ["acme-core>=2.1.0,<3"]},
+        }
+    )
+    out, tag_exit = both_modes(root, capsys, "acme-ext-v0.1.0")
+    assert (
+        "the plan job WILL refuse `acme-ext-v0.1.0`: check 4 needs acme-core 2.1.0 on "
+        "PyPI, and PyPI has 2.2.0 as its newest live version -- release acme-core first"
+        in out
+    )
+    assert "would be tested against acme-core 2.2.0" not in out
+    assert tag_exit == 1, "the planner promised a refusal; check 4 must deliver one"
+
+
+def test_a_yanked_tree_version_names_the_resolver_gate_not_the_plan_job(
+    workspace, capsys, offline
+) -> None:
+    """The reviewer's case (b): the per-version PyPI URL is 200 for a yanked release, so
+    check (4) PASSES -- what stops the release is resolving a range from the index."""
+    pypi_pair(
+        offline,
+        {"acme-core": {"2.0.0": False, "2.1.0": True}},
+    )
+    root = workspace(
+        {
+            "acme-core": {"version": "2.1.0"},
+            "acme-ext": {"version": "0.1.0", "dependencies": ["acme-core>=2.1.0,<3"]},
+        }
+    )
+    out, tag_exit = both_modes(root, capsys, "acme-ext-v0.1.0")
+    assert (
+        "the plan job passes (acme-core 2.1.0 is on PyPI) but every file of it is yanked, "
+        "so the resolver gate -- `uv pip install --dry-run` against the index -- will not "
+        "pick it for a range: release a new acme-core" in out
+    )
+    assert "the plan job WILL refuse" not in out
+    assert tag_exit == 0, "check 4 accepts a yanked release; the planner must not lie"
+
+
+def test_a_specifier_no_release_satisfies_names_the_resolver_gate_and_lint(
+    workspace, capsys, offline
+) -> None:
+    """The reviewer's case (c): C's tree version is published, but D's floor is above it."""
+    pypi_pair(offline, {"acme-core": {"2.0.0": False}})
+    root = workspace(
+        {
+            "acme-core": {"version": "2.0.0"},
+            "acme-ext": {"version": "0.1.0", "dependencies": ["acme-core>=3.0.0,<4"]},
+        }
+    )
+    out, tag_exit = both_modes(root, capsys, "acme-ext-v0.1.0")
+    assert (
+        "no published acme-core satisfies acme-core>=3.0.0,<4: the resolver gate fails "
+        "(and Lint's check-workspace refuses a specifier that does not admit the tree's "
+        "2.0.0)" in out
+    )
+    assert "the plan job WILL refuse" not in out
+    assert tag_exit == 0, "check 4 only asks whether acme-core 2.0.0 is published"
+
+
+def test_the_happy_path_still_describes_the_compat_cell(
+    workspace, capsys, offline
+) -> None:
+    """The reviewer's case (d): nothing is wrong, so the only thing left to say is what the
+    dependant would actually be tested against."""
+    pypi_pair(offline, {"acme-core": {"2.0.0": False}})
+    offline.setattr(release_plan, "list_tags", lambda cwd=None: ["acme-core-v2.0.0"])
+    root = workspace(DIAMOND)
+    out, tag_exit = both_modes(root, capsys, "acme-ext-v0.1.0")
+    assert (
+        "the compat cell installs acme-core from PyPI: `acme-ext-v0.1.0` would be tested "
+        "against acme-core 2.0.0" in out
+    )
+    assert "the plan job WILL refuse" not in out
+    assert "the resolver gate" not in out
+    assert tag_exit == 0
+
+
+# --- `--root` reaches git, on a real repository --------------------------------------------
+# Fix round 1, M3/M2. Nothing below monkeypatches a git seam: that is the point.
+
+
+def test_the_root_flag_drives_git_as_well_as_the_manifests(
+    git_workspace, capsys, monkeypatch
+) -> None:
+    """`--root` named a tree while every git call answered about the process's own.
+
+    The pytest process runs in THIS repository, whose HEAD, tags and history are nothing
+    like the scratch one -- so before the fix this printed confident, wrong advice at exit 0.
+    """
+    monkeypatch.setattr(release_plan, "published_versions", lambda name: {})
+    root = git_workspace({"acme-core": {"version": "1.0.0"}})
+    first = commit(
+        root,
+        "the released commit",
+        {"packages/acme-core/src/acme_core/__init__.py": "VALUE = 1\n"},
+    )
+    git_in(root, "tag", "acme-core-v1.0.0")
+    second = commit(
+        root,
+        "an unreleased change",
+        {"packages/acme-core/src/acme_core/x.py": "VALUE = 2\n"},
+    )
+    assert run(root) == 0
+    out = capsys.readouterr().out
+    assert f"HEAD {second} (main)" in out
+    assert "last release tag   acme-core-v1.0.0" in out
+    assert "1 commit since acme-core-v1.0.0 touched its shipped code" in out
+    assert f"{second}  an unreleased change" in out
+    assert f"{first}  the released commit" not in out
+    # a scratch repository has no origin/master, and that is a fact to report, not an error
+    assert "origin/master not found (no fetch?): ancestry not checked" in out
+
+
+def test_only_shipped_paths_count_as_unreleased_work(
+    git_workspace, capsys, monkeypatch
+) -> None:
+    """The planner's headline semantic, printed on every run and repeated in the docs:
+    `<member>/src` and `<member>/pyproject.toml` count; docs and tests do not."""
+    monkeypatch.setattr(
+        release_plan, "published_versions", lambda name: {Version("1.0.0"): False}
+    )
+    root = git_workspace({"acme-core": {"version": "1.0.0"}})
+    commit(
+        root,
+        "the released commit",
+        {"packages/acme-core/src/acme_core/__init__.py": "VALUE = 1\n"},
+    )
+    git_in(root, "tag", "acme-core-v1.0.0")
+    manifest = root / "packages/acme-core/pyproject.toml"
+    src = commit(
+        root, "src change", {"packages/acme-core/src/acme_core/x.py": "VALUE = 2\n"}
+    )
+    metadata = commit(
+        root,
+        "manifest change",
+        {
+            "packages/acme-core/pyproject.toml": manifest.read_text(encoding="utf-8")
+            + '\ndescription = "scratch"\n'
+        },
+    )
+    docs = commit(root, "docs change", {"packages/acme-core/docs/index.md": "hello\n"})
+    tests = commit(
+        root,
+        "tests change",
+        {"packages/acme-core/tests/test_x.py": "def test_x():\n    pass\n"},
+    )
+    assert run(root) == 0
+    out = capsys.readouterr().out
+    assert "2 unreleased commits since acme-core-v1.0.0" in out
+    assert f"{src}  src change" in out
+    assert f"{metadata}  manifest change" in out
+    assert f"{docs}  docs change" not in out
+    assert f"{tests}  tests change" not in out
+
+
+def test_a_non_ascii_path_is_not_lost_by_gits_quoting(
+    git_workspace, capsys, monkeypatch
+) -> None:
+    """git C-quotes such a path by default -- `"…/t\\303\\253st.py"`, quotes included -- and
+    `under()` then matches nothing, so the both-packages heuristic misses the commit."""
+
+    def published(name: str) -> dict[Version, bool]:
+        return {Version("1.0.0"): False} if name == "acme-core" else {}
+
+    monkeypatch.setattr(release_plan, "published_versions", published)
+    root = git_workspace(
+        {
+            "acme-core": {"version": "1.0.0"},
+            "acme-ext": {"version": "0.1.0", "dependencies": ["acme-core>=1.0.0,<2"]},
+        }
+    )
+    commit(
+        root,
+        "the released commit",
+        {"packages/acme-core/src/acme_core/__init__.py": "VALUE = 1\n"},
+    )
+    git_in(root, "tag", "acme-core-v1.0.0")
+    shared = commit(
+        root,
+        "a shared feature",
+        {
+            "packages/acme-core/src/acme_core/x.py": "VALUE = 2\n",
+            "packages/acme-ext/src/acme_ext/tëst.py": "VALUE = 3\n",
+        },
+    )
+    assert run(root) == 0
+    out = capsys.readouterr().out
+    assert "these changed both acme-core and acme-ext" in out
+    assert f"{shared}  a shared feature" in out
+
+
+# --- PyPI answers this function does not get to guess about --------------------------------
+
+
+def json_from(monkeypatch, payload: str) -> None:
+    monkeypatch.setattr(
+        release_plan.urllib.request,
+        "urlopen",
+        lambda url, timeout=30: io.BytesIO(payload.encode("utf-8")),
+    )
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        ("[1, 2, 3]", "PyPI returned a list, not an object"),
+        ('{"releases": []}', "`releases` for"),
+        (
+            '{"releases": {"1.0.0": [1, 2]}}',
+            "file list for acme-core 1.0.0 is not a list of objects",
+        ),
+    ],
+)
+def test_a_pypi_document_of_the_wrong_shape_is_refused(
+    monkeypatch, payload: str, expected: str
+) -> None:
+    """Before this these were `AttributeError` tracebacks out of the one script whose whole
+    subject is refusing to guess."""
+    json_from(monkeypatch, payload)
+    with pytest.raises(release_plan.PlanError) as excinfo:
+        release_plan.published_versions("acme-core")
+    assert expected in str(excinfo.value)
+
+
+def test_a_pypi_read_timeout_is_refused_not_a_traceback(monkeypatch) -> None:
+    """`TimeoutError` is an `OSError` and NOT a `URLError`: `urlopen`'s read phase does not
+    wrap it, so the narrower clause let a timeout through as a traceback."""
+
+    def raising(url: str, timeout: int = 30):
+        raise TimeoutError("The read operation timed out")
+
+    monkeypatch.setattr(release_plan.urllib.request, "urlopen", raising)
+    with pytest.raises(release_plan.PlanError) as excinfo:
+        release_plan.published_versions("acme-core")
+    message = str(excinfo.value)
+    assert "cannot reach PyPI" in message
+    assert "refusing to advise on a guess about what acme-core has published" in message
+
+
+def test_a_release_with_no_files_left_counts_as_yanked(monkeypatch) -> None:
+    """Nothing installable is left, which is the property `latest` is about."""
+    json_from(
+        monkeypatch,
+        '{"releases": {"1.0.0": [], "2.0.0": [{"yanked": false}],'
+        ' "3.0.0": [{"yanked": true}, {"yanked": true}],'
+        ' "4.0.0": [{"yanked": true}, {"yanked": false}]}}',
+    )
+    assert release_plan.published_versions("acme-core") == {
+        Version("1.0.0"): True,
+        Version("2.0.0"): False,
+        Version("3.0.0"): True,
+        # one usable file is enough to install, so this release is not yanked
+        Version("4.0.0"): False,
+    }
+
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        ("packages/core/src", True),
+        ("packages/core/src/x/a.py", True),
+        ("packages/core/pyproject.toml", True),
+        # the boundary: a sibling whose name merely starts with the same characters
+        ("packages/core/srcfoo/x.py", False),
+        ("packages/core/src.py", False),
+        ("packages/core/pyproject.toml.bak", False),
+        ("packages/core/docs/index.md", False),
+        ("packages/coretools/src/x.py", False),
+    ],
+)
+def test_under_respects_the_path_boundary(path: str, expected: bool) -> None:
+    roots = ["packages/core/src", "packages/core/pyproject.toml"]
+    assert release_plan.under(path, roots) is expected

--- a/tools/tests/test_release_plan.py
+++ b/tools/tests/test_release_plan.py
@@ -1,10 +1,17 @@
-"""`release_plan.py`: the five fail-closed checks, the rehearsal, and `previous_tag`.
+"""`release_plan.py`: the five fail-closed checks, the rehearsal, and the planner.
 
-PyPI and git are monkeypatched here -- `on_pypi`, `list_tags` and `is_ancestor` are the
-three functions that touch the outside world, and they are separate functions so that this
-file can run offline. The one thing that must never be mocked away is the *direction* of a
-failure: every check has to fail closed, so each test asserts the exit code as well as the
-message.
+PyPI and git are monkeypatched here -- every function that touches the outside world
+(`on_pypi`, `published_versions`, `list_tags`, `is_ancestor`, `commits_since`,
+`touched_files`, `head_context`, `resolve`) is a separate function for exactly that reason,
+so this file runs offline. It matters more for the planner than for the tag checks: git
+answers about the working directory, which in these tests is this repository rather than
+the scratch workspace under `tmp_path`, so an un-mocked seam would make a test agree with
+whatever the branch happens to look like today.
+
+The one thing that must never be mocked away is the *direction* of an answer. The tag
+checks fail closed, so each of those tests asserts the exit code as well as the message;
+the planner is advice and must never gate, so its tests assert exit 0 as hard as they
+assert the words.
 """
 
 from __future__ import annotations
@@ -12,6 +19,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from packaging.version import Version
 from sn_tools import release_plan
 
 pytestmark = pytest.mark.filterwarnings("error")
@@ -22,6 +30,14 @@ def offline(monkeypatch):
     """No network, no git, unless a test says otherwise."""
     monkeypatch.setattr(release_plan, "list_tags", lambda: [])
     monkeypatch.setattr(release_plan, "is_ancestor", lambda commit, branch: True)
+    # the planner's seams. A plain `run(root)` reaches all of them, so the defaults are
+    # "PyPI has nothing, git has nothing, HEAD is on origin/master" -- a workspace whose
+    # every member is unreleased, which each planner test then overrides
+    monkeypatch.setattr(release_plan, "published_versions", lambda name: {})
+    monkeypatch.setattr(release_plan, "commits_since", lambda ref, paths: [])
+    monkeypatch.setattr(release_plan, "touched_files", lambda ref, paths: {})
+    monkeypatch.setattr(release_plan, "head_context", lambda: ("abc1234", "master"))
+    monkeypatch.setattr(release_plan, "resolve", lambda ref: "abc1234")
     return monkeypatch
 
 
@@ -32,6 +48,29 @@ def published(monkeypatch, mapping: dict[tuple[str, str], bool]) -> None:
     monkeypatch.setattr(release_plan, "on_pypi", fake)
 
 
+def pypi(monkeypatch, mapping: dict[str, dict[str, bool]]) -> None:
+    """`published_versions` per distribution: {version: is the whole release yanked}."""
+
+    def fake(name: str) -> dict[Version, bool]:
+        return {Version(raw): yanked for raw, yanked in mapping.get(name, {}).items()}
+
+    monkeypatch.setattr(release_plan, "published_versions", fake)
+
+
+def history(monkeypatch, per_member: dict[str, list[tuple[str, str]]]) -> None:
+    """`commits_since`, keyed by the member whose shipped paths were asked about.
+
+    The scratch workspaces put every member at `packages/<name>`, so the second segment of
+    the path filter names the member -- which is also a small assertion that the planner
+    asked about the paths it said it would.
+    """
+
+    def fake(ref: str, paths: list[str]) -> list[tuple[str, str]]:
+        return per_member.get(paths[0].split("/")[1], [])
+
+    monkeypatch.setattr(release_plan, "commits_since", fake)
+
+
 def run(root: Path, *args: str) -> int:
     return release_plan.main([*args, "--root", str(root)])
 
@@ -39,7 +78,7 @@ def run(root: Path, *args: str) -> int:
 # --- the order ---------------------------------------------------------------------------
 
 
-def test_prints_the_topological_order(workspace, capsys) -> None:
+def test_prints_the_topological_order(workspace, capsys, offline) -> None:
     root = workspace(
         {
             "acme-core": {"version": "2.0.0"},
@@ -68,7 +107,9 @@ def test_a_cycle_is_an_error(workspace, capsys) -> None:
 # --- (0) a virtual member is never a release ---------------------------------------------
 
 
-def test_a_virtual_member_is_listed_but_not_numbered(workspace, capsys) -> None:
+def test_a_virtual_member_is_listed_but_not_numbered(
+    workspace, capsys, offline
+) -> None:
     root = workspace(
         {
             "acme-core": {"version": "2.0.0"},
@@ -530,3 +571,389 @@ def test_a_member_with_no_version_is_annotated_not_a_traceback(
     assert "::error::" in out
     assert "acme-core declares no [project] version" in out
     assert "Traceback" not in out
+
+
+# --- the planner: what to release, in what order, tested against what ---------------------
+# Everything below runs with no `--tag`. The planner is ADVICE: every one of these asserts
+# exit 0 unless the data itself could not be gathered.
+
+
+def test_up_to_date_says_nothing_to_release(workspace, capsys, offline) -> None:
+    pypi(offline, {"acme-core": {"2.0.0": False}})
+    offline.setattr(release_plan, "list_tags", lambda: ["acme-core-v2.0.0"])
+    root = workspace({"acme-core": {"version": "2.0.0"}})
+    assert run(root) == 0
+    out = capsys.readouterr().out
+    assert "up to date, nothing to release: 2.0.0 is on PyPI" in out
+    assert "no commit since acme-core-v2.0.0 touched its shipped code" in out
+    assert "nothing to release: every member is up to date" in out
+
+
+def test_unreleased_commits_on_a_published_version_ask_for_a_bump(
+    workspace, capsys, offline
+) -> None:
+    pypi(offline, {"acme-core": {"2.0.0": False}})
+    offline.setattr(release_plan, "list_tags", lambda: ["acme-core-v2.0.0"])
+    history(offline, {"acme-core": [("aaa1111", "a fix"), ("bbb2222", "another")]})
+    root = workspace({"acme-core": {"version": "2.0.0"}})
+    assert run(root) == 0
+    out = capsys.readouterr().out
+    assert "2 unreleased commits since acme-core-v2.0.0" in out
+    assert "2.0.0 is already published -- bump before tagging" in out
+    assert "uv version --package acme-core --bump {patch|minor|major} --no-sync" in out
+    assert "aaa1111  a fix" in out
+    assert "bbb2222  another" in out
+
+
+def test_a_declared_version_that_is_not_published_is_ready_to_tag(
+    workspace, capsys, offline
+) -> None:
+    pypi(offline, {"acme-core": {"1.9.0": False}})
+    offline.setattr(release_plan, "list_tags", lambda: ["acme-core-v1.9.0"])
+    history(offline, {"acme-core": [("aaa1111", "the feature")]})
+    root = workspace({"acme-core": {"version": "2.0.0"}})
+    assert run(root) == 0
+    out = capsys.readouterr().out
+    assert "release pending: 2.0.0 is not on PyPI, and this tree builds it" in out
+    assert "git tag acme-core-v2.0.0 && git push origin acme-core-v2.0.0" in out
+    assert "rehearse first: gh workflow run release.yaml -f tag=acme-core-v2.0.0" in out
+    assert "1 commit since acme-core-v1.9.0 touched its shipped code" in out
+
+
+def test_a_tag_whose_release_never_completed_says_so(
+    workspace, capsys, offline
+) -> None:
+    """The tag exists, PyPI does not have it: re-run the workflow, do not re-tag."""
+    pypi(offline, {"acme-core": {"1.9.0": False}})
+    offline.setattr(
+        release_plan, "list_tags", lambda: ["acme-core-v1.9.0", "acme-core-v2.0.0"]
+    )
+    root = workspace({"acme-core": {"version": "2.0.0"}})
+    assert run(root) == 0
+    out = capsys.readouterr().out
+    assert "the tag acme-core-v2.0.0 exists but PyPI has no 2.0.0" in out
+    assert "re-run the workflow from the tag, do not re-tag" in out
+
+
+def test_a_tree_behind_pypi_is_reported_and_still_exits_zero(
+    workspace, capsys, offline
+) -> None:
+    pypi(offline, {"acme-core": {"1.0.0": False, "2.0.0": False}})
+    root = workspace({"acme-core": {"version": "1.0.0"}})
+    assert run(root) == 0
+    out = capsys.readouterr().out
+    assert "this tree is BEHIND PyPI (1.0.0 vs 2.0.0) -- an old branch?" in out
+    assert "::error" not in out
+    assert "behind PyPI, so nothing to release from this tree: acme-core" in out
+
+
+def test_a_yanked_release_is_not_the_latest(workspace, capsys, offline) -> None:
+    """A yanked 3.0.0 must not make a 2.0.0 tree look BEHIND: it cannot be installed."""
+    pypi(offline, {"acme-core": {"2.0.0": False, "3.0.0": True}})
+    offline.setattr(release_plan, "list_tags", lambda: ["acme-core-v2.0.0"])
+    root = workspace({"acme-core": {"version": "2.0.0"}})
+    assert run(root) == 0
+    out = capsys.readouterr().out
+    assert "2 versions, latest 2.0.0, 1 yanked" in out
+    assert "up to date, nothing to release" in out
+    assert "BEHIND PyPI" not in out
+
+
+def test_a_project_pypi_has_never_heard_of_is_not_an_error(
+    workspace, capsys, offline
+) -> None:
+    """A whole-project 404 is a first release, not a failure."""
+    root = workspace({"acme-core": {"version": "0.1.0"}})
+    assert run(root) == 0
+    out = capsys.readouterr().out
+    assert "on PyPI            nothing -- acme-core has never been published" in out
+    assert "release pending: 0.1.0 is not on PyPI" in out
+    assert "::error" not in out
+
+
+def test_a_404_for_the_whole_project_is_an_empty_answer(monkeypatch) -> None:
+    import urllib.error
+
+    def raising(url: str, timeout: int = 30):
+        raise urllib.error.HTTPError(url, 404, "nope", None, None)  # ty: ignore[invalid-argument-type]
+
+    monkeypatch.setattr(release_plan.urllib.request, "urlopen", raising)
+    assert release_plan.published_versions("acme-core") == {}
+
+
+@pytest.mark.parametrize("status", [403, 500, 503])
+def test_a_non_404_pypi_answer_stops_the_planner(
+    workspace, capsys, offline, status: int
+) -> None:
+    """The planner never gates -- but it also never advises on a guess."""
+    import urllib.error
+
+    def raising(url: str, timeout: int = 30):
+        raise urllib.error.HTTPError(url, status, "boom", None, None)  # ty: ignore[invalid-argument-type]
+
+    offline.undo()
+    offline.setattr(release_plan, "list_tags", lambda: [])
+    offline.setattr(release_plan, "commits_since", lambda ref, paths: [])
+    offline.setattr(release_plan, "head_context", lambda: ("abc1234", "master"))
+    offline.setattr(release_plan, "resolve", lambda ref: None)
+    offline.setattr(release_plan.urllib.request, "urlopen", raising)
+    root = workspace({"acme-core": {"version": "1.0.0"}})
+    assert run(root) == 1
+    out = capsys.readouterr().out
+    assert f"PyPI returned {status}" in out
+    assert "refusing to advise on a guess about what acme-core has published" in out
+
+
+def test_a_git_failure_stops_the_planner(workspace, capsys, offline) -> None:
+    def raising(ref: str, paths: list[str]) -> list[tuple[str, str]]:
+        raise release_plan.PlanError("`git log` failed (128): not a git repository")
+
+    offline.setattr(release_plan, "commits_since", raising)
+    root = workspace({"acme-core": {"version": "1.0.0"}})
+    assert run(root) == 1
+    assert "::error::`git log` failed (128)" in capsys.readouterr().out
+
+
+def test_no_git_is_refused_in_planner_mode(workspace, capsys, offline) -> None:
+    """The planner IS git reasoning; --no-git would empty the answer, not skip a check."""
+    root = workspace({"acme-core": {"version": "1.0.0"}})
+    assert run(root, "--no-git") == 1
+    out = capsys.readouterr().out
+    assert "--no-git makes no sense without --tag" in out
+    assert "since each member's last release tag" in out
+
+
+def test_the_context_header_names_head_and_the_branch(
+    workspace, capsys, offline
+) -> None:
+    offline.setattr(release_plan, "head_context", lambda: ("deadbee", "detached"))
+    offline.setattr(release_plan, "is_ancestor", lambda commit, branch: False)
+    root = workspace({"acme-core": {"version": "1.0.0"}})
+    assert run(root) == 0
+    out = capsys.readouterr().out
+    assert "HEAD deadbee (detached)" in out
+    assert "HEAD is not on origin/master -- releases are cut from master" in out
+    assert "<member>/src and <member>/pyproject.toml" in out
+
+
+def test_an_absent_origin_master_is_reported_not_fatal(
+    workspace, capsys, offline
+) -> None:
+    def explode(commit: str, branch: str) -> bool:
+        raise AssertionError(
+            "is_ancestor must not be asked about a ref that is not there"
+        )
+
+    offline.setattr(release_plan, "resolve", lambda ref: None)
+    offline.setattr(release_plan, "is_ancestor", explode)
+    root = workspace({"acme-core": {"version": "1.0.0"}})
+    assert run(root) == 0
+    assert "origin/master not found (no fetch?): ancestry not checked" in (
+        capsys.readouterr().out
+    )
+
+
+# --- the planner: dependant advice --------------------------------------------------------
+
+
+DIAMOND = {
+    "acme-core": {"version": "2.0.0"},
+    "acme-ext": {"version": "0.1.0", "dependencies": ["acme-core>=2.0.0,<3"]},
+}
+
+
+def test_the_plan_job_would_refuse_the_dependant_is_said_in_advance(
+    workspace, capsys, offline
+) -> None:
+    """Check (4) of the tag mode, six minutes and one red job earlier."""
+    pypi(offline, {"acme-core": {"1.9.0": False}})
+    root = workspace(DIAMOND)
+    assert run(root) == 0
+    out = capsys.readouterr().out
+    # the manifest's own text, not `packaging`'s sorted rendering of it
+    assert "acme-ext 0.1.0 needs acme-core>=2.0.0,<3" in out
+    assert (
+        "the plan job WILL refuse `acme-ext-v0.1.0`: it needs acme-core>=2.0.0,<3, and "
+        "PyPI has only up to 1.9.0 -- release acme-core first" in out
+    )
+
+
+def test_advice_never_gates(workspace, capsys, offline) -> None:
+    """ "release acme-core first" is the strongest thing the planner says, and it exits 0."""
+    pypi(offline, {"acme-core": {"1.9.0": False}})
+    root = workspace(DIAMOND)
+    assert run(root) == 0
+    out = capsys.readouterr().out
+    assert "release acme-core first" in out
+    assert "::error" not in out
+
+
+def test_a_dependant_with_nothing_published_names_that_too(
+    workspace, capsys, offline
+) -> None:
+    root = workspace(DIAMOND)
+    assert run(root) == 0
+    assert (
+        "it needs acme-core>=2.0.0,<3, and PyPI has nothing" in capsys.readouterr().out
+    )
+
+
+def test_the_compat_cell_target_and_what_it_lacks(workspace, capsys, offline) -> None:
+    pypi(offline, {"acme-core": {"2.0.0": False}, "acme-ext": {"0.1.0": False}})
+    offline.setattr(release_plan, "list_tags", lambda: ["acme-core-v2.0.0"])
+    history(offline, {"acme-core": [("aaa1111", "a core fix"), ("bbb2222", "another")]})
+    root = workspace(DIAMOND)
+    assert run(root) == 0
+    out = capsys.readouterr().out
+    assert (
+        "the compat cell installs acme-core from PyPI: `acme-ext-v0.1.0` would be tested "
+        "against acme-core 2.0.0, which lacks acme-core's 2 commits since acme-core-v2.0.0"
+        in out
+    )
+    assert (
+        "`python tools/src/sn_tools/import_check.py acme-ext` installs the PUBLISHED "
+        "acme-core and imports every acme-ext module" in out
+    )
+    assert "behaviour changes still need the suite (the compat cell)" in out
+
+
+def test_a_commit_touching_both_packages_is_singled_out(
+    workspace, capsys, offline
+) -> None:
+    """Chris's scenario: one feature commit changed the core and the extension together."""
+    pypi(offline, {"acme-core": {"2.0.0": False}})
+    offline.setattr(release_plan, "list_tags", lambda: ["acme-core-v2.0.0"])
+    history(
+        offline,
+        {"acme-core": [("5ha12ed0", "the shared feature"), ("c0e0n1y0", "a core fix")]},
+    )
+    offline.setattr(
+        release_plan,
+        "touched_files",
+        lambda ref, paths: {
+            "5ha12ed0": {
+                "packages/acme-core/src/a.py",
+                "packages/acme-ext/src/b.py",
+            },
+            "c0e0n1y0": {"packages/acme-core/src/c.py"},
+        },
+    )
+    root = workspace(DIAMOND)
+    assert run(root) == 0
+    out = capsys.readouterr().out
+    assert (
+        "these changed both acme-core and acme-ext -- acme-ext very likely relies on the "
+        "unreleased acme-core; bump and release acme-core first" in out
+    )
+    assert "5ha12ed0  the shared feature" in out
+    # the core-only commit is counted, but it is not evidence about the extension
+    assert "which lacks acme-core's 2 commits" in out
+    assert "c0e0n1y0  a core fix" not in out.split("dependants:", 1)[1]
+
+
+def test_an_extra_only_edge_gets_the_same_advice(workspace, capsys, offline) -> None:
+    """`edges()` folds extras in, so the specifier lookup has to as well."""
+    pypi(offline, {"acme-core": {"1.9.0": False}})
+    root = workspace(
+        {
+            "acme-core": {"version": "2.0.0"},
+            "acme-ext": {
+                "version": "0.1.0",
+                "optional_dependencies": {"all": ["acme-core>=2.0.0,<3"]},
+            },
+        }
+    )
+    assert run(root) == 0
+    assert "the plan job WILL refuse `acme-ext-v0.1.0`" in capsys.readouterr().out
+
+
+# --- the planner: tags, the sequence, and the seam that must stay out of `--tag` ----------
+
+
+def test_a_bare_tag_is_a_release_of_sphinx_needs_only(
+    workspace, capsys, offline
+) -> None:
+    offline.setattr(release_plan, "list_tags", lambda: ["8.5.0"])
+    root = workspace(
+        {"sphinx-needs": {"version": "8.5.0"}, "acme-core": {"version": "8.5.0"}}
+    )
+    assert run(root) == 0
+    out = capsys.readouterr().out
+    assert "  last release tag   8.5.0" in out
+    assert "last release tag   none -- never tagged" in out
+
+
+def test_release_tags_skips_what_is_not_a_release(workspace) -> None:
+    """`v.1.4` and a backup ref are tags in this repository and are not releases.
+
+    `v2.0.0` is: PEP 440 normalises a leading `v` away, so it parses as 2.0.0 and names
+    the pre-move release it says it does. That is the behaviour `previous_tag` has always
+    had -- this factoring must not change it -- and it is harmless either way, because
+    `2.0.0` is tagged as well and neither is ever the maximum.
+    """
+    tags = [
+        "8.5.0",
+        "v2.0.0",
+        "v.1.4",
+        "depbatch-backup-f8556477",
+        "sphinx-needs-v8.6.0",
+    ]
+    assert release_plan.release_tags("sphinx-needs", tags) == [
+        (Version("8.5.0"), "8.5.0"),
+        (Version("2.0.0"), "v2.0.0"),
+        (Version("8.6.0"), "sphinx-needs-v8.6.0"),
+    ]
+    assert release_plan.release_tags("acme-core", tags) == []
+
+
+def test_the_suggested_sequence_is_dependencies_first(
+    workspace, capsys, offline
+) -> None:
+    pypi(offline, {"acme-core": {"2.0.0": False}})
+    offline.setattr(release_plan, "list_tags", lambda: ["acme-core-v2.0.0"])
+    history(offline, {"acme-core": [("aaa1111", "a core fix")]})
+    root = workspace(DIAMOND)
+    assert run(root) == 0
+    out = capsys.readouterr().out.split("suggested sequence")[1]
+    assert "1. after a bump: acme-core" in out
+    assert "uv version --package acme-core --bump {patch|minor|major} --no-sync" in out
+    assert "gh workflow run release.yaml -f tag=acme-core-v<new version>" in out
+    assert "2. acme-ext 0.1.0" in out
+    assert "git tag acme-ext-v0.1.0 && git push origin acme-ext-v0.1.0" in out
+
+
+def test_a_virtual_member_is_never_analysed(workspace, capsys, offline) -> None:
+    def explode(name: str):
+        assert name != "acme-tools", "the planner asked PyPI about a virtual member"
+        return {}
+
+    offline.setattr(release_plan, "published_versions", explode)
+    root = workspace(
+        {
+            "acme-core": {"version": "2.0.0"},
+            "acme-tools": {"version": "0", "virtual": True},
+        }
+    )
+    assert run(root) == 0
+    out = capsys.readouterr().out
+    assert "-- acme-tools 0   (virtual -- never published)" in out
+    assert "acme-tools 0   (packages/acme-tools)" not in out
+
+
+def test_tag_mode_never_reaches_the_planner_seams(workspace, capsys, offline) -> None:
+    """R3: the plan job runs `--tag` with `--no-project`; the planner must not wake up."""
+
+    def explode(*args, **kwargs):
+        raise AssertionError("`--tag` mode must not call the planner's seams")
+
+    published(offline, {("acme-core", "1.0.0"): False})
+    offline.setattr(release_plan, "published_versions", explode)
+    offline.setattr(release_plan, "commits_since", explode)
+    offline.setattr(release_plan, "touched_files", explode)
+    offline.setattr(release_plan, "head_context", explode)
+    offline.setattr(release_plan, "resolve", explode)
+    root = workspace({"acme-core": {"version": "1.0.0"}})
+    assert run(root, "--tag", "acme-core-v1.0.0") == 0
+    out = capsys.readouterr().out
+    assert "release plan -- advice" not in out
+    assert '"dist": "acme-core"' in out

--- a/tools/tests/test_release_plan.py
+++ b/tools/tests/test_release_plan.py
@@ -1083,7 +1083,11 @@ def test_a_yanked_tree_version_names_the_resolver_gate_not_the_plan_job(
     workspace, capsys, offline
 ) -> None:
     """The reviewer's case (b): the per-version PyPI URL is 200 for a yanked release, so
-    check (4) PASSES -- what stops the release is resolving a range from the index."""
+    check (4) PASSES -- what stops the release is resolving a range from the index.
+
+    Here the range has nothing else to resolve to: 2.0.0 is live but the dependant's floor
+    is 2.1.0. When it DOES have something, the answer is different -- see the test below.
+    """
     pypi_pair(
         offline,
         {"acme-core": {"2.0.0": False, "2.1.0": True}},
@@ -1096,9 +1100,10 @@ def test_a_yanked_tree_version_names_the_resolver_gate_not_the_plan_job(
     )
     out, tag_exit = both_modes(root, capsys, "acme-ext-v0.1.0")
     assert (
-        "the plan job passes (acme-core 2.1.0 is on PyPI) but every file of it is yanked, "
-        "so the resolver gate -- `uv pip install --dry-run` against the index -- will not "
-        "pick it for a range: release a new acme-core" in out
+        "the plan job passes (acme-core 2.1.0 is on PyPI) but every file of it is yanked "
+        "and no other live acme-core satisfies acme-core>=2.1.0,<3, so the resolver gate "
+        "-- `uv pip install --dry-run` against the index -- cannot resolve it: release a "
+        "new acme-core" in out
     )
     assert "the plan job WILL refuse" not in out
     assert tag_exit == 0, "check 4 accepts a yanked release; the planner must not lie"
@@ -1339,3 +1344,114 @@ def test_a_release_with_no_files_left_counts_as_yanked(monkeypatch) -> None:
 def test_under_respects_the_path_boundary(path: str, expected: bool) -> None:
     roots = ["packages/core/src", "packages/core/pyproject.toml"]
     assert release_plan.under(path, roots) is expected
+
+
+# --- fix round 2: the yank only matters when the range has nowhere else to go -------------
+
+
+def test_a_yanked_tree_version_the_range_can_route_around_is_not_a_blocker(
+    workspace, capsys, offline
+) -> None:
+    """V2. `2.1.0` is yanked, but `2.0.0` is live and satisfies `>=2.0.0,<3` -- so the
+    resolver gate succeeds and the compat cell tests against `2.0.0`.
+
+    Firing the yanked branch unconditionally asserted the opposite, told the reader to cut a
+    release that is not needed, and (because it returned first) suppressed the compat-cell
+    line, the "lacks N commits" clause and the both-packages heuristic entirely.
+    """
+    pypi_pair(offline, {"acme-core": {"2.0.0": False, "2.1.0": True}})
+    offline.setattr(release_plan, "list_tags", lambda cwd=None: ["acme-core-v2.0.0"])
+    history(offline, {"acme-core": [("5ha12ed0", "the shared feature")]})
+    offline.setattr(
+        release_plan,
+        "touched_files",
+        lambda ref, paths, cwd=None: {
+            "5ha12ed0": {"packages/acme-core/src/a.py", "packages/acme-ext/src/b.py"}
+        },
+    )
+    root = workspace(
+        {
+            "acme-core": {"version": "2.1.0"},
+            "acme-ext": {"version": "0.1.0", "dependencies": ["acme-core>=2.0.0,<3"]},
+        }
+    )
+    out, tag_exit = both_modes(root, capsys, "acme-ext-v0.1.0")
+    assert (
+        "the compat cell installs acme-core from PyPI: `acme-ext-v0.1.0` would be tested "
+        "against acme-core 2.0.0 (acme-core 2.1.0, this tree's version, is yanked, so the "
+        "index resolves to 2.0.0 instead), which lacks acme-core's 1 commit since "
+        "acme-core-v2.0.0" in out
+    )
+    # the branch that used to swallow all of this
+    assert "cannot resolve it: release a new acme-core" not in out
+    assert "these changed both acme-core and acme-ext" in out
+    assert "5ha12ed0  the shared feature" in out
+    assert tag_exit == 0
+
+
+def test_an_index_that_is_entirely_yanked_is_not_an_empty_one(
+    workspace, capsys, offline
+) -> None:
+    """V3. `core.latest` is None when every release is yanked, and "PyPI has nothing" is a
+    different, wronger fact -- `print_status` five lines above already gets this right."""
+    pypi_pair(offline, {"acme-core": {"1.0.0": True, "2.0.0": True}})
+    root = workspace(
+        {
+            "acme-core": {"version": "3.0.0"},
+            "acme-ext": {"version": "0.1.0", "dependencies": ["acme-core>=3.0.0,<4"]},
+        }
+    )
+    assert run(root) == 0
+    out = capsys.readouterr().out
+    assert (
+        "check 4 needs acme-core 3.0.0 on PyPI, and PyPI has 2 versions, all yanked -- "
+        "release acme-core first" in out
+    )
+    assert "PyPI has nothing" not in out
+    # and the member's own block agrees with the dependant's
+    assert "on PyPI            2 versions, latest: none -- every version yanked" in out
+
+
+# --- fix round 2: the sixth `cwd` call site --------------------------------------------
+
+
+def test_the_ancestry_check_asks_the_root_repository(
+    git_workspace, capsys, monkeypatch
+) -> None:
+    """V5. The one `--root` call site no test reached: the existing fixture has no
+    `origin/master`, so `is_ancestor` never ran and dropping its `cwd` stayed green.
+
+    Asking THIS repository instead would answer about a HEAD that is not on origin/master
+    (this branch is not), so the false line appears exactly when the true one should not.
+    """
+    monkeypatch.setattr(release_plan, "published_versions", lambda name: {})
+    root = git_workspace({"acme-core": {"version": "1.0.0"}})
+    commit(
+        root,
+        "the first commit",
+        {"packages/acme-core/src/acme_core/__init__.py": "VALUE = 1\n"},
+    )
+    git_in(root, "update-ref", "refs/remotes/origin/master", "HEAD")
+    assert run(root) == 0
+    out = capsys.readouterr().out
+    assert "origin/master not found" not in out
+    assert "HEAD is not on origin/master" not in out
+
+
+def test_a_head_off_the_root_repositorys_master_is_reported(
+    git_workspace, capsys, monkeypatch
+) -> None:
+    """The other direction, so the absence above is a measurement and not a silence."""
+    monkeypatch.setattr(release_plan, "published_versions", lambda name: {})
+    root = git_workspace({"acme-core": {"version": "1.0.0"}})
+    first = commit(
+        root,
+        "the first commit",
+        {"packages/acme-core/src/acme_core/__init__.py": "VALUE = 1\n"},
+    )
+    git_in(root, "update-ref", "refs/remotes/origin/master", first)
+    commit(root, "off master", {"packages/acme-core/src/acme_core/x.py": "VALUE = 2\n"})
+    assert run(root) == 0
+    out = capsys.readouterr().out
+    assert "HEAD is not on origin/master -- releases are cut from master" in out
+    assert "origin/master not found" not in out

--- a/tools/tests/test_release_plan.py
+++ b/tools/tests/test_release_plan.py
@@ -1455,3 +1455,20 @@ def test_a_head_off_the_root_repositorys_master_is_reported(
     out = capsys.readouterr().out
     assert "HEAD is not on origin/master -- releases are cut from master" in out
     assert "origin/master not found" not in out
+
+
+def test_an_unreachable_pypi_names_the_reason_not_the_wrapper(monkeypatch) -> None:
+    """A `URLError` is reported by its `.reason` -- `[Errno 61] Connection refused` -- exactly
+    as `on_pypi` reports it two functions away, not by the `<urlopen error ...>` wrapper that
+    `str(exc)` gives. The two messages must not drift: they describe the same outage."""
+    import urllib.error
+
+    def raising(url: str, timeout: int = 30):
+        raise urllib.error.URLError(OSError(61, "Connection refused"))
+
+    monkeypatch.setattr(release_plan.urllib.request, "urlopen", raising)
+    with pytest.raises(release_plan.PlanError) as caught:
+        release_plan.published_versions("acme-core")
+    message = str(caught.value)
+    assert "cannot reach PyPI ([Errno 61] Connection refused)" in message
+    assert "<urlopen error" not in message


### PR DESCRIPTION
Built on #1846 (merged as `7b5b5488`) and re-parented onto `master` afterwards; `git range-diff` shows every commit unchanged.

### The question this answers

Reviewing #1846, Chris asked whether the release ORDER could be suggested up front rather than learned from a red compat cell six minutes into a release job — "so you don't have to work it out by trial and error". The compat cell stays exactly where it is: it is the last line of defence and the only content-aware check in the pipeline. What it should not also be is the *first* place you learn the order. Two additions move that answer to before the release pull request.

### 1. A planner: `uv run poe release-plan`

`release_plan.py` run with no `--tag` used to print the topological order and stop. It now prints, per publishable member, the last release tag, what PyPI has, the commits since that tag that touched the member's **shipped** code (`<member>/src` and `<member>/pyproject.toml` — docs and tests deliberately not counted), and — for each dependant — which gate would stop a release of it, or the version the compat cell would install from PyPI; then a suggested sequence with the exact commands.

On this branch:

```
release order (dependencies first):
  1. sphinx-needs 8.5.0   depends on: -
  -- sphinx-needs-workspace-tools 0   (virtual -- never published)

release plan -- advice, never a gate: this exits 0 whatever it finds
  HEAD bd87173a (ci/release-planner)
  HEAD is not on origin/master -- releases are cut from master; this describes THIS tree
  "unreleased" counts commits touching a member's SHIPPED code -- <member>/src and <member>/pyproject.toml. Docs and tests are deliberately not counted

sphinx-needs 8.5.0   (packages/sphinx-needs)
  last release tag   8.5.0
  on PyPI            32 versions, latest 8.5.0
  3 unreleased commits since 8.5.0; 8.5.0 is already published -- bump before tagging:
      uv version --package sphinx-needs --bump {patch|minor|major} --no-sync
    7b5b5488  🔧 One tag-driven release workflow for every workspace member, on trusted publishing (#1846)
    62cb7670  ⬆️ Raise the Python floor to 3.11, and pin the workspace interpreter (#1844)
    a35c5dc8  🔧 Restructure the repository into a uv workspace (packages/sphinx-needs) (#1839)

suggested sequence (dependencies first):
  1. after a bump: sphinx-needs
       uv version --package sphinx-needs --bump {patch|minor|major} --no-sync
       rehearse: gh workflow run release.yaml -f tag=sphinx-needs-v<new version>
       tag:      git tag sphinx-needs-v<new version> && git push origin sphinx-needs-v<new version>
```

With a second package in the workspace it also names, per dependency edge, **the one gate that would actually stop a release of the dependant**, asked in the order the pipeline asks them. On a two-member scratch workspace whose core is at 2.1.0 with 2.0.0 and 2.2.0 on the index:

```
acme-core 2.1.0   (packages/acme-core)
  last release tag   acme-core-v2.0.0
  on PyPI            2 versions, latest 2.2.0
  this tree is BEHIND PyPI (2.1.0 vs 2.2.0) -- an old branch?
  dependants:
    acme-ext 0.1.0 needs acme-core>=2.1.0,<3
      the plan job WILL refuse `acme-ext-v0.1.0`: check 4 needs acme-core 2.1.0 on PyPI, and PyPI has 2.2.0 as its newest live version -- release acme-core first
      `uv run python tools/src/sn_tools/import_check.py acme-ext` installs the PUBLISHED acme-core and imports every acme-ext module -- a missing symbol is named in seconds; behaviour changes still need the suite (the compat cell)
```

That is check 4's own predicate — *is the core's tree version on the index* — said in advance, and the tag mode does exit 1 on the same facts (every dependant test runs both modes over one mocked index and asserts they agree). The other branches name the gate that would really fire: where the tree's version is on PyPI but yanked *and nothing else live satisfies the specifier*, the resolver gate; where no published version satisfies the specifier at all, the resolver gate and Lint's `check-workspace`. A yank the range can route around is not a blocker — it becomes a clause on the compat-cell line naming the version the index actually resolves to. Only when none of those fires does it describe the compat cell plainly:

> the compat cell installs sphinx-needs from PyPI: `sphinx-codelinks-v0.2.0` would be tested against sphinx-needs 8.5.0, which lacks sphinx-needs' 3 commits since 8.5.0

plus the heuristic no version comparison can express — the commits among those that **also** touched the dependant's shipped code, listed by sha:

> these changed both sphinx-needs and sphinx-codelinks — sphinx-codelinks very likely relies on the unreleased sphinx-needs; bump and release sphinx-needs first

### Design: advice, never a gate

**It exits 0 whatever it finds**, and 1 only when the data could not be gathered — a manifest it cannot read, a PyPI answer that is not a clean 404 (a 503, a read timeout, a malformed document), a git failure. No exit code and no `::error::` line ever encodes "do not release".

That is deliberate, and it is why this is a *tool* rather than a sixth check in the plan job. A `git log <last-tag>..HEAD` **gate** would force a premature core release off a master carrying unfinished work every time an unrelated extension shipped a fix (the design discussion in #1803 rejected it for that reason). The release ORDER stays enforced where it can be enforced without that cost: by the plan job's PyPI check (an extension cannot be published against a core that only exists on somebody's disk) and by the compat cell running the extension's suite against the core *as published*. The planner is that same reasoning, offered early, in words, to a human who decides. It may over-warn; that is the price of never being wrong in the expensive direction.

`--tag` mode is untouched and gains no network or git call. The plan job runs it with `--no-project --with packaging`; a test asserts that mode never reaches the planner's PyPI or git seams, and seven `--tag` invocations are byte-identical (stdout, stderr, exit status) against the script on the base branch — the one job standing between a mistyped tag and an upload must not grow new ways to fail.

### 2. A fast import check: `tools/src/sn_tools/import_check.py`

```
$ uv run poe import-check-needs
$ uv build --package sphinx-needs --no-sources -o …/dist
$ uv venv …/venv
$ uv pip install --python …/venv --no-sources …/sphinx_needs-8.5.0-py3-none-any.whl
$ …/venv/bin/python tools/src/sn_tools/import_check.py --walk sphinx_needs --expect-prefix …/venv
      sphinx_needs imported from …/venv/lib/python3.13/site-packages/sphinx_needs/__init__.py
OK    81 modules imported in 2.0s
import check finished in 4.8s
```

**The trick is the throwaway environment, plus `--expect-prefix`.** The wheel is installed with `uv pip install` into an environment *outside* this project, so uv reads the wheel's own `Requires-Dist` and resolves it from the index: the siblings arrive exactly as published. `--no-sources` is passed and kept — it makes the command the release build's and the compat cell's character for character, and it states the intent — but measured on uv 0.12.9 it is not the mechanism for a *wheel* install (it governs requirements uv reads from a pyproject; `uv pip install <wheel>` resolves from the index either way). Review caught this claim in the first draft and in the pre-existing `scripts/smoke_needs.py`; both are corrected here rather than left standing. What would silently make the check prove nothing is importing the checkout instead of the wheel, and `--expect-prefix` is what refuses that — for every module walked, not only the top-level one.

Importing every module of the member is then a complete answer to "is any name it uses missing from what is published": "sphinx-codelinks imports `sphinx_needs.x.y`, which is not in sphinx-needs 8.5.0" comes back in seconds instead of six minutes into a red compat cell. It is *not* an answer to "does it still work" — a behaviour change imports beautifully — and the compat cell remains the guard for that. The tool says so, and so do the docs.

Two layers in one file, so the outer can invoke the inner by path under a different interpreter:

* **outer** — `import_check.py <dist>`: build with character-for-character the release command (`uv build --package <dist> --no-sources -o <tmp>/dist`), `uv venv` on the root `.python-version` pin exactly as the compat cell does, install the wheel, run the inner with the environment's own interpreter. Echoes every command; `--wheel` / `--python` / `--keep` for the awkward cases.
* **inner** — `import_check.py --walk <module> [--expect-prefix <dir>]`: **stdlib only**, because it runs under the scratch interpreter, which has the wheel's dependencies and nothing else. It imports the top-level module, walks every submodule and imports each one, catching `Exception` **and `SystemExit`** per module so the reader gets *every* failure at once, with the innermost traceback frame of each. `<pkg>.__main__` is skipped and the skip announced: an entry point is not import surface, and importing one runs it against the walker's own argv. Warnings are not failures (measured: `sphinx_needs.api.exceptions` emits one deprecation warning today). Every path out of the walk prints at least one line, and **an incomplete walk fails**: a package whose import failed on the walker's pass and succeeded on the loop's — what a non-idempotent import does — leaves a subtree nobody checked, and that is not an `OK`.

### 3. In CI

The compat cell already asserted the import came from the wheel rather than the checkout, inline with `python -c`. That assertion is now `--expect-prefix`, so the inline block is replaced by the walk, placed before pytest:

```yaml
/tmp/compat/bin/python tools/src/sn_tools/import_check.py --walk "$module" --expect-prefix /tmp/compat
```

Same guarantee, plus every other module, before the six-minute suite starts (about three seconds of a six-minute job). Nothing else in the workflow changes.

### 4. The recipe

`AGENTS.md` § "Releasing a package" gains a **step 0** — run the planner, and for a member with an intra-workspace dependency run the import check — and `docs/contributing.rst` gains the same in prose before "A release is two steps". Both say the tools are advice and that the fences are still the plan job and the compat cell. Every tools-script invocation outside CI is written `uv run python tools/src/sn_tools/<script>.py …` (a bare `python` is whatever is on PATH, and these scripts need 3.11's `tomllib`). Every command written in either file was run on this branch.

### Tests and gates

* `tools/tests`: **171 passed** (96 before this PR), ~1.6 s, no network. Planner: all four verdicts; all five dependant branches, each running **both** the planner and `--tag` over one mocked index and asserting they agree; the both-packages heuristic (including that a core-only commit is *not* listed as evidence, and that a non-ASCII path is not lost to git's C-quoting); bare tags belonging to sphinx-needs alone; yanked-only versions not counting as latest; a whole-project 404 meaning "never published"; a 503, a read timeout and a malformed document each refusing to advise; a git failure; `--no-git` refused; "release C first" still exiting 0; `--tag` never touching the planner's seams. Three tests drive a **real scratch git repository** through `--root`, which is what pins the shipped-paths semantic and that `--root` reaches every git call. Import check: the inner walk run for real in a subprocess against scratch packages (clean; two different failures reported together; a broken subpackage; a module and a package that call `sys.exit`; a package that fails on its *first* import only; an unguarded `__main__`; a warning; `--expect-prefix` in both directions and per submodule), the outer on its exact argv.
* 22 mutation proofs, each red on the named test and green on revert — including "swallow `SystemExit`", "let an incomplete walk pass", "walk `__main__`", each dependant predicate, "ignore `--root` for git" at all six call sites, "count docs and tests as shipped", and "ignore `--expect-prefix`".
* `poe lint`, `poe typecheck-needs`, root-level pytest collection: green.
* Three rehearsals dispatched from this branch (the last from the final tip): plan green with both rehearsal notices, build green with `OK    81 modules imported` in the compat cell's log before the suite, publish and release skipped.

### Follow-ups (not in this PR)

* `poe bump` — the version bump, `propagate_floors.py` and the changelog stamp as one task.
* A compat matrix on pushes to master, once a second publishable member exists: the planner advises, the compat cell gates at release time, and neither notices a drift the day it lands.
* TestPyPI, if a dry publish is ever wanted before the real one.
* `on_pypi` (the plan job's own PyPI call) has the same read-timeout gap this PR closed in the planner's `published_versions`: a `TimeoutError` is an `OSError`, not a `URLError`, so it is an uncaught traceback rather than the fail-closed message the function is written for. It still exits non-zero, so nothing fails open. Left alone deliberately: this PR does not touch the tag path's behaviour.
