### PR TITLE
🧪 Probe: what status does a Read the Docs build cancelled with exit 183 report?

### DIFF
--- a/packages/sphinx-mounts/.readthedocs.yaml
+++ b/packages/sphinx-mounts/.readthedocs.yaml
@@ -17,6 +17,17 @@ build:
   os: ubuntu-24.04
   tools:
     python: "3.13"
+  jobs:
+    post_checkout:
+      # PROBE ONLY -- never to be merged. Cancels EVERY pull-request build of this project
+      # unconditionally, to observe what commit status Read the Docs reports for a build
+      # cancelled through exit code 183. The real, conditional job (cancel when nothing
+      # under packages/sphinx-mounts/ changed) lands separately once that is known.
+      - |
+        if [ "$READTHEDOCS_VERSION_TYPE" = "external" ]; then
+          echo "probe: cancelling this pull-request build via exit 183"
+          exit 183
+        fi
 
 sphinx:
   configuration: packages/sphinx-mounts/docs/conf.py


### PR DESCRIPTION
The sphinx-mounts Read the Docs configuration on this branch cancels every pull-request build unconditionally through a `post_checkout` job exiting 183. The only purpose is to observe the `docs/readthedocs.org:sphinx-mounts` commit status such a cancelled build reports (success, failure, pending forever, or nothing), which decides whether the real conditional job (cancel when nothing under `packages/sphinx-mounts/` changed) can be used on a project whose status is required. Not for merging; closed once recorded.