### PR TITLE
📚 Say in the README why this is one repository but still several packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,40 @@ definitions and the CI workflows.
 | [`packages/sphinx-needs`](packages/sphinx-needs) | [`sphinx-needs`](https://pypi.org/project/sphinx-needs/) | the Sphinx extension for managing requirements and specifications — [documentation](https://sphinx-needs.readthedocs.io), [README](packages/sphinx-needs/README.rst) |
 | [`packages/sphinx-mounts`](packages/sphinx-mounts) | [`sphinx-mounts`](https://pypi.org/project/sphinx-mounts/) | the Sphinx extension that mounts external source trees into a build without copying or symlinking — [documentation](https://sphinx-mounts.useblocks.com), [README](packages/sphinx-mounts/README.md) |
 
+## Why one repository, and why still several packages
+
+The question comes up, so here is the reasoning. The proposal and its discussion are in
+[#1803](https://github.com/useblocks/sphinx-needs/discussions/1803).
+
+One repository, because the extensions are developed against sphinx-needs as it is *now*:
+a change to sphinx-needs and the extension change it calls for land together, tested
+against each other at the same commit, with one lock file, one CI, one lint and typing
+configuration and one issue tracker.
+
+Still one distribution per package, and not one `sphinx-needs` with an extra per feature,
+because:
+
+- **An install is whole or absent.** An extension's dependencies — parser grammars, a
+  libclang binding, a build tool — land only on the people who asked for that extension,
+  and never half-present on everyone else.
+- **A Python extra is not a feature flag.** It is a set of additional requirements, and
+  nothing records that it was requested; a bundled feature has to probe its own imports at
+  run time, in its `setup()`, its console scripts and its type checking, and a user who
+  later uninstalls the dependency finds out at build time. sphinx-needs pays that once, for
+  matplotlib, and does not want to pay it per extension. A distribution boundary is
+  resolved by the installer, visible to the type checker and versioned.
+- **Each package keeps its own version and cadence.** An extension can change its
+  interface without a sphinx-needs major release, and ship a fix without waiting for the
+  next sphinx-needs release.
+- **Not every package depends on sphinx-needs.** sphinx-mounts does not, and an
+  extension's analysis engine or command line can be useful without it.
+
+The coupling that remains is a policy, and tooling keeps it honest: a package that depends
+on sphinx-needs requires the current release as its floor and caps at the next major (the
+workspace check enforces the range), the release workflow tests every built wheel against
+its siblings *as published*, and `uv run poe release-plan` says what is pending and in
+which order.
+
 ## Working here
 
 Two commands are enough to get started, from this directory:


### PR DESCRIPTION
The README explains the workspace layout but not why the extensions are separate distributions rather than one `sphinx-needs` with an extra per feature. That question was asked this week during the sphinx-codelinks preparation and will be asked again, so the README now answers it, in a section between the package table and "Working here", and points at #1803 for the discussion.

The argument, in short: one repository because the extensions are developed against the sphinx-needs of *now*, tested together at one commit; separate distributions because an install is whole or absent, because a Python extra is not a feature flag (nothing records that it was requested, so a bundled feature probes its imports at run time in `setup()`, console scripts and type checking, which sphinx-needs already pays once for matplotlib), because each package keeps its own version and cadence, and because not every package depends on sphinx-needs at all. The coupling that remains is a policy that tooling keeps honest: the tight-tracking range (workspace check 4), the release workflow's compat cell against published siblings, and `poe release-plan`.

Every claim in the section was checked against the tree: the range check is `check_workspace.py` check (4), the compat cell is `release.yaml`'s, the matplotlib probe is the `plotting` extra, and sphinx-mounts declares no sphinx-needs dependency.

Documentation only; no changelog entry.
