### PR TITLE
🧪 Run the sphinx-needs suite on four workers in CI, and print the slowest tests in every cell

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -193,7 +193,11 @@ jobs:
       cache-suffix: ${{ matrix.python-version }}-${{ matrix.sphinx-group }}
       test-path: packages/sphinx-needs/tests
       # `benchmarks` is `benchmark.yaml`'s; `jstest` is the `tests-js` lane's
-      pytest-args: '--ignore=packages/sphinx-needs/tests/benchmarks -m "not jstest"'
+      # `-n 4`: four workers, the runner's core count. The `-n auto` race this suite used to
+      # document was on a jar copied into every test project; since #1870 the jar is one
+      # file at a fixed path and nothing copies it, and the suite was measured at `-n 4`
+      # and `-n auto` with no failure and no flake. Measured locally: 535 s serial -> 164 s
+      pytest-args: '--ignore=packages/sphinx-needs/tests/benchmarks -m "not jstest" -n 4'
       cov-module: sphinx_needs
       codecov-flag: pytests
       codecov-name: sphinx-need-pytests

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -170,7 +170,9 @@ jobs:
           # before the `cd` below, so the script is where it says it is
           /tmp/compat/bin/python tools/src/sn_tools/import_check.py --walk "$module" --expect-prefix /tmp/compat
           cd "packages/$DIST"
-          # serial: plantuml is load-sensitive and `-n auto` races on the shared jar copy.
+          # serial, deliberately: this cell runs once per release, and a flake here costs a
+          # re-run at the worst moment. (CI's cells run `-n 4`; the "shared jar copy" race
+          # that used to keep everything serial is gone since #1870.)
           # `-o addopts=` drops the root config's `--import-mode=importlib` so it can be
           # given explicitly here, which is what lets the tests import the installed
           # package while running from the package directory

--- a/.github/workflows/test-extensions.yaml
+++ b/.github/workflows/test-extensions.yaml
@@ -103,7 +103,7 @@ jobs:
       # first and both uploads would carry the same numbers under different flags.
       - name: "sphinx-mounts: pytest"
         # `-m "not bazel"` deselects the two tests the `bazel` job owns
-        run: uv run --no-sync pytest -v packages/sphinx-mounts/tests -m "not bazel" --cov=sphinx_mounts --cov-report=xml:mounts.xml --cov-report=term-missing
+        run: uv run --no-sync pytest -v packages/sphinx-mounts/tests -m "not bazel" --durations=25 --cov=sphinx_mounts --cov-report=xml:mounts.xml --cov-report=term-missing
       - name: "sphinx-mounts: upload to Codecov"
         # dependabot PRs get no secrets; without a token the upload fails and takes the required `check` gate with it
         if: inputs.upload-coverage && github.event.pull_request.head.repo.full_name == github.repository && github.repository == 'useblocks/sphinx-needs' && github.actor != 'dependabot[bot]'
@@ -133,7 +133,7 @@ jobs:
         # that fix this suite passed only from `packages/sphinx-codelinks`, and a
         # `working-directory:` here would also have moved where `--cov-report` writes
         if: ${{ !cancelled() && steps.prepare.outcome == 'success' }}
-        run: uv run --no-sync pytest -v packages/sphinx-codelinks/tests --cov=sphinx_codelinks --cov-report=xml:codelinks.xml --cov-report=term-missing
+        run: uv run --no-sync pytest -v packages/sphinx-codelinks/tests --durations=25 --cov=sphinx_codelinks --cov-report=xml:codelinks.xml --cov-report=term-missing
       - name: "sphinx-codelinks: upload to Codecov"
         if: inputs.upload-coverage && github.event.pull_request.head.repo.full_name == github.repository && github.repository == 'useblocks/sphinx-needs' && github.actor != 'dependabot[bot]'
         uses: codecov/codecov-action@v7

--- a/.github/workflows/test-package.yaml
+++ b/.github/workflows/test-package.yaml
@@ -124,7 +124,10 @@ jobs:
           needs-graphviz: ${{ inputs.needs-graphviz }}
           needs-plantuml: ${{ inputs.needs-plantuml }}
       - name: Run pytest
-        run: uv run --no-sync pytest -v ${{ inputs.test-path }} ${{ inputs.pytest-args }} --cov=${{ inputs.cov-module }} --cov-report=xml --cov-report=term-missing
+        # `--durations=25`: the slowest tests, printed at the end of every cell, so a slow
+        # Windows run can be read rather than guessed at (there is no Windows machine to
+        # profile on otherwise)
+        run: uv run --no-sync pytest -v ${{ inputs.test-path }} ${{ inputs.pytest-args }} --durations=25 --cov=${{ inputs.cov-module }} --cov-report=xml --cov-report=term-missing
       - name: Upload to Codecov
         # dependabot PRs get no secrets; without a token the upload fails and takes the required `check` gate with it
         if: inputs.upload-coverage && github.event.pull_request.head.repo.full_name == github.repository && github.repository == 'useblocks/sphinx-needs' && github.actor != 'dependabot[bot]'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,9 +177,12 @@ that look like a docs regression. `docs-codelinks` adds one host to that list,
 `sphinx-needs.readthedocs.io`, and one requirement no other build has: it reads the git
 directory's `config` and `HEAD` to turn every traced source line into a blob link, so a
 checkout with no `origin` fails it under `-nW` (a linked worktree is fine — that is what
-`_git_dir`/`_git_common_dir` in `analyse/utils.py` are for). Run the test suite serially: plantuml is load-sensitive (a
-docs or wheel build running alongside it has failed a zero-warnings assertion), and
-`-n auto` races on the shared jar copy.
+`_git_dir`/`_git_common_dir` in `analyse/utils.py` are for). The suite runs on four workers in CI (`-n 4`; pytest-xdist is in the `test` group) and can
+locally: the `-n auto` race the suite used to document was on a jar copied into every test
+project, and since #1870 the jar is one file at a fixed path that nothing copies (measured at
+`-n 4` and `-n auto`: no failure, no flake). What still holds is that plantuml is load-sensitive
+across PROCESSES you start yourself: a docs or wheel build running alongside the suite has failed a
+zero-warnings assertion, so do not overlap those.
 
 Rough runtimes on a CI-class machine, so you can decide what to background: `lint` 15 s ·
 `typecheck` seconds once `.venvs/typing` exists (the first run creates it) ·


### PR DESCRIPTION
## Why

The sphinx-needs test step is the critical path of every CI run: 348–484 s on the eleven Ubuntu cells and 567–855 s on the three Windows cells (measured on run 34062332057). It ran serially everywhere because `AGENTS.md` said `-n auto` "races on the shared jar copy".

That reason is gone. It described a PlantUML jar copied into every test project; since #1870 the jar is one file at a fixed path under `vendor/plantuml/` and nothing copies it. Measured on the whole suite in a checkout: `-n 4` and `-n auto` both pass with no failure and no flake.

| | wall time |
|---|---|
| serial (today's CI shape) | 535 s |
| `-n 4` | 164 s |

## What changes

- **`ci.yaml`**: the sphinx-needs cells pass `-n 4` (the runner's core count) through the reusable unit's `pytest-args`. The extension suites stay as they are: they take 9–100 s and sphinx-mounts' suite asserts on a renderer under load.
- **`test-package.yaml` and `test-extensions.yaml`**: every pytest step prints `--durations=25`, so the slowest tests of a Windows cell can be read from the log rather than guessed at. There is no Windows machine to profile on otherwise.
- **`release.yaml`**: the compat cell stays serial, deliberately, and its comment now gives the true reason (it runs once per release; a flake there costs a re-run at the worst moment) instead of the stale one.
- **`AGENTS.md`**: the serial-run instruction is replaced by what still holds: plantuml is load-sensitive across processes you start yourself, so a docs or wheel build alongside the suite can still fail a zero-warnings assertion.

`pytest-xdist` is already in the `test` group; `pytest-cov` combines coverage across workers natively, so the Codecov upload is unchanged.

## What this run proves

The Windows cells are the first real test at `-n 4`: the local measurement was on macOS. Read the three Windows cells' times and their `--durations` tails before merging; the expectation is roughly a third of today's.

## Follow-up

The next step, measured separately, is to stop rendering PlantUML in the 1759 tests that do not need it (only 10 do): 164 s → 99 s on top of this. That is its own pull request.
