### PR TITLE
🔧 Skip the sphinx-needs Read the Docs build on pull requests that do not touch it

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -21,6 +21,41 @@ build:
   tools:
     python: "3.11"
   jobs:
+    post_checkout:
+      # Every pull request against this repository builds BOTH Read the Docs projects. A
+      # pull request that touches neither `packages/sphinx-needs/` nor this file has nothing
+      # for this one to build, so cancel it. Exit code 183 is Read the Docs' documented
+      # "skip" code (https://docs.readthedocs.com/platform/stable/guides/build/skip-build.html):
+      # the build is recorded as `cancelled`, and the commit status sent to GitHub is
+      # `success` with the description "Read the Docs build skipped" -- which matters here,
+      # because `docs/readthedocs.org:sphinx-needs` is a REQUIRED status on `master`, and a
+      # skipped build satisfies it. Measured on the sphinx-mounts project: build 34411602
+      # (pull request #1861) and the skipped build on #1864, both `cancelled` / `success`.
+      #
+      # Why a plain two-dot `git diff` and not a merge base: Read the Docs clones the default
+      # branch with `--depth 1` and then fetches the pull-request head with `--depth 50`, so
+      # `origin/master` is a shallow root with no ancestry and `git merge-base` has nothing
+      # to walk. The diff therefore compares against master's CURRENT tip: if master moved
+      # and touched this package, the build runs although the pull request did not touch it.
+      # That is the safe direction; it never skips a build that was needed.
+      #
+      # `packages/sphinx-needs/` plus this file is the complete set of inputs: `python.install`
+      # below pip-installs the package directory with its own extras (the root manifest and
+      # `uv.lock` take no part), `docs/conf.py` reads only files under `docs/`, and every
+      # `literalinclude` in the docs stays inside the package (`../../tests/doc_test/…`).
+      # Branch and tag builds (`latest`, `stable`, releases) are never cancelled.
+      - |
+        if [ "$READTHEDOCS_VERSION_TYPE" != "external" ]; then
+          exit 0
+        fi
+        if ! git rev-parse --verify --quiet origin/master > /dev/null; then
+          echo "origin/master is not available in this clone; building to be safe"
+          exit 0
+        fi
+        if git diff --quiet origin/master -- packages/sphinx-needs/ .readthedocs.yml; then
+          echo "nothing under packages/sphinx-needs/ or in .readthedocs.yml changed; skipping this build (exit 183)"
+          exit 183
+        fi
     pre_create_environment:
       - echo "DOT details"
       - which dot


### PR DESCRIPTION
The sphinx-needs Read the Docs project builds every pull request against this repository, including the ones that touch only `packages/sphinx-mounts/` or `.github/`. That is a two-minute build (a JDK, graphviz, the furo docs) for nothing, and `docs/readthedocs.org:sphinx-needs` is a required status on `master`, so every pull request waits for it.

This adds to the root `.readthedocs.yml` the same `post_checkout` job the sphinx-mounts project gained in #1862, with this project's inputs: on a pull-request build, if neither `packages/sphinx-needs/` nor `.readthedocs.yml` itself differs from `origin/master`, the job exits 183, Read the Docs' documented skip code. The build is recorded as `cancelled` and the commit status posted to GitHub is `success` with the description "Read the Docs build skipped", so the required status is satisfied rather than left hanging. Branch and tag builds (`latest`, `stable`, releases) are never cancelled.

**Why those two paths are the complete set of inputs.** `python.install` pip-installs `packages/sphinx-needs` with its own `docs` and `theme-furo` extras, so the root manifest and `uv.lock` take no part in the build; `docs/conf.py` reads only files under `docs/`; every `literalinclude` in the docs stays inside the package (`../../tests/doc_test/…`); and the configuration file is at the root, so it is named explicitly.

**Why a two-dot diff against `origin/master`.** Read the Docs clones the default branch with `--depth 1` and fetches the pull-request head with `--depth 50`, so `origin/master` is a shallow root with no ancestry and `git merge-base` has nothing to walk. The diff compares against master's current tip: if master moved and touched the package, the build runs although the pull request did not touch it. That is the safe direction.

**Measured.** Exit 183 → `cancelled` / status `success` "Read the Docs build skipped" was measured on the sphinx-mounts project: probe #1861 (build 34411602), then the skipped build on #1864 and the full build on #1863 after #1862 merged, one observation in each direction. Both projects post their statuses through the same mechanism. Locally, the job script was run in both directions against this branch: with the change to `.readthedocs.yml` present it exits 0, with it absent it exits 183.

**What this pull request itself shows.** It touches `.readthedocs.yml`, so its own Read the Docs build must run and succeed: that is the positive control. The skip direction will be visible on the first pull request after this merges that touches neither path.

No user-visible change; no changelog entry.
