### PR TITLE
🧪 Fence the PlantUML fence, and correct two sentences the dropped design left behind

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ on:
     branches: [master]
   pull_request:
 
-# A fix-up push otherwise leaves the superseded head's 25 jobs running to completion, and
+# A fix-up push otherwise leaves the superseded head's 26 jobs running to completion, and
 # the useblocks organisation shares 60 concurrent runners across all of its repositories.
 # The group is the pull request's number, so every run that is NOT a pull request -- every
 # push to master -- gets a group of its own and master runs neither queue behind nor cancel

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,8 +111,9 @@ The machine needs `java` and graphviz's `dot` on `PATH` — the needflow tests d
 without them, so install graphviz as CI does (`apt-get install graphviz`). **The PlantUML jar
 is committed**, once, at `vendor/plantuml/plantuml-<version>.jar` — the version
 `vendor/plantuml/pin.toml` names — so a checkout renders and **nothing has to reach the
-network**: not the 22 jobs of a CI run that render (measured on a run of this branch: 24
-jobs, all but `Lint` and the smoke test), not a Read the Docs build, not an offline machine,
+network**: not the 22 of a CI run's 26 jobs that render (counted on run 34057129950, on
+`a3aebf1f`: the four that do not are `Lint`, the smoke test, `Docs codelinks` and the `check`
+aggregator), not a Read the Docs build, not an offline machine,
 and not a sandboxed session whose allowlist this repository cannot set. `uv run poe verify-plantuml`
 checks the file against the pin (one sha256 of 30 MB, well under a second including `uv` and
 `poe` startup) and is what CI's Lint job runs; `uv run poe fetch-plantuml` downloads the jar

--- a/packages/sphinx-needs/docs/conf.py
+++ b/packages/sphinx-needs/docs/conf.py
@@ -318,7 +318,7 @@ def _resolve_plantuml() -> str:
             raise RuntimeError(
                 f"PLANTUML_JAR names {env_jar!r}, which is not a file. Point it at a "
                 "plantuml jar, or unset it to render with the jar "
-                "`uv run poe fetch-plantuml` puts in vendor/plantuml/."
+                "committed at vendor/plantuml/."
             )
         return quoted.format(env_jar)
     vendor = Path(__file__).resolve().parents[3] / "vendor" / "plantuml"

--- a/packages/sphinx-needs/performance/performance_test.py
+++ b/packages/sphinx-needs/performance/performance_test.py
@@ -43,7 +43,7 @@ def resolve_plantuml() -> str:
             raise RuntimeError(
                 f"PLANTUML_JAR names {env_jar!r}, which is not a file. Point it at a "
                 "plantuml jar, or unset it to render with the jar "
-                "`uv run poe fetch-plantuml` puts in vendor/plantuml/."
+                "committed at vendor/plantuml/."
             )
         return quoted.format(env_jar)
     vendor = Path(__file__).resolve().parents[3] / "vendor" / "plantuml"

--- a/packages/sphinx-needs/tests/conftest.py
+++ b/packages/sphinx-needs/tests/conftest.py
@@ -207,7 +207,7 @@ def resolve_plantuml_command(workspace_jar: Path | None) -> str:
             raise RuntimeError(
                 f"PLANTUML_JAR names {env_jar!r}, which is not a file. "
                 "Point it at a plantuml jar, or unset it to render with the "
-                "jar `uv run poe fetch-plantuml` puts in vendor/plantuml/."
+                "jar committed at vendor/plantuml/."
             )
         return _PLANTUML_JAVA.format(env_jar)
     if workspace_jar is not None and workspace_jar.is_file():

--- a/packages/sphinx-needs/tests/test_plantuml_command.py
+++ b/packages/sphinx-needs/tests/test_plantuml_command.py
@@ -127,8 +127,19 @@ def test_a_named_jar_that_is_not_there_is_an_error(
     monkeypatch.setenv("PLANTUML_JAR", str(missing))
     monkeypatch.setattr(shutil, "which", lambda _name: "/usr/local/bin/plantuml")
 
-    with pytest.raises(RuntimeError, match=_expected(missing)):
+    with pytest.raises(RuntimeError, match=_expected(missing)) as caught:
         resolve_plantuml_command(workspace_jar)
+
+    # and the alternative it offers is the true one. The jar is COMMITTED at
+    # ``vendor/plantuml/``: a checkout has it, and ``fetch_plantuml.py --verify`` -- which
+    # `poe lint` and CI's Lint job run -- downloads nothing at all, so a message saying
+    # ``poe fetch-plantuml`` "puts" it there named an action that path never takes. The same
+    # clause is in ``docs/conf.py``, ``performance/performance_test.py`` and
+    # ``tools/src/sn_tools/fetch_plantuml.py``, word for word, and this is the assertion that
+    # holds this copy of it to that wording
+    assert "unset it to render with the jar committed at vendor/plantuml/." in str(
+        caught.value
+    )
 
 
 def test_no_renderer_at_all_is_an_error(

--- a/tools/src/sn_tools/fetch_plantuml.py
+++ b/tools/src/sn_tools/fetch_plantuml.py
@@ -20,7 +20,7 @@ all of that.
 **A fetched design was built and reviewed on this same pull request first, and dropped.** In
 it nothing was committed and every consumer downloaded the jar on demand. That makes rendering
 depend on `release-assets.githubusercontent.com` (measured: what the release URL redirects to)
-at the 22 jobs of a CI run that render, at every Read the Docs build, on every offline
+at the 22 of a CI run's 26 jobs that render, at every Read the Docs build, on every offline
 machine, and in every sandboxed agent session whose network allowlist is set outside this
 repository and does not include that host. A committed jar needs none of it.
 
@@ -172,8 +172,8 @@ def named_jar() -> Path | None:
     if not path.is_file():
         raise SystemExit(
             f"error: PLANTUML_JAR names {value!r}, which is not a file. Point it at a "
-            "plantuml jar (with `java` on PATH), or unset it to render with the pinned jar "
-            "this fetches into vendor/plantuml/."
+            "plantuml jar (with `java` on PATH), or unset it to render with the jar "
+            "committed at vendor/plantuml/."
         )
     return path
 

--- a/tools/tests/test_ci_plantuml_steps.py
+++ b/tools/tests/test_ci_plantuml_steps.py
@@ -1,0 +1,215 @@
+"""Every CI site that runs `fetch_plantuml.py` runs it as the fence, not as a downloader.
+
+The committed jar rests on ONE flag. `--verify` checks the jar against
+`vendor/plantuml/pin.toml` and never touches the network; **without** it the same script is
+the bump tool, which *downloads* — so a site that loses the flag turns the fence into a
+self-healing download that exits **0** on exactly the mistake it exists to catch (a bumped
+pin with no jar), silently repairing the runner's tree and reporting green. That is reviewer
+B's B2 mutation, and nothing in this repository could see it: `check_workspace.py` reads
+manifests, not workflows; `actionlint` cannot know what a flag means; and the workflows are
+not executed by any test. This module is that missing check.
+
+Three other clauses of the capture shape are load-bearing in the same invisible way, all
+measured in the review and written up in `vendor/plantuml/README.md`, "The step CI runs":
+
+* **`shell: bash`** selects ``bash --noprofile --norc -eo pipefail``. The bash GitHub gives a
+  step with no `shell:` key is ``bash -e`` with **no pipefail**, under which a failing command
+  inside ``$( … )`` piped into `tr` exits **0** and the step goes green with `PLANTUML_JAR`
+  exported EMPTY — which every consumer then treats as "unset" (the deliberate
+  empty-is-unset rule) and falls back silently. A fence whose failure mode is green is not a
+  fence.
+* **`| tr -d '\\r'`**. On Windows python's `print()` writes CRLF and ``$( )`` strips trailing
+  newlines only, so without it the variable carries a carriage return into `$GITHUB_ENV`.
+  The two captures print IDENTICALLY in a log — a CR only returns the cursor — so this defect
+  cannot be found by reading one; only `test -f` finds it.
+* **the assignment form**: capture into a variable, then `echo` it to `$GITHUB_ENV` on the
+  next line. ``echo "PLANTUML_JAR=$(…)"`` would exit 0 with an empty value and leave the
+  failure to whatever reads the variable next.
+
+The walk is over the FILES rather than a list of sites, so a new rendering job that copies
+the step in gets checked, and a renamed script or a deleted step makes the count below wrong
+rather than making the walk quietly empty.
+
+The workflows are PARSED, not grepped: `shell:` is a sibling key of `run:`, so only a parse
+can tell which step declares it, and a regex over the file would have to re-implement block
+scalars to know where one `run:` ends. `pyyaml` comes from the root's shared `test` group --
+the environment CI's Lint job runs `pytest tools/tests` in, and the one a bare root `pytest`
+uses -- not from `tools/pyproject.toml`, whose dependencies are what the SCRIPTS import
+(`fetch_plantuml.py` is deliberately stdlib-only, and this module does not import it at all).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPT = "tools/src/sn_tools/fetch_plantuml.py"
+
+# The eight sites, counted by hand on this head and asserted below. Seven CAPTURE the jar's
+# path into `PLANTUML_JAR`; the eighth is CI's Lint job, which runs the same `--verify` with
+# no pipe and no capture — so it needs neither `shell: bash` nor the `tr`, and a plain `run:`
+# under `bash -e` already carries the script's exit status.
+#
+#   .github/actions/prepare-cell/action.yml  runs                 capture  (tests-core x14,
+#                                                                  tests-extensions x4)
+#   .github/workflows/benchmark.yaml         benchmarks           capture
+#   .github/workflows/ci.yaml                bazel                capture
+#   .github/workflows/ci.yaml                tests-js             capture
+#   .github/workflows/ci.yaml                tests-no-mpl         capture
+#   .github/workflows/docs.yaml              linkcheck            capture
+#   .github/workflows/release.yaml           build                capture
+#   .github/workflows/ci.yaml                lint                 the bare check
+#
+# Adding a job that renders means adding a site and raising these numbers — deliberately, so
+# that the addition is a decision someone made rather than a step nobody checked.
+EXPECTED_SITES = 8
+EXPECTED_CAPTURES = 7
+
+
+@dataclass(frozen=True)
+class Site:
+    """One step, anywhere under `.github/`, whose `run:` invokes the script."""
+
+    where: str  # "<file> :: <job or 'runs'> :: <step name>", for the failure message
+    run: str
+    shell: str | None
+
+    @property
+    def lines(self) -> list[str]:
+        return [line for line in self.run.splitlines() if line.strip()]
+
+    @property
+    def invocation(self) -> str:
+        """The one line that runs the script."""
+        return next(line for line in self.lines if SCRIPT in line)
+
+    @property
+    def captures(self) -> bool:
+        """True for the seven that read the path back into a shell variable."""
+        return "$(" in self.invocation
+
+
+def _steps(document: Any) -> list[tuple[str, list[Any]]]:
+    """Every `steps:` list in one workflow or composite action, with what holds it."""
+    found: list[tuple[str, list[Any]]] = []
+    jobs = document.get("jobs") if isinstance(document, dict) else None
+    if isinstance(jobs, dict):
+        for job_id, job in jobs.items():
+            # a job that `uses:` a reusable workflow has no steps of its own
+            if isinstance(job, dict) and isinstance(job.get("steps"), list):
+                found.append((str(job_id), job["steps"]))
+    runs = document.get("runs") if isinstance(document, dict) else None
+    if isinstance(runs, dict) and isinstance(runs.get("steps"), list):
+        found.append(("runs", runs["steps"]))
+    return found
+
+
+def _collect() -> list[Site]:
+    """Walk every workflow and composite action; return the steps that run the script.
+
+    Both suffixes for both kinds. GitHub accepts `.yml` and `.yaml` for each, and this
+    repository already uses both (`copilot-setup-steps.yml` beside `ci.yaml`), so a walk
+    that guessed one suffix would go green by not looking.
+    """
+    files = sorted(
+        {
+            *(REPO / ".github" / "workflows").glob("*.yaml"),
+            *(REPO / ".github" / "workflows").glob("*.yml"),
+            *REPO.glob(".github/actions/*/action.yaml"),
+            *REPO.glob(".github/actions/*/action.yml"),
+        }
+    )
+    assert files, f"no workflows or actions found under {REPO / '.github'}"
+    sites: list[Site] = []
+    for path in files:
+        document = yaml.safe_load(path.read_text(encoding="utf-8"))
+        for holder, steps in _steps(document):
+            for step in steps:
+                if not isinstance(step, dict):
+                    continue
+                run = step.get("run")
+                if not isinstance(run, str) or SCRIPT not in run:
+                    continue
+                where = f"{path.relative_to(REPO)} :: {holder} :: {step.get('name', '(unnamed)')}"
+                sites.append(Site(where=where, run=run, shell=step.get("shell")))
+    return sites
+
+
+SITES = _collect()
+
+
+def _ids(sites: list[Site]) -> list[str]:
+    return [site.where for site in sites]
+
+
+def test_every_site_was_found() -> None:
+    """The positive control: an empty walk, or a renamed script, is RED rather than green.
+
+    Every assertion below is parametrised over what the walk found, so a walk that found
+    nothing would report a tidy row of passes. This is the test that makes that impossible,
+    and it is why the counts are written down instead of being derived.
+    """
+    assert len(SITES) == EXPECTED_SITES, "\n".join(["found:", *_ids(SITES)])
+    captures = [site for site in SITES if site.captures]
+    assert len(captures) == EXPECTED_CAPTURES, "\n".join(["captures:", *_ids(captures)])
+
+
+@pytest.mark.parametrize("site", SITES, ids=_ids(SITES))
+def test_the_invocation_carries_verify(site: Site) -> None:
+    """`--verify` at every site. Without it the script DOWNLOADS, and green is the wrong answer."""
+    assert "--verify" in site.invocation, f"{site.where}\n  {site.invocation.strip()}"
+
+
+@pytest.mark.parametrize(
+    "site", [s for s in SITES if s.captures], ids=_ids([s for s in SITES if s.captures])
+)
+def test_the_capture_is_piped_through_tr(site: Site) -> None:
+    r"""`| tr -d '\r'`, or Windows exports a path with a carriage return in it."""
+    assert r"tr -d '\r'" in site.invocation, (
+        f"{site.where}\n  {site.invocation.strip()}"
+    )
+
+
+@pytest.mark.parametrize(
+    "site", [s for s in SITES if s.captures], ids=_ids([s for s in SITES if s.captures])
+)
+def test_the_capture_declares_shell_bash(site: Site) -> None:
+    """`shell: bash` — the runner's default has no `pipefail`, so the step would go green."""
+    assert site.shell == "bash", f"{site.where}: shell is {site.shell!r}, not 'bash'"
+
+
+@pytest.mark.parametrize(
+    "site", [s for s in SITES if s.captures], ids=_ids([s for s in SITES if s.captures])
+)
+def test_the_next_line_exports_plantuml_jar(site: Site) -> None:
+    """Capture, THEN export — on the very next line, so nothing can come between them."""
+    lines = site.lines
+    after = lines[lines.index(site.invocation) + 1 :]
+    assert after, f"{site.where}: the capture is the last line; nothing exports it"
+    export = after[0].strip()
+    assert export.startswith('echo "PLANTUML_JAR='), (
+        f"{site.where}: next line is {export!r}"
+    )
+    assert '>> "$GITHUB_ENV"' in export, f"{site.where}: next line is {export!r}"
+
+
+def test_the_lint_check_needs_neither() -> None:
+    """The eighth site, stated rather than assumed: a bare `run:`, so the two clauses do not apply.
+
+    It is exempt from `shell: bash` and the `tr` for a reason that has to hold, not by being
+    left out of a list: it captures nothing, so there is no pipeline whose status could be
+    lost and no variable a carriage return could contaminate. Assert that, and the exemption
+    stays honest — a future edit that turned it into a capture would be caught by this test
+    rather than quietly inheriting the exemption.
+    """
+    plain = [site for site in SITES if not site.captures]
+    assert len(plain) == EXPECTED_SITES - EXPECTED_CAPTURES, _ids(plain)
+    site = plain[0]
+    assert site.where.startswith(".github/workflows/ci.yaml :: lint ::"), site.where
+    assert "|" not in site.invocation, site.invocation
+    assert "GITHUB_ENV" not in site.run, site.run

--- a/tools/tests/test_fetch_plantuml.py
+++ b/tools/tests/test_fetch_plantuml.py
@@ -418,6 +418,31 @@ def test_verify_refuses_a_jar_that_is_not_the_pin(
     assert jar_of(root).read_bytes() == b"some other jar entirely"
 
 
+def test_verify_refuses_an_empty_jar(root: Path, no_network: None, capsys) -> None:
+    """A zero-byte jar is a mismatch like any other, and the message names its hash.
+
+    Its own case rather than a variant of the one above, because a zero-byte file is what
+    the plausible accidents actually leave behind -- an interrupted checkout, a failed LFS
+    smudge, a `: > vendor/plantuml/plantuml-<version>.jar` -- and because "has no content to
+    hash" is the shape a short-circuit takes when someone optimises this function: a
+    `st_size == 0` early return that accepted the file left the whole suite green
+    (reviewer B's B1 mutation, 263/263 passing). The hash of nothing is a real, stable
+    sha256, so the fence needs no special case to catch this -- it needs a test saying so.
+    """
+    jar_of(root).write_bytes(b"")
+
+    assert run(root, "--verify") == 1
+
+    err = capsys.readouterr().err
+    assert DIGEST in err  # what the pin names
+    # sha256 of the empty byte string, written out rather than computed: this is the digest
+    # that appears in the log of a truncated checkout, and it is worth being able to grep
+    assert "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" in err
+    assert "uv run poe fetch-plantuml" in err
+    # and the fence left it alone, as it does for every other mismatch
+    assert jar_of(root).read_bytes() == b""
+
+
 def test_verify_honours_plantuml_jar(
     root: Path,
     no_network: None,

--- a/tools/tests/test_fetch_plantuml.py
+++ b/tools/tests/test_fetch_plantuml.py
@@ -270,7 +270,12 @@ def test_a_plantuml_jar_naming_no_file_stops_the_run(
     assert repr(str(missing)) in message
     assert "is not a file" in message
     assert "Point it at a plantuml jar" in message
-    assert "unset it" in message
+    # the ALTERNATIVE the message offers, asserted literally rather than as "unset it":
+    # under this design the checkout puts the jar there and `--verify` fetches nothing, so a
+    # message promising that `poe fetch-plantuml` "puts" it there described an action this
+    # branch cannot take. The same clause is in `tests/conftest.py`, `docs/conf.py` and
+    # `performance_test.py`, word for word -- `tests/test_plantuml_command.py` pins it there
+    assert "unset it to render with the jar committed at vendor/plantuml/." in message
     assert urlopen == []  # and nothing was downloaded
     assert not jar_of(root).exists()
 

--- a/vendor/plantuml/README.md
+++ b/vendor/plantuml/README.md
@@ -111,6 +111,14 @@ check. That is the fence on the pin: a pull request that edits `pin.toml` and do
 the matching jar is one red step naming both hashes, rather than a rendering failure in some
 other job.
 
+**And a test fences the steps themselves.** `tools/tests/test_ci_plantuml_steps.py` parses
+every `.github/workflows/*.y{a,}ml` and `.github/actions/*/action.y{a,}ml`, finds each step
+whose `run:` invokes the script, and asserts the four clauses above of every one of them --
+plus the number of sites it found, so a renamed script or a deleted step is red rather than a
+quietly empty walk. It exists because losing `--verify` at one site would be **green**: the
+script's default mode downloads, so the step would repair the runner's tree and report
+success on exactly the mistake the fence is for. Lint runs it (`pytest tools/tests`).
+
 ## Bumping the pin
 
 1. Download the release asset and hash it:

--- a/vendor/plantuml/README.md
+++ b/vendor/plantuml/README.md
@@ -32,8 +32,9 @@ without a commit.
   1.2022.5, and sat four years and ~46 releases behind without anyone noticing, because
   nothing in the tree said what it was.
 - **Zero network.** A checkout renders. That is the whole point of committing it, and it is
-  worth more than the ~30 MB: 22 jobs of a CI run render (measured: 24 jobs, all but `Lint`
-  and the smoke test), Read the Docs builds on every pull request, developers work offline,
+  worth more than the ~30 MB: 22 of a CI run's 26 jobs render (counted on run 34057129950,
+  on `a3aebf1f`: the four that do not are `Lint`, the smoke test, `Docs codelinks` and the
+  `check` aggregator), Read the Docs builds on every pull request, developers work offline,
   and a sandboxed agent session's network allowlist is set
   on the environment rather than in this repository (this repository's own `CLAUDE.md` records
   `api.github.com` having to be added to it by hand).


### PR DESCRIPTION
Follow-up to #1870 (the committed jar at `vendor/plantuml/`), from `master` after #1871, closing
the four actionable findings of that pull request's round-2 review. **No behaviour changes**: two
new tests, two strengthened assertions, four string literals and three sentences — nothing under
any `src/`, so no changelog entry.

## The fence had no fence (review finding 5)

The committed jar rests on **one flag**. `--verify` hashes the jar against `pin.toml` and never
touches the network; without it the same script is the *bump* tool, which **downloads**. A site
that lost the flag would turn the fence into a self-healing download that exits **0** on exactly
the mistake it exists to catch — a bumped pin with no committed jar — repairing the runner's tree
and reporting green (measured in review: with the flag, `EXIT=1` naming the missing jar; without
it, a 29 MB download and `EXIT=0`). Nothing here could see that: `check_workspace.py` reads
manifests, `actionlint` cannot know what a flag means, and no test executed a workflow.

`tools/tests/test_ci_plantuml_steps.py` parses every `.github/workflows/*.y{a,}ml` and
`.github/actions/*/action.y{a,}ml`, finds each step whose `run:` invokes the script, and asserts:

- **`--verify`** at all **8** sites; and, for the **7** that capture the path, **`| tr -d '\r'`**,
  **`shell: bash`**, and the **very next line** writing `PLANTUML_JAR=` to `$GITHUB_ENV`;
- the eighth — CI's Lint job, a bare check with no pipe and no capture — is exempt from the last
  two, and that exemption is *asserted* rather than granted by being left off a list;
- **a positive control**: the site count. Every other case is parametrised over the walk, so
  without it an empty walk or a renamed script would report a tidy row of passes.

Both clauses are load-bearing invisibly. Without `shell: bash` the runner's default `bash -e` has
no `pipefail`: the failing script inside `$( )` exits 0, the step goes **green**, and
`PLANTUML_JAR` is exported **empty**, which every consumer reads as "unset". Without the `tr`,
Windows exports a path with a trailing CR that prints identically in a log and names no file. 31
cases, each named after the file and step; Lint already runs `pytest tools/tests`.

## A zero-byte jar (finding 4)

`--verify` already refuses one — the hash of nothing is a real sha256 — but nothing pinned it: a
`st_size == 0` early return that accepted the file left all 263 tests green.
`test_verify_refuses_an_empty_jar` writes a 0-byte jar and asserts exit 1 and `e3b0c442…b855` in
the message — what a truncated checkout or a failed LFS smudge leaves behind.

## "the jar `poe fetch-plantuml` puts in `vendor/plantuml/`" (finding 1)

A leftover from the fetched design #1870 dropped, in **four** places. `poe fetch-plantuml` does
not put the jar there — the checkout does, and the task re-hashes it; and the caller that reaches
this message in CI is `--verify`, which fetches nothing at all. All four now read "…or unset it to
render with the jar **committed at** `vendor/plantuml/`.", word for word, and both tests that
reach it assert that clause instead of the substring `"unset it"`.

## "22 jobs … (measured: 24 jobs, all but `Lint` and the smoke test)" (finding 2)

22 was right; 24 was not, and the job that went missing was `check`, the alls-green aggregator.
Re-counted on this head from run `34057129950` (`ci.yaml` on `a3aebf1f`, success): **26** jobs, now
that #1871 has added `Docs codelinks` and widened `tests-mounts` into `tests-extensions`. The four
that do not render are `Lint`, the smoke test, `Docs codelinks` (those docs draw no diagrams) and
`check`. Corrected in the root `AGENTS.md`, `vendor/plantuml/README.md` and the docstring; the
README also gains a paragraph naming the new test.

**Mutations.** `--verify` dropped at one site · `shell: bash` at one · the `tr` at one · capture
and export collapsed into one `echo` · `verify()` made to accept an empty file — **5 of 5 red**,
each naming the file and step, everything else green.