### PR TITLE
🔧 One reusable test unit for every package's pytest cell

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -130,9 +130,13 @@ jobs:
   # `Mounts …`), so the checks list on a pull request reads by package. `Lint` and
   # `check` are workspace-wide and are also required status contexts on master, so
   # their names must not change without updating the branch protection.
+  #
+  # The two matrix jobs below call `test-package.yaml`, which holds the steps they used
+  # to carry a copy each. A called job's name is appended to its caller's, so these
+  # checks read `Needs py3.13 sphinx-9 ubuntu-latest / pytest` -- the ` / ` join is
+  # unconditional and cannot be suppressed. Neither required context is among them.
   tests-core:
     name: "Needs py${{ matrix.python-version }} ${{ matrix.sphinx-group }} ${{ matrix.os }}"
-    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false # Set on "false" to get the results of ALL builds
       matrix:
@@ -154,48 +158,27 @@ jobs:
           # Sphinx 9.1 requires python 3.12, one above this project's floor, so the
           # `sphinx-9` group carries a `python_version >= '3.12'` marker and contributes
           # nothing on 3.11. The sync would still exit 0 -- the environment just falls back
-          # to the project's own sphinx range -- and `check_sphinx_cell.py` below would then
-          # fail the cell for testing a sphinx it never asked for. Exclude it instead.
+          # to the project's own sphinx range -- and `check_sphinx_cell.py` in the unit
+          # would then fail the cell for testing a sphinx it never asked for. Exclude it
+          # instead.
           - os: "ubuntu-latest"
             python-version: "3.11"
             sphinx-group: "sphinx-9"
-
-    steps:
-      - uses: actions/checkout@v7
-      - name: Install graphviz (linux)
-        if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get install graphviz
-      - name: Install graphviz (windows)
-        if: matrix.os == 'windows-latest'
-        run: choco install -y --no-progress graphviz
-      - uses: astral-sh/setup-uv@v10.0.1
-        with:
-          enable-cache: true
-          # the lock is the same file for every cell while the installed set is not,
-          # so each cell needs its own cache entry
-          cache-suffix: ${{ matrix.python-version }}-${{ matrix.sphinx-group }}
-          python-version: ${{ matrix.python-version }}
-      - name: Install the cell
-        run: uv sync --frozen --no-default-groups --group test --group ${{ matrix.sphinx-group }}
-      - name: Report the resolved versions
-        run: uv run --no-sync python -c "import sys, sphinx, docutils; print(sys.version, sphinx.__version__, docutils.__version__)"
-      - name: Check the cell installed the sphinx it names
-        # against the group's own specifier: a group whose marker excludes this python
-        # contributes nothing, the environment falls back to the project's sphinx range and
-        # the sync still exits 0, so without this the cell would silently test another series
-        run: uv run --no-sync python .github/scripts/check_sphinx_cell.py ${{ matrix.sphinx-group }}
-      - name: Run pytest
-        run: uv run --no-sync pytest -v packages/sphinx-needs/tests --ignore=packages/sphinx-needs/tests/benchmarks -m "not jstest" --cov=sphinx_needs --cov-report=xml --cov-report=term-missing
-      - name: Upload to Codecov
-        # dependabot PRs get no secrets; without a token the upload fails and takes the required `check` gate with it
-        if: github.event.pull_request.head.repo.full_name == github.repository && github.repository == 'useblocks/sphinx-needs' && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.14' && github.actor != 'dependabot[bot]'
-        uses: codecov/codecov-action@v7
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          name: sphinx-need-pytests
-          flags: pytests
-          files: ./coverage.xml # `file` was renamed to `files` in codecov-action v5
-          fail_ci_if_error: true
+    uses: ./.github/workflows/test-package.yaml
+    with:
+      os: ${{ matrix.os }}
+      python-version: ${{ matrix.python-version }}
+      sphinx-group: ${{ matrix.sphinx-group }}
+      cache-suffix: ${{ matrix.python-version }}-${{ matrix.sphinx-group }}
+      test-path: packages/sphinx-needs/tests
+      # `benchmarks` is `benchmark.yaml`'s; `jstest` is the `tests-js` lane's
+      pytest-args: '--ignore=packages/sphinx-needs/tests/benchmarks -m "not jstest"'
+      cov-module: sphinx_needs
+      codecov-flag: pytests
+      codecov-name: sphinx-need-pytests
+      upload-coverage: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.14' }}
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   tests-js:
     name: "Needs JS py${{ matrix.python-version }} ${{ matrix.sphinx-group }} ${{ matrix.os }}"
@@ -221,7 +204,7 @@ jobs:
         # these two cells want it
         run: uv sync --frozen --no-default-groups --group test --group js --group ${{ matrix.sphinx-group }}
       - name: Check the cell installed the sphinx it names
-        # against the group's own specifier — see the comment in tests-core
+        # against the group's own specifier — see the comment in test-package.yaml
         run: uv run --no-sync python .github/scripts/check_sphinx_cell.py ${{ matrix.sphinx-group }}
       - name: Install the browser
         # the binary is not a package: playwright fetches it from cdn.playwright.dev into
@@ -267,7 +250,6 @@ jobs:
 
   tests-mounts:
     name: "Mounts ${{ matrix.sphinx-group }} ${{ matrix.os }}"
-    runs-on: ${{ matrix.os }}
     # A matrix of its own rather than more paths in `tests-core`, the way `tests-js` and
     # `tests-no-mpl` already sit beside it: this package needs a diagram renderer that the
     # core cells do not, wants its own codecov flag, and takes 1-3 minutes -- which folded
@@ -282,51 +264,27 @@ jobs:
           # one Windows cell is not optional coverage; its own CI ran three
           - os: "windows-latest"
             sphinx-group: "sphinx-9"
-    env:
-      # no `plantuml` executable is installed anywhere: the uml tests take the jar
-      # `packages/sphinx-needs` vendors for its own suite, through `java`, which every
-      # runner image has. `_require_renderer` asserts rather than skips, so if this line
-      # ever stops naming a real file the cell goes red
-      PLANTUML_JAR: ${{ github.workspace }}/packages/sphinx-needs/tests/doc_test/utils/plantuml.jar
-    steps:
-      - uses: actions/checkout@v7
-      - name: Install graphviz (linux)
-        if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get install graphviz
-      - name: Install graphviz (windows)
-        if: matrix.os == 'windows-latest'
-        run: choco install -y --no-progress graphviz
-      - uses: astral-sh/setup-uv@v10.0.1
-        with:
-          enable-cache: true
-          cache-suffix: mounts-${{ matrix.sphinx-group }}
-          # deliberately NO `python-version`: that input becomes UV_PYTHON, which beats the
-          # root `.python-version`. These cells vary the sphinx series, not the
-          # interpreter, so they run on the repository's pin
-          cache-python: true
-      - name: Install the cell
-        run: uv sync --frozen --no-default-groups --group test --group ${{ matrix.sphinx-group }}
-      - name: Report the resolved versions
-        run: uv run --no-sync python -c "import sys, sphinx, docutils; print(sys.version, sphinx.__version__, docutils.__version__)"
-      - name: Check the cell installed the sphinx it names
-        # against the group's own specifier -- see the comment in tests-core
-        run: uv run --no-sync python .github/scripts/check_sphinx_cell.py ${{ matrix.sphinx-group }}
-      - name: Run pytest
-        # `-m "not bazel"` deselects the two tests the `bazel` job below owns; they would
-        # skip here rather than fail, but a skip nobody reads is what the separate lane
-        # exists to avoid
-        run: uv run --no-sync pytest -v packages/sphinx-mounts/tests -m "not bazel" --cov=sphinx_mounts --cov-report=xml --cov-report=term-missing
-      - name: Upload to Codecov
-        # its own flag: `codecov.yml` gives the two packages separate targets, so a young
-        # package's coverage is not averaged into a mature one's 80%
-        if: github.event.pull_request.head.repo.full_name == github.repository && github.repository == 'useblocks/sphinx-needs' && matrix.os == 'ubuntu-latest' && matrix.sphinx-group == 'sphinx-9' && github.actor != 'dependabot[bot]'
-        uses: codecov/codecov-action@v7
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          name: sphinx-mounts-pytests
-          flags: mounts
-          files: ./coverage.xml
-          fail_ci_if_error: true
+    uses: ./.github/workflows/test-package.yaml
+    with:
+      os: ${{ matrix.os }}
+      # deliberately NO `python-version`: that input becomes UV_PYTHON, which beats the
+      # root `.python-version`. These cells vary the sphinx series, not the interpreter,
+      # so they run on the repository's pin -- which is what the unit's empty default means
+      sphinx-group: ${{ matrix.sphinx-group }}
+      cache-suffix: mounts-${{ matrix.sphinx-group }}
+      test-path: packages/sphinx-mounts/tests
+      # `-m "not bazel"` deselects the two tests the `bazel` job below owns; they would
+      # skip here rather than fail, but a skip nobody reads is what the separate lane
+      # exists to avoid
+      pytest-args: '-m "not bazel"'
+      cov-module: sphinx_mounts
+      codecov-flag: mounts
+      codecov-name: sphinx-mounts-pytests
+      upload-coverage: ${{ matrix.os == 'ubuntu-latest' && matrix.sphinx-group == 'sphinx-9' }}
+      # the uml tests render for real and `_require_renderer` asserts rather than skips
+      needs-plantuml: true
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   bazel:
     name: Mounts Bazel integration

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,13 @@ on:
     branches: [master]
   pull_request:
 
+# A fix-up push otherwise leaves the superseded head's 25 jobs running to completion, and
+# the useblocks organisation shares 60 concurrent runners across all of its repositories.
+# `cancel-in-progress` is deliberately conditional: a push to master is never cancelled.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,9 +6,13 @@ on:
 
 # A fix-up push otherwise leaves the superseded head's 25 jobs running to completion, and
 # the useblocks organisation shares 60 concurrent runners across all of its repositories.
-# `cancel-in-progress` is deliberately conditional: a push to master is never cancelled.
+# The group is the pull request's number, so every run that is NOT a pull request -- every
+# push to master -- gets a group of its own and master runs neither queue behind nor cancel
+# each other. That last part is not `cancel-in-progress`'s doing: GitHub queues a run whose
+# group is busy as `pending`, and "any existing pending job or workflow in the same
+# concurrency group will be canceled", whatever `cancel-in-progress` says.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/test-package.yaml
+++ b/.github/workflows/test-package.yaml
@@ -59,7 +59,7 @@ on:
         required: true
       codecov-flag:
         # `codecov.yml` gives each flag a target of its own, so a young package's coverage
-        # is not averaged into a mature one's
+        # is not averaged into a mature one's 80% target
         description: The codecov flag this package's coverage lands on.
         type: string
         required: true
@@ -98,12 +98,6 @@ jobs:
     runs-on: ${{ inputs.os }}
     permissions:
       contents: read
-    env:
-      # the one place in CI this path is written. `_require_renderer` in sphinx-mounts and
-      # `resolve_plantuml_command` in sphinx-needs both read the variable, and both assert
-      # rather than skip, so if this stops naming a real file the cell goes red. Empty when
-      # the package does not want it, which both treat as "unset"
-      PLANTUML_JAR: ${{ inputs.needs-plantuml && format('{0}/packages/sphinx-needs/tests/doc_test/utils/plantuml.jar', github.workspace) || '' }}
     steps:
       - uses: actions/checkout@v7
       - name: Install graphviz (linux)
@@ -119,6 +113,25 @@ jobs:
         run: |
           echo "::error::no graphviz install step for macOS; add one before enabling this combination"
           exit 1
+      - name: Point PLANTUML_JAR at the vendored jar
+        # The one place in CI this path is written. No runner image carries a `plantuml`
+        # package and every one carries `java`, so the uml tests take the jar
+        # `packages/sphinx-needs` vendors for its own suite. The suites that read the
+        # variable ASSERT rather than skip when the renderer is missing (sphinx-mounts
+        # today; sphinx-needs from #1863), so if this ever stops naming a real file the
+        # cell goes red rather than quietly testing less.
+        #
+        # A STEP writing `$GITHUB_ENV`, not a job-level `env:`, because an `env:` value
+        # cannot be made conditional without an expression -- and that expression's
+        # failure mode is a literal string, not an absent variable: drop the `|| ''` from
+        # `${{ inputs.needs-plantuml && '<path>' || '' }}` and every cell that does not
+        # want a jar gets `PLANTUML_JAR=false`, which actionlint does not catch and both
+        # suites reject. Written only when it is wanted, the variable is genuinely UNSET
+        # everywhere else. `shell: bash` because the windows runners default to pwsh;
+        # bash is on all three images.
+        if: inputs.needs-plantuml
+        shell: bash
+        run: echo "PLANTUML_JAR=$GITHUB_WORKSPACE/packages/sphinx-needs/tests/doc_test/utils/plantuml.jar" >> "$GITHUB_ENV"
       - uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true

--- a/.github/workflows/test-package.yaml
+++ b/.github/workflows/test-package.yaml
@@ -132,6 +132,28 @@ jobs:
         if: inputs.needs-plantuml
         shell: bash
         run: echo "PLANTUML_JAR=$GITHUB_WORKSPACE/packages/sphinx-needs/tests/doc_test/utils/plantuml.jar" >> "$GITHUB_ENV"
+      - name: Check the renderers this cell asked for are really there
+        # `choco install graphviz` EXITS 0 WHEN THE FEED FAILS. Measured on run
+        # 34000562220, job 101398550280: "Failed to fetch results from V2 feed ... Unable
+        # to find package 'Graphviz' ... Chocolatey installed 0/0 packages", a green
+        # install step, and then two graphviz tests asserting 90 s later inside pytest. A
+        # renderer that did not arrive should be one red step that names it, not N
+        # assertions in the suite.
+        #
+        # For PlantUML this is also the mechanical check on the step above: if it ever
+        # stops writing a path that exists, THIS is the red, rather than every cell that
+        # wanted a jar. Deliberately no retry and no change of installer -- a pinned
+        # download or `ts-graphviz/setup-graphviz` is a separate argument.
+        if: inputs.needs-graphviz || inputs.needs-plantuml
+        shell: bash
+        run: |
+          if [ "${{ inputs.needs-graphviz }}" = "true" ]; then
+            dot -V || { echo "::error::graphviz did not install: no dot on PATH"; exit 1; }
+          fi
+          if [ "${{ inputs.needs-plantuml }}" = "true" ]; then
+            test -f "$PLANTUML_JAR" || { echo "::error::PLANTUML_JAR names no file: '$PLANTUML_JAR'"; exit 1; }
+            java -version || { echo "::error::no java on PATH, so the plantuml jar cannot be run"; exit 1; }
+          fi
       - uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true

--- a/.github/workflows/test-package.yaml
+++ b/.github/workflows/test-package.yaml
@@ -1,0 +1,151 @@
+name: Test a package
+
+# ONE package's pytest cell, called once per package from `ci.yaml`.
+#
+# It exists because `tests-core` and `tests-mounts` were 30 code lines each and 23 of them
+# were byte-identical: checkout, the two graphviz installs with their guards, the cell
+# sync, the version report, the `check_sphinx_cell.py` fence and the codecov block minus
+# three values. A third package would have been a third copy of all of it, and every
+# cross-cutting change -- a `setup-uv` bump, a new step, a different `uv sync` flag -- a
+# three-place edit. What genuinely varies per package is the caller's `with:` block, and
+# what varies per cell is the caller's matrix, so both stay in `ci.yaml` where a reviewer
+# reads them.
+#
+# Only this one shape is shared. `tests-js`, `tests-no-mpl`, `bazel` and `smoke-needs`
+# share the five-line prologue and nothing else, and `release.yaml`'s compat cell builds
+# its environment from a wheel rather than from the workspace, so none of them belongs
+# here: folding them in would need an input that switches the body, which is how a
+# reusable workflow turns into a scripting language.
+#
+# `./`-referenced workflows come from the caller's own commit, so a pull request that
+# changes this file and `ci.yaml` together is tested as one change.
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        description: The runner to test on.
+        type: string
+        default: ubuntu-latest
+      python-version:
+        # passed to `setup-uv`, which turns it into UV_PYTHON. Empty is exactly equivalent
+        # to omitting it -- setup-uv exports the variable only for a non-empty value -- so
+        # uv falls back to the root `.python-version`, which is what a package that varies
+        # the sphinx series but not the interpreter wants
+        description: The interpreter, or empty for the root `.python-version`.
+        type: string
+        default: ""
+      sphinx-group:
+        description: The dependency group naming the sphinx series this cell tests against.
+        type: string
+        required: true
+      cache-suffix:
+        # the lock is the same file for every cell while the installed set is not, so each
+        # cell needs its own cache entry
+        description: "`setup-uv`'s cache key suffix."
+        type: string
+        required: true
+      test-path:
+        description: The package's tests directory, relative to the repository root.
+        type: string
+        required: true
+      pytest-args:
+        description: 'Further pytest arguments, substituted into the command: `--ignore=…`, `-m "…"`.'
+        type: string
+        default: ""
+      cov-module:
+        description: The importable module coverage is measured over.
+        type: string
+        required: true
+      codecov-flag:
+        # `codecov.yml` gives each flag a target of its own, so a young package's coverage
+        # is not averaged into a mature one's
+        description: The codecov flag this package's coverage lands on.
+        type: string
+        required: true
+      codecov-name:
+        description: The upload's display name in codecov.
+        type: string
+        required: true
+      upload-coverage:
+        # which cell uploads is a per-package policy, so the caller computes this from its
+        # own matrix and the decision stays visible in `ci.yaml`
+        description: Whether THIS cell uploads coverage.
+        type: boolean
+        default: false
+      needs-graphviz:
+        # a package that never calls `dot` sets this false rather than paying 5-23 s of
+        # `apt-get`/`choco` per cell for a renderer it does not use
+        description: Install graphviz.
+        type: boolean
+        default: true
+      needs-plantuml:
+        # no runner image has a `plantuml` package, and every image has `java`
+        description: Point PLANTUML_JAR at the jar `packages/sphinx-needs` vendors.
+        type: boolean
+        default: false
+    secrets:
+      CODECOV_TOKEN:
+        description: Read only by the upload step, and only on this repository's own pull requests.
+        required: false
+
+jobs:
+  # The job id and its display name are both `pytest`, because a called job's name is
+  # appended to the caller's: the checks read `Needs py3.13 sphinx-9 ubuntu-latest /
+  # pytest`. The ` / ` join is unconditional and cannot be suppressed.
+  pytest:
+    name: pytest
+    runs-on: ${{ inputs.os }}
+    permissions:
+      contents: read
+    env:
+      # the one place in CI this path is written. `_require_renderer` in sphinx-mounts and
+      # `resolve_plantuml_command` in sphinx-needs both read the variable, and both assert
+      # rather than skip, so if this stops naming a real file the cell goes red. Empty when
+      # the package does not want it, which both treat as "unset"
+      PLANTUML_JAR: ${{ inputs.needs-plantuml && format('{0}/packages/sphinx-needs/tests/doc_test/utils/plantuml.jar', github.workspace) || '' }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install graphviz (linux)
+        if: inputs.needs-graphviz && runner.os == 'Linux'
+        run: sudo apt-get install graphviz
+      - name: Install graphviz (windows)
+        if: inputs.needs-graphviz && runner.os == 'Windows'
+        run: choco install -y --no-progress graphviz
+      - name: No graphviz install step for macOS
+        # neither branch above fires on macOS, so a cell that asked for graphviz would run
+        # without `dot` and fail somewhere far from the cause. Say so here instead
+        if: inputs.needs-graphviz && runner.os == 'macOS'
+        run: |
+          echo "::error::no graphviz install step for macOS; add one before enabling this combination"
+          exit 1
+      - uses: astral-sh/setup-uv@v10.0.1
+        with:
+          enable-cache: true
+          cache-suffix: ${{ inputs.cache-suffix }}
+          python-version: ${{ inputs.python-version }}
+          # only when no interpreter was named: those cells run on the root
+          # `.python-version`, which is not on the runner image, so without this uv
+          # downloads it on every run. A cell that names one gets it from setup-uv
+          cache-python: ${{ inputs.python-version == '' }}
+      - name: Install the cell
+        run: uv sync --frozen --no-default-groups --group test --group ${{ inputs.sphinx-group }}
+      - name: Report the resolved versions
+        run: uv run --no-sync python -c "import sys, sphinx, docutils; print(sys.version, sphinx.__version__, docutils.__version__)"
+      - name: Check the cell installed the sphinx it names
+        # against the group's own specifier: a group whose marker excludes this python
+        # contributes nothing, the environment falls back to the project's sphinx range and
+        # the sync still exits 0, so without this the cell would silently test another series
+        run: uv run --no-sync python .github/scripts/check_sphinx_cell.py ${{ inputs.sphinx-group }}
+      - name: Run pytest
+        run: uv run --no-sync pytest -v ${{ inputs.test-path }} ${{ inputs.pytest-args }} --cov=${{ inputs.cov-module }} --cov-report=xml --cov-report=term-missing
+      - name: Upload to Codecov
+        # dependabot PRs get no secrets; without a token the upload fails and takes the required `check` gate with it
+        if: inputs.upload-coverage && github.event.pull_request.head.repo.full_name == github.repository && github.repository == 'useblocks/sphinx-needs' && github.actor != 'dependabot[bot]'
+        uses: codecov/codecov-action@v7
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          name: ${{ inputs.codecov-name }}
+          flags: ${{ inputs.codecov-flag }}
+          files: ./coverage.xml # `file` was renamed to `files` in codecov-action v5
+          fail_ci_if_error: true


### PR DESCRIPTION
`tests-core` and `tests-mounts` were 30 code lines of `steps:` each, and 23 of those 60 lines
were byte-identical: the checkout, both graphviz installs with their `if:` guards, the cell
sync, the resolved-versions report, the `check_sphinx_cell.py` fence and the whole codecov
block bar three values. Seven lines out of thirty
actually differ. `tests-mounts` even carries "see the comment in tests-core" twice, which is
duplication acknowledging itself.

That is tolerable at two packages and stops being so at three. A third package cloned from
`tests-mounts` is **+63 lines** in `ci.yaml` and takes it from 411 to ~475; a fourth makes it
~538 lines holding four copies of the same steps. More to the point,
every cross-cutting change is then a three- or four-place edit: bumping `setup-uv`, changing
a `uv sync` flag, adding a step, changing how the sphinx fence is invoked. `check_sphinx_cell.py`
is the clearest case — a *policy* step that must be identical in every package's cells, and
which is currently retyped.

So the steps move into `.github/workflows/test-package.yaml`, a `workflow_call` workflow with
one job, and `tests-core` and `tests-mounts` become caller jobs that carry only their matrix
and a `with:` block. The `with:` block *is* the per-package difference table — test path,
pytest arguments, coverage module, codecov flag and name, which cell uploads, which renderers
are wanted — so the thing a reviewer reads is the thing that actually varies. `ci.yaml` goes
410 → 379 lines and the new file is 186, of which 70 are comments; the win is not on total lines, it is that a third package is now a ~24-line
caller instead of a 63-line copy, and that a cross-cutting change is one edit.

**Why a reusable workflow and not a composite action.** A composite action under
`.github/actions/` would collapse the same prologue and would leave the job names completely
alone, which is tempting. It is rejected because **dependabot would stop seeing the pins**.
Its `github_actions` ecosystem with `directory: /` fetches `/action.y{a,}ml` and
`.github/workflows/*.y{a,}ml` and nothing else — there is no recursion into `.github/actions/`
(measured against `dependabot-core`'s `file_fetcher.rb`). Moving
`actions/checkout@v7` and `astral-sh/setup-uv@v10.0.1` in there would freeze them silently:
no error, just no more bumps, unless a second `updates:` entry naming that exact directory is
added and then remembered for every future action directory. A reusable workflow needs zero
dependabot configuration, and its local `uses: ./…` reference is skipped by the parser rather
than mis-resolved.

**Why not one job with a matrix over `package × cell`.** The duplication would change medium
rather than go away: the two packages' axes are genuinely different — 14 needs cells varying
the interpreter, 4 mounts cells deliberately not varying it — so a product matrix cannot
express it and it would have to be 18 hand-written `include` rows each repeating the test
path, the coverage module and the flag. And it forces one step list on every package, so the
first package that wants a system dependency the others do not adds another
`if: matrix.package == '…'` guard — which is exactly how the two graphviz steps and their
guards came to be duplicated in the first place.

**The accepted cost: 20 status checks are renamed.** A called job's display name is appended
to its caller's with an unconditional ` / ` join, so `Needs py3.13 sphinx-9 ubuntu-latest`
becomes `Needs py3.13 sphinx-9 ubuntu-latest / pytest`. This cannot be suppressed; it was
measured on live check-run names in pytorch, setuptools and airflow, lines 186-211).
The called job is therefore named `pytest` rather than `run`, so the suffix reads as what it
is. **No required context is affected** — `Lint`, `check` and `docs/readthedocs.org:sphinx-needs`
are all still hand-written or posted by Read the Docs, and `check`'s `needs:` list is
byte-identical because the caller jobs keep the ids `tests-core` and `tests-mounts`. The second
cost is that reading "what does the sphinx-9 mounts cell run" now needs two files open, and a
typo in an input name becomes a workflow-validation error GitHub reports against the caller
with no line number in the callee.

None of this is speculative: `pypa/setuptools` runs precisely this shape today — a matrix
caller job calling a `workflow_call` workflow with scalar inputs, under the same
`re-actors/alls-green` aggregate job this repository uses, lines 232-261).

**Four details that are not just a move.**

- The unit takes `needs-graphviz` and `needs-plantuml`. Both packages here want graphviz and
  only mounts wants PlantUML, but a package that calls neither renderer should not pay 5-23 s
  of `apt-get`/`choco` per cell for one — and the next package in line calls neither (measured:
  zero plantuml and zero graphviz references in sphinx-codelinks).
- The two graphviz branches are Linux and Windows. A cell that asks for graphviz on macOS
  would get neither, run without `dot` and fail somewhere far from the cause, so there is a
  third branch that exits 1 and says so.
- `PLANTUML_JAR` is now written once. `ci.yaml` had it twice and `release.yaml` has it a third
  time; the `tests-mounts` copy becomes a step in the unit that appends the path to `$GITHUB_ENV`
  only when `needs-plantuml` is set, so the variable is genuinely unset in every other cell. A
  step rather than a job-level `env:` because an `env:` value can only be made conditional with an
  expression, and that expression's failure mode is a literal string, not an absent variable:
  review measured that dropping the `|| ''` yields `PLANTUML_JAR=false`, which actionlint does not
  catch and both suites reject. `bazel` keeps its own line because it is not a caller.
- The unit checks that the renderers a cell asked for actually arrived, before pytest runs: `dot -V`
  when graphviz was wanted, and that `PLANTUML_JAR` names a file and `java` is present when the jar
  was. This exists because of a measurement on this very pull request: `choco install graphviz` hit a
  chocolatey feed failure, reported `installed 0/0 packages`, exited 0, and the Windows mounts cell
  then failed two graphviz tests ninety seconds later. A renderer that did not arrive is now one red
  step that names it. No retry and no change of installer here; a pinned download is a separate
  argument.

**Also in this pull request: `ci.yaml` gains a `concurrency:` block.** Today a fix-up push to
a pull request leaves the superseded head's 25 jobs running to completion — over two hours of
runner time on a run that nobody will read — and the useblocks organisation shares 60
concurrent runners across all of its repositories. The group is the pull request's number, so every
run that is not a pull request, every push to `master`, gets a group of its own: master runs
neither queue behind nor cancel each other. That second half is not `cancel-in-progress`'s doing.
GitHub queues a run whose group is busy as pending and cancels any pending run in the same group
when another arrives, whatever `cancel-in-progress` says, so a shared per-ref group on master
would have serialized merges and dropped a middle commit's run outright. The group applies to the
whole caller run, so the called workflow needs nothing.

**What stays hand-written**, deliberately: `lint`, `check`, `tests-js`, `tests-no-mpl`,
`bazel`, `smoke-needs`, and all of `release.yaml`, `docs.yaml` and `benchmark.yaml`. Each of
the one-off jobs shares the five-to-nine-line prologue with the unit and then diverges
completely, and `release.yaml`'s compat cell builds its environment from a wheel in a
throwaway venv rather than from the workspace — zero steps in common. Folding any of them in
would need an input that switches the body, which is how a reusable workflow turns into a
scripting language.

Merge order with #1863 is free. The unit's comment says the suites that read `PLANTUML_JAR` assert
rather than skip "(sphinx-mounts today; sphinx-needs from #1863)", which is true in either order; and
the unit's renderer check is what #1863's Windows cells want, so if this lands first, #1863 is rebased
onto it.

**How to verify.** The caller matrices must expand to exactly the cells master had, with
exactly the same `setup-uv` cache suffixes — a changed suffix silently costs every cell one
cold run. That was checked mechanically before pushing (14 + 4 cells, identical suffix
strings), and on the pull request itself it is visible as 18 `… / pytest` checks plus the
five one-offs, `Lint` and `check`, and a Codecov comment still carrying both the `pytests`
and the `mounts` flags. `./`-referenced workflows come from the caller's own commit, so this
pull request tests both files as one change.

```
gh pr checks <n> --watch
```

**Out of scope**: folding `tests-js`, `tests-no-mpl`, `bazel`, `smoke-needs` or
`release.yaml`'s compat cell into the unit; a composite action for their shared prologue;
`codecov.yml`, `.github/labeler.yml` (`.github/**` already labels the new file `pkg: workspace`)
and every Read the Docs file; anything about the vendored PlantUML jars beyond the one
`PLANTUML_JAR` line that moves.
