### PR TITLE
🔧 One command for the mechanical half of a release pull request, and two release-pipeline follow-ups

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,7 @@ uv run poe docs-mounts                # the sphinx-mounts docs build
 uv run poe smoke-needs                # build the wheel and test the built package
 uv run poe check-workspace            # the manifests agree with each other (Lint runs it)
 uv run poe release-plan               # what is pending, in what order (advice; exits 0)
+uv run poe bump <dist> --bump minor   # stamp a release: version, literals, floors, lock, changelog
 uv run poe import-check-needs         # import the wheel against PyPI-resolved dependencies
 uv run --frozen --no-sync pytest tools/tests -q   # the tooling's own tests
 UV_PYTHON=3.12 uv run --no-sync poe test-needs-sphinx8   # one CI matrix cell
@@ -245,6 +246,34 @@ workflow holds no API token, and every one of its checks fails closed.
    cell.
 1. **Release pull request**, from `master` with a clean tree:
    ```bash
+   uv run poe bump <dist> --bump {patch|minor|major}    # or --to X.Y.Z; --dry-run to preview
+   ```
+   One command for every mechanical edit, printed step by step with the file it wrote:
+
+   - `[project] version` in `packages/<dist>/pyproject.toml`;
+   - `__version__` in `packages/<dist>/src/<module>/__init__.py` — it is stamped into every
+     generated `needs.json`, so it is a literal rather than an `importlib.metadata` lookup,
+     and `uv run poe check-workspace` fails when the two disagree;
+   - for sphinx-needs only, the `NEEDS_VERSION` fallback in `.github/workflows/docker.yaml`,
+     which becomes `sphinx-needs-v<version>`: it is used as a git ref, and only the runs
+     with no tag of their own read it. Nothing fences this one;
+   - every dependant's floor, when a member declares `<dist>` at runtime;
+   - `uv.lock`;
+   - the changelog entry in `packages/<dist>/docs/changelog.rst` — the `release:<version>`
+     label, the heading, `:Released:` in that file's own date format, and the
+     `:Full Changelog:` compare link where that file's newest entry has one. Both
+     conventions in this repository are honoured: a `sphinx-mounts`-style `Unreleased`
+     section is converted in place, keeping its bullets; a `sphinx-needs`-style entry is
+     inserted above the newest one, empty.
+
+   **By hand: the summary paragraph** under the new heading. `bump` deliberately writes no
+   prose — a placeholder in a changelog is a thing that ships — and it does not commit, tag
+   or push. It refuses to run if any file it would rewrite is dirty (`uv.lock` excepted:
+   `uv lock` derives it, and guarding it would make releasing two members in one pull
+   request impossible).
+
+   *What `bump` runs, for the by-hand path:*
+   ```bash
    uv version --package <dist> --bump {patch|minor|major} --no-sync
    uv run python tools/src/sn_tools/propagate_floors.py <dist>   # only if a member depends on <dist>
    uv lock
@@ -253,24 +282,19 @@ workflow holds no API token, and every one of its checks fails closed.
    the `uv-lock` hook then fails a release pull request for a reason that has nothing to do
    with the release; a bare `uv version --bump` creates and syncs `.venv` and re-resolves
    from cold, which reorders `resolution-markers` and stops the diff being readable.
-2. **The two numbers `uv version` does not write.** `__version__` in
-   `packages/<dist>/src/<module>/__init__.py` (it is stamped into every generated
-   `needs.json`, so it is a literal rather than an `importlib.metadata` lookup), and — for
-   sphinx-needs — the `NEEDS_VERSION` fallback in `.github/workflows/docker.yaml`, which
-   becomes `sphinx-needs-v<version>`: it is used as a git ref, and only the runs with no tag
-   of their own read it. `uv run poe check-workspace` fails on the first of them.
-3. **Changelog.** Stamp `packages/<dist>/docs/changelog.rst`: the `_release:<version>`
-   label, the version heading, `:Released: DD.MM.YYYY`, the `:Full Changelog:` compare link
-   (`…/compare/<previous tag>...<dist>-v<version>`) and the summary paragraph. The compare
-   link 404s in Docs-Linkcheck until the tag exists; that is expected and not a required
-   check.
-4. **Check it locally**: `uv run poe lint` (which now runs `check-workspace`) and
+2. **Write the summary paragraph** for the entry `bump` stamped, and check the rest of it:
+   `:Released: DD.MM.YYYY` for sphinx-needs, `:Released: YYYY-MM-DD` for sphinx-mounts, and
+   the compare link `…/compare/<previous tag>...<dist>-v<version>` — whose previous half is
+   a bare tag for a sphinx-needs release that follows one from before the monorepo move. The
+   compare link 404s in Docs-Linkcheck until the tag exists; that is expected and not a
+   required check.
+3. **Check it locally**: `uv run poe lint` (which now runs `check-workspace`) and
    `uv run poe smoke-needs`.
-5. **Merge**, then push the tag from `master`:
+4. **Merge**, then push the tag from `master`:
    ```bash
    git tag <dist>-v<version> && git push origin <dist>-v<version>
    ```
-6. The workflow does the rest: validate the tag, build, resolve the built wheel against
+5. The workflow does the rest: validate the tag, build, resolve the built wheel against
    PyPI alone, run the member's suite against its dependencies *as published*, publish, and
    create the GitHub Release titled `<dist> v<version>`. For sphinx-needs it then pushes a
    second, bare `<version>` tag, which is what keeps Read the Docs' `stable`, every

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -478,8 +478,8 @@ help = "Stamp a release of one member: version, __version__, the docker literal,
 # BARE, like `release-plan` and `check-workspace`, and unlike `smoke-needs`: the naming
 # rule suffixes a task whose command names one package, and this one takes the
 # distribution as an argument -- `poe bump sphinx-mounts --bump minor` is as much its
-# subject as sphinx-needs is. Steps 1-3 of AGENTS.md's release recipe; it writes no prose
-# and pushes no tag
+# subject as sphinx-needs is. Step 1 of AGENTS.md's release recipe; it writes no prose and
+# pushes no tag
 cmd = "python tools/src/sn_tools/bump.py"
 
 # --- The built package ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -473,6 +473,15 @@ help = "What is pending, in what order, and what the compat cell would test it a
 # Advice, never a gate -- it exits 0 whatever it finds. Step 0 of the release recipe
 cmd = "python tools/src/sn_tools/release_plan.py"
 
+[tool.poe.tasks.bump]
+help = "Stamp a release of one member: version, __version__, the docker literal, floors, lock, changelog"
+# BARE, like `release-plan` and `check-workspace`, and unlike `smoke-needs`: the naming
+# rule suffixes a task whose command names one package, and this one takes the
+# distribution as an argument -- `poe bump sphinx-mounts --bump minor` is as much its
+# subject as sphinx-needs is. Steps 1-3 of AGENTS.md's release recipe; it writes no prose
+# and pushes no tag
+cmd = "python tools/src/sn_tools/bump.py"
+
 # --- The built package ---
 # These two are named for the distribution they act on rather than for the repository, so
 # the names stay correct if a second distribution is ever built here. Every other task in

--- a/scripts/smoke_needs.py
+++ b/scripts/smoke_needs.py
@@ -320,9 +320,14 @@ def check_sdist_builds(
         ) from exc
     elapsed = time.monotonic() - started
     # `cwd=tmp` for the same reason as the wheel probe: python puts the working directory
-    # on `sys.path` for `-c`, so from the repository root this would import the checkout
+    # on `sys.path` for `-c`, so from the repository root this would import the checkout.
+    # `splitlines()`, not `split()`: the probe prints one value per LINE, and a path with a
+    # space in it -- which `TMPDIR="/…/with space"` gives every temporary directory here --
+    # makes a whitespace split yield three fields and unpack with a `ValueError`
     probe = f"import {module} as m; print(m.__version__); print(m.__file__)"
-    version, location = run([str(interpreter), "-c", probe], cwd=tmp).stdout.split()
+    version, location = run(
+        [str(interpreter), "-c", probe], cwd=tmp
+    ).stdout.splitlines()
     checks.check(
         version == expected,
         f"the wheel built from the sdist reports the manifest's version ({expected})",
@@ -443,8 +448,11 @@ def main() -> int:
         # `cwd=tmp` is not cosmetic: python puts the working directory on `sys.path` for
         # `-c`, so running this from the repository root imports the checkout instead of
         # the wheel -- which is precisely what the next assertion exists to catch
+        # `splitlines()`, not `split()`: see `check_sdist_builds` above -- the probe prints
+        # one value per line, and a temporary directory whose path contains a space made
+        # this unpack raise `ValueError: too many values to unpack`
         probe = f"import {module} as m; print(m.__version__); print(m.__file__)"
-        version, location = run([str(python), "-c", probe], cwd=tmp).stdout.split()
+        version, location = run([str(python), "-c", probe], cwd=tmp).stdout.splitlines()
         checks.check(True, f"{args.dist_name} imports", f"{version} from {location}")
         checks.check(
             Path(location).resolve().is_relative_to(venv.resolve()),

--- a/scripts/smoke_needs.py
+++ b/scripts/smoke_needs.py
@@ -22,7 +22,16 @@ invisible to all of them (issue #1829).  This script closes that gap:
 6. assert the wheel carries every file git tracks under the module directory -- the
    non-Python payload (vendored JS/CSS, images, templates, JSON schemas) is 88% of it by
    file count, and it is the part a packaging mistake drops;
-7. build a tiny documentation project with ``-W`` and assert the rendered need, the link,
+7. build a wheel *from the sdist* -- a second throwaway environment and ``uv pip install
+   <sdist>``, which runs the PEP 517 hook (``flit_core.buildapi``) on the tarball -- and
+   import it. Step 2 asserts what the tarball *contains*; only this asserts that the
+   tarball still builds. They are different failures: a sdist can ship every declared tree
+   and still be unbuildable (a ``[build-system]`` requirement that no longer resolves, a
+   ``[tool.flit]`` key the backend rejects, a module the ``include`` list quietly stopped
+   naming), and a user who installs from source -- as every ``pip install`` on a platform
+   with no wheel does, and as conda-forge and the distributions do -- is the only person
+   who would find out;
+8. build a tiny documentation project with ``-W`` and assert the rendered need, the link,
    the table, the flow image and the copied static assets.
 
 It is parameterised on the package directory and the distribution name so that a sibling
@@ -44,6 +53,7 @@ import sys
 import tarfile
 import tempfile
 import time
+import tomllib
 import zipfile
 from pathlib import Path
 from typing import Any
@@ -236,6 +246,96 @@ def check_wheel_contents(
         checks.check(name in owned, f"wheel has {module}/{name}")
 
 
+def interpreter_in(venv: Path) -> Path:
+    """The python of a `uv venv`, on this platform."""
+    return (
+        venv
+        / ("Scripts" if sys.platform == "win32" else "bin")
+        / ("python.exe" if sys.platform == "win32" else "python")
+    )
+
+
+def manifest_version(package_dir: Path) -> str:
+    """The version the member's manifest declares.
+
+    Read from the manifest rather than from the built artefact's file name so that the
+    assertion below compares two independent statements of the version: what the tree says
+    it is building, and what the module the sdist built actually reports.
+    """
+    data = tomllib.loads((package_dir / "pyproject.toml").read_text(encoding="utf-8"))
+    version = data.get("project", {}).get("version")
+    if not isinstance(version, str):
+        raise SmokeError(f"{package_dir}/pyproject.toml declares no [project] version")
+    return version
+
+
+def check_sdist_builds(
+    sdist: Path,
+    module: str,
+    expected: str,
+    tmp: Path,
+    python: str | None,
+    checks: Checks,
+) -> float:
+    """Build a wheel FROM the sdist, in an environment of its own, and import it.
+
+    `check_sdist_contents` above asserts what the tarball carries; this asserts that the
+    tarball still *builds*, which is a different failure and one nothing else in this
+    repository can see. `uv pip install <sdist>` is the whole mechanism: uv reads the
+    tarball's `[build-system]`, resolves it (flit_core) in an isolated build environment,
+    runs `build_wheel`, and installs the result -- exactly the path a user on a platform
+    with no wheel takes, and the one conda-forge and the distributions take always.
+
+    A SECOND environment, not the wheel's: installing the sdist over an already-installed
+    wheel of the same version is a no-op for uv, so the check would pass without ever
+    running the build backend.
+
+    Returns the seconds the build-and-install took, which is what this step costs the smoke
+    run; the caller prints it.
+    """
+    venv = tmp / "venv-sdist"
+    run(["uv", "venv", *(["--python", python] if python else []), str(venv)], cwd=tmp)
+    interpreter = interpreter_in(venv)
+    started = time.monotonic()
+    try:
+        # `--python` on every `uv pip` call: `uv pip` is NOT project-scoped, so without it
+        # this would target whatever virtualenv happens to be active
+        run(
+            [
+                "uv",
+                "pip",
+                "install",
+                "--python",
+                str(interpreter),
+                "--no-sources",
+                str(sdist),
+            ],
+            cwd=tmp,
+        )
+    except SmokeError as exc:
+        raise SmokeError(
+            f"{exc} -- could not build a wheel from the sdist {sdist}. That is a "
+            "`[build-system]` or `[tool.flit]` failure in the tarball, not a missing file: "
+            "the contents checks above passed"
+        ) from exc
+    elapsed = time.monotonic() - started
+    # `cwd=tmp` for the same reason as the wheel probe: python puts the working directory
+    # on `sys.path` for `-c`, so from the repository root this would import the checkout
+    probe = f"import {module} as m; print(m.__version__); print(m.__file__)"
+    version, location = run([str(interpreter), "-c", probe], cwd=tmp).stdout.split()
+    checks.check(
+        version == expected,
+        f"the wheel built from the sdist reports the manifest's version ({expected})",
+        f"got {version}",
+    )
+    checks.check(
+        Path(location).resolve().is_relative_to(venv.resolve()),
+        "the sdist-built import comes from ITS OWN environment, not the checkout",
+        location,
+    )
+    return elapsed
+
+
 def write_project(src: Path) -> None:
     src.mkdir(parents=True)
     (src / "conf.py").write_text(CONF_PY, encoding="utf-8")
@@ -320,11 +420,7 @@ def main() -> int:
             ],
             cwd=tmp,
         )
-        python = (
-            venv
-            / ("Scripts" if sys.platform == "win32" else "bin")
-            / ("python.exe" if sys.platform == "win32" else "python")
-        )
+        python = interpreter_in(venv)
         # `--no-sources` states the intent and keeps this identical to the release
         # workflow's install, but it is not what stops the source tree being installed:
         # measured on uv 0.12.9, `uv pip install <wheel>` resolves the wheel's
@@ -359,6 +455,11 @@ def main() -> int:
             [str(python), "-c", "import sys; print(sys.version.split()[0])"], cwd=tmp
         )
         print(f"interpreter: {interpreter.stdout.strip()}")
+
+        seconds = check_sdist_builds(
+            sdist, module, manifest_version(package_dir), tmp, args.python, checks
+        )
+        print(f"built and installed {sdist.name} from source in {seconds:.1f}s")
 
         src, out = tmp / "src", tmp / "out"
         write_project(src)

--- a/tools/src/sn_tools/bump.py
+++ b/tools/src/sn_tools/bump.py
@@ -1,6 +1,6 @@
 """Stamp a release into the tree: the version, the two literals, the floors, the lock, the changelog.
 
-Steps 1-3 of AGENTS.md's "Releasing a package" are six edits in five files that must all
+Step 1 of AGENTS.md's "Releasing a package" is six edits across five files that must all
 say the same number, and every one of them has a gate somewhere else that fails when it is
 forgotten -- `check_workspace.py` on the `__version__` literal, the `uv-lock` hook on the
 lock, the plan job on the manifest, a reader on the changelog. Doing them by hand is how a

--- a/tools/src/sn_tools/bump.py
+++ b/tools/src/sn_tools/bump.py
@@ -16,15 +16,31 @@ What it does NOT do is decide anything. It writes no prose: the changelog gets i
 its heading, its `:Released:` and (where that file's convention has one) its
 `:Full Changelog:` link, and the summary paragraph stays hand-written, because a
 placeholder in a changelog is a thing that ships. It does not commit, does not tag and does
-not push. And it is not a gate: `check_workspace.py` in Lint and the plan job in
-`release.yaml` are still what stand between a half-done bump and PyPI -- this only makes
-the half-done state unlikely rather than routine.
+not push.
+
+**RETRACTION.** An earlier version of this docstring said "it is not a gate:
+`check_workspace.py` in Lint and the plan job in `release.yaml` are still what stand
+between a half-done bump and PyPI -- this only makes the half-done state unlikely rather
+than routine." That is FALSE, and measured to be false for the half-done state this module
+can actually produce: a tree bumped everywhere except the changelog is green under
+`uv run poe lint`, `check_workspace.py` AND the plan job, because **nothing in this
+repository fences a missing changelog entry**. The manifest, the literal, the lock and the
+docker fallback all agree; the only thing absent is prose no gate reads. So there is no
+downstream fence to fall back on, and this module cannot be allowed to create that state
+by refusing halfway through -- which is why `bump()` below is split into a COMPUTE phase
+and an APPLY phase: every refusal any step can raise fires while the tree is still
+untouched. What remains possible is a crash, a `KeyboardInterrupt`, or a failure of the two
+subprocesses in the apply phase; for those, the failure message names the files already
+written and the `git checkout --` that undoes them.
 
 **Preconditions, all fail-closed**: the distribution is a member this repository publishes
-(the virtual `tools` member is refused, by the same rule that refuses its tag), and every
-file this run will write is clean in `git status --porcelain`. The rest of the tree may be
-dirty and the branch is not checked: a release pull request is cut from `master`, but so is
-a rehearsal, and refusing to run anywhere else would only teach people to bypass this.
+(the virtual `tools` member is refused, by the same rule that refuses its tag); every file
+this run will write is clean in `git status --porcelain`; the new version is strictly above
+the current one (a release never moves down, and re-releasing the current version is the
+same mistake wearing a different hat); and the changelog does not already carry a label for
+it. The rest of the tree may be dirty and the branch is not checked: a release pull request
+is cut from `master`, but so is a rehearsal, and refusing to run anywhere else would only
+teach people to bypass this.
 
 **Sharing with the other scripts.** These scripts are run by path
 (`uv run --no-project --with packaging python tools/src/sn_tools/<script>.py`), which puts
@@ -53,6 +69,8 @@ import tomllib
 from datetime import date
 from pathlib import Path
 from typing import Any
+
+from packaging.version import InvalidVersion, Version
 
 if __package__ in (None, ""):  # run by path: `sys.path[0]` is this directory
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -88,9 +106,20 @@ RELEASE_LABEL = re.compile(r"^\.\. _`release:(?P<version>[^`]+)`:\s*$")
 RELEASED = re.compile(r"^:Released:\s*(?P<value>\S.*?)\s*$")
 FULL_CHANGELOG = ":Full Changelog:"
 # `03.09.2026` (sphinx-needs) as against `2026-08-27` (sphinx-mounts). Both conventions are
-# in this repository today and a release must not change the one the file it stamps uses
-DAY_FIRST = re.compile(r"^\d{2}\.\d{2}\.\d{4}$")
+# in this repository today and a release must not change the one the file it stamps uses.
+# The day-first pattern is deliberately lenient about padding: a hand-stamped `3.9.2026` is
+# still that file's format, and reading it as "unrecognised" would silently flip the file to
+# ISO for that release and every one after it
+DAY_FIRST = re.compile(r"^\d{1,2}\.\d{1,2}\.\d{4}$")
+ISO_DATE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 UNRELEASED = "Unreleased"
+
+# Every character docutils accepts as a section adornment. RST fixes none of them: a
+# document picks its own, and the heading LEVEL follows first use -- so `Changelog` under
+# `=` and `Unreleased` under `-` are conventions of the two files in this repository, not
+# rules. Matching one hard-coded character per heading is how an `Unreleased` section
+# underlined with `=` came to be silently left standing while the new entry went in below it
+ADORNMENT = frozenset("!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~")
 
 
 class BumpError(RuntimeError):
@@ -127,21 +156,39 @@ class Runner:
 # --- the pure rewrites: everything below is text in, text out ----------------------------
 
 
-def rewrite_module_literal(text: str, old: str, new: str) -> str:
-    """Move `__version__` in a module's `__init__.py`. Exactly one match, or refuse.
+def rewrite_module_literal(
+    text: str, old: str, new: str, path: str = "__init__.py"
+) -> str:
+    """Move `__version__` in a module's `__init__.py`, or refuse. Two separate refusals.
 
-    Keyed on the OLD value, not just on the name: a module that carries two `__version__`
-    assignments, or one whose literal already disagrees with the manifest, is a state this
-    cannot silently pick a winner in -- `check_workspace.py`'s check (5) exists precisely
-    because the two numbers drift.
+    `old` is the MANIFEST's version, not the literal's own. That distinction is the whole
+    point: keying on the literal's value made the `old` argument match by construction, so
+    a literal that had drifted from the manifest was silently overwritten and the one gate
+    that knew about the drift -- `check_workspace.py`'s check (5) -- went green again
+    without anyone seeing which of the two numbers had won. A release bump is the worst
+    moment to guess which of two hand edits was the intended one.
+
+    The count is taken over EVERY `__version__` assignment, not only the matching ones, so
+    a module carrying two of them is refused whichever values they hold. (Both
+    `check_workspace.module_version` and this regex read top to bottom, so a second
+    assignment is what Python actually leaves in `__version__` at import time and what
+    would be stamped into `needs.json` -- while the fence, reading the first, stayed
+    green.)
     """
-    matches = [m for m in MODULE_LITERAL.finditer(text) if m.group("value") == old]
+    matches = list(MODULE_LITERAL.finditer(text))
     if len(matches) != 1:
         raise BumpError(
-            f'expected exactly one `__version__ = "{old}"` assignment, found '
+            f"{path}: expected exactly one `__version__` assignment, found "
             f"{len(matches)}; fix the module by hand and re-run"
         )
     match = matches[0]
+    found = match["value"]
+    if found != old:
+        raise BumpError(
+            f'{path}: `__version__` is "{found}", but the manifest declares "{old}". '
+            "`check-workspace` reports exactly this drift; fix it by hand first -- the "
+            "release bump will not guess which of the two numbers is right"
+        )
     replacement = f"{match['head']}{match['quote']}{new}{match['quote']}"
     return text[: match.start()] + replacement + text[match.end() :]
 
@@ -186,21 +233,36 @@ def dependants(projects: dict[str, dict[str, Any]], target: str) -> list[str]:
     )
 
 
-def released_line(text: str, when: date) -> str:
-    """`:Released:` in THIS file's own date format.
+def released_line(text: str, when: date, path: str = "changelog.rst") -> str:
+    """`:Released:` in THIS file's own date format, or refuse.
 
     sphinx-needs writes `03.09.2026` and sphinx-mounts writes `2026-08-27`. Neither is more
     correct, and a release is not the moment to unify them -- so the format is read off the
     newest existing entry (changelogs here are newest-first, so that is the first
-    `:Released:` in the file) and ISO is the answer only when the file has none.
+    `:Released:` in the file).
+
+    "ISO when the file has none" and "ISO when the file has one I cannot classify" are
+    different rules, and only the first is a documented convention. The second was the
+    behaviour: one hand-stamped `3 Sep 2026` -- or `2026/08/27` -- would have flipped the
+    file to ISO for that release and, by the same detection, every release after it. So an
+    unrecognised value is a refusal naming the line, and ISO is reached only by a file with
+    no `:Released:` at all, which is a first release.
     """
     for line in text.splitlines():
         match = RELEASED.match(line)
         if match:
-            iso = not DAY_FIRST.match(match["value"])
-            return (
-                f":Released: {when:%Y-%m-%d}" if iso else f":Released: {when:%d.%m.%Y}"
+            value = match["value"]
+            if DAY_FIRST.match(value):
+                return f":Released: {when:%d.%m.%Y}"
+            if ISO_DATE.match(value):
+                return f":Released: {when:%Y-%m-%d}"
+            raise BumpError(
+                f"{path}: the newest `:Released: {value}` is neither DD.MM.YYYY nor "
+                "YYYY-MM-DD, so this file states no date format to follow; fix that line, "
+                "or stamp this entry by hand"
             )
+    # the documented fallback, and the only way to reach it: a changelog with no released
+    # entry at all
     return f":Released: {when:%Y-%m-%d}"
 
 
@@ -229,30 +291,54 @@ def newest_entry_has_compare(lines: list[str]) -> bool:
     return False
 
 
+def is_heading(lines: list[str], index: int, title: str) -> bool:
+    """Is `lines[index]` a section heading reading `title`, adorned by the line below it?
+
+    By SHAPE, not by character. RST fixes no adornment character and no level ordering: a
+    document's first-used adornment becomes its top level, so `Changelog` under `=` with
+    `Unreleased` under `-` (this repository) and the same two under `-` and `=` are both
+    valid, and only one of them used to be recognised. What docutils actually requires is a
+    run of one repeated punctuation character, at least as long as the title text -- which
+    is what this asks, once, for both headings this module looks for. Two hard-coded and
+    DIFFERENT characters in one module was the drift waiting to happen: an `Unreleased`
+    section adorned with `=` was left standing above a new, empty release entry, keeping
+    the bullets that were meant to be that release's changelog, and nothing was raised.
+    """
+    if index + 1 >= len(lines) or lines[index].strip() != title:
+        return False
+    adornment = lines[index + 1].strip()
+    return (
+        len(adornment) >= len(title)
+        and len(set(adornment)) == 1
+        and adornment[0] in ADORNMENT
+    )
+
+
 def changelog_title(lines: list[str]) -> int | None:
     """The index of the `Changelog` section title, if the file has one."""
-    for index in range(len(lines) - 1):
-        underline = lines[index + 1].strip()
-        if (
-            lines[index].strip() == "Changelog"
-            and underline
-            and set(underline) == {"="}
-        ):
-            return index
-    return None
+    return next(
+        (index for index in range(len(lines)) if is_heading(lines, index, "Changelog")),
+        None,
+    )
 
 
 def unreleased_section(
     lines: list[str], title_at: int | None, label_at: int | None
 ) -> int | None:
-    """The index of an `Unreleased` heading sitting above every released entry."""
+    """The index of an `Unreleased` heading sitting above every released entry.
+
+    The `label_at` bound is what "above every released entry" means, and it is load-bearing
+    rather than tidy: an `Unreleased` heading left by mistake INSIDE an older entry's body
+    would otherwise be converted, which inserts the new release below the older one --
+    newest-first ordering broken and the older entry's body silently annexed. Below the
+    first label, the insert branch is the right answer.
+    """
     start = 0 if title_at is None else title_at + 2
-    stop = len(lines) - 1 if label_at is None else min(label_at, len(lines) - 1)
-    for index in range(start, stop):
-        underline = lines[index + 1].strip()
-        if lines[index].strip() == UNRELEASED and underline and set(underline) == {"-"}:
-            return index
-    return None
+    stop = len(lines) if label_at is None else min(label_at, len(lines))
+    return next(
+        (index for index in range(start, stop) if is_heading(lines, index, UNRELEASED)),
+        None,
+    )
 
 
 def stamp_changelog(
@@ -276,14 +362,26 @@ def stamp_changelog(
       The summary paragraph is hand-written; a placeholder here is a thing that ships.
 
     Returns the new text and a one-line description of what was written, for the caller's
-    step line.
+    step line. The output is LF-joined whatever the input used, so a CRLF changelog would
+    come back rewritten whole; in this repository `.gitattributes`' `* text=auto` normalises
+    the blobs either way, so the diff stays one hunk -- the sentence "the diff is the whole
+    file" is false here only because of that line, which nothing else connects to this code.
     """
     lines = text.splitlines()
     label_at = next(
         (i for i, line in enumerate(lines) if RELEASE_LABEL.match(line)), None
     )
     title_at = changelog_title(lines)
-    if label_at is None and title_at is None:
+    # the line a new entry goes in ABOVE: the newest label, or the first line after the
+    # `Changelog` title's adornment when the file has no released entry yet. Bound here,
+    # where each branch narrows locally, rather than re-derived as a ternary 40 lines on --
+    # which is the same invariant stated twice, and the second statement needed a
+    # `ty: ignore` because the narrowing does not survive a compound guard
+    if label_at is not None:
+        at = label_at
+    elif title_at is not None:
+        at = title_at + 2
+    else:
         raise BumpError(
             f"{path} has neither a `Changelog` title nor a `release:` label, so there is "
             "no entry shape to mirror; stamp this release by hand"
@@ -294,7 +392,7 @@ def stamp_changelog(
         version,
         "-" * len(version),
         "",
-        released_line(text, when),
+        released_line(text, when, path),
     ]
     if newest_entry_has_compare(lines):
         if not previous_tag:
@@ -326,7 +424,6 @@ def stamp_changelog(
             f"({kept} top-level bullet{'' if kept == 1 else 's'} kept)",
         )
 
-    at = label_at if label_at is not None else title_at + 2  # ty: ignore[unsupported-operator]
     before = lines[:at]
     while before and not before[-1].strip():
         before.pop()  # exactly one blank line before the new label, however many there were
@@ -361,10 +458,28 @@ def preview_version(output: str) -> str:
 
 
 def bump(args: argparse.Namespace, runner: Runner) -> int:
+    """Compute everything, refuse if anything is wrong, and only then write.
+
+    The two phases are the whole design. Every refusal this module can raise -- a drifted
+    `__version__`, a `NEEDS_VERSION` line that is not there, a changelog with no shape to
+    mirror, a `:Released:` format it cannot read, a missing previous tag for a compare
+    link, a version that does not move -- is reachable only from data, so all of them can
+    fire before a byte is written. They used to fire in file order instead, which meant the
+    changelog's refusal arrived with four files and the lock already rewritten: the exact
+    half-done state no gate in this repository can see (see the RETRACTION at the top of
+    this module). Two `uv version` calls is what that costs -- a `--dry-run` for the
+    preflight and the real one in the apply phase -- and `--no-sync` makes each of them a
+    manifest read and a manifest write, so the cost is nothing.
+
+    What is still not atomic: the apply phase runs `propagate_floors.py` and `uv lock`, and
+    a crash or a `KeyboardInterrupt` anywhere in it leaves part of the tree written. That
+    is why the apply phase tracks what it wrote and says so, with the `git checkout --`
+    that undoes it, on any failure.
+    """
     root: Path = args.root
     dry = args.dry_run
 
-    # --- 1. preconditions ----------------------------------------------------------------
+    # === PRECONDITIONS ===================================================================
     workspace = release_plan.members(root)
     dist = release_plan.canonicalize_name(args.dist)
     if dist not in workspace.projects:
@@ -388,14 +503,16 @@ def bump(args: argparse.Namespace, runner: Runner) -> int:
     changelog = directory / "docs" / "changelog.rst"
     if not changelog.is_file():
         raise BumpError(f"no changelog at {changelog.relative_to(root)}")
+    changelog_path = changelog.relative_to(root).as_posix()
     needs_docker = dist == DOCKER_DIST and (root / DOCKER_WORKFLOW).is_file()
+    workflow = root / DOCKER_WORKFLOW
     downstream = dependants(workspace.projects, dist)
 
     writes = [manifest, changelog]
     if literal is not None:
         writes.append(literal[0])
     if needs_docker:
-        writes.append(root / DOCKER_WORKFLOW)
+        writes.append(workflow)
     writes += [workspace.directories[name] / "pyproject.toml" for name in downstream]
     guarded = sorted(path.relative_to(root).as_posix() for path in writes)
     status = runner.run(
@@ -419,133 +536,212 @@ def bump(args: argparse.Namespace, runner: Runner) -> int:
         "hand-written files are clean (uv.lock is regenerated, not guarded)"
     )
 
-    # --- 2. the manifest version, written by uv and read back ----------------------------
+    # === COMPUTE: nothing below writes anything ==========================================
     value = ["--bump", args.bump] if args.bump else [args.to]
-    printed = runner.run(
-        [
-            "uv",
-            "version",
-            "--package",
-            dist,
-            *value,
-            "--no-sync",
-            *(["--dry-run"] if dry else []),
-        ]
-    )
-    # read back rather than computed: `uv version` owns the bump semantics, and a second
-    # implementation of them here is a second thing to be wrong. A dry run writes no
-    # manifest to read back from, so its own `<name> <old> => <new>` line is the preview
-    version = preview_version(printed) if dry else read_version(manifest)
-    tag = f"{dist}-v{version}"
-    print(
-        f'2. {"would set" if dry else "set"} version = "{version}" in {manifest.relative_to(root)}'
-    )
-
-    # --- 3. the `__version__` literal ----------------------------------------------------
-    if literal is None:
-        print(
-            f"3. no `__version__` literal under {directory.relative_to(root)}/src/"
-            f"{member.module}/ -- nothing to rewrite"
-        )
-    else:
-        module_path, module_value = literal
-        text = rewrite_module_literal(
-            module_path.read_text(encoding="utf-8"), module_value, version
-        )
-        if not dry:
-            module_path.write_text(text, encoding="utf-8")
-        print(
-            f'3. {"would write" if dry else "wrote"} __version__ = "{version}" in '
-            f"{module_path.relative_to(root)}"
-        )
-
-    # --- 4. the docker workflow's NEEDS_VERSION fallback ---------------------------------
-    if not needs_docker:
-        print(f"4. no version literal in a workflow for {args.dist} -- skipped")
-    else:
-        workflow = root / DOCKER_WORKFLOW
-        text = rewrite_docker_literal(workflow.read_text(encoding="utf-8"), tag)
-        if not dry:
-            workflow.write_text(text, encoding="utf-8")
-        print(
-            f"4. {'would write' if dry else 'wrote'} NEEDS_VERSION fallback `{tag}` in {DOCKER_WORKFLOW}"
-        )
-
-    # --- 5. the dependants' floors -------------------------------------------------------
-    if not downstream:
-        print(
-            f"5. no dependants: no member declares {args.dist} at runtime -- propagate_floors skipped"
-        )
-    elif dry:
-        print(
-            f"5. would run propagate_floors.py {args.dist} for {', '.join(downstream)}"
-        )
-    else:
+    # `--dry-run` prints `<name> <old> => <new>` and writes no manifest, so this is the
+    # version the real call in the apply phase will produce, obtained without producing it
+    version = preview_version(
         runner.run(
-            [
-                sys.executable,
-                str(Path(__file__).resolve().with_name("propagate_floors.py")),
-                args.dist,
-                "--root",
-                str(root),
-            ]
+            ["uv", "version", "--package", dist, *value, "--no-sync", "--dry-run"]
         )
-        print(
-            f"5. propagated the {args.dist} {version} floor to {', '.join(downstream)}"
+    )
+    tag = f"{dist}-v{version}"
+
+    try:
+        moved = Version(version) > Version(old_version)
+    except InvalidVersion as exc:
+        raise BumpError(
+            f"`{version}` is not a PEP 440 version, so nothing downstream -- the tag "
+            f"check, the index, `check-workspace` -- can compare it with {old_version}"
+        ) from exc
+    if not moved:
+        raise BumpError(
+            f"{args.dist} {old_version} -> {version} is not a release: a version never "
+            "moves down, and re-releasing the current one cannot be published again "
+            "(the plan job's check 3 refuses a version already on PyPI). Name a higher "
+            "version, or use --bump {patch|minor|major}"
+        )
+    changelog_text = changelog.read_text(encoding="utf-8")
+    if any(
+        (match := RELEASE_LABEL.match(line)) and match["version"] == version
+        for line in changelog_text.splitlines()
+    ):
+        raise BumpError(
+            f"{changelog_path} already carries a `release:{version}` label, so this would "
+            "stamp a second entry for the same version -- two identical RST targets, which "
+            "`poe docs-needs` fails on (`-nW`) minutes later with a docutils warning that "
+            "says nothing about a release. Was this release already stamped?"
         )
 
-    # --- 6. the lock ---------------------------------------------------------------------
-    # NOT `--frozen`: `--no-sync` above left uv.lock claiming the old version, and the
-    # `uv-lock` prek hook would fail the release pull request for a reason that has nothing
-    # to do with the release
-    if dry:
-        print(
-            "6. would run `uv lock` (not --frozen: the lock still claims the old version)"
-        )
-    else:
-        runner.run(["uv", "lock"])
-        print("6. relocked uv.lock")
-
-    # --- 7. the changelog ----------------------------------------------------------------
-    # through the runner like every other git call, so the whole orchestration is one seam
+    # the tag list is a pure read, and `previous_tag` is a pure function of it, the
+    # distribution and the new version -- so the compare link can be resolved here, which
+    # is what lets the changelog's refusals fire before the manifest moves
     tags = [
         line.strip()
         for line in runner.run(["git", "tag", "--list"], quiet=True).splitlines()
         if line.strip()
     ]
     previous = release_plan.previous_tag(dist, version, tags)
-    text, what = stamp_changelog(
-        changelog.read_text(encoding="utf-8"),
+
+    module_text: str | None = None
+    if literal is not None:
+        module_path, _ = literal
+        module_text = rewrite_module_literal(
+            module_path.read_text(encoding="utf-8"),
+            old_version,
+            version,
+            module_path.relative_to(root).as_posix(),
+        )
+    workflow_text: str | None = None
+    if needs_docker:
+        workflow_text = rewrite_docker_literal(
+            workflow.read_text(encoding="utf-8"), tag
+        )
+    changelog_new, what = stamp_changelog(
+        changelog_text,
         version=version,
         when=args.date,
         previous_tag=previous,
         new_tag=tag,
-        path=changelog.relative_to(root).as_posix(),
+        path=changelog_path,
     )
-    if not dry:
-        changelog.write_text(text, encoding="utf-8")
     print(
-        f"7. {'would stamp' if dry else 'stamped'} {changelog.relative_to(root)}: {what}"
+        f"   preflight: {old_version} -> {version}; every rewrite computed, "
+        f"{'nothing will be written (--dry-run)' if dry else 'nothing written yet'}"
     )
 
-    # --- 8. what was written, and what is left ------------------------------------------
+    # === APPLY ============================================================================
+    written: list[str] = []
+    try:
+        # --- 2. the manifest version, written by uv and read back -------------------------
+        if not dry:
+            runner.run(["uv", "version", "--package", dist, *value, "--no-sync"])
+            written.append(manifest.relative_to(root).as_posix())
+            # read back rather than trusted: `uv version` owns the bump semantics, and the
+            # preview above is only a preview until the manifest agrees with it
+            got = read_version(manifest)
+            if got != version:
+                raise BumpError(
+                    f"`uv version` previewed {version} but wrote {got} to "
+                    f"{manifest.relative_to(root)}; refusing to stamp two different numbers"
+                )
+        print(
+            f'2. {"would set" if dry else "set"} version = "{version}" in '
+            f"{manifest.relative_to(root)}"
+        )
+
+        # --- 3. the `__version__` literal -------------------------------------------------
+        if literal is None:
+            print(
+                f"3. no `__version__` literal under {directory.relative_to(root)}/src/"
+                f"{member.module}/ -- nothing to rewrite"
+            )
+        else:
+            module_path, _ = literal
+            if not dry:
+                module_path.write_text(module_text or "", encoding="utf-8")
+                written.append(module_path.relative_to(root).as_posix())
+            print(
+                f'3. {"would write" if dry else "wrote"} __version__ = "{version}" in '
+                f"{module_path.relative_to(root)}"
+            )
+
+        # --- 4. the docker workflow's NEEDS_VERSION fallback ------------------------------
+        if not needs_docker:
+            print(f"4. no version literal in a workflow for {args.dist} -- skipped")
+        else:
+            if not dry:
+                workflow.write_text(workflow_text or "", encoding="utf-8")
+                written.append(DOCKER_WORKFLOW)
+            print(
+                f"4. {'would write' if dry else 'wrote'} NEEDS_VERSION fallback `{tag}` "
+                f"in {DOCKER_WORKFLOW}"
+            )
+
+        # --- 5. the dependants' floors ----------------------------------------------------
+        # the numbered line comes BEFORE the subprocess, so the transcript reads as a
+        # recipe rather than as output with a caption underneath it
+        if not downstream:
+            print(
+                f"5. no dependants: no member declares {args.dist} at runtime -- "
+                "propagate_floors skipped"
+            )
+        elif dry:
+            print(
+                f"5. would run propagate_floors.py {args.dist} for {', '.join(downstream)}"
+            )
+        else:
+            print(
+                f"5. propagate the {args.dist} {version} floor to "
+                f"{', '.join(downstream)}:"
+            )
+            runner.run(
+                [
+                    sys.executable,
+                    str(Path(__file__).resolve().with_name("propagate_floors.py")),
+                    args.dist,
+                    "--root",
+                    str(root),
+                ]
+            )
+            written += [
+                (workspace.directories[name] / "pyproject.toml")
+                .relative_to(root)
+                .as_posix()
+                for name in downstream
+            ]
+
+        # --- 6. the lock ------------------------------------------------------------------
+        # NOT `--frozen`: `--no-sync` above left uv.lock claiming the old version, and the
+        # `uv-lock` prek hook would fail the release pull request for a reason that has
+        # nothing to do with the release
+        if dry:
+            print(
+                "6. would run `uv lock` (not --frozen: the lock still claims the old "
+                "version)"
+            )
+        else:
+            runner.run(["uv", "lock"])
+            written.append("uv.lock")
+            print("6. relocked uv.lock")
+
+        # --- 7. the changelog -------------------------------------------------------------
+        if not dry:
+            changelog.write_text(changelog_new, encoding="utf-8")
+            written.append(changelog_path)
+        print(f"7. {'would stamp' if dry else 'stamped'} {changelog_path}: {what}")
+    except BaseException:
+        # a crash, a Ctrl-C or a failing subprocess is the one way a half-done tree is
+        # still reachable; the least this can do is name it and how to undo it
+        if written:
+            print()
+            print(
+                "this run had already written "
+                + ", ".join(sorted(written))
+                + " when it failed. To undo them:"
+            )
+            print(f"  git checkout -- {' '.join(sorted(written))}")
+        raise
+
+    # --- 8. what was written, and what is left --------------------------------------------
     print()
     print(f"{'would write' if dry else 'wrote'}:")
     for path in relative:
         print(f"  {path}")
     print()
     print('by hand, from AGENTS.md "Releasing a package":')
+    # bullets, not numbers: the actions below are AGENTS.md's steps 2 to 4, and a second
+    # numbering that starts at 1 drifts against the file this line claims to quote every
+    # time either changes
     print(
-        f"  1. write the summary paragraph under the new {version} heading in {changelog.relative_to(root)}"
+        f"  - write the summary paragraph under the new {version} heading in "
+        f"{changelog_path}"
     )
-    print("  2. uv run poe lint")
+    print("  - uv run poe lint")
     if dist == DOCKER_DIST:
-        print("  3. uv run poe smoke-needs")
-        print("  4. merge the release pull request, then from master:")
-        print(f"  5. git tag {tag} && git push origin {tag}")
-    else:
-        print("  3. merge the release pull request, then from master:")
-        print(f"  4. git tag {tag} && git push origin {tag}")
+        print("  - uv run poe smoke-needs")
+    print("  - merge the release pull request, then from master:")
+    print(f"  - git tag {tag} && git push origin {tag}")
     return 0
 
 

--- a/tools/src/sn_tools/bump.py
+++ b/tools/src/sn_tools/bump.py
@@ -1,0 +1,591 @@
+"""Stamp a release into the tree: the version, the two literals, the floors, the lock, the changelog.
+
+Steps 1-3 of AGENTS.md's "Releasing a package" are six edits in five files that must all
+say the same number, and every one of them has a gate somewhere else that fails when it is
+forgotten -- `check_workspace.py` on the `__version__` literal, the `uv-lock` hook on the
+lock, the plan job on the manifest, a reader on the changelog. Doing them by hand is how a
+release pull request comes to fail Lint for a reason that has nothing to do with the
+release. This does them in one command, in the order the recipe gives, and prints the file
+it wrote at each step::
+
+    python tools/src/sn_tools/bump.py sphinx-needs --bump minor
+    python tools/src/sn_tools/bump.py sphinx-mounts --to 0.3.0 --date 2026-09-06
+    uv run poe bump sphinx-needs --bump minor --dry-run
+
+What it does NOT do is decide anything. It writes no prose: the changelog gets its label,
+its heading, its `:Released:` and (where that file's convention has one) its
+`:Full Changelog:` link, and the summary paragraph stays hand-written, because a
+placeholder in a changelog is a thing that ships. It does not commit, does not tag and does
+not push. And it is not a gate: `check_workspace.py` in Lint and the plan job in
+`release.yaml` are still what stand between a half-done bump and PyPI -- this only makes
+the half-done state unlikely rather than routine.
+
+**Preconditions, all fail-closed**: the distribution is a member this repository publishes
+(the virtual `tools` member is refused, by the same rule that refuses its tag), and every
+file this run will write is clean in `git status --porcelain`. The rest of the tree may be
+dirty and the branch is not checked: a release pull request is cut from `master`, but so is
+a rehearsal, and refusing to run anywhere else would only teach people to bypass this.
+
+**Sharing with the other scripts.** These scripts are run by path
+(`uv run --no-project --with packaging python tools/src/sn_tools/<script>.py`), which puts
+`tools/src/sn_tools` on `sys.path` and NOT `tools/src` -- so `import sn_tools` fails, as
+AGENTS.md says. The guard below adds `tools/src` in exactly that case, so this module can
+take the member discovery, the runtime-edge rule, the release-tag parser and
+`previous_tag` from `release_plan.py`, and the module-location and `__version__`-literal
+readers from `check_workspace.py`, rather than growing a second copy of each that would
+drift from the fences they belong to. `tools/tests/conftest.py` already imports these
+modules the same way; the guard is what makes the by-path invocation agree with it.
+`propagate_floors.py` is deliberately NOT imported: it is run as a subprocess with
+`sys.executable`, so its argv contract stays the one the recipe documents and its `tomlkit`
+dependency stays out of this module's import graph.
+
+Run at the workspace root (or pass `--root`). Needs `packaging`, and `uv` and `git` on
+`PATH`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+import tomllib
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+if __package__ in (None, ""):  # run by path: `sys.path[0]` is this directory
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from sn_tools import check_workspace, release_plan
+
+# Both distributions live in this repository, so one compare URL serves both; the tags in
+# it are not both prefixed, which is why `previous_tag` is asked rather than assumed (a
+# sphinx-needs release before the monorepo move is a bare `8.5.0` tag)
+COMPARE = "https://github.com/useblocks/sphinx-needs/compare/{previous}...{new}"
+
+# The one workflow carrying a version literal, and the only member it names. It is a git
+# REF, not a version: the Dockerfile installs `git+...@$NEEDS_VERSION`, so the value is the
+# prefixed tag. `check_workspace.py` does not fence this one (it reads manifests and module
+# source, not workflows), which is exactly why forgetting it is invisible until a docker
+# run on a branch with no tag of its own tries to check out a ref that does not exist
+DOCKER_WORKFLOW = ".github/workflows/docker.yaml"
+DOCKER_DIST = "sphinx-needs"
+
+# `NEEDS_VERSION: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || '8.5.0' }}`
+# -- the literal after `||` is the fallback for a run with no tag, and it is the only part
+# a release moves
+DOCKER_LITERAL = re.compile(
+    r"(?m)^(?P<head>\s*NEEDS_VERSION:.*\|\|\s*')(?P<literal>[^']*)(?P<tail>'.*)$"
+)
+
+# `__version__ = "8.5.0"`, with or without an annotation, in either quote
+MODULE_LITERAL = re.compile(
+    r"""(?m)^(?P<head>__version__\s*(?::[^=\n]+)?=\s*)(?P<quote>["'])(?P<value>[^"']*)(?P=quote)"""
+)
+
+RELEASE_LABEL = re.compile(r"^\.\. _`release:(?P<version>[^`]+)`:\s*$")
+RELEASED = re.compile(r"^:Released:\s*(?P<value>\S.*?)\s*$")
+FULL_CHANGELOG = ":Full Changelog:"
+# `03.09.2026` (sphinx-needs) as against `2026-08-27` (sphinx-mounts). Both conventions are
+# in this repository today and a release must not change the one the file it stamps uses
+DAY_FIRST = re.compile(r"^\d{2}\.\d{2}\.\d{4}$")
+UNRELEASED = "Unreleased"
+
+
+class BumpError(RuntimeError):
+    """A condition that must stop the bump rather than be guessed at."""
+
+
+class Runner:
+    """The one seam this module reaches `uv`, `git` and `propagate_floors.py` through.
+
+    One class rather than direct `subprocess` calls so the orchestration -- which command
+    runs, with what arguments, in what order -- is testable without a uv, a git or a
+    network anywhere near it. Every call runs at the workspace root.
+    """
+
+    def __init__(self, root: Path) -> None:
+        self.root = root
+
+    def run(self, command: list[str], *, quiet: bool = False) -> str:
+        if not quiet:
+            print("$", " ".join(command))
+        proc = subprocess.run(
+            command, cwd=self.root, text=True, capture_output=True, check=False
+        )
+        if proc.stdout and not quiet:
+            print(proc.stdout, end="")
+        if proc.returncode != 0:
+            print(proc.stderr, end="", file=sys.stderr)
+            raise BumpError(
+                f"`{' '.join(command)}` failed ({proc.returncode}): {proc.stderr.strip()}"
+            )
+        return proc.stdout
+
+
+# --- the pure rewrites: everything below is text in, text out ----------------------------
+
+
+def rewrite_module_literal(text: str, old: str, new: str) -> str:
+    """Move `__version__` in a module's `__init__.py`. Exactly one match, or refuse.
+
+    Keyed on the OLD value, not just on the name: a module that carries two `__version__`
+    assignments, or one whose literal already disagrees with the manifest, is a state this
+    cannot silently pick a winner in -- `check_workspace.py`'s check (5) exists precisely
+    because the two numbers drift.
+    """
+    matches = [m for m in MODULE_LITERAL.finditer(text) if m.group("value") == old]
+    if len(matches) != 1:
+        raise BumpError(
+            f'expected exactly one `__version__ = "{old}"` assignment, found '
+            f"{len(matches)}; fix the module by hand and re-run"
+        )
+    match = matches[0]
+    replacement = f"{match['head']}{match['quote']}{new}{match['quote']}"
+    return text[: match.start()] + replacement + text[match.end() :]
+
+
+def rewrite_docker_literal(text: str, tag: str) -> str:
+    """Move the `NEEDS_VERSION` fallback in docker.yaml. Exactly one match, or refuse.
+
+    `tag` is a git ref (`sphinx-needs-v8.6.0`), not a bare version: the Dockerfile uses the
+    value as a ref, and the prefixed tag is the one `release.yaml` is triggered by -- the
+    bare companion tag it pushes afterwards may not exist yet when the docker workflow
+    starts (#540).
+    """
+    matches = list(DOCKER_LITERAL.finditer(text))
+    if len(matches) != 1:
+        raise BumpError(
+            f"expected exactly one `NEEDS_VERSION: ... || '<literal>'` line in "
+            f"{DOCKER_WORKFLOW}, found {len(matches)}"
+        )
+    match = matches[0]
+    return (
+        text[: match.start()]
+        + match["head"]
+        + tag
+        + match["tail"]
+        + text[match.end() :]
+    )
+
+
+def dependants(projects: dict[str, dict[str, Any]], target: str) -> list[str]:
+    """The members with a runtime (or extra) dependency on `target`.
+
+    `release_plan.edges` is the edge rule `check_workspace.py`'s check (4) and the plan
+    job's check (4) both use -- `[project] dependencies` plus every
+    `[project.optional-dependencies]` list -- so "does this release need floors propagated"
+    is answered by the same reading of the manifests that later fails if it was not.
+    """
+    names = set(projects)
+    return sorted(
+        name
+        for name, project in projects.items()
+        if name != target and target in release_plan.edges(project, names)
+    )
+
+
+def released_line(text: str, when: date) -> str:
+    """`:Released:` in THIS file's own date format.
+
+    sphinx-needs writes `03.09.2026` and sphinx-mounts writes `2026-08-27`. Neither is more
+    correct, and a release is not the moment to unify them -- so the format is read off the
+    newest existing entry (changelogs here are newest-first, so that is the first
+    `:Released:` in the file) and ISO is the answer only when the file has none.
+    """
+    for line in text.splitlines():
+        match = RELEASED.match(line)
+        if match:
+            iso = not DAY_FIRST.match(match["value"])
+            return (
+                f":Released: {when:%Y-%m-%d}" if iso else f":Released: {when:%d.%m.%Y}"
+            )
+    return f":Released: {when:%Y-%m-%d}"
+
+
+def compare_line(previous: str, new: str) -> str:
+    """The `:Full Changelog:` line, in the exact RST shape the file already uses."""
+    return f":Full Changelog: `{previous}...{new} <{COMPARE.format(previous=previous, new=new)}>`__"
+
+
+def newest_entry_has_compare(lines: list[str]) -> bool:
+    """Does the newest existing release entry carry a `:Full Changelog:` line?
+
+    sphinx-needs' entries do and sphinx-mounts' do not, and that is the whole rule: the
+    stamp mirrors the file rather than imposing one convention on both.
+    """
+    start = next(
+        (i for i, line in enumerate(lines) if RELEASE_LABEL.match(line)),
+        None,
+    )
+    if start is None:
+        return False
+    for line in lines[start + 1 :]:
+        if RELEASE_LABEL.match(line):
+            return False
+        if line.startswith(FULL_CHANGELOG):
+            return True
+    return False
+
+
+def changelog_title(lines: list[str]) -> int | None:
+    """The index of the `Changelog` section title, if the file has one."""
+    for index in range(len(lines) - 1):
+        underline = lines[index + 1].strip()
+        if (
+            lines[index].strip() == "Changelog"
+            and underline
+            and set(underline) == {"="}
+        ):
+            return index
+    return None
+
+
+def unreleased_section(
+    lines: list[str], title_at: int | None, label_at: int | None
+) -> int | None:
+    """The index of an `Unreleased` heading sitting above every released entry."""
+    start = 0 if title_at is None else title_at + 2
+    stop = len(lines) - 1 if label_at is None else min(label_at, len(lines) - 1)
+    for index in range(start, stop):
+        underline = lines[index + 1].strip()
+        if lines[index].strip() == UNRELEASED and underline and set(underline) == {"-"}:
+            return index
+    return None
+
+
+def stamp_changelog(
+    text: str,
+    *,
+    version: str,
+    when: date,
+    previous_tag: str,
+    new_tag: str,
+    path: str = "changelog.rst",
+) -> tuple[str, str]:
+    """Stamp one release entry, in the convention the file already follows.
+
+    Two shapes, and which one applies is read off the file rather than configured:
+
+    * an `Unreleased` section above every released entry (sphinx-mounts today) is
+      CONVERTED -- the label goes in above it, the heading becomes the version, the
+      `:Released:` line goes in at the top of its body, and every bullet already written
+      there is kept, because that is the release's changelog;
+    * otherwise a new entry is INSERTED above the newest existing one, with no body at all.
+      The summary paragraph is hand-written; a placeholder here is a thing that ships.
+
+    Returns the new text and a one-line description of what was written, for the caller's
+    step line.
+    """
+    lines = text.splitlines()
+    label_at = next(
+        (i for i, line in enumerate(lines) if RELEASE_LABEL.match(line)), None
+    )
+    title_at = changelog_title(lines)
+    if label_at is None and title_at is None:
+        raise BumpError(
+            f"{path} has neither a `Changelog` title nor a `release:` label, so there is "
+            "no entry shape to mirror; stamp this release by hand"
+        )
+    header = [
+        f".. _`release:{version}`:",
+        "",
+        version,
+        "-" * len(version),
+        "",
+        released_line(text, when),
+    ]
+    if newest_entry_has_compare(lines):
+        if not previous_tag:
+            raise BumpError(
+                f"{path}'s newest entry carries a `{FULL_CHANGELOG}` line, but no release "
+                f"tag below {version} exists in this checkout, so the compare link would "
+                "be broken. Fetch the tags (`git fetch --tags`), or stamp by hand"
+            )
+        header.append(compare_line(previous_tag, new_tag))
+
+    unreleased_at = unreleased_section(lines, title_at, label_at)
+    if unreleased_at is not None:
+        body = lines[unreleased_at + 2 :]
+        # a field list must be separated from what follows it, or docutils reads the next
+        # block as part of the field's body
+        if body and body[0].strip():
+            body = ["", *body]
+        # only THIS section's bullets: `body` runs to the end of the file, and every
+        # released entry below it has bullets of its own
+        section: list[str] = []
+        for line in body:
+            if RELEASE_LABEL.match(line):
+                break
+            section.append(line)
+        kept = sum(1 for line in section if line.startswith("- "))
+        return (
+            "\n".join(lines[:unreleased_at] + header + body) + "\n",
+            f"converted the `{UNRELEASED}` section to {version} "
+            f"({kept} top-level bullet{'' if kept == 1 else 's'} kept)",
+        )
+
+    at = label_at if label_at is not None else title_at + 2  # ty: ignore[unsupported-operator]
+    before = lines[:at]
+    while before and not before[-1].strip():
+        before.pop()  # exactly one blank line before the new label, however many there were
+    after = lines[at:]
+    return (
+        "\n".join(before + [""] + header + ([""] if after else []) + after) + "\n",
+        f"inserted {version} above the newest entry -- the summary paragraph is yours to write",
+    )
+
+
+# --- the run ------------------------------------------------------------------------------
+
+
+def read_version(manifest: Path) -> str:
+    """The `[project] version` a member's manifest declares, right now."""
+    data = tomllib.loads(manifest.read_text(encoding="utf-8"))
+    version = data.get("project", {}).get("version")
+    if not isinstance(version, str):
+        raise BumpError(f"{manifest} declares no static [project] version")
+    return version
+
+
+def preview_version(output: str) -> str:
+    """The new version out of `uv version --dry-run`'s `<name> <old> => <new>` line."""
+    for line in reversed(output.splitlines()):
+        _, arrow, new = line.strip().rpartition("=>")
+        if arrow and new.strip():
+            return new.strip()
+    raise BumpError(
+        f"could not read a new version out of `uv version`'s output: {output!r}"
+    )
+
+
+def bump(args: argparse.Namespace, runner: Runner) -> int:
+    root: Path = args.root
+    dry = args.dry_run
+
+    # --- 1. preconditions ----------------------------------------------------------------
+    workspace = release_plan.members(root)
+    dist = release_plan.canonicalize_name(args.dist)
+    if dist not in workspace.projects:
+        raise BumpError(
+            f"`{args.dist}` is not a member of this workspace (members: "
+            f"{', '.join(sorted(workspace.projects))})"
+        )
+    if dist in workspace.virtual:
+        raise BumpError(
+            f"`{args.dist}` is a virtual member (`[tool.uv] package = false`): this "
+            "repository never releases it, and the plan job refuses its tag, so there is "
+            "no version to bump"
+        )
+    directory = workspace.directories[dist]
+    manifest = directory / "pyproject.toml"
+    old_version = read_version(manifest)
+    member = check_workspace.Member(
+        root, manifest, tomllib.loads(manifest.read_text(encoding="utf-8"))
+    )
+    literal = check_workspace.module_version(member)
+    changelog = directory / "docs" / "changelog.rst"
+    if not changelog.is_file():
+        raise BumpError(f"no changelog at {changelog.relative_to(root)}")
+    needs_docker = dist == DOCKER_DIST and (root / DOCKER_WORKFLOW).is_file()
+    downstream = dependants(workspace.projects, dist)
+
+    writes = [manifest, changelog]
+    if literal is not None:
+        writes.append(literal[0])
+    if needs_docker:
+        writes.append(root / DOCKER_WORKFLOW)
+    writes += [workspace.directories[name] / "pyproject.toml" for name in downstream]
+    guarded = sorted(path.relative_to(root).as_posix() for path in writes)
+    status = runner.run(
+        ["git", "status", "--porcelain", "--", *guarded], quiet=True
+    ).splitlines()
+    if any(line.strip() for line in status):
+        raise BumpError(
+            "these files are not clean, and this run would overwrite them -- commit or "
+            "revert them first (the rest of the tree may be dirty):\n  "
+            + "\n  ".join(line for line in status if line.strip())
+        )
+    # `uv.lock` is written but NOT guarded, and the difference is what "overwrite" means.
+    # Every file above carries text somebody typed, so a dirty one is work this run would
+    # destroy. The lock carries none: `uv lock` derives it from the manifests, so a dirty
+    # lock is work this run REDOES. Guarding it would also make the release sequence the
+    # planner prints impossible -- releasing two members in one pull request means the
+    # second `bump` necessarily meets the lock the first one left dirty.
+    relative = sorted([*guarded, "uv.lock"])
+    print(
+        f"1. {args.dist} {old_version} is a publishable member; its {len(guarded)} "
+        "hand-written files are clean (uv.lock is regenerated, not guarded)"
+    )
+
+    # --- 2. the manifest version, written by uv and read back ----------------------------
+    value = ["--bump", args.bump] if args.bump else [args.to]
+    printed = runner.run(
+        [
+            "uv",
+            "version",
+            "--package",
+            dist,
+            *value,
+            "--no-sync",
+            *(["--dry-run"] if dry else []),
+        ]
+    )
+    # read back rather than computed: `uv version` owns the bump semantics, and a second
+    # implementation of them here is a second thing to be wrong. A dry run writes no
+    # manifest to read back from, so its own `<name> <old> => <new>` line is the preview
+    version = preview_version(printed) if dry else read_version(manifest)
+    tag = f"{dist}-v{version}"
+    print(
+        f'2. {"would set" if dry else "set"} version = "{version}" in {manifest.relative_to(root)}'
+    )
+
+    # --- 3. the `__version__` literal ----------------------------------------------------
+    if literal is None:
+        print(
+            f"3. no `__version__` literal under {directory.relative_to(root)}/src/"
+            f"{member.module}/ -- nothing to rewrite"
+        )
+    else:
+        module_path, module_value = literal
+        text = rewrite_module_literal(
+            module_path.read_text(encoding="utf-8"), module_value, version
+        )
+        if not dry:
+            module_path.write_text(text, encoding="utf-8")
+        print(
+            f'3. {"would write" if dry else "wrote"} __version__ = "{version}" in '
+            f"{module_path.relative_to(root)}"
+        )
+
+    # --- 4. the docker workflow's NEEDS_VERSION fallback ---------------------------------
+    if not needs_docker:
+        print(f"4. no version literal in a workflow for {args.dist} -- skipped")
+    else:
+        workflow = root / DOCKER_WORKFLOW
+        text = rewrite_docker_literal(workflow.read_text(encoding="utf-8"), tag)
+        if not dry:
+            workflow.write_text(text, encoding="utf-8")
+        print(
+            f"4. {'would write' if dry else 'wrote'} NEEDS_VERSION fallback `{tag}` in {DOCKER_WORKFLOW}"
+        )
+
+    # --- 5. the dependants' floors -------------------------------------------------------
+    if not downstream:
+        print(
+            f"5. no dependants: no member declares {args.dist} at runtime -- propagate_floors skipped"
+        )
+    elif dry:
+        print(
+            f"5. would run propagate_floors.py {args.dist} for {', '.join(downstream)}"
+        )
+    else:
+        runner.run(
+            [
+                sys.executable,
+                str(Path(__file__).resolve().with_name("propagate_floors.py")),
+                args.dist,
+                "--root",
+                str(root),
+            ]
+        )
+        print(
+            f"5. propagated the {args.dist} {version} floor to {', '.join(downstream)}"
+        )
+
+    # --- 6. the lock ---------------------------------------------------------------------
+    # NOT `--frozen`: `--no-sync` above left uv.lock claiming the old version, and the
+    # `uv-lock` prek hook would fail the release pull request for a reason that has nothing
+    # to do with the release
+    if dry:
+        print(
+            "6. would run `uv lock` (not --frozen: the lock still claims the old version)"
+        )
+    else:
+        runner.run(["uv", "lock"])
+        print("6. relocked uv.lock")
+
+    # --- 7. the changelog ----------------------------------------------------------------
+    # through the runner like every other git call, so the whole orchestration is one seam
+    tags = [
+        line.strip()
+        for line in runner.run(["git", "tag", "--list"], quiet=True).splitlines()
+        if line.strip()
+    ]
+    previous = release_plan.previous_tag(dist, version, tags)
+    text, what = stamp_changelog(
+        changelog.read_text(encoding="utf-8"),
+        version=version,
+        when=args.date,
+        previous_tag=previous,
+        new_tag=tag,
+        path=changelog.relative_to(root).as_posix(),
+    )
+    if not dry:
+        changelog.write_text(text, encoding="utf-8")
+    print(
+        f"7. {'would stamp' if dry else 'stamped'} {changelog.relative_to(root)}: {what}"
+    )
+
+    # --- 8. what was written, and what is left ------------------------------------------
+    print()
+    print(f"{'would write' if dry else 'wrote'}:")
+    for path in relative:
+        print(f"  {path}")
+    print()
+    print('by hand, from AGENTS.md "Releasing a package":')
+    print(
+        f"  1. write the summary paragraph under the new {version} heading in {changelog.relative_to(root)}"
+    )
+    print("  2. uv run poe lint")
+    if dist == DOCKER_DIST:
+        print("  3. uv run poe smoke-needs")
+        print("  4. merge the release pull request, then from master:")
+        print(f"  5. git tag {tag} && git push origin {tag}")
+    else:
+        print("  3. merge the release pull request, then from master:")
+        print(f"  4. git tag {tag} && git push origin {tag}")
+    return 0
+
+
+def main(argv: list[str] | None = None, runner: Runner | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Stamp a release of one workspace member into the tree.",
+    )
+    parser.add_argument("dist", help="the member being released, e.g. sphinx-needs")
+    level = parser.add_mutually_exclusive_group(required=True)
+    level.add_argument(
+        "--bump",
+        choices=["patch", "minor", "major"],
+        help="how far to move the version",
+    )
+    level.add_argument("--to", metavar="X.Y.Z", help="the exact version to release")
+    parser.add_argument(
+        "--date",
+        type=date.fromisoformat,
+        default=date.today(),
+        metavar="YYYY-MM-DD",
+        help="the release date (default: today); written in the changelog's own format",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="print every step with the values it would write, and write nothing",
+    )
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path.cwd(),
+        help="the workspace root (default: the working directory)",
+    )
+    args = parser.parse_args(argv)
+    try:
+        return bump(args, runner or Runner(args.root))
+    except (BumpError, release_plan.PlanError) as exc:
+        print(f"::error::{exc}")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/src/sn_tools/bump.py
+++ b/tools/src/sn_tools/bump.py
@@ -304,9 +304,13 @@ def is_heading(lines: list[str], index: int, title: str) -> bool:
     section adorned with `=` was left standing above a new, empty release entry, keeping
     the bullets that were meant to be that release's changelog, and nothing was raised.
     """
-    if index + 1 >= len(lines) or lines[index].strip() != title:
+    # at COLUMN 0, both lines: docutils does not allow an indented section heading, so an
+    # `Unreleased` / `----------` pair sitting inside a `::` literal block (a changelog that
+    # documents its own stamping, say) is text, not a heading -- and converting it would
+    # orphan the block's marker and turn its indented body into the release's
+    if index + 1 >= len(lines) or lines[index].rstrip() != title:
         return False
-    adornment = lines[index + 1].strip()
+    adornment = lines[index + 1].rstrip()
     return (
         len(adornment) >= len(title)
         and len(set(adornment)) == 1
@@ -460,16 +464,26 @@ def preview_version(output: str) -> str:
 def bump(args: argparse.Namespace, runner: Runner) -> int:
     """Compute everything, refuse if anything is wrong, and only then write.
 
-    The two phases are the whole design. Every refusal this module can raise -- a drifted
-    `__version__`, a `NEEDS_VERSION` line that is not there, a changelog with no shape to
-    mirror, a `:Released:` format it cannot read, a missing previous tag for a compare
-    link, a version that does not move -- is reachable only from data, so all of them can
-    fire before a byte is written. They used to fire in file order instead, which meant the
-    changelog's refusal arrived with four files and the lock already rewritten: the exact
-    half-done state no gate in this repository can see (see the RETRACTION at the top of
-    this module). Two `uv version` calls is what that costs -- a `--dry-run` for the
-    preflight and the real one in the apply phase -- and `--no-sync` makes each of them a
-    manifest read and a manifest write, so the cost is nothing.
+    The two phases are the whole design. Every refusal that can be DECIDED FROM THE TREE --
+    a drifted `__version__`, a `NEEDS_VERSION` line that is not there, a changelog with no
+    shape to mirror, a `:Released:` format it cannot read, a missing previous tag for a
+    compare link, a version that does not move -- is computed in the first phase, so all of
+    them fire before a byte is written. They used to fire in file order instead, which meant
+    the changelog's refusal arrived with four files and the lock already rewritten: the
+    exact half-done state no gate in this repository can see (see the RETRACTION at the top
+    of this module).
+
+    That claim is deliberately narrower than "every refusal": ONE refusal is raised after a
+    write, the read-back guard in step 2 below, and it cannot be otherwise -- it compares
+    what `uv version` previewed with what `uv version` wrote. It is defensive (measured
+    unreachable on uv 0.12.9, see its comment) and it reports the recovery line like any
+    other apply-phase failure.
+
+    The cost is two `uv version` calls. `--no-sync` does NOT mean "do not touch the lock":
+    uv's own help reads "avoid syncing the virtual environment AFTER RE-LOCKING the
+    project", and `--frozen` is the flag that skips the re-lock. So each call is a manifest
+    read, a manifest write and a resolve of the whole workspace -- measured 31-420 ms warm,
+    cheap, but not the "nothing" an earlier version of this docstring claimed.
 
     What is still not atomic: the apply phase runs `propagate_floors.py` and `uv lock`, and
     a crash or a `KeyboardInterrupt` anywhere in it leaves part of the tree written. That
@@ -540,9 +554,14 @@ def bump(args: argparse.Namespace, runner: Runner) -> int:
     value = ["--bump", args.bump] if args.bump else [args.to]
     # `--dry-run` prints `<name> <old> => <new>` and writes no manifest, so this is the
     # version the real call in the apply phase will produce, obtained without producing it
+    # `quiet=True`: this call and the real one in step 2 print the SAME
+    # `<name> <old> => <new>` line, and two identical lines separated only by a `--dry-run`
+    # suffix on the echoed command read like the work happening twice. The preflight line
+    # below says what this call was for; step 2's echo is the receipt for the real write
     version = preview_version(
         runner.run(
-            ["uv", "version", "--package", dist, *value, "--no-sync", "--dry-run"]
+            ["uv", "version", "--package", dist, *value, "--no-sync", "--dry-run"],
+            quiet=True,
         )
     )
     tag = f"{dist}-v{version}"
@@ -606,8 +625,8 @@ def bump(args: argparse.Namespace, runner: Runner) -> int:
         path=changelog_path,
     )
     print(
-        f"   preflight: {old_version} -> {version}; every rewrite computed, "
-        f"{'nothing will be written (--dry-run)' if dry else 'nothing written yet'}"
+        f"   preflight (`uv version --dry-run`): {old_version} -> {version}; every rewrite "
+        f"computed, {'nothing will be written (--dry-run)' if dry else 'nothing written yet'}"
     )
 
     # === APPLY ============================================================================
@@ -617,8 +636,22 @@ def bump(args: argparse.Namespace, runner: Runner) -> int:
         if not dry:
             runner.run(["uv", "version", "--package", dist, *value, "--no-sync"])
             written.append(manifest.relative_to(root).as_posix())
+            # `uv.lock` is written HERE, not at step 6. `--no-sync` re-locks -- uv's help
+            # says "avoid syncing the virtual environment after re-locking the project" --
+            # so the lock carries the new version the moment this call returns. Recording
+            # it only after step 6 meant a failure at step 3, 4 or 5 printed a recovery
+            # line that restored the manifests and left the lock claiming the new version:
+            # a tree the `uv-lock` prek hook then fails, which is the "red for a reason
+            # that has nothing to do with the release" this module opens by promising to
+            # prevent. Measured, with the module made read-only so step 3 failed for real
+            written.append("uv.lock")
             # read back rather than trusted: `uv version` owns the bump semantics, and the
-            # preview above is only a preview until the manifest agrees with it
+            # preview above is only a preview until the manifest agrees with it.
+            # DEFENSIVE ONLY: measured unreachable on uv 0.12.9, where `--dry-run` and the
+            # real call go through the same normalisation -- `8.6`, `8.6.0.0`, `08.6.0`,
+            # `8.6.0-rc1`, `8.6.0RC1` and `  8.6.0` all preview exactly what they write. It
+            # is also the one refusal in this function that fires after a write, which is
+            # why it says so here rather than pretending otherwise
             got = read_version(manifest)
             if got != version:
                 raise BumpError(
@@ -692,18 +725,22 @@ def bump(args: argparse.Namespace, runner: Runner) -> int:
             ]
 
         # --- 6. the lock ------------------------------------------------------------------
-        # NOT `--frozen`: `--no-sync` above left uv.lock claiming the old version, and the
-        # `uv-lock` prek hook would fail the release pull request for a reason that has
-        # nothing to do with the release
+        # NOT for the version: step 2's `uv version --no-sync` already re-locked that. This
+        # is for the FLOORS step 5 may have moved -- `propagate_floors.py` edits dependants'
+        # manifests with tomlkit and nothing re-resolves after it, which is exactly why its
+        # own last line says "now run `uv lock`". With no dependants it is a no-op re-lock,
+        # kept because "sometimes needed, always harmless" is a better rule for a release
+        # recipe than one the reader has to evaluate. `--frozen` is still the wrong flag
+        # here, for its own reason: it skips the re-lock altogether
         if dry:
             print(
-                "6. would run `uv lock` (not --frozen: the lock still claims the old "
-                "version)"
+                "6. would run `uv lock` (for the floors step 5 may have moved; step 2's "
+                "`uv version --no-sync` already re-locked the version)"
             )
         else:
             runner.run(["uv", "lock"])
             written.append("uv.lock")
-            print("6. relocked uv.lock")
+            print("6. relocked uv.lock (the version was already locked by step 2)")
 
         # --- 7. the changelog -------------------------------------------------------------
         if not dry:
@@ -713,14 +750,22 @@ def bump(args: argparse.Namespace, runner: Runner) -> int:
     except BaseException:
         # a crash, a Ctrl-C or a failing subprocess is the one way a half-done tree is
         # still reachable; the least this can do is name it and how to undo it
-        if written:
+        # `dict.fromkeys` rather than `sorted(set(...))`: `uv.lock` is appended twice on a
+        # run that reaches step 6, and the reader should see each path once, in the order it
+        # was written. One over-claim is deliberate: the dependants' manifests are recorded
+        # after `propagate_floors.py` returns 0, and that script writes nothing when every
+        # floor is already correct -- so a name here may be a file that did not change.
+        # `git checkout --` on an unchanged file is a no-op, and parsing the subprocess's
+        # output to find out would be more code than the risk
+        undo = list(dict.fromkeys(written))
+        if undo:
             print()
             print(
                 "this run had already written "
-                + ", ".join(sorted(written))
+                + ", ".join(undo)
                 + " when it failed. To undo them:"
             )
-            print(f"  git checkout -- {' '.join(sorted(written))}")
+            print(f"  git checkout -- {' '.join(undo)}")
         raise
 
     # --- 8. what was written, and what is left --------------------------------------------
@@ -779,6 +824,13 @@ def main(argv: list[str] | None = None, runner: Runner | None = None) -> int:
     try:
         return bump(args, runner or Runner(args.root))
     except (BumpError, release_plan.PlanError) as exc:
+        print(f"::error::{exc}")
+        return 1
+    except OSError as exc:
+        # a read-only file, a full disk, no `uv` on PATH. These used to leave a traceback
+        # printed AFTER the apply phase's recovery block, which buried the one line the
+        # reader needed. The recovery block has already run by the time this catches, so
+        # the advice is the last thing on the terminal
         print(f"::error::{exc}")
         return 1
 

--- a/tools/src/sn_tools/release_plan.py
+++ b/tools/src/sn_tools/release_plan.py
@@ -191,7 +191,17 @@ def order(graph: dict[str, set[str]]) -> list[str]:
 
 
 def on_pypi(name: str, version: str) -> bool:
-    """True if this exact version is published. Any non-404 answer is fatal, not a pass."""
+    """True if this exact version is published. Any non-404 answer is fatal, not a pass.
+
+    `except OSError` rather than `except URLError`, exactly as `published_versions` below:
+    a socket read timeout raises `TimeoutError`, which is an `OSError` and NOT a
+    `URLError` -- `urlopen`'s read phase does not wrap it -- so the narrower clause let a
+    timeout out of THIS function, the one the plan job calls, as a traceback rather than
+    the fail-closed message it is written for. Nothing failed open (the job still exits
+    non-zero), but the reader was shown a stack instead of "cannot reach PyPI". The
+    `HTTPError` branch stays first: `HTTPError` is a `URLError` is an `OSError`, so a 404
+    would otherwise be swallowed by the clause below and reported as an outage.
+    """
     url = PYPI.format(name=name, version=version)
     try:
         with urllib.request.urlopen(url, timeout=30) as response:
@@ -203,9 +213,12 @@ def on_pypi(name: str, version: str) -> bool:
             f"PyPI returned {exc.code} for {url}; refusing to guess whether "
             f"{name} {version} is published"
         ) from exc
-    except urllib.error.URLError as exc:
+    except OSError as exc:  # URLError, and a read TimeoutError, which is not one
+        # `.reason` where there is one, so a URLError still reads `[Errno 61] Connection
+        # refused` rather than the `<urlopen error ...>` wrapper -- which is the shape
+        # `published_versions` prints two functions away, and the two should not drift
         raise PlanError(
-            f"cannot reach PyPI ({exc.reason}); refusing to guess whether "
+            f"cannot reach PyPI ({getattr(exc, 'reason', exc)}); refusing to guess whether "
             f"{name} {version} is published"
         ) from exc
 

--- a/tools/tests/test_bump.py
+++ b/tools/tests/test_bump.py
@@ -1,0 +1,580 @@
+"""`bump.py`: the rewrites, the changelog's two conventions, and the order of the run.
+
+Every rewrite is a pure function -- text in, text out -- so the assertions here need no
+`uv`, no `git` and no network, which is what makes them cheap enough to be run. The steps
+that DO shell out go through one `Runner`, and the fake below records the commands in
+order: what this file asserts about the orchestration is the sequence, because the order is
+the part of the recipe that matters (`--no-sync` before `uv lock`, the floors before the
+lock, nothing at all before the cleanliness check).
+
+The changelog is tested in BOTH conventions this repository actually has, because the whole
+design of `stamp_changelog` is that it mirrors the file rather than imposing one shape:
+sphinx-needs' entries carry a `:Full Changelog:` line and a `DD.MM.YYYY` date and there is
+no `Unreleased` section; sphinx-mounts' carry neither the link nor that date format, and an
+`Unreleased` section is what a release converts.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pytest
+from sn_tools import bump
+
+pytestmark = pytest.mark.filterwarnings("error")
+
+
+NEEDS_STYLE = """\
+.. _ubcode: https://ubcode.useblocks.com/
+.. _changelog:
+
+Changelog
+=========
+
+.. _`release:8.5.0`:
+
+8.5.0
+-----
+
+:Released: 03.09.2026
+:Full Changelog: `v8.4.0...v8.5.0 <https://github.com/useblocks/sphinx-needs/compare/8.4.0...8.5.0>`__
+
+This release is about charts.
+
+Improvements
+............
+
+- something (:pr:`1831`)
+
+.. _`release:8.4.0`:
+
+8.4.0
+-----
+
+:Released: 27.08.2026
+"""
+
+MOUNTS_STYLE = """\
+.. _changelog:
+
+Changelog
+=========
+
+Unreleased
+----------
+
+- **Python 3.11 is supported again**: the floor moves down from 3.12 to 3.11.
+
+- **A second bullet**, so that dropping one is visible.
+
+.. _`release:0.2.0`:
+
+0.2.0
+-----
+
+:Released: 2026-08-27
+
+- the previous release.
+"""
+
+WHEN = date(2026, 9, 6)
+
+
+class FakeRunner:
+    """Records the commands in order and answers the ones whose output is read."""
+
+    def __init__(self, answers: dict[str, str] | None = None) -> None:
+        self.calls: list[list[str]] = []
+        self.answers = answers or {}
+
+    def run(self, command: list[str], *, quiet: bool = False) -> str:
+        self.calls.append(command)
+        joined = " ".join(command)
+        for key, value in self.answers.items():
+            if key in joined:
+                return value
+        return ""
+
+
+def writing_runner(manifest: Path, old: str, new: str) -> FakeRunner:
+    """A fake `uv version` that writes the manifest the way the real one does.
+
+    Which is the point: `bump` READS the new version back out of the manifest rather than
+    computing it, so a fake that only records the call would let the run carry on with the
+    old number and every later assertion would be about the wrong version.
+    """
+
+    class Writing(FakeRunner):
+        def run(self, command: list[str], *, quiet: bool = False) -> str:
+            if command[:2] == ["uv", "version"]:
+                manifest.write_text(
+                    manifest.read_text(encoding="utf-8").replace(
+                        f'version = "{old}"', f'version = "{new}"'
+                    ),
+                    encoding="utf-8",
+                )
+            return super().run(command, quiet=quiet)
+
+    return Writing()
+
+
+# --- the `__version__` literal -------------------------------------------------------------
+
+
+def test_the_module_literal_moves() -> None:
+    text = '"""A module."""\n\n__version__ = "8.5.0"\n\nX = 1\n'
+    assert bump.rewrite_module_literal(text, "8.5.0", "8.6.0") == (
+        '"""A module."""\n\n__version__ = "8.6.0"\n\nX = 1\n'
+    )
+
+
+def test_an_annotated_literal_in_single_quotes_moves_too() -> None:
+    text = "__version__: str = '0.2.0'\n"
+    assert bump.rewrite_module_literal(text, "0.2.0", "0.3.0") == (
+        "__version__: str = '0.3.0'\n"
+    )
+
+
+def test_nothing_else_that_mentions_the_version_is_touched() -> None:
+    """The match is anchored to the assignment, not to the number: a docstring or a
+    fallback carrying the same string must not move with it."""
+    text = (
+        '"""Version 8.5.0 of the thing."""\n\n__version__ = "8.5.0"\nOTHER = "8.5.0"\n'
+    )
+    got = bump.rewrite_module_literal(text, "8.5.0", "8.6.0")
+    assert (
+        got
+        == '"""Version 8.5.0 of the thing."""\n\n__version__ = "8.6.0"\nOTHER = "8.5.0"\n'
+    )
+
+
+@pytest.mark.parametrize(
+    ("text", "count"),
+    [
+        ('__version__ = "9.9.9"\n', 0),
+        ('__version__ = "8.5.0"\nif True:\n    pass\n__version__ = "8.5.0"\n', 2),
+    ],
+)
+def test_anything_but_exactly_one_literal_is_refused(text: str, count: int) -> None:
+    """A module whose literal already disagrees with the manifest, or that carries two, is
+    a state no rewrite may pick a winner in."""
+    with pytest.raises(bump.BumpError) as caught:
+        bump.rewrite_module_literal(text, "8.5.0", "8.6.0")
+    assert f"found {count}" in str(caught.value)
+
+
+# --- the docker workflow's NEEDS_VERSION fallback --------------------------------------------
+
+DOCKER = """\
+env:
+  # a comment mentioning 8.5.0
+  NEEDS_VERSION: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || '8.5.0' }}
+  DEPLOY_IMAGE: ${{ github.event_name != 'pull_request' }}
+"""
+
+
+def test_the_docker_fallback_becomes_the_prefixed_tag() -> None:
+    """It is a git REF, not a version: the Dockerfile checks it out. AGENTS.md step 2 says
+    `sphinx-needs-v<version>`, and a bare version would be a ref that resolves to the tag
+    of a tree in which `packages/sphinx-needs` does not exist."""
+    got = bump.rewrite_docker_literal(DOCKER, "sphinx-needs-v8.6.0")
+    assert "|| 'sphinx-needs-v8.6.0' }}" in got
+    assert "# a comment mentioning 8.5.0" in got  # only the literal moves
+    assert "DEPLOY_IMAGE" in got
+
+
+def test_no_needs_version_line_is_refused() -> None:
+    with pytest.raises(bump.BumpError) as caught:
+        bump.rewrite_docker_literal("env:\n  OTHER: 1\n", "sphinx-needs-v8.6.0")
+    assert "found 0" in str(caught.value)
+
+
+# --- dependant detection ----------------------------------------------------------------
+
+
+def test_dependants_are_found_through_both_dependency_tables() -> None:
+    """check (4)'s edge rule: `dependencies` AND every `optional-dependencies` list."""
+    projects = {
+        "acme-core": {"name": "acme-core", "dependencies": []},
+        "acme-plugin": {"name": "acme-plugin", "dependencies": ["acme-core>=1,<2"]},
+        "acme-extra": {
+            "name": "acme-extra",
+            "dependencies": ["sphinx"],
+            "optional-dependencies": {"all": ["acme-core>=1,<2"]},
+        },
+        "acme-other": {"name": "acme-other", "dependencies": ["sphinx"]},
+    }
+    assert bump.dependants(projects, "acme-core") == ["acme-extra", "acme-plugin"]
+    assert bump.dependants(projects, "acme-other") == []
+
+
+# --- the changelog, in sphinx-needs' convention -------------------------------------------
+
+
+def test_a_needs_style_entry_is_inserted_with_the_files_date_format() -> None:
+    got, what = bump.stamp_changelog(
+        NEEDS_STYLE,
+        version="8.6.0",
+        when=WHEN,
+        previous_tag="8.5.0",
+        new_tag="sphinx-needs-v8.6.0",
+    )
+    head = got.splitlines()[:14]
+    assert head == [
+        ".. _ubcode: https://ubcode.useblocks.com/",
+        ".. _changelog:",
+        "",
+        "Changelog",
+        "=========",
+        "",
+        ".. _`release:8.6.0`:",
+        "",
+        "8.6.0",
+        "-----",
+        "",
+        ":Released: 06.09.2026",
+        ":Full Changelog: `8.5.0...sphinx-needs-v8.6.0 <https://github.com/useblocks/sphinx-needs/compare/8.5.0...sphinx-needs-v8.6.0>`__",
+        "",
+    ]
+    # the file's own format, DD.MM.YYYY -- not ISO
+    assert ":Released: 2026-09-06" not in got
+    # nothing is invented under the heading, and the old entry is untouched
+    assert ".. _`release:8.5.0`:" in got
+    assert "This release is about charts." in got
+    assert "TODO" not in got
+    assert "summary paragraph is yours to write" in what
+
+
+def test_the_bare_previous_tag_is_used_verbatim_in_both_halves_of_the_link() -> None:
+    """sphinx-needs' releases before the monorepo move are bare tags and the new one is
+    prefixed, so the compare link legitimately mixes the two namespaces. Rendering either
+    half from the version instead would produce a 404."""
+    got, _ = bump.stamp_changelog(
+        NEEDS_STYLE,
+        version="8.6.0",
+        when=WHEN,
+        previous_tag="8.5.0",
+        new_tag="sphinx-needs-v8.6.0",
+    )
+    line = next(
+        line for line in got.splitlines() if line.startswith(":Full Changelog:")
+    )
+    assert line.count("8.5.0...sphinx-needs-v8.6.0") == 2  # the text and the URL
+    assert line.endswith("`__")
+
+
+def test_a_missing_previous_tag_refuses_rather_than_link_to_nothing() -> None:
+    with pytest.raises(bump.BumpError) as caught:
+        bump.stamp_changelog(
+            NEEDS_STYLE,
+            version="8.6.0",
+            when=WHEN,
+            previous_tag="",
+            new_tag="sphinx-needs-v8.6.0",
+            path="docs/changelog.rst",
+        )
+    assert "docs/changelog.rst" in str(caught.value)
+    assert "git fetch --tags" in str(caught.value)
+
+
+# --- the changelog, in sphinx-mounts' convention ------------------------------------------
+
+
+def test_a_mounts_style_unreleased_section_is_converted_keeping_every_bullet() -> None:
+    got, what = bump.stamp_changelog(
+        MOUNTS_STYLE,
+        version="0.3.0",
+        when=WHEN,
+        previous_tag="sphinx-mounts-v0.2.0",
+        new_tag="sphinx-mounts-v0.3.0",
+    )
+    head = got.splitlines()[:11]
+    assert head == [
+        ".. _changelog:",
+        "",
+        "Changelog",
+        "=========",
+        "",
+        ".. _`release:0.3.0`:",
+        "",
+        "0.3.0",
+        "-----",
+        "",
+        ":Released: 2026-09-06",
+    ]
+    assert "Unreleased" not in got
+    # every bullet the section carried IS the release's changelog
+    assert "**Python 3.11 is supported again**" in got
+    assert "**A second bullet**" in got
+    assert "2 top-level bullets kept" in what
+
+
+def test_a_mounts_style_entry_gets_no_compare_line() -> None:
+    """The rule is the file's own: emit the link iff the newest existing entry has one.
+    sphinx-mounts' entries do not, and a release must not start a convention."""
+    got, _ = bump.stamp_changelog(
+        MOUNTS_STYLE,
+        version="0.3.0",
+        when=WHEN,
+        previous_tag="sphinx-mounts-v0.2.0",
+        new_tag="sphinx-mounts-v0.3.0",
+    )
+    assert ":Full Changelog:" not in got
+
+
+def test_the_iso_date_format_is_read_off_the_file_not_assumed() -> None:
+    for text, expected in (
+        (NEEDS_STYLE, ":Released: 06.09.2026"),
+        (MOUNTS_STYLE, ":Released: 2026-09-06"),
+    ):
+        assert bump.released_line(text, WHEN) == expected
+    # a file with no `:Released:` at all falls back to ISO
+    assert bump.released_line("Changelog\n=========\n", WHEN) == ":Released: 2026-09-06"
+
+
+def test_a_file_with_no_title_and_no_label_is_refused_by_name() -> None:
+    with pytest.raises(bump.BumpError) as caught:
+        bump.stamp_changelog(
+            "Some notes\n==========\n",
+            version="1.0.0",
+            when=WHEN,
+            previous_tag="",
+            new_tag="acme-v1.0.0",
+            path="packages/acme/docs/changelog.rst",
+        )
+    assert "packages/acme/docs/changelog.rst" in str(caught.value)
+
+
+def test_an_empty_changelog_gets_its_first_entry_under_the_title() -> None:
+    got, _ = bump.stamp_changelog(
+        ".. _changelog:\n\nChangelog\n=========\n",
+        version="1.0.0",
+        when=WHEN,
+        previous_tag="",
+        new_tag="acme-v1.0.0",
+    )
+    assert got == (
+        ".. _changelog:\n\nChangelog\n=========\n\n"
+        ".. _`release:1.0.0`:\n\n1.0.0\n-----\n\n:Released: 2026-09-06\n"
+    )
+
+
+# --- the run: preconditions and the order of the commands ----------------------------------
+
+
+@pytest.fixture
+def tree(workspace, tmp_path: Path):
+    """A scratch workspace with a member that has a changelog, as the real ones do."""
+
+    def build(**kwargs):
+        root = workspace(
+            {
+                "acme-core": {"version": "1.2.3", "module_version": "1.2.3"},
+                "acme-plugin": {
+                    "version": "0.1.0",
+                    "module_version": "0.1.0",
+                    "dependencies": ["acme-core>=1.2.3,<2"],
+                },
+            },
+            **kwargs,
+        )
+        for name, text in (("acme-core", MOUNTS_STYLE), ("acme-plugin", MOUNTS_STYLE)):
+            docs = root / "packages" / name / "docs"
+            docs.mkdir(parents=True, exist_ok=True)
+            (docs / "changelog.rst").write_text(text, encoding="utf-8")
+        return root
+
+    return build
+
+
+def run(root: Path, *argv: str, runner=None) -> tuple[int, FakeRunner]:
+    fake = runner or FakeRunner()
+    return bump.main([*argv, "--root", str(root)], runner=fake), fake  # ty: ignore[invalid-argument-type]
+
+
+def test_an_unknown_distribution_is_refused(tree, capsys) -> None:
+    code, fake = run(tree(), "acme-nope", "--bump", "patch")
+    assert code == 1
+    assert "is not a member of this workspace" in capsys.readouterr().out
+    # refused BEFORE anything ran
+    assert fake.calls == []
+
+
+def test_a_virtual_member_is_refused(tree, capsys) -> None:
+    root = tree()
+    manifest = root / "packages" / "acme-plugin" / "pyproject.toml"
+    manifest.write_text(
+        manifest.read_text(encoding="utf-8") + "\n[tool.uv]\npackage = false\n",
+        encoding="utf-8",
+    )
+    code, fake = run(root, "acme-plugin", "--bump", "patch")
+    assert code == 1
+    out = capsys.readouterr().out
+    assert "virtual member" in out and "no version to bump" in out
+    assert fake.calls == []
+
+
+def test_a_dirty_target_file_is_refused_and_named(tree, capsys) -> None:
+    root = tree()
+    fake = FakeRunner({"git status": " M packages/acme-core/pyproject.toml\n"})
+    code, _ = run(root, "acme-core", "--bump", "minor", runner=fake)
+    assert code == 1
+    out = capsys.readouterr().out
+    assert "not clean" in out
+    assert "M packages/acme-core/pyproject.toml" in out
+    # the cleanliness check is the ONLY thing that ran
+    assert [call[:2] for call in fake.calls] == [["git", "status"]]
+
+
+def test_a_dirty_lock_does_not_block_the_run(tree) -> None:
+    """The lock is written but not guarded: `uv lock` derives it from the manifests, so a
+    dirty one is work this run redoes rather than destroys -- and guarding it would make
+    the planner's own sequence impossible, since releasing two members in one pull request
+    means the second bump always meets the lock the first left dirty. The pathspec the
+    check is asked with is what encodes that."""
+    fake = FakeRunner()
+    code, _ = run(
+        tree(), "acme-plugin", "--to", "0.2.0", "--date", "2026-09-06", runner=fake
+    )
+    assert code == 0
+    assert "uv.lock" not in fake.calls[0]
+    assert "packages/acme-plugin/pyproject.toml" in fake.calls[0]
+
+
+def test_the_dry_run_writes_nothing_and_locks_nothing(tree, capsys) -> None:
+    root = tree()
+    before = {path: path.read_bytes() for path in root.rglob("*") if path.is_file()}
+    fake = FakeRunner({"uv version": "acme-core 1.2.3 => 1.3.0\n"})
+    code, _ = run(root, "acme-core", "--bump", "minor", "--dry-run", runner=fake)
+    assert code == 0
+    assert {
+        path: path.read_bytes() for path in root.rglob("*") if path.is_file()
+    } == before
+    # `uv lock` and `propagate_floors.py` do not run at all in a dry run; the two git
+    # reads and `uv version --dry-run` do, because a preview that guessed at the new
+    # version or the previous tag would not be a preview of this run
+    assert [call[:2] for call in fake.calls] == [
+        ["git", "status"],
+        ["uv", "version"],
+        ["git", "tag"],
+    ]
+    assert fake.calls[1][-1] == "--dry-run"
+    out = capsys.readouterr().out
+    assert 'would set version = "1.3.0"' in out
+    assert "would run `uv lock`" in out
+
+
+def test_the_commands_run_in_the_recipes_order(tree, capsys) -> None:
+    """`uv version --no-sync` (which leaves the lock stale), then the dependants' floors,
+    then `uv lock` -- and the cleanliness check before any of them."""
+    root = tree()
+    fake = FakeRunner()
+    code, _ = run(
+        root, "acme-core", "--bump", "minor", "--date", "2026-09-06", runner=fake
+    )
+    assert code == 0
+    assert [call[:2] for call in fake.calls] == [
+        ["git", "status"],
+        ["uv", "version"],
+        [fake.calls[2][0], fake.calls[2][1]],  # <interpreter> propagate_floors.py
+        ["uv", "lock"],
+        ["git", "tag"],
+    ]
+    assert fake.calls[1] == [
+        "uv",
+        "version",
+        "--package",
+        "acme-core",
+        "--bump",
+        "minor",
+        "--no-sync",
+    ]
+    assert fake.calls[2][1].endswith("propagate_floors.py")
+    assert fake.calls[2][2] == "acme-core"
+
+
+def test_a_real_run_writes_all_four_files(tree, capsys) -> None:
+    root = tree()
+    manifest = root / "packages" / "acme-core" / "pyproject.toml"
+    code, _ = run(
+        root,
+        "acme-core",
+        "--bump",
+        "minor",
+        "--date",
+        "2026-09-06",
+        runner=writing_runner(manifest, "1.2.3", "1.3.0"),
+    )
+    assert code == 0
+    module = root / "packages" / "acme-core" / "src" / "acme_core" / "__init__.py"
+    assert '__version__ = "1.3.0"' in module.read_text(encoding="utf-8")
+    changelog = (root / "packages" / "acme-core" / "docs" / "changelog.rst").read_text(
+        encoding="utf-8"
+    )
+    assert ".. _`release:1.3.0`:" in changelog
+    assert ":Released: 2026-09-06" in changelog
+    out = capsys.readouterr().out
+    assert (
+        "acme-plugin" in out
+    )  # the dependant was named, and the floors were propagated
+    assert "git tag acme-core-v1.3.0 && git push origin acme-core-v1.3.0" in out
+
+
+def test_the_docker_workflow_is_rewritten_only_for_sphinx_needs(
+    workspace, tmp_path: Path, capsys
+) -> None:
+    """The step is gated on the distribution name, and what it writes is the PREFIXED tag.
+
+    The pure rewrite is asserted above; this asserts the caller hands it a git ref rather
+    than a bare version -- the mistake the unit test cannot see, and the one whose symptom
+    is a docker build on an untagged branch checking out a ref that does not exist.
+    """
+    root = workspace(
+        {"sphinx-needs": {"version": "8.5.0", "module_version": "8.5.0"}},
+        directories={"sphinx-needs": "packages/sphinx-needs"},
+    )
+    docs = root / "packages" / "sphinx-needs" / "docs"
+    docs.mkdir(parents=True)
+    (docs / "changelog.rst").write_text(MOUNTS_STYLE, encoding="utf-8")
+    workflow = root / ".github" / "workflows" / "docker.yaml"
+    workflow.parent.mkdir(parents=True)
+    workflow.write_text(DOCKER, encoding="utf-8")
+
+    code, _ = run(
+        root,
+        "sphinx-needs",
+        "--to",
+        "8.6.0",
+        "--date",
+        "2026-09-06",
+        runner=writing_runner(
+            root / "packages" / "sphinx-needs" / "pyproject.toml", "8.5.0", "8.6.0"
+        ),
+    )
+    assert code == 0
+    written = workflow.read_text(encoding="utf-8")
+    assert "|| 'sphinx-needs-v8.6.0' }}" in written
+    assert "|| '8.6.0' }}" not in written
+    out = capsys.readouterr().out
+    assert "NEEDS_VERSION fallback `sphinx-needs-v8.6.0`" in out
+    # and the smoke test is in the hand steps for this member, as AGENTS.md says
+    assert "uv run poe smoke-needs" in out
+
+
+def test_a_member_with_no_dependants_skips_propagate_floors(tree, capsys) -> None:
+    fake = FakeRunner()
+    code, _ = run(
+        tree(), "acme-plugin", "--to", "0.2.0", "--date", "2026-09-06", runner=fake
+    )
+    assert code == 0
+    assert not any("propagate_floors" in " ".join(call) for call in fake.calls)
+    assert "no dependants" in capsys.readouterr().out
+    assert fake.calls[1] == [
+        "uv",
+        "version",
+        "--package",
+        "acme-plugin",
+        "0.2.0",
+        "--no-sync",
+    ]

--- a/tools/tests/test_bump.py
+++ b/tools/tests/test_bump.py
@@ -175,9 +175,9 @@ env:
 
 
 def test_the_docker_fallback_becomes_the_prefixed_tag() -> None:
-    """It is a git REF, not a version: the Dockerfile checks it out. AGENTS.md step 2 says
-    `sphinx-needs-v<version>`, and a bare version would be a ref that resolves to the tag
-    of a tree in which `packages/sphinx-needs` does not exist."""
+    """It is a git REF, not a version: the Dockerfile checks it out. AGENTS.md's release
+    recipe says `sphinx-needs-v<version>`, and a bare version would be a ref that resolves
+    to the tag of a tree in which `packages/sphinx-needs` does not exist."""
     got = bump.rewrite_docker_literal(DOCKER, "sphinx-needs-v8.6.0")
     assert "|| 'sphinx-needs-v8.6.0' }}" in got
     assert "# a comment mentioning 8.5.0" in got  # only the literal moves

--- a/tools/tests/test_bump.py
+++ b/tools/tests/test_bump.py
@@ -97,26 +97,35 @@ class FakeRunner:
         return ""
 
 
-def writing_runner(manifest: Path, old: str, new: str) -> FakeRunner:
-    """A fake `uv version` that writes the manifest the way the real one does.
+def uv_runner(
+    manifest: Path, old: str, new: str, name: str = "acme-core", tags: str = ""
+) -> FakeRunner:
+    """A fake `uv version` with both halves `bump` depends on, plus a fake tag list.
 
-    Which is the point: `bump` READS the new version back out of the manifest rather than
-    computing it, so a fake that only records the call would let the run carry on with the
-    old number and every later assertion would be about the wrong version.
+    `bump` PREVIEWS the new version with `uv version --dry-run` in its compute phase and
+    READS IT BACK from the manifest after the real call, and it refuses if the two
+    disagree. So the fake has to answer the preview with uv's own
+    `<name> <old> => <new>` line AND move the manifest on the real call; a fake that did
+    only one of those would make every integration test below about the wrong version.
     """
 
-    class Writing(FakeRunner):
+    class Uv(FakeRunner):
         def run(self, command: list[str], *, quiet: bool = False) -> str:
+            recorded = super().run(command, quiet=quiet)
             if command[:2] == ["uv", "version"]:
+                if "--dry-run" in command:
+                    return f"{name} {old} => {new}\n"
                 manifest.write_text(
                     manifest.read_text(encoding="utf-8").replace(
                         f'version = "{old}"', f'version = "{new}"'
                     ),
                     encoding="utf-8",
                 )
-            return super().run(command, quiet=quiet)
+            elif command[:2] == ["git", "tag"]:
+                return tags
+            return recorded
 
-    return Writing()
+    return Uv()
 
 
 # --- the `__version__` literal -------------------------------------------------------------
@@ -152,16 +161,36 @@ def test_nothing_else_that_mentions_the_version_is_touched() -> None:
 @pytest.mark.parametrize(
     ("text", "count"),
     [
-        ('__version__ = "9.9.9"\n', 0),
         ('__version__ = "8.5.0"\nif True:\n    pass\n__version__ = "8.5.0"\n', 2),
+        # two DIFFERING assignments: the readers -- this one and
+        # `check_workspace.module_version` -- both take the first, while Python leaves the
+        # second in `__version__` at import time and stamps it into `needs.json`. Counting
+        # every assignment rather than the matching ones is what refuses it
+        ('__version__ = "8.5.0"\n__version__ = "2.0"\n', 2),
+        ("X = 1\n", 0),
     ],
 )
-def test_anything_but_exactly_one_literal_is_refused(text: str, count: int) -> None:
-    """A module whose literal already disagrees with the manifest, or that carries two, is
-    a state no rewrite may pick a winner in."""
+def test_anything_but_exactly_one_assignment_is_refused(text: str, count: int) -> None:
     with pytest.raises(bump.BumpError) as caught:
-        bump.rewrite_module_literal(text, "8.5.0", "8.6.0")
+        bump.rewrite_module_literal(text, "8.5.0", "8.6.0", "src/m/__init__.py")
     assert f"found {count}" in str(caught.value)
+    assert "src/m/__init__.py" in str(caught.value)
+
+
+def test_a_literal_that_disagrees_with_the_manifest_is_refused_naming_both() -> None:
+    """The defect this closes: the rewrite used to be keyed on the literal's OWN value, so
+    `old` matched by construction and a drifted literal was silently overwritten -- healing
+    the one drift `check-workspace` was shouting about, without anyone seeing which of the
+    two numbers won."""
+    with pytest.raises(bump.BumpError) as caught:
+        bump.rewrite_module_literal(
+            '__version__ = "8.4.9"\n', "8.5.0", "8.6.0", "src/m/__init__.py"
+        )
+    message = str(caught.value)
+    assert '`__version__` is "8.4.9"' in message
+    assert 'the manifest declares "8.5.0"' in message
+    assert "src/m/__init__.py" in message
+    assert "will not guess" in message
 
 
 # --- the docker workflow's NEEDS_VERSION fallback --------------------------------------------
@@ -333,6 +362,114 @@ def test_the_iso_date_format_is_read_off_the_file_not_assumed() -> None:
     assert bump.released_line("Changelog\n=========\n", WHEN) == ":Released: 2026-09-06"
 
 
+def test_the_prefixed_previous_tag_keeps_its_prefix_in_both_halves() -> None:
+    """The mirror of the bare case above, and the one that is not sphinx-needs.
+
+    `previous_tag` returns a PREFIXED tag for every member whose releases postdate the
+    monorepo move. Rendering either half from the version instead would not merely 404 in
+    this repository -- the bare tag namespace here is sphinx-needs' own pre-move history
+    (`0.3.5`, `0.5.0`, `0.7.9`, ...), so a future `sphinx-mounts-v0.5.0` stripped to
+    `0.5.0` would resolve to a sphinx-needs tag from 2020 and render a plausible, entirely
+    wrong diff.
+    """
+    needs_style_mounts = MOUNTS_STYLE.replace(
+        ":Released: 2026-08-27",
+        ":Released: 2026-08-27\n:Full Changelog: `sphinx-mounts-v0.1.4...sphinx-mounts-v0.2.0"
+        " <https://github.com/useblocks/sphinx-needs/compare/sphinx-mounts-v0.1.4...sphinx-mounts-v0.2.0>`__",
+    )
+    got, _ = bump.stamp_changelog(
+        needs_style_mounts,
+        version="0.3.0",
+        when=WHEN,
+        previous_tag="sphinx-mounts-v0.2.0",
+        new_tag="sphinx-mounts-v0.3.0",
+    )
+    line = next(
+        line for line in got.splitlines() if line.startswith(":Full Changelog:")
+    )
+    assert line.count("sphinx-mounts-v0.2.0...sphinx-mounts-v0.3.0") == 2
+    assert (
+        "compare/0.2.0..." not in line
+    )  # the prefix survives in the URL, not just the text
+
+
+def test_an_unreleased_heading_below_the_first_label_takes_the_insert_branch() -> None:
+    """The `above every released entry` bound, made load-bearing.
+
+    Without it, an `Unreleased` heading left by mistake inside an older entry's body is
+    converted -- which puts the NEW release below the older one, breaking newest-first
+    ordering and silently annexing that entry's body.
+    """
+    text = (
+        ".. _changelog:\n\nChangelog\n=========\n\n"
+        ".. _`release:1.0.0`:\n\n1.0.0\n-----\n\n:Released: 2026-08-27\n\n"
+        "Unreleased\n----------\n\n- a stray heading someone left in 1.0.0's body\n"
+    )
+    got, what = bump.stamp_changelog(
+        text, version="1.1.0", when=WHEN, previous_tag="", new_tag="acme-v1.1.0"
+    )
+    assert "inserted 1.1.0 above the newest entry" in what
+    lines = got.splitlines()
+    assert lines.index(".. _`release:1.1.0`:") < lines.index(".. _`release:1.0.0`:")
+    assert "Unreleased" in got  # left exactly where it was, for a human to deal with
+
+
+@pytest.mark.parametrize("adornment", ["==========", "~~~~~~~~~~", "----------"])
+def test_an_unreleased_section_is_found_under_any_rst_adornment(adornment: str) -> None:
+    """RST fixes no adornment character -- a document's first-used one becomes its top
+    level -- so `-` was a convention of the two files here, not a rule. Matching it alone
+    left an `Unreleased` section standing above a new, empty entry, keeping the bullets
+    that were meant to be that release's changelog, and raised nothing."""
+    text = MOUNTS_STYLE.replace("Unreleased\n----------", f"Unreleased\n{adornment}")
+    got, what = bump.stamp_changelog(
+        text,
+        version="0.3.0",
+        when=WHEN,
+        previous_tag="sphinx-mounts-v0.2.0",
+        new_tag="sphinx-mounts-v0.3.0",
+    )
+    assert (
+        what == "converted the `Unreleased` section to 0.3.0 (2 top-level bullets kept)"
+    )
+    assert "Unreleased" not in got
+    assert "**Python 3.11 is supported again**" in got
+
+
+def test_the_changelog_title_is_found_under_any_rst_adornment() -> None:
+    """The same rule, asked of the other heading: the two used to hard-code DIFFERENT
+    characters in one module, which is the drift that produced the bug above."""
+    text = ".. _changelog:\n\nChangelog\n#########\n"
+    got, _ = bump.stamp_changelog(
+        text, version="1.0.0", when=WHEN, previous_tag="", new_tag="acme-v1.0.0"
+    )
+    assert got.endswith(
+        ".. _`release:1.0.0`:\n\n1.0.0\n-----\n\n:Released: 2026-09-06\n"
+    )
+
+
+@pytest.mark.parametrize("value", ["3.9.2026", "27.8.2026", "03.09.2026"])
+def test_an_unpadded_day_first_date_is_still_day_first(value: str) -> None:
+    """`^\\d{2}\\.` refused a hand-stamped `3.9.2026`, so ONE such line would have flipped
+    the file to ISO for that release and every one after it."""
+    assert bump.released_line(f":Released: {value}\n", WHEN) == ":Released: 06.09.2026"
+
+
+@pytest.mark.parametrize("value", ["3 Sep 2026", "2026/08/27", "September 3, 2026"])
+def test_an_unrecognised_released_format_refuses_rather_than_silently_going_iso(
+    value: str,
+) -> None:
+    """ "ISO when the file has none" and "ISO when the file has one I cannot classify" are
+    different rules, and only the first is a documented convention."""
+    with pytest.raises(bump.BumpError) as caught:
+        bump.released_line(
+            f":Released: {value}\n", WHEN, "packages/acme/docs/changelog.rst"
+        )
+    message = str(caught.value)
+    assert value in message
+    assert "packages/acme/docs/changelog.rst" in message
+    assert "neither DD.MM.YYYY nor YYYY-MM-DD" in message
+
+
 def test_a_file_with_no_title_and_no_label_is_refused_by_name() -> None:
     with pytest.raises(bump.BumpError) as caught:
         bump.stamp_changelog(
@@ -427,25 +564,44 @@ def test_a_dirty_target_file_is_refused_and_named(tree, capsys) -> None:
     assert [call[:2] for call in fake.calls] == [["git", "status"]]
 
 
-def test_a_dirty_lock_does_not_block_the_run(tree) -> None:
-    """The lock is written but not guarded: `uv lock` derives it from the manifests, so a
-    dirty one is work this run redoes rather than destroys -- and guarding it would make
-    the planner's own sequence impossible, since releasing two members in one pull request
-    means the second bump always meets the lock the first left dirty. The pathspec the
-    check is asked with is what encodes that."""
-    fake = FakeRunner()
+def test_the_cleanliness_pathspec_is_every_guarded_file_and_not_the_lock(tree) -> None:
+    """The WHOLE pathspec, not two members of it.
+
+    Asserting only "uv.lock is absent" and "one manifest is present" left the fence able to
+    drop the module literal, the changelog, the docker workflow or a dependant's manifest
+    and stay green -- and the step-1 line would still count them, because the count comes
+    from the guarded list and the check from the pathspec. This is a release of the member
+    that HAS a dependant, so all five hand-written files are in it.
+
+    `uv.lock` is written but deliberately not guarded: `uv lock` derives it from the
+    manifests, so a dirty one is work this run redoes rather than destroys -- and guarding
+    it would make the planner's own sequence impossible, since releasing two members in one
+    pull request means the second bump always meets the lock the first left dirty.
+    """
+    root = tree()
+    fake = uv_runner(
+        root / "packages" / "acme-core" / "pyproject.toml", "1.2.3", "1.3.0"
+    )
     code, _ = run(
-        tree(), "acme-plugin", "--to", "0.2.0", "--date", "2026-09-06", runner=fake
+        root, "acme-core", "--bump", "minor", "--date", "2026-09-06", runner=fake
     )
     assert code == 0
+    assert fake.calls[0][:4] == ["git", "status", "--porcelain", "--"]
+    assert fake.calls[0][4:] == [
+        "packages/acme-core/docs/changelog.rst",
+        "packages/acme-core/pyproject.toml",
+        "packages/acme-core/src/acme_core/__init__.py",
+        "packages/acme-plugin/pyproject.toml",
+    ]
     assert "uv.lock" not in fake.calls[0]
-    assert "packages/acme-plugin/pyproject.toml" in fake.calls[0]
 
 
 def test_the_dry_run_writes_nothing_and_locks_nothing(tree, capsys) -> None:
     root = tree()
     before = {path: path.read_bytes() for path in root.rglob("*") if path.is_file()}
-    fake = FakeRunner({"uv version": "acme-core 1.2.3 => 1.3.0\n"})
+    fake = uv_runner(
+        root / "packages" / "acme-core" / "pyproject.toml", "1.2.3", "1.3.0"
+    )
     code, _ = run(root, "acme-core", "--bump", "minor", "--dry-run", runner=fake)
     assert code == 0
     assert {
@@ -466,22 +622,30 @@ def test_the_dry_run_writes_nothing_and_locks_nothing(tree, capsys) -> None:
 
 
 def test_the_commands_run_in_the_recipes_order(tree, capsys) -> None:
-    """`uv version --no-sync` (which leaves the lock stale), then the dependants' floors,
-    then `uv lock` -- and the cleanliness check before any of them."""
+    """Compute, then apply.
+
+    Every read comes first -- the cleanliness check, the `--dry-run` preview of the new
+    version, the tag list -- because the refusals that depend on them must fire while the
+    tree is untouched. Only then the real `uv version --no-sync` (which leaves the lock
+    stale), the dependants' floors, and `uv lock`.
+    """
     root = tree()
-    fake = FakeRunner()
+    fake = uv_runner(
+        root / "packages" / "acme-core" / "pyproject.toml", "1.2.3", "1.3.0"
+    )
     code, _ = run(
         root, "acme-core", "--bump", "minor", "--date", "2026-09-06", runner=fake
     )
     assert code == 0
     assert [call[:2] for call in fake.calls] == [
         ["git", "status"],
-        ["uv", "version"],
-        [fake.calls[2][0], fake.calls[2][1]],  # <interpreter> propagate_floors.py
-        ["uv", "lock"],
+        ["uv", "version"],  # --dry-run: the preview
         ["git", "tag"],
+        ["uv", "version"],  # the real one
+        [fake.calls[4][0], fake.calls[4][1]],  # <interpreter> propagate_floors.py
+        ["uv", "lock"],
     ]
-    assert fake.calls[1] == [
+    preview = [
         "uv",
         "version",
         "--package",
@@ -490,8 +654,10 @@ def test_the_commands_run_in_the_recipes_order(tree, capsys) -> None:
         "minor",
         "--no-sync",
     ]
-    assert fake.calls[2][1].endswith("propagate_floors.py")
-    assert fake.calls[2][2] == "acme-core"
+    assert fake.calls[1] == [*preview, "--dry-run"]
+    assert fake.calls[3] == preview
+    assert fake.calls[4][1].endswith("propagate_floors.py")
+    assert fake.calls[4][2] == "acme-core"
 
 
 def test_a_real_run_writes_all_four_files(tree, capsys) -> None:
@@ -504,7 +670,7 @@ def test_a_real_run_writes_all_four_files(tree, capsys) -> None:
         "minor",
         "--date",
         "2026-09-06",
-        runner=writing_runner(manifest, "1.2.3", "1.3.0"),
+        runner=uv_runner(manifest, "1.2.3", "1.3.0"),
     )
     assert code == 0
     module = root / "packages" / "acme-core" / "src" / "acme_core" / "__init__.py"
@@ -548,8 +714,11 @@ def test_the_docker_workflow_is_rewritten_only_for_sphinx_needs(
         "8.6.0",
         "--date",
         "2026-09-06",
-        runner=writing_runner(
-            root / "packages" / "sphinx-needs" / "pyproject.toml", "8.5.0", "8.6.0"
+        runner=uv_runner(
+            root / "packages" / "sphinx-needs" / "pyproject.toml",
+            "8.5.0",
+            "8.6.0",
+            name="sphinx-needs",
         ),
     )
     assert code == 0
@@ -562,10 +731,162 @@ def test_the_docker_workflow_is_rewritten_only_for_sphinx_needs(
     assert "uv run poe smoke-needs" in out
 
 
-def test_a_member_with_no_dependants_skips_propagate_floors(tree, capsys) -> None:
-    fake = FakeRunner()
+def snapshot(root: Path) -> dict[Path, bytes]:
+    return {path: path.read_bytes() for path in root.rglob("*") if path.is_file()}
+
+
+def test_a_refusal_from_the_last_step_leaves_the_tree_untouched(tree, capsys) -> None:
+    """The HIGH finding this closes.
+
+    A changelog whose newest entry carries a `:Full Changelog:` line, and a checkout with
+    no tag below the new version, is a legitimate refusal from what used to be step 7. It
+    used to arrive with the manifest, the module literal, the docker fallback and the lock
+    already rewritten -- and that tree is green under `poe lint`, `check-workspace` AND the
+    plan job, because nothing in this repository fences a missing changelog entry. It also
+    blocked its own re-run, because bump's cleanliness precondition then saw bump's own
+    leftovers.
+
+    Now every rewrite is computed before any of them is written, so the refusal happens
+    with the tree untouched: no file changed, and no `uv version` without `--dry-run`, no
+    `propagate_floors.py`, no `uv lock` ever ran.
+    """
+    root = tree()
+    with_compare = MOUNTS_STYLE.replace(
+        ":Released: 2026-08-27", ":Released: 2026-08-27\n:Full Changelog: `a...b <u>`__"
+    )
+    (root / "packages" / "acme-core" / "docs" / "changelog.rst").write_text(
+        with_compare, encoding="utf-8"
+    )
+    before = snapshot(root)
+    fake = uv_runner(
+        root / "packages" / "acme-core" / "pyproject.toml", "1.2.3", "1.3.0", tags=""
+    )
     code, _ = run(
-        tree(), "acme-plugin", "--to", "0.2.0", "--date", "2026-09-06", runner=fake
+        root, "acme-core", "--bump", "minor", "--date", "2026-09-06", runner=fake
+    )
+    assert code == 1
+    assert (
+        "no release tag below 1.3.0 exists in this checkout" in capsys.readouterr().out
+    )
+    assert snapshot(root) == before
+    assert [call[:2] for call in fake.calls] == [
+        ["git", "status"],
+        ["uv", "version"],
+        ["git", "tag"],
+    ]
+    assert fake.calls[1][-1] == "--dry-run"  # the only `uv version` was the preview
+
+
+def test_a_drifted_module_literal_refuses_before_anything_is_written(
+    tree, capsys
+) -> None:
+    """A3 and A1 together: the drift refusal is one of the ones that used to fire with the
+    manifest already moved."""
+    root = tree()
+    module = root / "packages" / "acme-core" / "src" / "acme_core" / "__init__.py"
+    module.write_text('"""scratch."""\n\n__version__ = "1.2.2"\n', encoding="utf-8")
+    before = snapshot(root)
+    fake = uv_runner(
+        root / "packages" / "acme-core" / "pyproject.toml", "1.2.3", "1.3.0"
+    )
+    code, _ = run(
+        root, "acme-core", "--bump", "minor", "--date", "2026-09-06", runner=fake
+    )
+    assert code == 1
+    out = capsys.readouterr().out
+    assert '`__version__` is "1.2.2"' in out and 'the manifest declares "1.2.3"' in out
+    assert snapshot(root) == before
+    assert not any(
+        call[:2] == ["uv", "version"] and "--dry-run" not in call for call in fake.calls
+    )
+
+
+@pytest.mark.parametrize("target", ["1.0.0", "1.2.3"])
+def test_a_version_that_does_not_move_up_is_refused(tree, capsys, target: str) -> None:
+    """A downgrade (a typo) and a re-release of the current version. Neither is a release,
+    and neither was refused: the plan job's check 2 compares the tag to the manifest, and
+    after a downgrade they agree."""
+    root = tree()
+    before = snapshot(root)
+    fake = uv_runner(
+        root / "packages" / "acme-core" / "pyproject.toml", "1.2.3", target
+    )
+    code, _ = run(
+        root, "acme-core", "--to", target, "--date", "2026-09-06", runner=fake
+    )
+    assert code == 1
+    out = capsys.readouterr().out
+    assert f"acme-core 1.2.3 -> {target} is not a release" in out
+    assert "a version never moves down" in out
+    assert snapshot(root) == before
+
+
+def test_a_version_the_changelog_already_carries_is_refused(tree, capsys) -> None:
+    """A re-stamp produces two identical RST targets, which `poe docs-needs` fails on with
+    a docutils warning that says nothing about a release -- minutes later."""
+    root = tree()
+    before = snapshot(root)
+    # the mounts-shaped scratch changelog already carries `release:0.2.0`
+    fake = uv_runner(
+        root / "packages" / "acme-plugin" / "pyproject.toml",
+        "0.1.0",
+        "0.2.0",
+        name="acme-plugin",
+    )
+    code, _ = run(
+        root, "acme-plugin", "--to", "0.2.0", "--date", "2026-09-06", runner=fake
+    )
+    assert code == 1
+    out = capsys.readouterr().out
+    assert (
+        "packages/acme-plugin/docs/changelog.rst already carries a `release:0.2.0` label"
+        in out
+    )
+    assert snapshot(root) == before
+
+
+def test_the_previous_tag_comes_from_git_and_keeps_its_prefix(tree, capsys) -> None:
+    """End to end for B3: the tag list is read from git, `previous_tag` picks the release
+    below the new one out of it, and the prefix reaches the compare link."""
+    root = tree()
+    with_compare = MOUNTS_STYLE.replace(
+        ":Released: 2026-08-27",
+        ":Released: 2026-08-27\n:Full Changelog: `acme-core-v1.1.0...acme-core-v1.2.3"
+        " <https://github.com/useblocks/sphinx-needs/compare/acme-core-v1.1.0...acme-core-v1.2.3>`__",
+    )
+    changelog = root / "packages" / "acme-core" / "docs" / "changelog.rst"
+    changelog.write_text(with_compare, encoding="utf-8")
+    fake = uv_runner(
+        root / "packages" / "acme-core" / "pyproject.toml",
+        "1.2.3",
+        "1.3.0",
+        tags="acme-core-v1.1.0\nacme-core-v1.2.3\nacme-plugin-v0.1.0\nnot-a-tag\n",
+    )
+    code, _ = run(
+        root, "acme-core", "--bump", "minor", "--date", "2026-09-06", runner=fake
+    )
+    assert code == 0
+    line = next(
+        line
+        for line in changelog.read_text(encoding="utf-8").splitlines()
+        if line.startswith(":Full Changelog:")
+    )
+    assert line.count("acme-core-v1.2.3...acme-core-v1.3.0") == 2
+    assert "compare/1.2.3..." not in line
+
+
+def test_a_member_with_no_dependants_skips_propagate_floors(tree, capsys) -> None:
+    root = tree()
+    # 0.3.0, not 0.2.0: the scratch changelog is the mounts shape, which already carries a
+    # `release:0.2.0` label, and the precondition below refuses a duplicate
+    fake = uv_runner(
+        root / "packages" / "acme-plugin" / "pyproject.toml",
+        "0.1.0",
+        "0.3.0",
+        name="acme-plugin",
+    )
+    code, _ = run(
+        root, "acme-plugin", "--to", "0.3.0", "--date", "2026-09-06", runner=fake
     )
     assert code == 0
     assert not any("propagate_floors" in " ".join(call) for call in fake.calls)
@@ -575,6 +896,7 @@ def test_a_member_with_no_dependants_skips_propagate_floors(tree, capsys) -> Non
         "version",
         "--package",
         "acme-plugin",
-        "0.2.0",
+        "0.3.0",
         "--no-sync",
+        "--dry-run",
     ]

--- a/tools/tests/test_bump.py
+++ b/tools/tests/test_bump.py
@@ -447,6 +447,44 @@ def test_the_changelog_title_is_found_under_any_rst_adornment() -> None:
     )
 
 
+@pytest.mark.parametrize(
+    ("adornment", "found"),
+    [
+        ("----------", True),  # exactly as long as the title
+        ("--------------", True),  # longer is fine
+        ("---", False),  # SHORTER is a transition, not an adornment
+        ("-", False),
+    ],
+)
+def test_an_adornment_shorter_than_the_title_is_not_a_heading(
+    adornment: str, found: bool
+) -> None:
+    """The length rule is what tells a heading from a `---` transition. Without it,
+    `Unreleased` above a three-dash transition converts, and the transition becomes the new
+    release's underline."""
+    lines = ["Unreleased", adornment, "", "- a bullet"]
+    assert bump.is_heading(lines, 0, "Unreleased") is found
+
+
+def test_an_indented_unreleased_inside_a_literal_block_is_not_a_heading() -> None:
+    """docutils does not allow an indented section heading either. A changelog that
+    documents its own stamping in a `::` literal block would otherwise have that block
+    converted: its marker orphaned, its indented body annexed as the release's."""
+    text = (
+        ".. _changelog:\n\nChangelog\n=========\n\n"
+        "How this file is stamped, for the record::\n\n"
+        "    Unreleased\n    ----------\n\n    - your bullets go here\n\n"
+        ".. _`release:0.2.0`:\n\n0.2.0\n-----\n\n:Released: 2026-08-27\n"
+    )
+    got, what = bump.stamp_changelog(
+        text, version="0.3.0", when=WHEN, previous_tag="", new_tag="acme-v0.3.0"
+    )
+    assert "inserted 0.3.0 above the newest entry" in what
+    assert "    Unreleased\n    ----------" in got  # left exactly as written
+    lines = got.splitlines()
+    assert lines.index(".. _`release:0.3.0`:") < lines.index(".. _`release:0.2.0`:")
+
+
 @pytest.mark.parametrize("value", ["3.9.2026", "27.8.2026", "03.09.2026"])
 def test_an_unpadded_day_first_date_is_still_day_first(value: str) -> None:
     """`^\\d{2}\\.` refused a hand-stamped `3.9.2026`, so ONE such line would have flipped
@@ -873,6 +911,187 @@ def test_the_previous_tag_comes_from_git_and_keeps_its_prefix(tree, capsys) -> N
     )
     assert line.count("acme-core-v1.2.3...acme-core-v1.3.0") == 2
     assert "compare/1.2.3..." not in line
+
+
+def exploding(
+    manifest: Path, old: str, new: str, on: list[str], what: BaseException, **kwargs
+) -> FakeRunner:
+    """`uv_runner`'s two behaviours, plus a raise once the named command has run.
+
+    The only way to exercise the apply phase's recovery block: the failures it exists for
+    -- a subprocess exiting non-zero, a Ctrl-C, an OS error -- cannot be produced by a
+    scratch workspace on its own. The raise happens AFTER the command is recorded and its
+    side effect applied, which is what the real `Runner` does too (it raises on a non-zero
+    exit, by which time the subprocess has already done whatever it did).
+    """
+
+    class Boom(type(uv_runner(manifest, old, new, **kwargs))):
+        def run(self, command: list[str], *, quiet: bool = False) -> str:
+            out = super().run(command, quiet=quiet)
+            if command[: len(on)] == on:
+                raise what
+            return out
+
+    return Boom()
+
+
+def test_the_recovery_block_names_the_lock_that_step_2_wrote(tree, capsys) -> None:
+    """`uv version --no-sync` RE-LOCKS -- uv's help says "avoid syncing the virtual
+    environment after re-locking the project" -- so `uv.lock` is written at step 2, not at
+    step 6. Recording it only after step 6 meant a failure in between printed a recovery
+    line that restored the manifests and left the lock claiming the new version: a tree the
+    `uv-lock` hook then fails, measured with a real runner.
+
+    So the failure here is at `uv lock` itself, which is the latest point at which the old
+    bookkeeping was still wrong: everything before it is written, the changelog is not.
+    """
+    root = tree()
+    manifest = root / "packages" / "acme-core" / "pyproject.toml"
+    code, _ = run(
+        root,
+        "acme-core",
+        "--bump",
+        "minor",
+        "--date",
+        "2026-09-06",
+        runner=exploding(
+            manifest,
+            "1.2.3",
+            "1.3.0",
+            ["uv", "lock"],
+            bump.BumpError("`uv lock` failed (1): boom"),
+        ),
+    )
+    assert code == 1
+    out = capsys.readouterr().out
+    listed = out.split("this run had already written ")[1].split(" when it failed")[0]
+    assert listed.split(", ") == [
+        "packages/acme-core/pyproject.toml",
+        "uv.lock",
+        "packages/acme-core/src/acme_core/__init__.py",
+        "packages/acme-plugin/pyproject.toml",
+    ]
+    # the changelog is step 7 and had not run; `uv.lock` appears once, not twice
+    assert "docs/changelog.rst" not in listed
+    assert listed.count("uv.lock") == 1
+    assert (
+        "git checkout -- packages/acme-core/pyproject.toml uv.lock "
+        "packages/acme-core/src/acme_core/__init__.py "
+        "packages/acme-plugin/pyproject.toml" in out
+    )
+
+
+def test_a_keyboard_interrupt_prints_the_recovery_block_and_re_raises(tree) -> None:
+    """`except BaseException`, not `except BumpError`. A Ctrl-C mid-apply is one of the two
+    ways a half-done tree is still reachable, and it must not become a tidy exit 1 either:
+    the block prints and the interrupt goes on being an interrupt."""
+    root = tree()
+    manifest = root / "packages" / "acme-core" / "pyproject.toml"
+    runner = exploding(manifest, "1.2.3", "1.3.0", ["uv", "lock"], KeyboardInterrupt())
+    with pytest.raises(KeyboardInterrupt):
+        bump.main(
+            [
+                "acme-core",
+                "--bump",
+                "minor",
+                "--date",
+                "2026-09-06",
+                "--root",
+                str(root),
+            ],
+            runner=runner,  # ty: ignore[invalid-argument-type]
+        )
+
+
+def test_an_os_error_is_reported_after_the_recovery_block(tree, capsys) -> None:
+    """A read-only file or a missing `uv` used to leave a traceback printed after the
+    recovery block, burying the one line the reader needed."""
+    root = tree()
+    manifest = root / "packages" / "acme-core" / "pyproject.toml"
+    code, _ = run(
+        root,
+        "acme-core",
+        "--bump",
+        "minor",
+        "--date",
+        "2026-09-06",
+        runner=exploding(
+            manifest,
+            "1.2.3",
+            "1.3.0",
+            ["uv", "lock"],
+            OSError("[Errno 13] Permission denied"),
+        ),
+    )
+    assert code == 1
+    out = capsys.readouterr().out
+    assert out.index("this run had already written") < out.index("::error::")
+    assert "::error::[Errno 13] Permission denied" in out
+
+
+def test_a_release_candidates_label_does_not_block_its_own_final_release(
+    tree, capsys
+) -> None:
+    """The duplicate-label guard compares the label's version for EQUALITY. Containment
+    would make a `release:1.3.0rc1` entry block `1.3.0` -- a release candidate rendering its
+    own final release unstampable."""
+    root = tree()
+    changelog = root / "packages" / "acme-core" / "docs" / "changelog.rst"
+    changelog.write_text(
+        MOUNTS_STYLE.replace("release:0.2.0", "release:1.3.0rc1").replace(
+            "0.2.0\n-----", "1.3.0rc1\n--------"
+        ),
+        encoding="utf-8",
+    )
+    code, _ = run(
+        root,
+        "acme-core",
+        "--to",
+        "1.3.0",
+        "--date",
+        "2026-09-06",
+        runner=uv_runner(
+            root / "packages" / "acme-core" / "pyproject.toml", "1.2.3", "1.3.0"
+        ),
+    )
+    assert code == 0
+    assert ".. _`release:1.3.0`:" in changelog.read_text(encoding="utf-8")
+
+
+def test_a_uv_that_writes_a_version_other_than_it_previewed_is_refused(
+    tree, capsys
+) -> None:
+    """The read-back guard. Defensive -- measured unreachable on uv 0.12.9, where the
+    preview and the write normalise identically -- but a guard nothing exercises is a guard
+    that can rot silently, which is the whole reason it is tested rather than deleted."""
+    root = tree()
+    manifest = root / "packages" / "acme-core" / "pyproject.toml"
+
+    class Lying(FakeRunner):
+        def run(self, command: list[str], *, quiet: bool = False) -> str:
+            super().run(command, quiet=quiet)
+            if command[:2] == ["uv", "version"]:
+                if "--dry-run" in command:
+                    return "acme-core 1.2.3 => 1.3.0\n"
+                manifest.write_text(
+                    manifest.read_text(encoding="utf-8").replace(
+                        'version = "1.2.3"', 'version = "1.3.1"'
+                    ),
+                    encoding="utf-8",
+                )
+            return ""
+
+    code, _ = run(
+        root, "acme-core", "--bump", "minor", "--date", "2026-09-06", runner=Lying()
+    )
+    assert code == 1
+    out = capsys.readouterr().out
+    assert "`uv version` previewed 1.3.0 but wrote 1.3.1" in out
+    assert "refusing to stamp two different numbers" in out
+    # and it reports the recovery line like any other apply-phase failure
+    assert (
+        "this run had already written packages/acme-core/pyproject.toml, uv.lock" in out
+    )
 
 
 def test_a_member_with_no_dependants_skips_propagate_floors(tree, capsys) -> None:

--- a/tools/tests/test_bump.py
+++ b/tools/tests/test_bump.py
@@ -981,10 +981,14 @@ def test_the_recovery_block_names_the_lock_that_step_2_wrote(tree, capsys) -> No
     )
 
 
-def test_a_keyboard_interrupt_prints_the_recovery_block_and_re_raises(tree) -> None:
+def test_a_keyboard_interrupt_prints_the_recovery_block_and_re_raises(
+    tree, capsys
+) -> None:
     """`except BaseException`, not `except BumpError`. A Ctrl-C mid-apply is one of the two
     ways a half-done tree is still reachable, and it must not become a tidy exit 1 either:
-    the block prints and the interrupt goes on being an interrupt."""
+    the block prints and the interrupt goes on being an interrupt. Both halves are asserted:
+    without the first, narrowing the clause to `except Exception` still passes this test
+    (the interrupt propagates untouched) while the recovery block silently stops printing."""
     root = tree()
     manifest = root / "packages" / "acme-core" / "pyproject.toml"
     runner = exploding(manifest, "1.2.3", "1.3.0", ["uv", "lock"], KeyboardInterrupt())
@@ -1001,6 +1005,9 @@ def test_a_keyboard_interrupt_prints_the_recovery_block_and_re_raises(tree) -> N
             ],
             runner=runner,  # ty: ignore[invalid-argument-type]
         )
+    out = capsys.readouterr().out
+    assert "this run had already written" in out
+    assert "git checkout -- " in out
 
 
 def test_an_os_error_is_reported_after_the_recovery_block(tree, capsys) -> None:

--- a/tools/tests/test_import_check.py
+++ b/tools/tests/test_import_check.py
@@ -18,6 +18,7 @@ environment plus `--expect-prefix`, and those are tested against real imports ab
 from __future__ import annotations
 
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -166,11 +167,18 @@ def test_a_package_that_cannot_import_stops_its_own_subtree(tmp_path: Path) -> N
     assert "FAIL  pkg.broken: RuntimeError: no" in out
     assert "pkg.broken did not import, so anything under it was never walked" in out
     # the count understates the tree -- `pkg.broken.child` exists and was never reached --
-    # so the summary says how many packages hid contents from it
-    assert (
-        "FAIL  1 of 3 modules failed to import in 0.0s (2 imported; 1 package(s) did not "
-        "import, so their contents were never walked)" in out
-    )
+    # so the summary says how many packages hid contents from it.
+    #
+    # Matched with a regex around the elapsed time rather than asserting a literal
+    # `in 0.0s`: that is `{elapsed:.1f}` of a real subprocess, so on a machine under load
+    # -- a CI runner, or a local `lint`, `typecheck` and the suite back to back -- it
+    # rounds to `0.1s` and the test fails for a reason that has nothing to do with what it
+    # is about. Everything either side of the number is still asserted exactly.
+    assert re.search(
+        r"FAIL  1 of 3 modules failed to import in \d+\.\ds \(2 imported; "
+        r"1 package\(s\) did not import, so their contents were never walked\)",
+        out,
+    ), out
 
 
 def test_a_warning_at_import_time_is_not_a_failure(tmp_path: Path) -> None:

--- a/tools/tests/test_release_plan.py
+++ b/tools/tests/test_release_plan.py
@@ -447,6 +447,59 @@ def test_a_404_means_not_published(monkeypatch) -> None:
     assert release_plan.on_pypi("acme-core", "1.0.0") is False
 
 
+def test_a_read_timeout_in_the_tag_path_is_refused_not_a_traceback(monkeypatch) -> None:
+    """The gap this closes: `TimeoutError` is an `OSError` and NOT a `URLError`, because
+    `urlopen`'s READ phase does not wrap it -- so `except URLError` let a timeout out of
+    the plan job's own PyPI call as a traceback instead of the fail-closed message. The
+    twin assertion on `published_versions` is
+    `test_a_pypi_read_timeout_is_refused_not_a_traceback`; the two functions must not
+    drift, which is the whole reason this one exists."""
+
+    def raising(url: str, timeout: int = 30):
+        raise TimeoutError("timed out")
+
+    monkeypatch.setattr(release_plan.urllib.request, "urlopen", raising)
+    with pytest.raises(release_plan.PlanError) as caught:
+        release_plan.on_pypi("acme-core", "1.0.0")
+    message = str(caught.value)
+    assert "cannot reach PyPI (timed out)" in message
+    assert "refusing to guess whether acme-core 1.0.0 is published" in message
+
+
+def test_a_urlerror_in_the_tag_path_still_names_the_reason(monkeypatch) -> None:
+    """Widening the clause must not change what a `URLError` reads like: `.reason` where
+    there is one, so this stays `[Errno 61] Connection refused` rather than the
+    `<urlopen error ...>` wrapper `str(exc)` would give."""
+    import urllib.error
+
+    def raising(url: str, timeout: int = 30):
+        raise urllib.error.URLError(OSError(61, "Connection refused"))
+
+    monkeypatch.setattr(release_plan.urllib.request, "urlopen", raising)
+    with pytest.raises(release_plan.PlanError) as caught:
+        release_plan.on_pypi("acme-core", "1.0.0")
+    message = str(caught.value)
+    assert "cannot reach PyPI ([Errno 61] Connection refused)" in message
+    assert "<urlopen error" not in message
+
+
+def test_an_http_error_is_still_answered_before_the_oserror_clause(monkeypatch) -> None:
+    """`HTTPError` is a `URLError` is an `OSError`. With the widened clause the order of
+    the two `except`s is what keeps a 404 meaning "not published" instead of "PyPI is
+    unreachable"."""
+    import urllib.error
+
+    def raising(url: str, timeout: int = 30):
+        raise urllib.error.HTTPError(url, 503, "boom", None, None)  # ty: ignore[invalid-argument-type]
+
+    monkeypatch.setattr(release_plan.urllib.request, "urlopen", raising)
+    with pytest.raises(release_plan.PlanError) as caught:
+        release_plan.on_pypi("acme-core", "1.0.0")
+    message = str(caught.value)
+    assert "PyPI returned 503" in message
+    assert "cannot reach PyPI" not in message
+
+
 # --- (5) the tagged commit is on the default branch --------------------------------------
 
 


### PR DESCRIPTION
Three items from #1849, chosen because none of them needs a decision and each is testable
locally: `poe bump`, a build-from-the-sdist step in the smoke test, and the plan job's
read-timeout gap. Tooling only — nothing published changes, so there is **no changelog
entry**.

### `poe bump` — one command for the mechanical half of a release pull request

Step 1 of AGENTS.md's "Releasing a package" is six edits across five files that must all
say the same number: the member's `[project] version`, its module's `__version__`, the
`NEEDS_VERSION` fallback in `docker.yaml`, every dependant's floor, `uv.lock`, and the
changelog's label / heading / `:Released:` / compare link. Each has a gate somewhere else
that fails when it is forgotten — `check_workspace.py` in Lint, the `uv-lock` hook, the
plan job — so forgetting one turns a release pull request red for a reason that has nothing
to do with the release. `tools/src/sn_tools/bump.py`, wired as `poe bump`, does them in the
recipe's order and prints the file it wrote at each step. It decides nothing: no prose, no
commit, no tag, no push, and the summary paragraph stays hand-written, because a
placeholder in a changelog is a thing that ships.

**It computes everything before it writes anything.** That is not a detail: a tree bumped
everywhere *except* the changelog is green under `poe lint`, `check-workspace` and the plan
job, because nothing in this repository fences a missing changelog entry — so a tool that
refused halfway through would leave the one state no gate can see, and its own cleanliness
precondition would then refuse the obvious re-run. So `bump()` runs a compute phase (the
preconditions, `uv version --no-sync --dry-run` for the new version, the tag list, and all
three rewrites into memory) and only then an apply phase. **Every refusal it can decide
from the tree fires with the tree untouched.** Exactly one refusal is necessarily later —
the read-back guard comparing what `uv version` previewed with what it wrote, which is
defensive and measured unreachable on uv 0.12.9 — and it reports the recovery line like any
other apply-phase failure. A crash, a Ctrl-C or a failing subprocess mid-apply is still
possible, and the message then names the files written and the `git checkout --` that undoes
them — `uv.lock` included, because `uv version --no-sync` re-locks (uv's help: "avoid
syncing the virtual environment *after re-locking* the project"), so the lock is written at
step 2 and following a recovery line that omitted it left the `uv-lock` hook red.

The refusals, all fail-closed and all in the compute phase: the distribution must be a
member this repository publishes (the virtual `tools` member is refused, by the rule that
refuses its tag); every file the run would rewrite must be clean — `uv.lock` excepted,
because it is derived from the manifests rather than typed, and guarding it would make
releasing two members in one pull request impossible; the module's `__version__` must agree
with the manifest, and the refusal names both numbers rather than silently healing the
drift `check-workspace` was shouting about; the new version must be strictly above the
current one, so a `--to` typo cannot downgrade and the current version cannot be
re-released; and the changelog must not already carry the new version's label, which would
stamp two identical RST targets that only `poe docs-needs` would notice, minutes later.

The changelog stamp mirrors the file it is stamping rather than imposing one shape — a
sphinx-mounts-style `Unreleased` section is converted in place keeping every bullet, a
sphinx-needs-style entry is inserted above the newest one with no body. Headings are found
by shape rather than by adornment character, because RST fixes neither. The date format is
read off the newest existing `:Released:` line (`03.09.2026` in one file, `2026-08-27` in
the other), an unpadded `3.9.2026` still counts as day-first, and a format that is neither
is a refusal rather than a silent switch to ISO. The `:Full Changelog:` link is emitted
only where that file already has one, with its previous half from
`release_plan.previous_tag`, so sphinx-needs' first monorepo release correctly compares the
bare `8.5.0` tag with the prefixed new one — and a member whose previous tag *is* prefixed
keeps the prefix in both halves of the link.

### Build from the sdist in `smoke_needs.py`

The smoke test asserted the tarball's *contents* — `tests/`, `docs/`, no build rubbish —
and installed the *wheel*. Nothing anywhere in this repository built a wheel **from** the
sdist, so a tarball that ships every declared tree and is nonetheless unbuildable passed
every gate: a `[build-system]` requirement that no longer resolves, a `[tool.flit]` key the
backend rejects, a module the `include` list quietly stopped naming. The person who finds
out is whoever installs from source — every `pip install` on a platform with no wheel, and
conda-forge and the distributions always. So: a **second** throwaway environment (installing
the sdist over an already-installed wheel of the same version is a no-op for uv, and the
check would pass without ever running the backend), `uv pip install --python <that env>
<sdist>`, then an import asserting the version equals the manifest's and that `__file__` is
inside that environment rather than the checkout. It costs **about a second on a warm
cache** — measured as a delta rather than an absolute, because the same script on the same
machine ranges from 6 s to 13 s with load; the step prints the build-and-install half of it
for itself on every run. Both import probes in that script now read their output by line
rather than by whitespace: they print a version and a *path*, so a `TMPDIR` containing a
space made the older, pre-existing `stdout.split()` unpack raise `ValueError` before any
assertion ran.

### `on_pypi`'s read-timeout gap

`on_pypi` is the PyPI call the release workflow's `plan` job makes, and it is written to
fail closed: any answer that is not a clean 404 is a `PlanError` naming what it refused to
guess. Its `except urllib.error.URLError` did not cover the read phase — `urlopen` wraps a
connect failure in `URLError` but lets a socket read timeout out as `TimeoutError`, which
is an `OSError` and not a `URLError` — so a timeout came out of the one script whose
subject is never guessing as a traceback. Nothing failed open (the job still exits
non-zero); what was lost is the message. #1848 closed the identical gap in the planner's
`published_versions` and deliberately left the tag path alone. The `HTTPError` branch stays
first, because `HTTPError` is a `URLError` is an `OSError` and a 404 must keep meaning "not
published", and `getattr(exc, "reason", exc)` keeps a `URLError` reading `[Errno 61]
Connection refused` rather than the `<urlopen error …>` wrapper, so the two functions'
messages do not drift.

### The rehearsal

`poe bump` was run for real against both members in a scratch worktree and then reverted.
`sphinx-mounts --bump minor` → 0.3.0: four files, +9/−5 — the `Unreleased` heading becomes
`.. _`release:0.3.0`:` / `0.3.0` / `:Released: 2026-09-06` with its bullet kept, plus the
manifest, `__version__` and one line of `uv.lock`. `sphinx-needs --bump minor` → 8.6.0
(applied on top, which is what proves the two-member sequence works): five files — the
manifest, `__version__`, the `docker.yaml` fallback becoming `'sphinx-needs-v8.6.0'`, a new
empty `8.6.0` changelog entry with `:Released: 06.09.2026` and
`:Full Changelog: `8.5.0...sphinx-needs-v8.6.0 <…/compare/8.5.0...sphinx-needs-v8.6.0>`__`,
and `uv.lock`. On that tree `check-workspace`, `lint` and `typecheck` are green and
`release-plan` names 0.3.0 and 8.6.0 as the tree's versions with both tags pending.

### Deliberately out of scope

The attestations step swap in `release.yaml`'s publish job is its own pull request and its
own decision: it changes the publish mechanism and no rehearsal reaches that job. Also out,
from the same issue: the master-push compat matrix (wants a second dependant member), a
TestPyPI run, the release train, and `import_check.py`'s `__main__` skip.

### One drive-by

Called out because it is not this PR's subject:
`tools/tests/test_import_check.py::test_a_package_that_cannot_import_stops_its_own_subtree`
asserted a literal `failed to import in 0.0s` against a real subprocess's elapsed time, so
it went red on a machine under load — including in CI, and including on a reviewer's first
run of this branch. It came in with #1848 and neither file it touches is otherwise part of
this PR; the assertion is now a regex around the number. It is fixed here because it lives
in the directory this PR adds tests to and it fails every contributor's suite.

Gates: `lint`, `typecheck`, `pytest tools/tests` (243 passed), `smoke-needs`,
`check-workspace`.
