### PR TITLE
🔧 Skip the sphinx-mounts Read the Docs build on pull requests that do not touch it

### DIFF
--- a/packages/sphinx-mounts/.readthedocs.yaml
+++ b/packages/sphinx-mounts/.readthedocs.yaml
@@ -17,6 +17,40 @@ build:
   os: ubuntu-24.04
   tools:
     python: "3.13"
+  jobs:
+    post_checkout:
+      # Every pull request against this repository builds BOTH Read the Docs projects. A
+      # pull request that leaves `packages/sphinx-mounts/` untouched has nothing for this
+      # one to build, so cancel it. Exit code 183 is Read the Docs' documented "skip" code
+      # (https://docs.readthedocs.com/platform/stable/guides/build/skip-build.html): the
+      # build is recorded as `cancelled`, and the commit status sent to GitHub is `success`
+      # with the description "Read the Docs build skipped", so no pull request is ever
+      # blocked by it. Measured on build 34411602 (pull request #1861): 10 s, `cancelled`,
+      # status `success`.
+      #
+      # Why a plain two-dot `git diff` and not a merge base: Read the Docs clones the default
+      # branch with `--depth 1` and then fetches the pull-request head with `--depth 50`, so
+      # `origin/master` is a shallow root with no ancestry and `git merge-base` has nothing
+      # to walk. The diff therefore compares against master's CURRENT tip: if master moved
+      # and touched this package, the build runs although the pull request did not touch it.
+      # That is the safe direction; it never skips a build that was needed.
+      #
+      # `packages/sphinx-mounts/` is the complete set of inputs: this file lives inside it,
+      # `docs/conf.py` reads only the package's own `pyproject.toml`, and `python.install`
+      # below installs the package directory with its own `docs` extra, so no root file takes
+      # part in this build. Branch and tag builds (`latest`, releases) are never cancelled.
+      - |
+        if [ "$READTHEDOCS_VERSION_TYPE" != "external" ]; then
+          exit 0
+        fi
+        if ! git rev-parse --verify --quiet origin/master > /dev/null; then
+          echo "origin/master is not available in this clone; building to be safe"
+          exit 0
+        fi
+        if git diff --quiet origin/master -- packages/sphinx-mounts/; then
+          echo "nothing under packages/sphinx-mounts/ changed; skipping this build (exit 183)"
+          exit 183
+        fi
 
 sphinx:
   configuration: packages/sphinx-mounts/docs/conf.py


### PR DESCRIPTION
Every pull request against this repository builds both Read the Docs projects, and a pull request that leaves `packages/sphinx-mounts/` untouched has nothing for the sphinx-mounts project to build. This adds a `post_checkout` job to `packages/sphinx-mounts/.readthedocs.yaml` that cancels such builds through exit code 183, Read the Docs' documented skip code ([guide](https://docs.readthedocs.com/platform/stable/guides/build/skip-build.html)). Branch and tag builds are never cancelled.

**Why this is safe to merge.** Measured on the throwaway probe #1861 rather than assumed: a build cancelled this way is recorded as `cancelled` after about 10 seconds, and the commit status Read the Docs posts is `success` with the description "Read the Docs build skipped". A skipped build therefore never blocks a merge, which also means the same recipe can later go on the sphinx-needs project, whose status is a required check, once this one has been observed in the wild.

**Why a plain two-dot diff.** Read the Docs clones the default branch at depth 1 and fetches the pull-request head at depth 50, so `origin/master` is a shallow root with no ancestry and a merge base cannot be computed. The job compares the pull-request head against master's current tip instead. If master has moved and touched the package, the build runs even though the pull request did not touch it; that is the safe direction, because it never skips a build that was needed. If `origin/master` is somehow absent, the job builds rather than skips.

**What to look at on this pull request.** It touches `packages/sphinx-mounts/`, so the sphinx-mounts Read the Docs build here must run to completion and go green. That is the negative control: a cancelled build on this pull request would mean the condition is inverted, and it must not be merged.

**What to look at afterwards.** The next pull request that touches only `packages/sphinx-needs/` or `.github/` should show `docs/readthedocs.org:sphinx-mounts` green with "Read the Docs build skipped", and the project's build list should show a `cancelled` build of about 10 seconds. The next pull request that does touch the package should build normally, about 35 seconds.

Out of scope: the sphinx-needs project's own configuration (follows after the observation above), and Read the Docs automation rules with file filters, which gate a whole project's builds rather than one pull request's and post no status when they suppress a build.
