### PR TITLE
🧪 Probe: does the sphinx-mounts Read the Docs project build pull requests?

### DIFF
--- a/packages/sphinx-mounts/.readthedocs.yaml
+++ b/packages/sphinx-mounts/.readthedocs.yaml
@@ -32,3 +32,6 @@ python:
         # the MEMBER's extra, not the root's `docs-mounts` pass-through: RTD pip-installs
         # the package directory itself, so the name it resolves is the member's own
         - docs
+
+# Pull request builds are a per-project setting on Read the Docs ("Build pull requests for
+# this project"); each project posts its own commit status, `docs/readthedocs.org:<slug>`.


### PR DESCRIPTION
A comment-only change under `packages/sphinx-mounts/`, opened purely to observe the new sphinx-mounts Read the Docs project: its webhook on this repository was created today, "Build pull requests" is enabled, but the repository URL is set by hand rather than connected. The questions are whether a pull request triggers a mounts build at all, and whether that build posts a `docs/readthedocs.org:sphinx-mounts` commit status with a preview link. Not for merging; it will be closed once the answer is recorded.