### PR TITLE
🧪 Let the sphinx-needs test suite be pointed at any PlantUML

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,10 @@ and its tests assert rather than skip**: either a `plantuml` executable on `PATH
 `release.yaml` use, pointed at the jar sphinx-needs already vendors, so no runner installs
 a plantuml package:
 `PLANTUML_JAR=$PWD/packages/sphinx-needs/tests/doc_test/utils/plantuml.jar uv run poe test-mounts`.
+**sphinx-needs' own suite honours `PLANTUML_JAR` too**, ahead of the jar it vendors and ahead
+of any `plantuml` on `PATH`, so one export points both suites at one renderer — and a run from
+the sdist, whose embedded jar a distribution packager repacks away, has a supported route to a
+system PlantUML.
 `bazel` (or `bazelisk`) is the other optional binary — without it the `bazel`-marked tests
 skip, and `test-mounts` deselects them anyway. The browser tests (`-m jstest`, which
 `test-needs` excludes) additionally need a browser, and it is not a package: `uv run poe

--- a/packages/sphinx-mounts/AGENTS.md
+++ b/packages/sphinx-mounts/AGENTS.md
@@ -127,6 +127,8 @@ as a standalone repository cannot be built there at all. Do not reintroduce it.
     `packages/sphinx-needs/tests/doc_test/utils/plantuml.jar`, which that package vendors
     for its own tests. Locally:
     `PLANTUML_JAR=$PWD/packages/sphinx-needs/tests/doc_test/utils/plantuml.jar uv run poe test-mounts`.
+    sphinx-needs' suite reads the same variable, ahead of that vendored jar, so one export
+    serves both packages.
 
   Mermaid uses `raw` output, so no `mmdc` binary is needed.
 - **The three sphinx-needs integration tests assert rather than skip too.** They are the

--- a/packages/sphinx-mounts/tests/test_path_directives.py
+++ b/packages/sphinx-mounts/tests/test_path_directives.py
@@ -1335,6 +1335,23 @@ def _plantuml_jar_command() -> tuple[str, ...] | None:
     return ("java", "-Djava.awt.headless=true", "-jar", jar)
 
 
+def test_an_empty_plantuml_jar_is_treated_as_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An empty ``PLANTUML_JAR`` means "no jar", not "a jar named nothing".
+
+    That is how the variable arrives from a developer shell with ``PLANTUML_JAR=``
+    exported, and from a workflow that computes the value with an expression rather than
+    deciding whether to set it at all. Read the other way, every cell that does not want
+    a jar would go red. sphinx-needs' suite agrees, and pins it in
+    ``tests/test_plantuml_command.py``; this is the same four lines on this side, because
+    the two implementations are separate and nothing else links them.
+    """
+    monkeypatch.setenv("PLANTUML_JAR", "")
+
+    assert _plantuml_jar_command() is None
+
+
 def _require_renderer(directive_rst: str) -> None:
     """Fail the test when a diagram directive's renderer is not available.
 

--- a/packages/sphinx-needs/performance/project/conf.template
+++ b/packages/sphinx-needs/performance/project/conf.template
@@ -53,7 +53,7 @@ needs_fields = {"number": {}}
 
 {% endif %}
 
-plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "..", "docs", "utils", "plantuml.jar")
+plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "..", "docs", "utils", "plantuml-1.2022.14.jar")
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/packages/sphinx-needs/tests/conftest.py
+++ b/packages/sphinx-needs/tests/conftest.py
@@ -109,21 +109,69 @@ def sphinx_test_tempdir(request) -> Path:
     return sphinx_test_tempdir
 
 
+_PLANTUML_JAVA = "java -Djava.awt.headless=true -jar {}"
+
+
+def resolve_plantuml_command(vendored_jar: Path) -> str:
+    """Work out how this suite renders PlantUML, from three sources in this order.
+
+    The point of the chain is that the jar's *location* is an implementation detail of
+    this package rather than a fact its callers have to know.
+
+    1. ``PLANTUML_JAR``, run through ``java``. Naming a jar is an explicit choice, so it
+       wins: it is how sphinx-mounts' suite is already pointed at a renderer, and it is
+       the only route open to someone running these tests from the sdist with the jar
+       unpacked elsewhere -- or repacked away, which is what a distribution packager does
+       with an embedded pre-built jar. A variable that is set but names no file is a
+       mistake worth a red run rather than a silent fall-through: falling through would
+       render with a renderer the caller did not ask for and say nothing.
+    2. The vendored jar, as copied into the test tempdir. The default, and unchanged: a
+       fresh clone still renders with the copy under ``tests/doc_test/utils/`` and needs
+       nothing installed.
+    3. A ``plantuml`` executable on ``PATH`` -- and only once (2) is gone. This suite
+       renders for real and asserts on the output, so a developer machine that happens to
+       carry a homebrew ``plantuml`` must not quietly swap the renderer version out from
+       under it. The executable is the fallback for a checkout or sdist with no jar, not
+       a preference.
+
+    :param vendored_jar: Where the vendored jar was copied to for this session.
+    :return: The value for the ``plantuml`` configuration.
+    """
+    env_jar = os.environ.get("PLANTUML_JAR")
+    if env_jar:
+        if not Path(env_jar).is_file():
+            raise RuntimeError(
+                f"PLANTUML_JAR names {env_jar!r}, which is not a file. "
+                "Point it at a plantuml jar, or unset it to render with the "
+                "jar this package vendors."
+            )
+        return _PLANTUML_JAVA.format(env_jar)
+    if vendored_jar.is_file():
+        return _PLANTUML_JAVA.format(vendored_jar)
+    if executable := shutil.which("plantuml"):
+        return executable
+    raise RuntimeError(
+        f"no PlantUML to render with: {vendored_jar} does not exist, no `plantuml` is "
+        "on PATH, and PLANTUML_JAR is unset. Set PLANTUML_JAR to a plantuml jar (with "
+        "java on PATH), or install a plantuml executable."
+    )
+
+
 @pytest.fixture(scope="session")
 def plantuml_command(sphinx_test_tempdir) -> str:
     """The plantuml command every test project must build its diagrams with.
 
     CI runners have java and the vendored jar but no ``plantuml`` on ``PATH``, so a
     project left on sphinxcontrib-plantuml's default command fails to render there while
-    passing on any machine that happens to have one installed. Every test therefore
-    points at the jar this fixture set copies, whether it goes through :func:`test_app`
-    or calls ``make_app`` itself.
+    passing on any machine that happens to have one installed. Every test therefore takes
+    its command from here, whether it goes through :func:`test_app` or calls ``make_app``
+    itself -- no test builds the path to the jar for itself.
 
     :param sphinx_test_tempdir: The directory holding the copied jar.
     :return: The value for the ``plantuml`` configuration.
     """
-    return "java -Djava.awt.headless=true -jar {}".format(
-        os.path.join(sphinx_test_tempdir, "utils", "plantuml.jar")
+    return resolve_plantuml_command(
+        Path(sphinx_test_tempdir) / "utils" / "plantuml.jar"
     )
 
 

--- a/packages/sphinx-needs/tests/conftest.py
+++ b/packages/sphinx-needs/tests/conftest.py
@@ -76,6 +76,31 @@ def pytest_addoption(parser):
     )
 
 
+def copy_test_utils(source: Path, destination: Path) -> None:
+    """Copy ``tests/doc_test/utils`` into the session tempdir, if it is there at all.
+
+    Guarded rather than unconditional, because the directory is not guaranteed to
+    survive into every tree this suite runs in. It holds exactly one file -- the
+    vendored plantuml jar -- and flit writes no directory entries into the sdist, so a
+    distribution packager who strips ``*.jar`` from the tarball before repacking it is
+    left with no ``doc_test/utils`` at all. Unguarded, ``copytree`` then raises
+    ``FileNotFoundError`` out of a session fixture that every rendering test depends
+    on, and :func:`resolve_plantuml_command` -- the whole point of which is to let such
+    a tree be pointed at a PlantUML of its own -- is never reached.
+
+    The destination is created only when there is something to put in it, so
+    ``<tempdir>/utils/plantuml.jar`` is absent rather than empty and route (2) of the
+    chain declines cleanly.
+
+    :param source: The suite's own ``doc_test/utils`` directory.
+    :param destination: Where it is copied to for this session.
+    """
+    if not source.is_dir():
+        return
+    destination.mkdir(exist_ok=True)
+    shutil.copytree(source, destination, dirs_exist_ok=True)
+
+
 @pytest.fixture(scope="session")
 def sphinx_test_tempdir(request) -> Path:
     """
@@ -94,22 +119,27 @@ def sphinx_test_tempdir(request) -> Path:
     )
 
     sphinx_test_tempdir = Path(temp_base).joinpath("sn_test_build_data")
-    utils_dir = sphinx_test_tempdir.joinpath("utils")
 
     # if not (sphinx_test_tempdir.exists() and sphinx_test_tempdir.isdir()):
     sphinx_test_tempdir.mkdir(exist_ok=True)
-    # if not (utils_dir.exists() and utils_dir.isdir()):
-    utils_dir.mkdir(exist_ok=True)
 
     # copy plantuml.jar to current test tempdir. We want to do this once
     # since the same plantuml.jar is used for each test
-    plantuml_jar_file = Path(__file__).parent.resolve() / "doc_test/utils"
-    shutil.copytree(plantuml_jar_file, utils_dir, dirs_exist_ok=True)
+    copy_test_utils(
+        Path(__file__).parent.resolve() / "doc_test/utils",
+        sphinx_test_tempdir / "utils",
+    )
 
     return sphinx_test_tempdir
 
 
-_PLANTUML_JAVA = "java -Djava.awt.headless=true -jar {}"
+# The jar path is DOUBLE-QUOTED. sphinxcontrib-plantuml passes a list or tuple through
+# untouched and `shlex`-splits anything else -- `posix=True` off Windows, `posix=False`
+# plus its own `_ntunquote` on it -- so an unquoted path containing a space arrives as
+# two argv elements and the render dies. Both split paths strip these quotes again, so
+# the argv is unchanged for a path without one. sphinx-mounts solves the same problem by
+# returning a tuple; a string is what this fixture's callers already pass around.
+_PLANTUML_JAVA = 'java -Djava.awt.headless=true -jar "{}"'
 
 
 def resolve_plantuml_command(vendored_jar: Path) -> str:
@@ -134,6 +164,10 @@ def resolve_plantuml_command(vendored_jar: Path) -> str:
        under it. The executable is the fallback for a checkout or sdist with no jar, not
        a preference.
 
+    An EMPTY ``PLANTUML_JAR`` is treated as unset rather than as a mistake, because that
+    is how it arrives: a developer shell with ``PLANTUML_JAR=`` exported, and a workflow
+    that computes the value with an expression. sphinx-mounts reads it the same way.
+
     :param vendored_jar: Where the vendored jar was copied to for this session.
     :return: The value for the ``plantuml`` configuration.
     """
@@ -148,12 +182,18 @@ def resolve_plantuml_command(vendored_jar: Path) -> str:
         return _PLANTUML_JAVA.format(env_jar)
     if vendored_jar.is_file():
         return _PLANTUML_JAVA.format(vendored_jar)
-    if executable := shutil.which("plantuml"):
-        return executable
+    # sphinxcontrib.plantuml invokes the command synchronously; on Windows the
+    # chocolatey package's `plantuml` shim is non-blocking (javaw), so its `plantumlc`
+    # (java) shim is the one to use there -- a lesson sphinx-mounts has already paid for
+    # (see `_plantuml_extra_conf` in its tests/test_path_directives.py)
+    for name in ("plantumlc", "plantuml") if os.name == "nt" else ("plantuml",):
+        if executable := shutil.which(name):
+            return executable
     raise RuntimeError(
-        f"no PlantUML to render with: {vendored_jar} does not exist, no `plantuml` is "
-        "on PATH, and PLANTUML_JAR is unset. Set PLANTUML_JAR to a plantuml jar (with "
-        "java on PATH), or install a plantuml executable."
+        f"no PlantUML to render with: {vendored_jar} does not exist, no `plantuml` "
+        "(nor, on Windows, `plantumlc`) is on PATH, and PLANTUML_JAR is unset. Set "
+        "PLANTUML_JAR to a plantuml jar (with java on PATH), or install a plantuml "
+        "executable."
     )
 
 

--- a/packages/sphinx-needs/tests/test_needs_external_needs_build.py
+++ b/packages/sphinx-needs/tests/test_needs_external_needs_build.py
@@ -1,4 +1,3 @@
-import os
 import sys
 from pathlib import Path
 
@@ -15,16 +14,21 @@ from sphinx.util.console import strip_colors
     [{"buildername": "html", "srcdir": "doc_test/doc_needs_external_needs"}],
     indirect=True,
 )
-def test_doc_build_html(test_app: SphinxTestApp, sphinx_test_tempdir):
+def test_doc_build_html(test_app: SphinxTestApp, plantuml_command: str):
     import subprocess
 
     src_dir = Path(test_app.srcdir)
     out_dir = Path(test_app.outdir)
-    plantuml = r"java -Djava.awt.headless=true -jar {}".format(
-        os.path.join(sphinx_test_tempdir, "utils", "plantuml.jar")
-    )
     output = subprocess.run(
-        ["sphinx-build", "-b", "html", "-D", rf"plantuml={plantuml}", src_dir, out_dir],
+        [
+            "sphinx-build",
+            "-b",
+            "html",
+            "-D",
+            f"plantuml={plantuml_command}",
+            src_dir,
+            out_dir,
+        ],
         capture_output=True,
     )
     expected_warnings = [
@@ -35,7 +39,15 @@ def test_doc_build_html(test_app: SphinxTestApp, sphinx_test_tempdir):
 
     # run second time and check
     output_second = subprocess.run(
-        ["sphinx-build", "-b", "html", "-D", rf"plantuml={plantuml}", src_dir, out_dir],
+        [
+            "sphinx-build",
+            "-b",
+            "html",
+            "-D",
+            f"plantuml={plantuml_command}",
+            src_dir,
+            out_dir,
+        ],
         capture_output=True,
     )
 

--- a/packages/sphinx-needs/tests/test_plantuml_command.py
+++ b/packages/sphinx-needs/tests/test_plantuml_command.py
@@ -22,6 +22,7 @@ here too, since it decides whether route (2) is reachable at all.
 from __future__ import annotations
 
 import os
+import re
 import shutil
 from pathlib import Path
 
@@ -48,6 +49,20 @@ def _no_inherited_jar(monkeypatch: pytest.MonkeyPatch) -> None:
     developer may well have it exported, so a case that means "unset" has to say so.
     """
     monkeypatch.delenv("PLANTUML_JAR", raising=False)
+
+
+def _expected(path: Path) -> str:
+    """A ``pytest.raises`` pattern matching the message's rendering of ``path``.
+
+    Two escapes, and both are load-bearing on Windows. ``match=`` is a REGULAR
+    EXPRESSION, so a raw ``C:\\Users\\...`` is not a path there but a pattern beginning
+    with the invalid escape ``\\U`` -- ``re`` rejects it before the assertion is reached,
+    and the three Windows cells go red on every run. And the message renders the value
+    with ``!r`` (deliberately: it is what makes a whitespace-only ``PLANTUML_JAR``
+    visible), so what appears in it is ``repr`` of the path -- with the backslashes
+    DOUBLED. Escaping the bare ``str`` fixes the crash and then fails to match.
+    """
+    return re.escape(repr(str(path)))
 
 
 def test_the_environment_variable_wins(
@@ -103,7 +118,7 @@ def test_a_named_jar_that_is_not_there_is_an_error(
     monkeypatch.setenv("PLANTUML_JAR", str(missing))
     monkeypatch.setattr(shutil, "which", lambda _name: "/usr/local/bin/plantuml")
 
-    with pytest.raises(RuntimeError, match=str(missing)):
+    with pytest.raises(RuntimeError, match=_expected(missing)):
         resolve_plantuml_command(vendored_jar)
 
 
@@ -146,7 +161,7 @@ def test_a_named_jar_that_is_a_directory_is_an_error(
     """
     monkeypatch.setenv("PLANTUML_JAR", str(tmp_path))
 
-    with pytest.raises(RuntimeError, match=str(tmp_path)):
+    with pytest.raises(RuntimeError, match=_expected(tmp_path)):
         resolve_plantuml_command(vendored_jar)
 
 

--- a/packages/sphinx-needs/tests/test_plantuml_command.py
+++ b/packages/sphinx-needs/tests/test_plantuml_command.py
@@ -1,0 +1,110 @@
+"""The order in which the suite decides how to render PlantUML.
+
+Every test project's ``plantuml`` configuration comes from the ``plantuml_command``
+fixture, which is :func:`tests.conftest.resolve_plantuml_command` applied to the copy of
+the vendored jar that ``sphinx_test_tempdir`` made. The order that function applies is
+load-bearing rather than incidental, so it is asserted here instead of being left to the
+several hundred rendering tests that would merely go a strange colour if it changed:
+
+* ``PLANTUML_JAR`` beats everything, because naming a jar is an explicit choice;
+* the vendored jar beats a ``plantuml`` on ``PATH``, because this suite renders for real
+  and a developer machine carrying a homebrew ``plantuml`` must not silently swap the
+  renderer version out from under it;
+* the executable is reached only when the vendored jar is gone, which is what a checkout
+  or an sdist without the jar looks like.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import resolve_plantuml_command
+
+
+@pytest.fixture
+def vendored_jar(tmp_path: Path) -> Path:
+    """A stand-in for the copy of the vendored jar in the test tempdir."""
+    jar = tmp_path / "utils" / "plantuml.jar"
+    jar.parent.mkdir()
+    jar.write_bytes(b"not really a jar")
+    return jar
+
+
+@pytest.fixture(autouse=True)
+def _no_inherited_jar(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Start every case from an unset ``PLANTUML_JAR``.
+
+    CI sets it for the sphinx-mounts cells and the release workflow's build job, and a
+    developer may well have it exported, so a case that means "unset" has to say so.
+    """
+    monkeypatch.delenv("PLANTUML_JAR", raising=False)
+
+
+def test_the_environment_variable_wins(
+    tmp_path: Path, vendored_jar: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``PLANTUML_JAR`` is chosen over both the vendored jar and an executable."""
+    named = tmp_path / "somewhere-else.jar"
+    named.write_bytes(b"not really a jar either")
+    monkeypatch.setenv("PLANTUML_JAR", str(named))
+    monkeypatch.setattr(shutil, "which", lambda _name: "/usr/local/bin/plantuml")
+
+    assert (
+        resolve_plantuml_command(vendored_jar)
+        == f"java -Djava.awt.headless=true -jar {named}"
+    )
+
+
+def test_the_vendored_jar_is_the_default(
+    vendored_jar: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With no ``PLANTUML_JAR``, the vendored jar is used even when ``plantuml`` is on
+    ``PATH`` -- the developer-machine guard."""
+    monkeypatch.setattr(shutil, "which", lambda _name: "/usr/local/bin/plantuml")
+
+    assert (
+        resolve_plantuml_command(vendored_jar)
+        == f"java -Djava.awt.headless=true -jar {vendored_jar}"
+    )
+
+
+def test_an_executable_is_the_fallback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With the jar gone -- a checkout or sdist without it -- ``plantuml`` on ``PATH``
+    is used."""
+    monkeypatch.setattr(shutil, "which", lambda _name: "/usr/local/bin/plantuml")
+
+    assert (
+        resolve_plantuml_command(tmp_path / "utils" / "plantuml.jar")
+        == "/usr/local/bin/plantuml"
+    )
+
+
+def test_a_named_jar_that_is_not_there_is_an_error(
+    tmp_path: Path, vendored_jar: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A ``PLANTUML_JAR`` naming no file fails loudly, and never falls through.
+
+    Falling back to the vendored jar here would render with a renderer the caller did not
+    ask for and report nothing about it.
+    """
+    missing = tmp_path / "gone.jar"
+    monkeypatch.setenv("PLANTUML_JAR", str(missing))
+    monkeypatch.setattr(shutil, "which", lambda _name: "/usr/local/bin/plantuml")
+
+    with pytest.raises(RuntimeError, match=str(missing)):
+        resolve_plantuml_command(vendored_jar)
+
+
+def test_no_renderer_at_all_is_an_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No variable, no jar and no executable names all three routes in the message."""
+    monkeypatch.setattr(shutil, "which", lambda _name: None)
+
+    with pytest.raises(RuntimeError, match="no PlantUML to render with"):
+        resolve_plantuml_command(tmp_path / "utils" / "plantuml.jar")

--- a/packages/sphinx-needs/tests/test_plantuml_command.py
+++ b/packages/sphinx-needs/tests/test_plantuml_command.py
@@ -12,16 +12,23 @@ several hundred rendering tests that would merely go a strange colour if it chan
   renderer version out from under it;
 * the executable is reached only when the vendored jar is gone, which is what a checkout
   or an sdist without the jar looks like.
+
+The command it returns is a *string*, which sphinxcontrib-plantuml splits for itself, so
+two of the cases below assert through that real split rather than on the string -- what has
+to survive is the argv, not the spelling. :func:`tests.conftest.copy_test_utils` is pinned
+here too, since it decides whether route (2) is reachable at all.
 """
 
 from __future__ import annotations
 
+import os
 import shutil
 from pathlib import Path
 
 import pytest
+from sphinxcontrib.plantuml import _split_cmdargs
 
-from tests.conftest import resolve_plantuml_command
+from tests.conftest import copy_test_utils, resolve_plantuml_command
 
 
 @pytest.fixture
@@ -54,7 +61,7 @@ def test_the_environment_variable_wins(
 
     assert (
         resolve_plantuml_command(vendored_jar)
-        == f"java -Djava.awt.headless=true -jar {named}"
+        == f'java -Djava.awt.headless=true -jar "{named}"'
     )
 
 
@@ -67,7 +74,7 @@ def test_the_vendored_jar_is_the_default(
 
     assert (
         resolve_plantuml_command(vendored_jar)
-        == f"java -Djava.awt.headless=true -jar {vendored_jar}"
+        == f'java -Djava.awt.headless=true -jar "{vendored_jar}"'
     )
 
 
@@ -108,3 +115,135 @@ def test_no_renderer_at_all_is_an_error(
 
     with pytest.raises(RuntimeError, match="no PlantUML to render with"):
         resolve_plantuml_command(tmp_path / "utils" / "plantuml.jar")
+
+
+def test_an_empty_variable_is_treated_as_unset(
+    vendored_jar: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An empty ``PLANTUML_JAR`` falls through to the vendored jar.
+
+    Not a curiosity: it is how the variable arrives from a developer shell with
+    ``PLANTUML_JAR=`` exported, and from a workflow that computes the value with an
+    expression rather than deciding whether to set it. Read as "set but names no file"
+    it would instead raise, which is a red run for every cell that does not want a jar.
+    sphinx-mounts' `_plantuml_jar_command` agrees, and its own suite pins it too.
+    """
+    monkeypatch.setenv("PLANTUML_JAR", "")
+
+    assert (
+        resolve_plantuml_command(vendored_jar)
+        == f'java -Djava.awt.headless=true -jar "{vendored_jar}"'
+    )
+
+
+def test_a_named_jar_that_is_a_directory_is_an_error(
+    tmp_path: Path, vendored_jar: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A ``PLANTUML_JAR`` naming a directory is as wrong as one naming nothing.
+
+    ``java -jar <a directory>`` fails at render time, far from the mistake, so this is
+    the same fail-loud case as a missing file and is rejected by the same branch.
+    """
+    monkeypatch.setenv("PLANTUML_JAR", str(tmp_path))
+
+    with pytest.raises(RuntimeError, match=str(tmp_path)):
+        resolve_plantuml_command(vendored_jar)
+
+
+def test_a_jar_path_with_a_space_stays_one_argument(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The command survives sphinxcontrib-plantuml's own splitting.
+
+    That module `shlex`-splits any command that is not already a list or tuple, so an
+    unquoted path containing a space arrives as two argv elements and the render dies
+    with an unhelpful message. Asserted through the real ``_split_cmdargs``, which takes
+    both the posix and the Windows branch depending on where this runs.
+    """
+    jar = tmp_path / "My Jars" / "plantuml.jar"
+    jar.parent.mkdir()
+    jar.write_bytes(b"not really a jar")
+    monkeypatch.setenv("PLANTUML_JAR", str(jar))
+
+    argv = _split_cmdargs(resolve_plantuml_command(tmp_path / "unused.jar"))
+
+    assert argv == ["java", "-Djava.awt.headless=true", "-jar", str(jar)]
+
+
+def test_the_ordinary_jar_path_splits_to_the_same_argv(
+    vendored_jar: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Quoting the path changes the string and not the argv."""
+    monkeypatch.setattr(shutil, "which", lambda _name: None)
+
+    argv = _split_cmdargs(resolve_plantuml_command(vendored_jar))
+
+    assert argv == ["java", "-Djava.awt.headless=true", "-jar", str(vendored_jar)]
+
+
+def test_windows_prefers_the_blocking_shim(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """On Windows route (3) asks for ``plantumlc`` before ``plantuml``.
+
+    sphinxcontrib.plantuml runs the command synchronously, and the chocolatey package's
+    ``plantuml`` shim is a non-blocking ``javaw`` launcher -- so a build that used it
+    would race its own renderer. ``plantumlc`` is the blocking ``java`` one.
+    """
+    monkeypatch.setattr(os, "name", "nt")
+    monkeypatch.setattr(shutil, "which", lambda name: f"C:/bin/{name}.exe")
+
+    assert (
+        resolve_plantuml_command(tmp_path / "utils" / "plantuml.jar")
+        == "C:/bin/plantumlc.exe"
+    )
+
+
+def test_elsewhere_the_plain_executable_is_used(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Off Windows ``plantumlc`` is not asked for at all -- it is a chocolatey artefact."""
+    monkeypatch.setattr(os, "name", "posix")
+    asked: list[str] = []
+
+    def _which(name: str) -> str | None:
+        asked.append(name)
+        return f"/usr/local/bin/{name}"
+
+    monkeypatch.setattr(shutil, "which", _which)
+
+    assert (
+        resolve_plantuml_command(tmp_path / "utils" / "plantuml.jar")
+        == "/usr/local/bin/plantuml"
+    )
+    assert asked == ["plantuml"]
+
+
+def test_a_missing_utils_directory_is_not_an_error(tmp_path: Path) -> None:
+    """`copy_test_utils` declines quietly when there is nothing to copy.
+
+    flit writes no directory entries into the sdist and ``doc_test/utils`` holds exactly
+    one file, so a packager who strips ``*.jar`` from the tarball is left without the
+    directory. Unguarded, the session fixture would raise ``FileNotFoundError`` before
+    the precedence chain above was consulted at all -- and the sdist route this whole
+    module exists for would be unreachable.
+    """
+    destination = tmp_path / "tempdir" / "utils"
+    destination.parent.mkdir()
+
+    copy_test_utils(tmp_path / "not-there", destination)
+
+    assert not destination.exists()
+
+
+def test_a_present_utils_directory_is_copied(tmp_path: Path) -> None:
+    """The ordinary case: the directory and its contents arrive in the tempdir."""
+    source = tmp_path / "doc_test" / "utils"
+    source.mkdir(parents=True)
+    (source / "plantuml.jar").write_bytes(b"not really a jar")
+    destination = tmp_path / "tempdir" / "utils"
+    destination.parent.mkdir()
+
+    copy_test_utils(source, destination)
+
+    assert (destination / "plantuml.jar").read_bytes() == b"not really a jar"

--- a/packages/sphinx-needs/tests/test_plantuml_incdir.py
+++ b/packages/sphinx-needs/tests/test_plantuml_incdir.py
@@ -198,15 +198,14 @@ def mounted_project(tmp_path: Path) -> tuple[Path, Path]:
 
 def test_incdir_uses_physical_source_dir(
     mounted_project: tuple[Path, Path],
-    sphinx_test_tempdir: Path,
+    plantuml_command: str,
     make_app: Callable[..., SphinxTestApp],
     get_warnings_list: Callable[[SphinxTestApp], list[str]],
 ) -> None:
     host, bundle = mounted_project
-    plantuml = "java -Djava.awt.headless=true -jar {}".format(
-        sphinx_test_tempdir / "utils" / "plantuml.jar"
+    app = make_app(
+        srcdir=host, freshenv=True, confoverrides={"plantuml": plantuml_command}
     )
-    app = make_app(srcdir=host, freshenv=True, confoverrides={"plantuml": plantuml})
     app.build()
 
     incdirs: dict[str, list[str]] = app.collected_incdirs  # type: ignore[attr-defined]


### PR DESCRIPTION
`packages/sphinx-needs/tests/conftest.py` built one string — `java -Djava.awt.headless=true
-jar <tempdir>/utils/plantuml.jar` — and two test modules built the same string a second and
a third time for themselves. So the vendored jar's *path* was a fact three places in the
suite knew, and the suite had no way to be pointed at any other PlantUML at all. That last
part is a real gap rather than a tidiness one: `tests/` ships in the sdist (`smoke-needs`
asserts it does on every run), so someone building the package from that tarball can run
this suite — and a distribution packager, who has to repack an embedded pre-built jar away
before it may be shipped, then has nothing to set. sphinx-mounts' suite has honoured
`PLANTUML_JAR` since it arrived; sphinx-needs' did not, which is also why the two AGENTS.md
files had to explain that the variable is a mounts-only affair.

`plantuml_command` now goes through a `resolve_plantuml_command()` helper that takes three
sources in a fixed order, and the order is the whole point:

1. **`PLANTUML_JAR`**, run through `java`. Naming a jar is an explicit choice, so it wins.
   If it is set and names no file the run fails immediately with the path in the message —
   falling through would render with something the caller did not ask for and say nothing
   about it.
2. **The jar this package vendors**, as copied into the test tempdir. Unchanged, and still
   the default: a fresh clone renders with `tests/doc_test/utils/plantuml.jar` and needs
   nothing installed.
3. **A `plantuml` executable on `PATH`** — and only once (2) is gone. This is deliberately
   *last*. The suite renders for real and asserts on the output, and a developer machine
   with a homebrew `plantuml` (PlantUML 1.2026.x) would otherwise silently swap the renderer
   out from under a suite that vendors 1.2022.5. The executable is the fallback for a
   checkout or sdist with no jar, not a preference.

With no jar, no executable and no variable, the message names all three routes instead of
letting sphinxcontrib-plantuml fail somewhere further downstream.

`tests/test_needs_external_needs_build.py` and `tests/test_plantuml_incdir.py` now take the
`plantuml_command` fixture instead of rebuilding the path from `sphinx_test_tempdir`; a new
`tests/test_plantuml_command.py` pins the ordering directly, so it is asserted rather than
implied by the several hundred rendering tests that would merely go a strange colour if it
changed.

One unrelated line comes along because it is the same mistake arriving on its own:
`performance/project/conf.template` pointed at `docs/utils/plantuml.jar`, which has never
existed — the docs jar is `docs/utils/plantuml-1.2022.14.jar`. `performance/` is not run by
CI, so nothing caught it.

The default path through the fixture produces the same argv it produced before; the string now
double-quotes the jar path, so a `PLANTUML_JAR` under a path with a space survives
sphinxcontrib-plantuml's `shlex` split the way sphinx-mounts' tuple already did. One thing in CI
does change as a consequence, and it is an improvement rather than an omission: `release.yaml`'s
build job sets `PLANTUML_JAR` for its compat cell, so the sphinx-needs suite there now takes the
explicit route to the same vendored bytes, and would fail loudly if that path ever stopped naming a jar.

Review closed four gaps in the first version, each now pinned by a test: an empty `PLANTUML_JAR` is
treated as unset (the same four-line pin is added to sphinx-mounts' suite, since CI and developer
shells can both produce `PLANTUML_JAR=`); a variable naming a directory is an error, not a
fall-through; the copy of `tests/doc_test/utils` into the session tempdir is guarded, so a tree
with the jar's directory stripped, which is what an sdist repacked without the jar looks like,
reaches the fixture at all instead of dying in `copytree`; and on Windows route (3) prefers the
blocking `plantumlc` shim over the non-blocking `plantuml` one, a lesson sphinx-mounts had already
paid for.

Merge order with #1864 is free. If #1864 lands first, this branch is rebased onto it so its Windows
cells run through the unit's renderer check, which turns a failed graphviz install into one named red
step instead of fifty test failures; if this lands first, #1864's unit comment that names this fixture
simply becomes true a little earlier.

**How to verify.** The explicit route and the default must give the same result:

```
uv run poe test-needs -k plantuml
PLANTUML_JAR=$PWD/packages/sphinx-needs/tests/doc_test/utils/plantuml.jar uv run poe test-needs -k plantuml
```

**Out of scope**, deliberately: renaming either vendored jar; collapsing the two of them
into one at a repository-level `vendor/`, fetched rather than vendored; bumping PlantUML off
the four-year-old 1.2022.5 (measured green and 11 % faster on 1.2026.8, but a rendering
change wants its own reviewable diff); and every workflow file — the `PLANTUML_JAR` lines in
`ci.yaml` and `release.yaml` are a separate change.

**No changelog entry.** This is test infrastructure; the published module is untouched.
