### PR TITLE
🧪 Render PlantUML only where a test asks for it

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -198,10 +198,12 @@ jobs:
       codecov-flag: pytests
       codecov-name: sphinx-need-pytests
       upload-coverage: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.14' }}
-      # Rendering is opt in now, so this is a couple of dozen tests rather than 478: the
-      # twelve `test_app` parameter dicts that say `"plantuml": True`, plus the tests that
-      # call `make_app` themselves and take the `plantuml_command` fixture (the needflow
-      # conformance corpus, test_needflow, test_plantuml_command, test_plantuml_incdir).
+      # Rendering is opt in now, but that does not make the jar optional here: measured with
+      # a logging shim on PATH, the suite still starts it 233 times across about a hundred
+      # cases (102) in nine files -- the twelve `test_app` parameter dicts that say
+      # `"plantuml": True`, and, for most of it, the tests that call `make_app` themselves and
+      # take the `plantuml_command` fixture (test_needflow and the needflow conformance corpus
+      # between them are 190 of the 233).
       # That fixture still RAISES rather than skipping when it finds no renderer -- these
       # tests assert on rendered output and skipping them would be a false green -- so the
       # cells still need a jar. `actions/checkout` brings the committed one along and they

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -198,14 +198,17 @@ jobs:
       codecov-flag: pytests
       codecov-name: sphinx-need-pytests
       upload-coverage: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.14' }}
-      # The whole sphinx-needs suite renders, and not only its uml tests: `test_app` takes
-      # the `plantuml_command` fixture, which RAISES rather than skipping when it can find
-      # no renderer -- so every test that goes through that fixture errors without one, 478
-      # of them, measured in this exact shape. `actions/checkout` brings the committed jar
-      # along, so these cells would resolve it themselves; this input is what makes them
-      # CHECK it against `vendor/plantuml/pin.toml` first, set PLANTUML_JAR explicitly, and
-      # run the `test -f` / `java -version` step -- a jar that did not survive the checkout
-      # is then one red step naming it rather than those 478 errors. These cells run bare
+      # Rendering is opt in now, so this is a couple of dozen tests rather than 478: the
+      # twelve `test_app` parameter dicts that say `"plantuml": True`, plus the tests that
+      # call `make_app` themselves and take the `plantuml_command` fixture (the needflow
+      # conformance corpus, test_needflow, test_plantuml_command, test_plantuml_incdir).
+      # That fixture still RAISES rather than skipping when it finds no renderer -- these
+      # tests assert on rendered output and skipping them would be a false green -- so the
+      # cells still need a jar. `actions/checkout` brings the committed one along and they
+      # would resolve it themselves; this input is what makes them CHECK it against
+      # `vendor/plantuml/pin.toml` first, set PLANTUML_JAR explicitly, and run the
+      # `test -f` / `java -version` step, so a jar that did not survive the checkout is one
+      # red step naming it rather than a scatter of render failures. These cells run bare
       # `pytest`, not `poe`, so the tasks' `deps = ["fetch-plantuml"]` never fires here
       needs-plantuml: true
     secrets:
@@ -230,15 +233,10 @@ jobs:
           enable-cache: true
           cache-suffix: ${{ matrix.python-version }}-${{ matrix.sphinx-group }}
           python-version: ${{ matrix.python-version }}
-      - name: Point PLANTUML_JAR at the vendored jar
-        # yes, the browser cells need a jar: two of the three cases build through `test_app`,
-        # whose `plantuml_command` fixture raises rather than skips without a renderer.
-        # `shell: bash` (pipefail) and `tr -d '\r'` (Windows) are both load-bearing --
-        # vendor/plantuml/README.md, "The step CI runs", says why
-        shell: bash
-        run: |
-          jar="$(uv run --no-project python tools/src/sn_tools/fetch_plantuml.py --verify | tr -d '\r')"
-          echo "PLANTUML_JAR=$jar" >> "$GITHUB_ENV"
+      # NO PlantUML step: none of the three browser cases opts into rendering, and
+      # `test_app` resolves a renderer only for a build that did. The step used to be here
+      # because the fixture took `plantuml_command` unconditionally and it raises rather
+      # than skips
       - name: Install the cell
         # `js` is the browser driver (pytest-playwright); it is not in `test`, because only
         # these two cells want it

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,11 +110,28 @@ run on the pin, and Lint asserts the series it got equals the file.
 The machine needs `java` and graphviz's `dot` on `PATH` — the tests that render do not skip
 without them, so install graphviz as CI does (`apt-get install graphviz`). **`java` is needed
 by less of the sphinx-needs suite than it used to be**: rendering through the `test_app`
-fixture is opt in (`"plantuml": True` in the parameter dict — twelve parameter dicts do), and
-the rest of what needs a jar calls `make_app` itself: `tests/conformance/needflow/`,
-`tests/test_needflow.py`, `tests/test_plantuml_command.py` and `tests/test_plantuml_incdir.py`.
-Everything else in that suite renders nothing. `docs-needs` and the whole sphinx-mounts suite
-still need a renderer as before. **The PlantUML jar
+fixture is opt in (`"plantuml": True` in the parameter dict — twelve parameter dicts do).
+Measured with a logging `plantuml`/`java` shim first on `PATH`, the whole suite starts the
+pinned jar **233 times across 102 cases in 44 test functions in nine files**:
+`tests/test_needflow.py` (144 starts), `tests/conformance/needflow/` (46),
+`tests/test_needuml.py` (16), `tests/test_needs_external_needs_build.py` (12),
+`tests/test_plantuml_incdir.py` (5), `tests/test_arch.py` (4), and two each from
+`tests/test_github_issues.py`, `tests/test_needarch.py` and `tests/test_plantuml.py`. Most of
+those come from tests that call `make_app` themselves and take the `plantuml_command` fixture
+rather than opting in through `test_app`. `tests/test_plantuml_command.py` renders **nothing**
+— it fabricates a jar in `tmp_path` and unit-tests the resolution chain's string output.
+`docs-needs` and the whole sphinx-mounts suite still need a renderer as before.
+
+**What the inert renderer does and does not cover.** It is a property of the app object
+`test_app` builds, so it covers in-process builds through that fixture and nothing else. Two
+routes are outside it, both pre-dating the opt-in and both measured: a test that shells out to
+`sphinx-build` gets a process the fixture cannot patch (the two that do now pass the suite's
+own command in with the `plantuml_subprocess_args` fixture, so they render with the pinned
+jar); and a test that calls `make_app` directly on a project that loads
+`sphinxcontrib.plantuml` without taking `plantuml_command` renders with whatever `plantuml` is
+on `PATH` — `tests/test_needpie.py`'s two such cases are the whole of that today, six ambient
+renders, and closing it is the job of the slice that moves the renderer resolution into the
+shared test layer. **The PlantUML jar
 is committed**, once, at `vendor/plantuml/plantuml-<version>.jar` — the version
 `vendor/plantuml/pin.toml` names — so a checkout renders and **nothing has to reach the
 network**: not the 20 of a CI run's 26 jobs that render (counted on run 34057129950, on

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,48 +108,22 @@ CI's Lint job (and the monthly `prek-update` job) deliberately pass no such inpu
 run on the pin, and Lint asserts the series it got equals the file.
 
 The machine needs `java` and graphviz's `dot` on `PATH` — the tests that render do not skip
-without them, so install graphviz as CI does (`apt-get install graphviz`). **`java` is needed
-by less of the sphinx-needs suite than it used to be**: rendering through the `test_app`
-fixture is opt in (`"plantuml": True` in the parameter dict — twelve parameter dicts do).
-Measured with a logging `plantuml`/`java` shim first on `PATH`, the whole suite starts the
-pinned jar **233 times across 102 cases in 44 test functions in nine files**:
-`tests/test_needflow.py` (144 starts), `tests/conformance/needflow/` (46),
-`tests/test_needuml.py` (16), `tests/test_needs_external_needs_build.py` (12),
-`tests/test_plantuml_incdir.py` (5), `tests/test_arch.py` (4), and two each from
-`tests/test_github_issues.py`, `tests/test_needarch.py` and `tests/test_plantuml.py`. Most of
-those come from tests that call `make_app` themselves and take the `plantuml_command` fixture
-rather than opting in through `test_app`. `tests/test_plantuml_command.py` renders **nothing**
-— it fabricates a jar in `tmp_path` and unit-tests the resolution chain's string output.
-`docs-needs` and the whole sphinx-mounts suite still need a renderer as before.
-
-**What the inert renderer does and does not cover.** It is a property of the app object
-`test_app` builds, so it covers in-process builds through that fixture and nothing else. Two
-routes are outside it, both pre-dating the opt-in and both measured: a test that shells out to
-`sphinx-build` gets a process the fixture cannot patch (the two that do now pass the suite's
-own command in with the `plantuml_subprocess_args` fixture, so they render with the pinned
-jar); and a test that calls `make_app` directly on a project that loads
-`sphinxcontrib.plantuml` without taking `plantuml_command` renders with whatever `plantuml` is
-on `PATH` — `tests/test_needpie.py`'s two such cases are the whole of that today, six ambient
-renders, and closing it is the job of the slice that moves the renderer resolution into the
-shared test layer. **The PlantUML jar
-is committed**, once, at `vendor/plantuml/plantuml-<version>.jar` — the version
-`vendor/plantuml/pin.toml` names — so a checkout renders and **nothing has to reach the
-network**: not the 20 of a CI run's 26 jobs that render (counted on run 34057129950, on
-`a3aebf1f`, minus the two `Needs JS` cells this repository stopped pointing at a jar when
-rendering became opt in: the six that do not are `Lint`, the smoke test, `Docs codelinks`,
-the `check` aggregator and those two), not a Read the Docs build, not an offline machine,
-and not a sandboxed session whose allowlist this repository cannot set. `uv run poe verify-plantuml`
-checks the file against the pin (one sha256 of 30 MB, well under a second including `uv` and
-`poe` startup) and is what CI's Lint job runs; `uv run poe fetch-plantuml` downloads the jar
-the pin names, which is a **bump** step and otherwise the same hash check. **You will rarely
-run either by hand**: every task that renders declares `fetch-plantuml` — the sphinx-needs
-suites, `docs-needs*` and `benchmark-needs` through `deps`, the sphinx-mounts suites through
-`uses = { PLANTUML_JAR = "fetch-plantuml" }`, because that suite reads the variable and
-nothing else — and `lint` declares `verify-plantuml`. `smoke-needs` does not (its doc renders
-needflow through graphviz), neither do the sphinx-mounts docs (they render nothing, which
-is why their RTD config has no `default-jdk`), and neither does `test-needs-js`: none of the
-three browser cases opts into rendering, and the fixture no longer resolves a renderer for a
-build that did not ask for one.
+without them, so install graphviz as CI does (`apt-get install graphviz`). Rendering in the
+sphinx-needs suite is opt in: a `test_app` build draws no diagram unless its parameter dict
+says `"plantuml": True`, so most of the suite runs without `java` at all, and the tests that do
+render fail loudly without it. `docs-needs` and the sphinx-mounts suite still need a renderer.
+**The PlantUML jar is committed**, once, at `vendor/plantuml/plantuml-<version>.jar` — the
+version `vendor/plantuml/pin.toml` names — so a checkout renders and **nothing has to reach the
+network**: not a CI job, not a Read the Docs build, not an offline machine, and not a sandboxed
+session whose allowlist this repository cannot set. `uv run poe verify-plantuml` checks the file
+against the pin (one sha256 of 30 MB, well under a second including `uv` and `poe` startup) and
+is what CI's Lint job runs; `uv run poe fetch-plantuml` downloads the jar the pin names, which
+is a **bump** step and otherwise the same hash check. **You will rarely run either by hand**:
+every task that renders declares `fetch-plantuml` — the sphinx-needs suites, `docs-needs*` and
+`benchmark-needs` through `deps`, the sphinx-mounts suites through
+`uses = { PLANTUML_JAR = "fetch-plantuml" }`, because that suite reads the variable and nothing
+else — and `lint` declares `verify-plantuml`. `smoke-needs`, `test-needs-js` and the
+sphinx-mounts docs render nothing and declare neither.
 
 Both suites resolve a renderer in the same order, and **both assert rather than skip** when
 they find none: `PLANTUML_JAR` (an explicit choice, and an error when it names no file) →

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,13 +107,20 @@ matrix cells do — `setup-uv`'s `python-version` input is documented as setting
 CI's Lint job (and the monthly `prek-update` job) deliberately pass no such input, so they
 run on the pin, and Lint asserts the series it got equals the file.
 
-The machine needs `java` and graphviz's `dot` on `PATH` — the needflow tests do not skip
-without them, so install graphviz as CI does (`apt-get install graphviz`). **The PlantUML jar
+The machine needs `java` and graphviz's `dot` on `PATH` — the tests that render do not skip
+without them, so install graphviz as CI does (`apt-get install graphviz`). **`java` is needed
+by less of the sphinx-needs suite than it used to be**: rendering through the `test_app`
+fixture is opt in (`"plantuml": True` in the parameter dict — twelve parameter dicts do), and
+the rest of what needs a jar calls `make_app` itself: `tests/conformance/needflow/`,
+`tests/test_needflow.py`, `tests/test_plantuml_command.py` and `tests/test_plantuml_incdir.py`.
+Everything else in that suite renders nothing. `docs-needs` and the whole sphinx-mounts suite
+still need a renderer as before. **The PlantUML jar
 is committed**, once, at `vendor/plantuml/plantuml-<version>.jar` — the version
 `vendor/plantuml/pin.toml` names — so a checkout renders and **nothing has to reach the
-network**: not the 22 of a CI run's 26 jobs that render (counted on run 34057129950, on
-`a3aebf1f`: the four that do not are `Lint`, the smoke test, `Docs codelinks` and the `check`
-aggregator), not a Read the Docs build, not an offline machine,
+network**: not the 20 of a CI run's 26 jobs that render (counted on run 34057129950, on
+`a3aebf1f`, minus the two `Needs JS` cells this repository stopped pointing at a jar when
+rendering became opt in: the six that do not are `Lint`, the smoke test, `Docs codelinks`,
+the `check` aggregator and those two), not a Read the Docs build, not an offline machine,
 and not a sandboxed session whose allowlist this repository cannot set. `uv run poe verify-plantuml`
 checks the file against the pin (one sha256 of 30 MB, well under a second including `uv` and
 `poe` startup) and is what CI's Lint job runs; `uv run poe fetch-plantuml` downloads the jar
@@ -122,8 +129,10 @@ run either by hand**: every task that renders declares `fetch-plantuml` — the 
 suites, `docs-needs*` and `benchmark-needs` through `deps`, the sphinx-mounts suites through
 `uses = { PLANTUML_JAR = "fetch-plantuml" }`, because that suite reads the variable and
 nothing else — and `lint` declares `verify-plantuml`. `smoke-needs` does not (its doc renders
-needflow through graphviz) and neither do the sphinx-mounts docs (they render nothing, which
-is why their RTD config has no `default-jdk`).
+needflow through graphviz), neither do the sphinx-mounts docs (they render nothing, which
+is why their RTD config has no `default-jdk`), and neither does `test-needs-js`: none of the
+three browser cases opts into rendering, and the fixture no longer resolves a renderer for a
+build that did not ask for one.
 
 Both suites resolve a renderer in the same order, and **both assert rather than skip** when
 they find none: `PLANTUML_JAR` (an explicit choice, and an error when it names no file) →

--- a/packages/sphinx-needs/AGENTS.md
+++ b/packages/sphinx-needs/AGENTS.md
@@ -95,11 +95,20 @@ def process_need(
 A `.. uml::`, `needflow`, `needuml`, `needarch`, `needsequence` or `needgantt` directive still
 parses and still reaches the doctree — so a test that inspects the emitted diagram *source*,
 or the `.puml` files sphinx-needs writes itself, needs nothing — but the renderer is inert:
-the node visitors drop the node, the app's own `PlantumlBuilder` refuses to render, and the
-`plantuml` configuration is pointed at a command that cannot be run. A build that reaches a
-renderer anyway fails loudly, naming the parameter that would have enabled it, instead of
-quietly using whatever `plantuml` the machine happens to carry (`make_plantuml_inert` in
-`tests/conftest.py`).
+the node visitors drop the node, the app's own `PlantumlBuilder` refuses to render with an
+`AssertionError` naming the parameter, and the `plantuml` configuration is pointed at a
+command that cannot be run (`make_plantuml_inert` in `tests/conftest.py`).
+
+**It fences the app `test_app` builds, and nothing else.** Two routes go round it, and both
+are older than the opt-in:
+
+- a test that runs `sphinx-build` as a **subprocess** gets a process the fixture cannot
+  patch, and it reads the project's own `conf.py` — where sphinxcontrib-plantuml's default is
+  the bare word `plantuml`. Pass the `plantuml_subprocess_args` fixture into the argv, as the
+  two tests that render this way do, and the subprocess uses the suite's own pinned renderer;
+- a test that calls **`make_app` directly** on a project that loads `sphinxcontrib.plantuml`,
+  without taking the `plantuml_command` fixture, renders with whatever `plantuml` is on
+  `PATH`. `tests/test_needpie.py` has the only two such cases today.
 
 Opt in only when the test asserts on a RENDERED diagram — the `<object data=…>` in the HTML,
 the SVG behind it, or a warning only the render path emits. Twelve of the suite's 266

--- a/packages/sphinx-needs/AGENTS.md
+++ b/packages/sphinx-needs/AGENTS.md
@@ -91,42 +91,20 @@ def process_need(
 
 ### Rendering PlantUML is opt in
 
-**A `test_app` build renders no diagram unless its parameter dict says `"plantuml": True`.**
-A `.. uml::`, `needflow`, `needuml`, `needarch`, `needsequence` or `needgantt` directive still
-parses and still reaches the doctree — so a test that inspects the emitted diagram *source*,
-or the `.puml` files sphinx-needs writes itself, needs nothing — but the renderer is inert:
-the node visitors drop the node, the app's own `PlantumlBuilder` refuses to render with an
-`AssertionError` naming the parameter, and the `plantuml` configuration is pointed at a
-command that cannot be run (`make_plantuml_inert` in `tests/conftest.py`).
+A `test_app` build renders no diagram unless its parameter dict says `"plantuml": True`.
+Otherwise the renderer is inert (`make_plantuml_inert` in `tests/conftest.py`): diagram
+directives still parse and reach the doctree, so a test that inspects diagram *source* or the
+`.puml` files sphinx-needs writes needs nothing, but no JVM starts — about two seconds each,
+which used to be a third of the suite's wall time. Opt in only when the test asserts on a
+**rendered** diagram: the `<object>` in the HTML, the SVG behind it, or a warning only the
+render path emits.
 
-**It fences the app `test_app` builds, and nothing else.** Two routes go round it, and both
-are older than the opt-in:
-
-- a test that runs `sphinx-build` as a **subprocess** gets a process the fixture cannot
-  patch, and it reads the project's own `conf.py` — where sphinxcontrib-plantuml's default is
-  the bare word `plantuml`. Pass the `plantuml_subprocess_args` fixture into the argv, as the
-  two tests that render this way do, and the subprocess uses the suite's own pinned renderer;
-- a test that calls **`make_app` directly** on a project that loads `sphinxcontrib.plantuml`,
-  without taking the `plantuml_command` fixture, renders with whatever `plantuml` is on
-  `PATH`. `tests/test_needpie.py` has the only two such cases today.
-
-Opt in only when the test asserts on a RENDERED diagram — the `<object data=…>` in the HTML,
-the SVG behind it, or a warning only the render path emits. Twelve of the suite's 266
-parameter dicts do (`git grep -n '"plantuml": True' tests`), and each JVM start costs about
-two seconds, which is where a third of the suite's wall time used to go.
-
-Six test projects render through matplotlib instead (`needpie`, `needbar`); they are
-unaffected, and need no jar.
-
-The tests that need a jar without going through `test_app` call `make_app` themselves and
-take the session-scoped `plantuml_command` fixture: `tests/conformance/needflow/`,
-`tests/test_needflow.py`, `tests/test_plantuml_incdir.py` — or run `sphinx-build` as a
-subprocess and take `plantuml_subprocess_args`: `tests/test_needuml.py::test_needuml_diagram_allowmixing`,
-`tests/test_needs_external_needs_build.py::test_doc_build_html`. (`tests/test_plantuml_command.py`
-renders nothing: it unit-tests the resolution chain against a fabricated jar.)
-That fixture RAISES rather than skipping when it finds no renderer, which is why it is
-requested inside the opt-in branch of `test_app` rather than named in its signature — a
-fixture named in a signature is resolved whether or not the body uses it.
+The fence covers the app `test_app` builds and nothing else. A test that runs `sphinx-build`
+as a subprocess passes the `plantuml_subprocess_args` fixture into its argv; a test that calls
+`make_app` directly on a project that loads `sphinxcontrib.plantuml` takes the
+`plantuml_command` fixture. Both then render with the suite's pinned jar; without them a build
+renders with whatever `plantuml` is on `PATH`, silently. `plantuml_command` raises rather than
+skips when it finds no renderer, so request it only where a render is asserted.
 
 ### Writing Tests
 

--- a/packages/sphinx-needs/AGENTS.md
+++ b/packages/sphinx-needs/AGENTS.md
@@ -89,11 +89,39 @@ def process_need(
 - Snapshot testing uses `syrupy` - update snapshots with `--snapshot-update`
 - Browser tests use pytest-playwright and require the `@pytest.mark.jstest` marker
 
+### Rendering PlantUML is opt in
+
+**A `test_app` build renders no diagram unless its parameter dict says `"plantuml": True`.**
+A `.. uml::`, `needflow`, `needuml`, `needarch`, `needsequence` or `needgantt` directive still
+parses and still reaches the doctree — so a test that inspects the emitted diagram *source*,
+or the `.puml` files sphinx-needs writes itself, needs nothing — but the renderer is inert:
+the node visitors drop the node, the app's own `PlantumlBuilder` refuses to render, and the
+`plantuml` configuration is pointed at a command that cannot be run. A build that reaches a
+renderer anyway fails loudly, naming the parameter that would have enabled it, instead of
+quietly using whatever `plantuml` the machine happens to carry (`make_plantuml_inert` in
+`tests/conftest.py`).
+
+Opt in only when the test asserts on a RENDERED diagram — the `<object data=…>` in the HTML,
+the SVG behind it, or a warning only the render path emits. Twelve of the suite's 266
+parameter dicts do (`git grep -n '"plantuml": True' tests`), and each JVM start costs about
+two seconds, which is where a third of the suite's wall time used to go.
+
+Six test projects render through matplotlib instead (`needpie`, `needbar`); they are
+unaffected, and need no jar.
+
+The tests that need a jar without going through `test_app` call `make_app` themselves and
+take the session-scoped `plantuml_command` fixture: `tests/conformance/needflow/`,
+`tests/test_needflow.py`, `tests/test_plantuml_command.py`, `tests/test_plantuml_incdir.py`.
+That fixture RAISES rather than skipping when it finds no renderer, which is why it is
+requested inside the opt-in branch of `test_app` rather than named in its signature — a
+fixture named in a signature is resolved whether or not the body uses it.
+
 ### Writing Tests
 
 1. Create a test documentation project in `tests/doc_test/` if needed
 2. Use the `test_app` fixture for Sphinx application testing
-3. Mark tests appropriately:
+3. Add `"plantuml": True` to the parameter dict only if the test asserts on a rendered diagram
+4. Mark tests appropriately:
    - `@pytest.mark.jstest` - browser tests (pytest-playwright)
    - `@pytest.mark.benchmark` - Performance benchmarks
    - `@pytest.mark.fixture_file` - Tests using fixture files

--- a/packages/sphinx-needs/AGENTS.md
+++ b/packages/sphinx-needs/AGENTS.md
@@ -120,7 +120,10 @@ unaffected, and need no jar.
 
 The tests that need a jar without going through `test_app` call `make_app` themselves and
 take the session-scoped `plantuml_command` fixture: `tests/conformance/needflow/`,
-`tests/test_needflow.py`, `tests/test_plantuml_command.py`, `tests/test_plantuml_incdir.py`.
+`tests/test_needflow.py`, `tests/test_plantuml_incdir.py` — or run `sphinx-build` as a
+subprocess and take `plantuml_subprocess_args`: `tests/test_needuml.py::test_needuml_diagram_allowmixing`,
+`tests/test_needs_external_needs_build.py::test_doc_build_html`. (`tests/test_plantuml_command.py`
+renders nothing: it unit-tests the resolution chain against a fabricated jar.)
 That fixture RAISES rather than skipping when it finds no renderer, which is why it is
 requested inside the opt-in branch of `test_app` rather than named in its signature — a
 fixture named in a signature is resolved whether or not the body uses it.

--- a/packages/sphinx-needs/tests/conftest.py
+++ b/packages/sphinx-needs/tests/conftest.py
@@ -303,17 +303,35 @@ def make_plantuml_inert(app: SphinxTestApp) -> None:
       starts, and a JVM start is 2.04 s of every 2.13 s render, measured.
     * THIS APP'S OWN ``PlantumlBuilder`` has its two render entry points replaced with one
       that raises. That is the assertion that nothing renders, and it is made on the app
-      rather than on the output directory because two tests in this suite
-      (``test_needs_external_needs_build.py::test_doc_build_html`` and
-      ``test_needuml.py::test_needuml_diagram_allowmixing``) run a real ``sphinx-build``
-      SUBPROCESS into ``app.outdir``: a rendered file found there cannot be attributed to
-      the fixture's app, while a call reaching this object can only have come from it.
-    * the ``plantuml`` configuration is pointed at :data:`_INERT_PLANTUML_COMMAND`, so
-      anything that builds its own command line out of the config -- rather than going
-      through the object above -- fails naming the parameter that would have enabled it,
-      instead of quietly running whatever ``plantuml`` the machine happens to carry.
-      sphinxcontrib's own default is the bare word ``plantuml``, so "unset" would mean
-      "render with an unpinned renderer, and say nothing".
+      rather than on the output directory because ten test functions in this suite run a
+      real ``sphinx-build`` SUBPROCESS (eight of them in ``test_needuml.py``), two of them
+      into ``app.outdir`` itself: a rendered file found in that directory cannot be
+      attributed to the fixture's app, while a call reaching this object can only have come
+      from it.
+    * the ``plantuml`` configuration is pointed at :data:`_INERT_PLANTUML_COMMAND`. This one
+      is a SENTINEL rather than a fence, and the difference is worth stating: its whole
+      protection is that the token cannot be ``exec``-ed, and when sphinxcontrib does try it
+      the resulting ``PlantUmlError`` is caught by its own ``_prepare_html_render``, logged as
+      a warning and turned into a ``SkipNode`` -- so a build that got past both layers above
+      would warn and drop the diagram rather than fail. It also does not reach the batch
+      renderer: ``PlantumlBuilder.__init__`` freezes ``_base_cmdargs`` at ``builder-inited``,
+      before this function runs, and only ``render()`` and ``render_plantuml_inline()`` read
+      the live config (layer two is what covers that path). What it does buy is that "not
+      opted in" never means "run sphinxcontrib's default", which is the bare word
+      ``plantuml`` -- i.e. render with an unpinned renderer, and say nothing.
+
+    Layer one could also be spelled with a PUBLIC config value: ``plantuml_output_format =
+    "none"`` makes ``_prepare_html_render`` raise ``SkipNode`` and zeroes the batch path's
+    ``image_formats``, in every sphinxcontrib-plantuml back to 0.18.1. It is not used here
+    because it covers only the html and latex builders, where ``_NODE_VISITORS`` covers all
+    seven; and the private name is safe to depend on precisely because layer two is loud --
+    if a future release dropped it, the import below raises ``ImportError`` at fixture setup
+    rather than quietly restoring rendering.
+
+    **What this does NOT cover**: anything that is not this app object. A test that runs
+    ``sphinx-build`` as a subprocess gets a process with its own config (see
+    :func:`plantuml_subprocess_args`), and a test that calls ``make_app`` directly without
+    taking :func:`plantuml_command` never comes through here at all.
 
     All of it happens after the app exists rather than through ``confoverrides``, because a
     project that does not load ``sphinxcontrib.plantuml`` -- 88 of this suite's 138 test

--- a/packages/sphinx-needs/tests/conftest.py
+++ b/packages/sphinx-needs/tests/conftest.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import pytest
 import yaml
 from _pytest.mark import ParameterSet
+from docutils import nodes
 from docutils.nodes import document
 from sphinx import version_info
 from sphinx.application import Sphinx
@@ -244,17 +245,105 @@ def resolve_plantuml_command(workspace_jar: Path | None) -> str:
 
 @pytest.fixture(scope="session")
 def plantuml_command() -> str:
-    """The plantuml command every test project must build its diagrams with.
+    """The plantuml command every test project that RENDERS builds its diagrams with.
 
     CI runners have java and the checkout's jar but no ``plantuml`` on ``PATH``, so a
     project left on sphinxcontrib-plantuml's default command fails to render there while
-    passing on any machine that happens to have one installed. Every test therefore takes
-    its command from here, whether it goes through :func:`test_app` or calls ``make_app``
-    itself -- no test builds the path to the jar for itself.
+    passing on any machine that happens to have one installed. Every test that renders
+    therefore takes its command from here, whether it goes through :func:`test_app` or
+    calls ``make_app`` itself -- no test builds the path to the jar for itself.
+
+    :func:`resolve_plantuml_command` RAISES when it finds no renderer at all, which is
+    why :func:`test_app` does NOT name this fixture in its signature: a fixture named
+    there is resolved whether or not the body uses it, and on a machine with no jar and
+    no ``PLANTUML_JAR`` that difference is the whole suite erroring instead of the dozen
+    tests that genuinely need a renderer. It is pulled in with
+    ``request.getfixturevalue`` inside the opt-in branch instead.
 
     :return: The value for the ``plantuml`` configuration.
     """
     return resolve_plantuml_command(workspace_plantuml_jar())
+
+
+# The ``plantuml`` command for a build that did NOT opt in: one that cannot be run. Not
+# merely a placeholder -- sphinxcontrib-plantuml's own default is the bare word
+# ``plantuml``, so a build left on the default renders for real, silently, with whatever
+# unpinned renderer the developer's machine happens to carry. One token, no spaces, so
+# that whatever splits it (``shlex`` off Windows, sphinxcontrib's own unquoting on it)
+# still names it in the ``plantuml command %r cannot be run`` error it raises.
+_INERT_PLANTUML_COMMAND = (
+    "sphinx-needs-tests-this-build-did-not-opt-into-plantuml"
+    "--add-plantuml-True-to-its-test_app-parameters"
+)
+
+
+def _skip_plantuml_node(self, node: nodes.Element) -> None:
+    """Visit a ``plantuml`` node by dropping it: no subprocess, no warning, no markup."""
+    raise nodes.SkipNode
+
+
+def make_plantuml_inert(app: SphinxTestApp) -> None:
+    """Neutralise PlantUML rendering for one app, for a test that did not opt in.
+
+    Two halves, and both earn their place:
+
+    * every node visitor sphinxcontrib-plantuml registers is replaced with one that
+      raises ``SkipNode``. The directive still parses and the ``plantuml`` node still
+      lands in the doctree -- which is why the tests that inspect those nodes, or the
+      ``.puml`` files sphinx-needs writes itself, keep passing untouched -- but no JVM
+      starts. That is where the time goes: 2.04 s a render, measured, over the 107
+      renders the old default triggered.
+    * the ``plantuml`` configuration is pointed at :data:`_INERT_PLANTUML_COMMAND`, so a
+      render reached by a route these visitors do not cover (sphinxcontrib's batch path,
+      say, or a future one) fails LOUDLY and names the parameter that would have enabled
+      it, rather than quietly using a renderer this suite never chose.
+
+    Both happen after the app exists rather than through ``confoverrides``, because a
+    project that does not load ``sphinxcontrib.plantuml`` -- 88 of this suite's 138 test
+    projects -- would otherwise collect an "unknown config value 'plantuml' in override,
+    ignoring" warning that it never used to have.
+
+    :param app: The application to neutralise, already constructed and not yet built.
+    """
+    if "sphinxcontrib.plantuml" not in app.extensions:
+        return
+
+    from sphinxcontrib.plantuml import _NODE_VISITORS, plantuml
+
+    app.config.plantuml = _INERT_PLANTUML_COMMAND
+    app.add_node(
+        plantuml,
+        override=True,
+        **dict.fromkeys(_NODE_VISITORS, (_skip_plantuml_node, None)),
+    )
+
+
+def assert_nothing_rendered(app: SphinxTestApp) -> None:
+    """Assert a build that did not opt in really rendered no diagram.
+
+    :func:`make_plantuml_inert` is what makes that true; this is what keeps it true.
+    sphinxcontrib-plantuml writes every render into ``<outdir>/<plantuml_cache_path>``
+    before copying it to the image directory, so an empty (or absent) cache is the
+    cheapest proof that no renderer ran.
+
+    :param app: The built application.
+    """
+    if "sphinxcontrib.plantuml" not in app.extensions:
+        return
+
+    cache = Path(app.outdir) / app.config.plantuml_cache_path
+    rendered = (
+        sorted(
+            str(path.relative_to(cache)) for path in cache.rglob("*") if path.is_file()
+        )
+        if cache.is_dir()
+        else []
+    )
+    assert not rendered, (
+        f"PlantUML rendered {rendered} for a test that did not ask it to. "
+        "Add '\"plantuml\": True' to this test's test_app parameters if it means to "
+        "render; otherwise find out what got past the inert renderer."
+    )
 
 
 # node classes from extensions outside sphinx-needs are exempt from the parent check:
@@ -275,7 +364,7 @@ def _check_parent_child(app: Sphinx, doctree: document, docname: str):
 
 
 @pytest.fixture(scope="function")
-def test_app(make_app, sphinx_test_tempdir, plantuml_command, request):
+def test_app(make_app, sphinx_test_tempdir, request):
     """
     Fixture for creating a Sphinx application for testing.
 
@@ -284,20 +373,34 @@ def test_app(make_app, sphinx_test_tempdir, plantuml_command, request):
     directory. The fixture yields the Sphinx application, and cleans up the temporary
     source directory after the test function has executed.
 
+    **Rendering PlantUML is opt in**: a parameter dict that says ``"plantuml": True``
+    gets the session's :func:`plantuml_command`; every other build gets an inert
+    renderer (:func:`make_plantuml_inert`), and is held to it (:func:`assert_nothing_rendered`).
+    Twelve of this suite's 266 parameter dicts opt in -- diagrams are parsed everywhere,
+    but only those twelve assert on a rendered one, and rendering the rest cost a third
+    of the suite's wall time.
+
     :param make_app: A fixture for creating Sphinx applications.
     :param sphinx_test_tempdir: A fixture for providing the Sphinx test temporary directory.
-    :param plantuml_command: A fixture for the plantuml command to render with.
     :param request: A pytest request object for accessing fixture parameters.
 
     :return: A Sphinx application object.
     """
     builder_params = request.param
 
-    sphinx_conf_overrides = builder_params.get("confoverrides", {})
-    if not builder_params.get("no_plantuml", False):
-        # Since we don't want copy the plantuml.jar file for each test function,
-        # we need to override the plantuml conf variable and set it to what we have already
-        sphinx_conf_overrides.update(plantuml=plantuml_command)
+    # a COPY, because ``builder_params`` is the dict object in the test module's own
+    # ``@pytest.mark.parametrize`` argument list -- evaluated once at collection and
+    # shared by every rerun of that parameter, so updating it in place writes into the
+    # test's source-level literal
+    sphinx_conf_overrides = dict(builder_params.get("confoverrides", {}))
+    renders = builder_params.get("plantuml", False)
+    if renders:
+        # requested HERE and not in the signature: `plantuml_command` raises on a machine
+        # with no renderer, and a fixture named in a signature is resolved whether or not
+        # the body uses it
+        sphinx_conf_overrides.update(
+            plantuml=request.getfixturevalue("plantuml_command")
+        )
 
     srcdir = builder_params.get("srcdir")
     files = builder_params.get("files")
@@ -330,6 +433,9 @@ def test_app(make_app, sphinx_test_tempdir, plantuml_command, request):
         docutilsconf=builder_params.get("docutilsconf"),
         parallel=builder_params.get("parallel", 0),
     )
+
+    if not renders:
+        make_plantuml_inert(app)
     # Add the Sphinx warning as list to the app
     # Somehow "app._warning" seems to be just a boolean, if the builder is "latex" or "singlehtml".
     # In this case we don't catch the warnings.
@@ -347,6 +453,9 @@ def test_app(make_app, sphinx_test_tempdir, plantuml_command, request):
     app.connect("doctree-resolved", _check_parent_child, priority=999)
 
     yield app
+
+    if not renders:
+        assert_nothing_rendered(app)
 
     app.cleanup()
 

--- a/packages/sphinx-needs/tests/conftest.py
+++ b/packages/sphinx-needs/tests/conftest.py
@@ -339,6 +339,24 @@ def make_plantuml_inert(app: SphinxTestApp) -> None:
         plantuml_builder.render_batches = _refuse_to_render
 
 
+@pytest.fixture(scope="session")
+def plantuml_subprocess_args(plantuml_command: str) -> list[str]:
+    """``sphinx-build`` arguments pointing a SUBPROCESS build at this suite's renderer.
+
+    :func:`make_plantuml_inert` patches an app object, and a test that shells out to
+    ``sphinx-build`` gets a process the fixture cannot reach: it reads the project's own
+    ``conf.py``, where sphinxcontrib-plantuml's default is the bare word ``plantuml``. Such
+    a build therefore renders with whatever renderer the machine happens to carry, unpinned
+    and silently -- measured, before this fixture existed, as eight diagrams drawn by a
+    developer's homebrew PlantUML 1.2026.1 against the 1.2026.8 ``vendor/plantuml/pin.toml``
+    names. Passing these in makes a subprocess build render with the same command every
+    in-process build uses, and raise on a machine that has no renderer at all.
+
+    :return: ``["-D", "plantuml=<command>"]``, to splat into a ``sphinx-build`` argv.
+    """
+    return ["-D", f"plantuml={plantuml_command}"]
+
+
 # node classes from extensions outside sphinx-needs are exempt from the parent check:
 # sphinx-design installs its tab nodes by assigning ``children`` directly, so they never get
 # a parent (#1757), and the invariant guarded here (#1564) is about sphinx-needs' own nodes

--- a/packages/sphinx-needs/tests/conftest.py
+++ b/packages/sphinx-needs/tests/conftest.py
@@ -303,8 +303,8 @@ def make_plantuml_inert(app: SphinxTestApp) -> None:
       starts, and a JVM start is 2.04 s of every 2.13 s render, measured.
     * THIS APP'S OWN ``PlantumlBuilder`` has its two render entry points replaced with one
       that raises. That is the assertion that nothing renders, and it is made on the app
-      rather than on the output directory because ten test functions in this suite run a
-      real ``sphinx-build`` SUBPROCESS (eight of them in ``test_needuml.py``), two of them
+      rather than on the output directory because 23 test functions in this suite run a
+      real ``sphinx-build`` SUBPROCESS (twelve of them in ``test_needuml.py``), four of them
       into ``app.outdir`` itself: a rendered file found in that directory cannot be
       attributed to the fixture's app, while a call reaching this object can only have come
       from it.

--- a/packages/sphinx-needs/tests/conftest.py
+++ b/packages/sphinx-needs/tests/conftest.py
@@ -393,7 +393,13 @@ def test_app(make_app, sphinx_test_tempdir, request):
         # with no renderer, and a fixture named in a signature is resolved whether or not
         # the body uses it
         sphinx_conf_overrides.update(
-            plantuml=request.getfixturevalue("plantuml_command")
+            plantuml=request.getfixturevalue("plantuml_command"),
+            # sphinxcontrib-plantuml renders one diagram per `java` process by default
+            # (`plantuml_batch_size` is 1, and `collect_nodes` is only called above 1), and
+            # the JVM start is 2.04 s of every 2.13 s render, measured. Batching renders a
+            # whole document's diagrams in one process. 100 is "as many as there are": the
+            # largest opted-in project draws a dozen
+            plantuml_batch_size=100,
         )
 
     srcdir = builder_params.get("srcdir")

--- a/packages/sphinx-needs/tests/conftest.py
+++ b/packages/sphinx-needs/tests/conftest.py
@@ -282,23 +282,40 @@ def _skip_plantuml_node(self, node: nodes.Element) -> None:
     raise nodes.SkipNode
 
 
+def _refuse_to_render(*args: object, **kwargs: object) -> None:
+    """Stand in for sphinxcontrib-plantuml's renderer on a build that did not opt in."""
+    raise AssertionError(
+        "PlantUML rendering was reached by a test_app build that did not opt into it. "
+        "Add '\"plantuml\": True' to that test's test_app parameter dict if it means "
+        "to render; otherwise find out what got past the inert node visitors."
+    )
+
+
 def make_plantuml_inert(app: SphinxTestApp) -> None:
     """Neutralise PlantUML rendering for one app, for a test that did not opt in.
 
-    Two halves, and both earn their place:
+    Three layers, and each covers what the one before it cannot:
 
-    * every node visitor sphinxcontrib-plantuml registers is replaced with one that
-      raises ``SkipNode``. The directive still parses and the ``plantuml`` node still
-      lands in the doctree -- which is why the tests that inspect those nodes, or the
+    * every node visitor sphinxcontrib-plantuml registers is replaced with one that raises
+      ``SkipNode``. That is where the time goes: the directive still parses and the node
+      still reaches the doctree -- so the tests that inspect ``plantuml`` nodes, or the
       ``.puml`` files sphinx-needs writes itself, keep passing untouched -- but no JVM
-      starts. That is where the time goes: 2.04 s a render, measured, over the 107
-      renders the old default triggered.
-    * the ``plantuml`` configuration is pointed at :data:`_INERT_PLANTUML_COMMAND`, so a
-      render reached by a route these visitors do not cover (sphinxcontrib's batch path,
-      say, or a future one) fails LOUDLY and names the parameter that would have enabled
-      it, rather than quietly using a renderer this suite never chose.
+      starts, and a JVM start is 2.04 s of every 2.13 s render, measured.
+    * THIS APP'S OWN ``PlantumlBuilder`` has its two render entry points replaced with one
+      that raises. That is the assertion that nothing renders, and it is made on the app
+      rather than on the output directory because two tests in this suite
+      (``test_needs_external_needs_build.py::test_doc_build_html`` and
+      ``test_needuml.py::test_needuml_diagram_allowmixing``) run a real ``sphinx-build``
+      SUBPROCESS into ``app.outdir``: a rendered file found there cannot be attributed to
+      the fixture's app, while a call reaching this object can only have come from it.
+    * the ``plantuml`` configuration is pointed at :data:`_INERT_PLANTUML_COMMAND`, so
+      anything that builds its own command line out of the config -- rather than going
+      through the object above -- fails naming the parameter that would have enabled it,
+      instead of quietly running whatever ``plantuml`` the machine happens to carry.
+      sphinxcontrib's own default is the bare word ``plantuml``, so "unset" would mean
+      "render with an unpinned renderer, and say nothing".
 
-    Both happen after the app exists rather than through ``confoverrides``, because a
+    All of it happens after the app exists rather than through ``confoverrides``, because a
     project that does not load ``sphinxcontrib.plantuml`` -- 88 of this suite's 138 test
     projects -- would otherwise collect an "unknown config value 'plantuml' in override,
     ignoring" warning that it never used to have.
@@ -316,34 +333,10 @@ def make_plantuml_inert(app: SphinxTestApp) -> None:
         override=True,
         **dict.fromkeys(_NODE_VISITORS, (_skip_plantuml_node, None)),
     )
-
-
-def assert_nothing_rendered(app: SphinxTestApp) -> None:
-    """Assert a build that did not opt in really rendered no diagram.
-
-    :func:`make_plantuml_inert` is what makes that true; this is what keeps it true.
-    sphinxcontrib-plantuml writes every render into ``<outdir>/<plantuml_cache_path>``
-    before copying it to the image directory, so an empty (or absent) cache is the
-    cheapest proof that no renderer ran.
-
-    :param app: The built application.
-    """
-    if "sphinxcontrib.plantuml" not in app.extensions:
-        return
-
-    cache = Path(app.outdir) / app.config.plantuml_cache_path
-    rendered = (
-        sorted(
-            str(path.relative_to(cache)) for path in cache.rglob("*") if path.is_file()
-        )
-        if cache.is_dir()
-        else []
-    )
-    assert not rendered, (
-        f"PlantUML rendered {rendered} for a test that did not ask it to. "
-        "Add '\"plantuml\": True' to this test's test_app parameters if it means to "
-        "render; otherwise find out what got past the inert renderer."
-    )
+    plantuml_builder = getattr(app.builder, "plantuml_builder", None)
+    if plantuml_builder is not None:
+        plantuml_builder.render = _refuse_to_render
+        plantuml_builder.render_batches = _refuse_to_render
 
 
 # node classes from extensions outside sphinx-needs are exempt from the parent check:
@@ -375,7 +368,8 @@ def test_app(make_app, sphinx_test_tempdir, request):
 
     **Rendering PlantUML is opt in**: a parameter dict that says ``"plantuml": True``
     gets the session's :func:`plantuml_command`; every other build gets an inert
-    renderer (:func:`make_plantuml_inert`), and is held to it (:func:`assert_nothing_rendered`).
+    renderer (:func:`make_plantuml_inert`), which REFUSES to render rather than
+    quietly rendering with whatever renderer the machine happens to carry.
     Twelve of this suite's 266 parameter dicts opt in -- diagrams are parsed everywhere,
     but only those twelve assert on a rendered one, and rendering the rest cost a third
     of the suite's wall time.
@@ -453,9 +447,6 @@ def test_app(make_app, sphinx_test_tempdir, request):
     app.connect("doctree-resolved", _check_parent_child, priority=999)
 
     yield app
-
-    if not renders:
-        assert_nothing_rendered(app)
 
     app.cleanup()
 

--- a/packages/sphinx-needs/tests/doc_test/arch_doc/conf.py
+++ b/packages/sphinx-needs/tests/doc_test/arch_doc/conf.py
@@ -1,5 +1,6 @@
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
-# note, the plantuml executable command is set globally in the test suite
+# note, the plantuml command comes from the test suite, not from here: the pinned
+# renderer for a build that opts into it, an inert one for every other build
 plantuml_output_format = "svg"
 
 needs_types = [

--- a/packages/sphinx-needs/tests/doc_test/doc_complex/conf.py
+++ b/packages/sphinx-needs/tests/doc_test/doc_complex/conf.py
@@ -2,7 +2,8 @@ project = "basic test"
 
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 
-# note, the plantuml executable command is set globally in the test suite
+# note, the plantuml command comes from the test suite, not from here: the pinned
+# renderer for a build that opts into it, an inert one for every other build
 plantuml_output_format = "svg"
 
 needs_id_regex = "^[A-Za-z0-9_]"

--- a/packages/sphinx-needs/tests/doc_test/doc_github_issue_160/conf.py
+++ b/packages/sphinx-needs/tests/doc_test/doc_github_issue_160/conf.py
@@ -1,6 +1,7 @@
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 
-# note, the plantuml executable command is set globally in the test suite
+# note, the plantuml command comes from the test suite, not from here: the pinned
+# renderer for a build that opts into it, an inert one for every other build
 plantuml_output_format = "svg"
 
 needs_id_regex = "^[A-Z0-9]-[A-Z0-9]+"

--- a/packages/sphinx-needs/tests/doc_test/doc_github_issue_1664/conf.py
+++ b/packages/sphinx-needs/tests/doc_test/doc_github_issue_1664/conf.py
@@ -1,6 +1,7 @@
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 
-# note, the plantuml executable command is set globally in the test suite
+# note, the plantuml command comes from the test suite, not from here: the pinned
+# renderer for a build that opts into it, an inert one for every other build
 plantuml_output_format = "svg"
 
 # needs_types entries without an explicit 'color' field.

--- a/packages/sphinx-needs/tests/doc_test/doc_github_issue_61/conf.py
+++ b/packages/sphinx-needs/tests/doc_test/doc_github_issue_61/conf.py
@@ -1,6 +1,7 @@
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 
-# note, the plantuml executable command is set globally in the test suite
+# note, the plantuml command comes from the test suite, not from here: the pinned
+# renderer for a build that opts into it, an inert one for every other build
 plantuml_output_format = "svg"
 
 needs_id_regex = "^[A-Z0-9]-[A-Z0-9]+"

--- a/packages/sphinx-needs/tests/doc_test/doc_links/conf.py
+++ b/packages/sphinx-needs/tests/doc_test/doc_links/conf.py
@@ -2,7 +2,8 @@ project = "needs test docs"
 
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 
-# note, the plantuml executable command is set globally in the test suite
+# note, the plantuml command comes from the test suite, not from here: the pinned
+# renderer for a build that opts into it, an inert one for every other build
 plantuml_output_format = "svg"
 
 needs_types = [

--- a/packages/sphinx-needs/tests/doc_test/doc_list2need/conf.py
+++ b/packages/sphinx-needs/tests/doc_test/doc_list2need/conf.py
@@ -1,6 +1,7 @@
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 
-# note, the plantuml executable command is set globally in the test suite
+# note, the plantuml command comes from the test suite, not from here: the pinned
+# renderer for a build that opts into it, an inert one for every other build
 plantuml_output_format = "svg"
 
 needs_table_style = "TABLE"

--- a/packages/sphinx-needs/tests/doc_test/doc_measure_time/conf.py
+++ b/packages/sphinx-needs/tests/doc_test/doc_measure_time/conf.py
@@ -9,7 +9,8 @@ sys.path.insert(0, os.path.abspath("."))
 
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 
-# note, the plantuml executable command is set globally in the test suite
+# note, the plantuml command comes from the test suite, not from here: the pinned
+# renderer for a build that opts into it, an inert one for every other build
 plantuml_output_format = "svg"
 
 needs_debug_measurement = True

--- a/packages/sphinx-needs/tests/doc_test/doc_need_delete/conf.py
+++ b/packages/sphinx-needs/tests/doc_test/doc_need_delete/conf.py
@@ -1,6 +1,7 @@
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 
-# note, the plantuml executable command is set globally in the test suite
+# note, the plantuml command comes from the test suite, not from here: the pinned
+# renderer for a build that opts into it, an inert one for every other build
 plantuml_output_format = "svg"
 
 needs_id_regex = "^[A-Za-z0-9_]"

--- a/packages/sphinx-needs/tests/doc_test/doc_need_jinja_content/conf.py
+++ b/packages/sphinx-needs/tests/doc_test/doc_need_jinja_content/conf.py
@@ -1,6 +1,7 @@
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 
-# note, the plantuml executable command is set globally in the test suite
+# note, the plantuml command comes from the test suite, not from here: the pinned
+# renderer for a build that opts into it, an inert one for every other build
 plantuml_output_format = "svg"
 
 needs_id_regex = "^[A-Za-z0-9_]"

--- a/packages/sphinx-needs/tests/doc_test/doc_needarch/conf.py
+++ b/packages/sphinx-needs/tests/doc_test/doc_needarch/conf.py
@@ -1,6 +1,7 @@
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 
-# note, the plantuml executable command is set globally in the test suite
+# note, the plantuml command comes from the test suite, not from here: the pinned
+# renderer for a build that opts into it, an inert one for every other build
 plantuml_output_format = "svg"
 
 needs_table_style = "TABLE"

--- a/packages/sphinx-needs/tests/doc_test/doc_needarch_jinja_func_import/conf.py
+++ b/packages/sphinx-needs/tests/doc_test/doc_needarch_jinja_func_import/conf.py
@@ -1,6 +1,7 @@
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 
-# note, the plantuml executable command is set globally in the test suite
+# note, the plantuml command comes from the test suite, not from here: the pinned
+# renderer for a build that opts into it, an inert one for every other build
 plantuml_output_format = "svg"
 
 needs_types = [

--- a/packages/sphinx-needs/tests/doc_test/doc_needarch_jinja_func_need/conf.py
+++ b/packages/sphinx-needs/tests/doc_test/doc_needarch_jinja_func_need/conf.py
@@ -1,6 +1,7 @@
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 
-# note, the plantuml executable command is set globally in the test suite
+# note, the plantuml command comes from the test suite, not from here: the pinned
+# renderer for a build that opts into it, an inert one for every other build
 plantuml_output_format = "svg"
 
 needs_table_style = "TABLE"

--- a/packages/sphinx-needs/tests/doc_test/doc_needarch_negative_tests/conf.py
+++ b/packages/sphinx-needs/tests/doc_test/doc_needarch_negative_tests/conf.py
@@ -1,6 +1,7 @@
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 
-# note, the plantuml executable command is set globally in the test suite
+# note, the plantuml command comes from the test suite, not from here: the pinned
+# renderer for a build that opts into it, an inert one for every other build
 plantuml_output_format = "svg"
 
 needs_table_style = "TABLE"

--- a/packages/sphinx-needs/tests/doc_test/doc_needflow/conf.py
+++ b/packages/sphinx-needs/tests/doc_test/doc_needflow/conf.py
@@ -1,6 +1,7 @@
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 
-# note, the plantuml executable command is set globally in the test suite
+# note, the plantuml command comes from the test suite, not from here: the pinned
+# renderer for a build that opts into it, an inert one for every other build
 plantuml_output_format = "svg"
 
 needs_table_style = "TABLE"

--- a/packages/sphinx-needs/tests/doc_test/doc_needflow_incl_child_needs/conf.py
+++ b/packages/sphinx-needs/tests/doc_test/doc_needflow_incl_child_needs/conf.py
@@ -1,6 +1,7 @@
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 
-# note, the plantuml executable command is set globally in the test suite
+# note, the plantuml command comes from the test suite, not from here: the pinned
+# renderer for a build that opts into it, an inert one for every other build
 plantuml_output_format = "svg"
 
 needs_table_style = "TABLE"

--- a/packages/sphinx-needs/tests/doc_test/doc_needimport_noindex/conf.py
+++ b/packages/sphinx-needs/tests/doc_test/doc_needimport_noindex/conf.py
@@ -6,5 +6,6 @@ extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 # figures, tables and code-blocks are automatically numbered if they have a caption
 numfig = True
 
-# note, the plantuml executable command is set globally in the test suite
+# note, the plantuml command comes from the test suite, not from here: the pinned
+# renderer for a build that opts into it, an inert one for every other build
 plantuml_output_format = "svg"

--- a/packages/sphinx-needs/tests/doc_test/doc_needpie/conf.py
+++ b/packages/sphinx-needs/tests/doc_test/doc_needpie/conf.py
@@ -1,6 +1,7 @@
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 
-# note, the plantuml executable command is set globally in the test suite
+# note, the plantuml command comes from the test suite, not from here: the pinned
+# renderer for a build that opts into it, an inert one for every other build
 plantuml_output_format = "svg"
 
 needs_table_style = "TABLE"

--- a/packages/sphinx-needs/tests/doc_test/doc_needs_external_needs/conf.py
+++ b/packages/sphinx-needs/tests/doc_test/doc_needs_external_needs/conf.py
@@ -1,6 +1,7 @@
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 
-# note, the plantuml executable command is set globally in the test suite
+# note, the plantuml command comes from the test suite, not from here: the pinned
+# renderer for a build that opts into it, an inert one for every other build
 plantuml_output_format = "svg"
 
 needs_table_style = "TABLE"

--- a/packages/sphinx-needs/tests/doc_test/doc_needs_external_needs_remote/conf.py
+++ b/packages/sphinx-needs/tests/doc_test/doc_needs_external_needs_remote/conf.py
@@ -1,6 +1,7 @@
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 
-# note, the plantuml executable command is set globally in the test suite
+# note, the plantuml command comes from the test suite, not from here: the pinned
+# renderer for a build that opts into it, an inert one for every other build
 plantuml_output_format = "svg"
 
 needs_table_style = "TABLE"

--- a/packages/sphinx-needs/tests/doc_test/doc_needs_external_needs_with_target_url/conf.py
+++ b/packages/sphinx-needs/tests/doc_test/doc_needs_external_needs_with_target_url/conf.py
@@ -1,6 +1,7 @@
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 
-# note, the plantuml executable command is set globally in the test suite
+# note, the plantuml command comes from the test suite, not from here: the pinned
+# renderer for a build that opts into it, an inert one for every other build
 plantuml_output_format = "svg"
 
 needs_table_style = "TABLE"

--- a/packages/sphinx-needs/tests/doc_test/doc_needs_filter_data/conf.py
+++ b/packages/sphinx-needs/tests/doc_test/doc_needs_filter_data/conf.py
@@ -5,7 +5,8 @@ sys.path.insert(0, os.path.abspath("./"))
 
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 
-# note, the plantuml executable command is set globally in the test suite
+# note, the plantuml command comes from the test suite, not from here: the pinned
+# renderer for a build that opts into it, an inert one for every other build
 plantuml_output_format = "svg"
 
 needs_id_regex = "^[A-Za-z0-9_]*"

--- a/packages/sphinx-needs/tests/doc_test/doc_needuml/conf.py
+++ b/packages/sphinx-needs/tests/doc_test/doc_needuml/conf.py
@@ -1,6 +1,7 @@
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 
-# note, the plantuml executable command is set globally in the test suite
+# note, the plantuml command comes from the test suite, not from here: the pinned
+# renderer for a build that opts into it, an inert one for every other build
 plantuml_output_format = "svg"
 
 needs_table_style = "TABLE"

--- a/packages/sphinx-needs/tests/doc_test/doc_needuml_diagram_allowmixing/conf.py
+++ b/packages/sphinx-needs/tests/doc_test/doc_needuml_diagram_allowmixing/conf.py
@@ -1,6 +1,7 @@
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 
-# note, the plantuml executable command is set globally in the test suite
+# note, the plantuml command comes from the test suite, not from here: the pinned
+# renderer for a build that opts into it, an inert one for every other build
 plantuml_output_format = "svg"
 
 needs_table_style = "TABLE"

--- a/packages/sphinx-needs/tests/doc_test/doc_needuml_duplicate_key/conf.py
+++ b/packages/sphinx-needs/tests/doc_test/doc_needuml_duplicate_key/conf.py
@@ -1,6 +1,7 @@
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 
-# note, the plantuml executable command is set globally in the test suite
+# note, the plantuml command comes from the test suite, not from here: the pinned
+# renderer for a build that opts into it, an inert one for every other build
 plantuml_output_format = "svg"
 
 needs_table_style = "TABLE"

--- a/packages/sphinx-needs/tests/doc_test/doc_needuml_filter/conf.py
+++ b/packages/sphinx-needs/tests/doc_test/doc_needuml_filter/conf.py
@@ -1,6 +1,7 @@
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 
-# note, the plantuml executable command is set globally in the test suite
+# note, the plantuml command comes from the test suite, not from here: the pinned
+# renderer for a build that opts into it, an inert one for every other build
 plantuml_output_format = "svg"
 
 needs_table_style = "TABLE"

--- a/packages/sphinx-needs/tests/doc_test/doc_needuml_import_string_option/conf.py
+++ b/packages/sphinx-needs/tests/doc_test/doc_needuml_import_string_option/conf.py
@@ -1,4 +1,5 @@
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 
-# note, the plantuml executable command is set globally in the test suite
+# note, the plantuml command comes from the test suite, not from here: the pinned
+# renderer for a build that opts into it, an inert one for every other build
 plantuml_output_format = "svg"

--- a/packages/sphinx-needs/tests/doc_test/doc_needuml_jinja_func_flow/conf.py
+++ b/packages/sphinx-needs/tests/doc_test/doc_needuml_jinja_func_flow/conf.py
@@ -1,6 +1,7 @@
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 
-# note, the plantuml executable command is set globally in the test suite
+# note, the plantuml command comes from the test suite, not from here: the pinned
+# renderer for a build that opts into it, an inert one for every other build
 plantuml_output_format = "svg"
 
 needs_table_style = "TABLE"

--- a/packages/sphinx-needs/tests/doc_test/doc_needuml_jinja_func_import_negative_tests/conf.py
+++ b/packages/sphinx-needs/tests/doc_test/doc_needuml_jinja_func_import_negative_tests/conf.py
@@ -1,6 +1,7 @@
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 
-# note, the plantuml executable command is set globally in the test suite
+# note, the plantuml command comes from the test suite, not from here: the pinned
+# renderer for a build that opts into it, an inert one for every other build
 plantuml_output_format = "svg"
 
 needs_types = [

--- a/packages/sphinx-needs/tests/doc_test/doc_needuml_jinja_func_need_removed/conf.py
+++ b/packages/sphinx-needs/tests/doc_test/doc_needuml_jinja_func_need_removed/conf.py
@@ -1,6 +1,7 @@
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 
-# note, the plantuml executable command is set globally in the test suite
+# note, the plantuml command comes from the test suite, not from here: the pinned
+# renderer for a build that opts into it, an inert one for every other build
 plantuml_output_format = "svg"
 
 needs_table_style = "TABLE"

--- a/packages/sphinx-needs/tests/doc_test/doc_needuml_jinja_func_ref/conf.py
+++ b/packages/sphinx-needs/tests/doc_test/doc_needuml_jinja_func_ref/conf.py
@@ -1,6 +1,7 @@
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 
-# note, the plantuml executable command is set globally in the test suite
+# note, the plantuml command comes from the test suite, not from here: the pinned
+# renderer for a build that opts into it, an inert one for every other build
 plantuml_output_format = "svg"
 
 needs_table_style = "TABLE"

--- a/packages/sphinx-needs/tests/doc_test/doc_needuml_jinja_warnings/conf.py
+++ b/packages/sphinx-needs/tests/doc_test/doc_needuml_jinja_warnings/conf.py
@@ -1,6 +1,7 @@
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 
-# note, the plantuml executable command is set globally in the test suite
+# note, the plantuml command comes from the test suite, not from here: the pinned
+# renderer for a build that opts into it, an inert one for every other build
 plantuml_output_format = "svg"
 
 # defined for every need, set on none of them: the shape import() must ignore

--- a/packages/sphinx-needs/tests/doc_test/doc_needuml_key_missing/conf.py
+++ b/packages/sphinx-needs/tests/doc_test/doc_needuml_key_missing/conf.py
@@ -1,4 +1,5 @@
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 
-# note, the plantuml executable command is set globally in the test suite
+# note, the plantuml command comes from the test suite, not from here: the pinned
+# renderer for a build that opts into it, an inert one for every other build
 plantuml_output_format = "svg"

--- a/packages/sphinx-needs/tests/doc_test/doc_needuml_key_name_diagram/conf.py
+++ b/packages/sphinx-needs/tests/doc_test/doc_needuml_key_name_diagram/conf.py
@@ -1,6 +1,7 @@
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 
-# note, the plantuml executable command is set globally in the test suite
+# note, the plantuml command comes from the test suite, not from here: the pinned
+# renderer for a build that opts into it, an inert one for every other build
 plantuml_output_format = "svg"
 
 needs_table_style = "TABLE"

--- a/packages/sphinx-needs/tests/doc_test/doc_needuml_option_warnings/conf.py
+++ b/packages/sphinx-needs/tests/doc_test/doc_needuml_option_warnings/conf.py
@@ -1,4 +1,5 @@
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 
-# note, the plantuml executable command is set globally in the test suite
+# note, the plantuml command comes from the test suite, not from here: the pinned
+# renderer for a build that opts into it, an inert one for every other build
 plantuml_output_format = "svg"

--- a/packages/sphinx-needs/tests/doc_test/doc_needuml_save/conf.py
+++ b/packages/sphinx-needs/tests/doc_test/doc_needuml_save/conf.py
@@ -1,6 +1,7 @@
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 
-# note, the plantuml executable command is set globally in the test suite
+# note, the plantuml command comes from the test suite, not from here: the pinned
+# renderer for a build that opts into it, an inert one for every other build
 plantuml_output_format = "svg"
 
 needs_table_style = "TABLE"

--- a/packages/sphinx-needs/tests/doc_test/doc_needuml_save_with_abs_path/conf.py
+++ b/packages/sphinx-needs/tests/doc_test/doc_needuml_save_with_abs_path/conf.py
@@ -1,6 +1,7 @@
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 
-# note, the plantuml executable command is set globally in the test suite
+# note, the plantuml command comes from the test suite, not from here: the pinned
+# renderer for a build that opts into it, an inert one for every other build
 plantuml_output_format = "svg"
 
 needs_table_style = "TABLE"

--- a/packages/sphinx-needs/tests/doc_test/doc_report_dead_links_false/conf.py
+++ b/packages/sphinx-needs/tests/doc_test/doc_report_dead_links_false/conf.py
@@ -1,6 +1,7 @@
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 
-# note, the plantuml executable command is set globally in the test suite
+# note, the plantuml command comes from the test suite, not from here: the pinned
+# renderer for a build that opts into it, an inert one for every other build
 plantuml_output_format = "svg"
 
 needs_types = [

--- a/packages/sphinx-needs/tests/doc_test/doc_report_dead_links_true/conf.py
+++ b/packages/sphinx-needs/tests/doc_test/doc_report_dead_links_true/conf.py
@@ -1,6 +1,7 @@
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 
-# note, the plantuml executable command is set globally in the test suite
+# note, the plantuml command comes from the test suite, not from here: the pinned
+# renderer for a build that opts into it, an inert one for every other build
 plantuml_output_format = "svg"
 
 needs_types = [

--- a/packages/sphinx-needs/tests/doc_test/doc_ubcode_compat/conf.py
+++ b/packages/sphinx-needs/tests/doc_test/doc_ubcode_compat/conf.py
@@ -1,6 +1,7 @@
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 
-# note, the plantuml executable command is set globally in the test suite
+# note, the plantuml command comes from the test suite, not from here: the pinned
+# renderer for a build that opts into it, an inert one for every other build
 plantuml_output_format = "svg"
 
 needs_id_regex = "^[A-Za-z0-9_]"

--- a/packages/sphinx-needs/tests/doc_test/external_doc/conf.py
+++ b/packages/sphinx-needs/tests/doc_test/external_doc/conf.py
@@ -4,7 +4,8 @@ version = "1.0"
 
 extensions = ["sphinxcontrib.plantuml", "sphinx_needs"]
 
-# note, the plantuml executable command is set globally in the test suite
+# note, the plantuml command comes from the test suite, not from here: the pinned
+# renderer for a build that opts into it, an inert one for every other build
 plantuml_output_format = "svg"
 
 needs_id_regex = "^[A-Za-z0-9_]"

--- a/packages/sphinx-needs/tests/doc_test/filter_doc/conf.py
+++ b/packages/sphinx-needs/tests/doc_test/filter_doc/conf.py
@@ -2,7 +2,8 @@ import os
 
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 
-# note, the plantuml executable command is set globally in the test suite
+# note, the plantuml command comes from the test suite, not from here: the pinned
+# renderer for a build that opts into it, an inert one for every other build
 plantuml_output_format = "svg"
 
 needs_id_regex = "^[A-Za-z0-9_]"

--- a/packages/sphinx-needs/tests/doc_test/role_need_doc/conf.py
+++ b/packages/sphinx-needs/tests/doc_test/role_need_doc/conf.py
@@ -2,7 +2,8 @@ import os
 
 extensions = ["sphinxcontrib.plantuml", "sphinx_needs"]
 
-# note, the plantuml executable command is set globally in the test suite
+# note, the plantuml command comes from the test suite, not from here: the pinned
+# renderer for a build that opts into it, an inert one for every other build
 plantuml_output_format = "svg"
 
 needs_id_regex = "^[A-Za-z0-9_]"

--- a/packages/sphinx-needs/tests/doc_test/variant_doc/conf.py
+++ b/packages/sphinx-needs/tests/doc_test/variant_doc/conf.py
@@ -2,7 +2,8 @@ tags.add("tag_b")  # noqa: F821
 
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 
-# note, the plantuml executable command is set globally in the test suite
+# note, the plantuml command comes from the test suite, not from here: the pinned
+# renderer for a build that opts into it, an inert one for every other build
 plantuml_output_format = "svg"
 
 needs_id_regex = "^[A-Za-z0-9_]"

--- a/packages/sphinx-needs/tests/doc_test/variant_options/conf.py
+++ b/packages/sphinx-needs/tests/doc_test/variant_options/conf.py
@@ -2,7 +2,8 @@ tags.add("tag_b")  # noqa: F821
 
 extensions = ["sphinx_needs", "sphinxcontrib.plantuml"]
 
-# note, the plantuml executable command is set globally in the test suite
+# note, the plantuml command comes from the test suite, not from here: the pinned
+# renderer for a build that opts into it, an inert one for every other build
 plantuml_output_format = "svg"
 
 needs_id_regex = "^[A-Za-z0-9_]"

--- a/packages/sphinx-needs/tests/schema/test_schema.py
+++ b/packages/sphinx-needs/tests/schema/test_schema.py
@@ -77,7 +77,7 @@ def test_schemas(
 
 @pytest.mark.parametrize(
     "test_app",
-    [{"buildername": "html", "srcdir": "doc_test/schema_typing", "no_plantuml": True}],
+    [{"buildername": "html", "srcdir": "doc_test/schema_typing"}],
     indirect=True,
 )
 def test_schema_typing(test_app: SphinxTestApp, snapshot) -> None:
@@ -96,7 +96,7 @@ def test_schema_typing(test_app: SphinxTestApp, snapshot) -> None:
 
 @pytest.mark.parametrize(
     "test_app",
-    [{"buildername": "html", "srcdir": "doc_test/doc_schema_e2e", "no_plantuml": True}],
+    [{"buildername": "html", "srcdir": "doc_test/doc_schema_e2e"}],
     indirect=True,
 )
 def test_schema_e2e(test_app: SphinxTestApp, snapshot) -> None:
@@ -123,7 +123,6 @@ def test_schema_e2e(test_app: SphinxTestApp, snapshot) -> None:
         {
             "buildername": "html",
             "srcdir": "doc_test/doc_schema_example",
-            "no_plantuml": True,
         }
     ],
     indirect=True,
@@ -162,7 +161,6 @@ Test
 """,
                 ),
             ],
-            "no_plantuml": True,
         }
     ],
     indirect=True,

--- a/packages/sphinx-needs/tests/test_add_sections_sigs.py
+++ b/packages/sphinx-needs/tests/test_add_sections_sigs.py
@@ -12,7 +12,6 @@ from sphinx.testing.util import SphinxTestApp
         {
             "buildername": "html",
             "srcdir": "doc_test/add_sections_sigs",
-            "no_plantuml": True,
         }
     ],
     indirect=True,

--- a/packages/sphinx-needs/tests/test_api_usage.py
+++ b/packages/sphinx-needs/tests/test_api_usage.py
@@ -54,7 +54,6 @@ def setup(app):
         {
             "buildername": "html",
             "srcdir": "doc_test/doc_basic",
-            "no_plantuml": True,
             "confoverrides": {"extensions": ["sphinx_needs", "dummy_extension.dummy"]},
         }
     ],
@@ -77,7 +76,6 @@ def test_api_configuration(test_app: SphinxTestApp):
         {
             "buildername": "html",
             "srcdir": "doc_test/doc_basic",
-            "no_plantuml": True,
             "confoverrides": {"extensions": ["sphinx_needs", "dummy_extension.dummy"]},
         }
     ],
@@ -97,7 +95,6 @@ def test_api_get_types(test_app: SphinxTestApp):
         {
             "buildername": "html",
             "srcdir": "doc_test/doc_basic",
-            "no_plantuml": True,
             "confoverrides": {"extensions": ["sphinx_needs", "dummy_extension.dummy"]},
         }
     ],

--- a/packages/sphinx-needs/tests/test_arch.py
+++ b/packages/sphinx-needs/tests/test_arch.py
@@ -4,7 +4,9 @@ import pytest
 
 
 @pytest.mark.parametrize(
-    "test_app", [{"buildername": "html", "srcdir": "doc_test/arch_doc"}], indirect=True
+    "test_app",
+    [{"buildername": "html", "srcdir": "doc_test/arch_doc", "plantuml": True}],
+    indirect=True,
 )
 def test_doc_build_html(test_app):
     app = test_app

--- a/packages/sphinx-needs/tests/test_basic_doc.py
+++ b/packages/sphinx-needs/tests/test_basic_doc.py
@@ -18,7 +18,7 @@ from sphinx_needs.directives.needtable import Needtable
 
 @pytest.mark.parametrize(
     "test_app",
-    [{"buildername": "html", "srcdir": "doc_test/doc_basic", "no_plantuml": True}],
+    [{"buildername": "html", "srcdir": "doc_test/doc_basic"}],
     indirect=True,
 )
 def test_build_html(test_app: SphinxTestApp, snapshot_doctree):
@@ -58,7 +58,7 @@ def test_build_html(test_app: SphinxTestApp, snapshot_doctree):
 )
 @pytest.mark.parametrize(
     "test_app",
-    [{"buildername": "html", "srcdir": "doc_test/doc_basic", "no_plantuml": True}],
+    [{"buildername": "html", "srcdir": "doc_test/doc_basic"}],
     indirect=True,
 )
 def test_html_head_files(test_app: SphinxTestApp):
@@ -89,7 +89,6 @@ def test_html_head_files(test_app: SphinxTestApp):
         {
             "buildername": "singlehtml",
             "srcdir": "doc_test/doc_basic",
-            "no_plantuml": True,
         }
     ],
     indirect=True,
@@ -102,7 +101,7 @@ def test_build_singlehtml(test_app: SphinxTestApp):
 
 @pytest.mark.parametrize(
     "test_app",
-    [{"buildername": "latex", "srcdir": "doc_test/doc_basic", "no_plantuml": True}],
+    [{"buildername": "latex", "srcdir": "doc_test/doc_basic"}],
     indirect=True,
 )
 def test_build_latex(test_app: SphinxTestApp):
@@ -129,7 +128,7 @@ def test_build_latex(test_app: SphinxTestApp):
 
 @pytest.mark.parametrize(
     "test_app",
-    [{"buildername": "epub", "srcdir": "doc_test/doc_basic", "no_plantuml": True}],
+    [{"buildername": "epub", "srcdir": "doc_test/doc_basic"}],
     indirect=True,
 )
 def test_build_epub(test_app: SphinxTestApp):
@@ -140,7 +139,7 @@ def test_build_epub(test_app: SphinxTestApp):
 
 @pytest.mark.parametrize(
     "test_app",
-    [{"buildername": "json", "srcdir": "doc_test/doc_basic", "no_plantuml": True}],
+    [{"buildername": "json", "srcdir": "doc_test/doc_basic"}],
     indirect=True,
 )
 def test_build_json(test_app: SphinxTestApp):
@@ -151,7 +150,7 @@ def test_build_json(test_app: SphinxTestApp):
 
 @pytest.mark.parametrize(
     "test_app",
-    [{"buildername": "needs", "srcdir": "doc_test/doc_basic", "no_plantuml": True}],
+    [{"buildername": "needs", "srcdir": "doc_test/doc_basic"}],
     indirect=True,
 )
 def test_build_needs(test_app: SphinxTestApp, snapshot):

--- a/packages/sphinx-needs/tests/test_broken_docs.py
+++ b/packages/sphinx-needs/tests/test_broken_docs.py
@@ -21,7 +21,6 @@ def get_warnings(app: SphinxTestApp):
             "buildername": "html",
             "srcdir": "doc_test/doc_basic",
             "confoverrides": {"needs_id_required": True},
-            "no_plantuml": True,
         }
     ],
     indirect=True,
@@ -35,7 +34,7 @@ def test_id_required_build_html(test_app: SphinxTestApp):
 
 @pytest.mark.parametrize(
     "test_app",
-    [{"buildername": "html", "srcdir": "doc_test/broken_doc", "no_plantuml": True}],
+    [{"buildername": "html", "srcdir": "doc_test/broken_doc"}],
     indirect=True,
 )
 def test_duplicate_id(test_app: SphinxTestApp):
@@ -50,7 +49,7 @@ def test_duplicate_id(test_app: SphinxTestApp):
 
 @pytest.mark.parametrize(
     "test_app",
-    [{"buildername": "html", "srcdir": "doc_test/broken_links", "no_plantuml": True}],
+    [{"buildername": "html", "srcdir": "doc_test/broken_links"}],
     indirect=True,
 )
 def test_broken_links(test_app: SphinxTestApp):
@@ -69,7 +68,6 @@ def test_broken_links(test_app: SphinxTestApp):
         {
             "buildername": "html",
             "srcdir": "doc_test/broken_statuses",
-            "no_plantuml": True,
         }
     ],
     indirect=True,
@@ -93,7 +91,6 @@ def test_broken_statuses(test_app: SphinxTestApp):
         {
             "buildername": "html",
             "srcdir": "doc_test/broken_syntax_doc",
-            "no_plantuml": True,
         }
     ],
     indirect=True,
@@ -113,7 +110,7 @@ def test_broken_syntax(test_app: SphinxTestApp):
 
 @pytest.mark.parametrize(
     "test_app",
-    [{"buildername": "html", "srcdir": "doc_test/broken_tags", "no_plantuml": True}],
+    [{"buildername": "html", "srcdir": "doc_test/broken_tags"}],
     indirect=True,
 )
 def test_broken_tags(test_app: SphinxTestApp):

--- a/packages/sphinx-needs/tests/test_card_layouts.py
+++ b/packages/sphinx-needs/tests/test_card_layouts.py
@@ -1302,7 +1302,6 @@ def conf_py(specs: dict[str, Any], extra: str = "") -> str:
     [
         {
             "buildername": "html",
-            "no_plantuml": True,
             "files": [
                 (
                     Path("conf.py"),
@@ -1338,7 +1337,6 @@ def test_compiled_card_renders(test_app: Any) -> None:
     [
         {
             "buildername": "html",
-            "no_plantuml": True,
             "files": [
                 (
                     Path("conf.py"),
@@ -1380,7 +1378,6 @@ def test_compiled_side_card_skeleton(test_app: Any) -> None:
     [
         {
             "buildername": "html",
-            "no_plantuml": True,
             "files": [
                 (
                     Path("conf.py"),
@@ -1452,7 +1449,6 @@ PIC_SVG = (
     [
         {
             "buildername": "html",
-            "no_plantuml": True,
             "files": [
                 (
                     Path("conf.py"),
@@ -1544,7 +1540,6 @@ Object form
     [
         {
             "buildername": "html",
-            "no_plantuml": True,
             "files": [
                 (
                     Path("conf.py"),
@@ -1752,7 +1747,6 @@ def test_name_collisions_are_refused(
     [
         {
             "buildername": "html",
-            "no_plantuml": True,
             "files": [
                 (
                     Path("conf.py"),
@@ -1796,7 +1790,6 @@ def setup(app):
     [
         {
             "buildername": "html",
-            "no_plantuml": True,
             "files": [
                 (
                     Path("conf.py"),
@@ -1860,7 +1853,6 @@ def test_compile_card_layouts_rebinds_instead_of_mutating() -> None:
     [
         {
             "buildername": "html",
-            "no_plantuml": True,
             "files": [
                 (Path("conf.py"), conf_py({})),
                 (Path("index.rst"), INDEX.replace("   :layout: my_card\n", "")),

--- a/packages/sphinx-needs/tests/test_chart_scope.py
+++ b/packages/sphinx-needs/tests/test_chart_scope.py
@@ -34,7 +34,6 @@ CHART_SCOPE = pytest.mark.parametrize(
             "srcdir": "doc_test/doc_chart_scope",
             # the fixture needs no diagrams, so the suite-wide plantuml override
             # would only add an "unknown config value" warning to assert around
-            "no_plantuml": True,
         }
     ],
     indirect=True,

--- a/packages/sphinx-needs/tests/test_dynamic_functions.py
+++ b/packages/sphinx-needs/tests/test_dynamic_functions.py
@@ -130,7 +130,6 @@ def test_dynamic_function_from_string_fail(func_str, error_message):
         {
             "buildername": "html",
             "srcdir": "doc_test/doc_dynamic_functions",
-            "no_plantuml": True,
         }
     ],
     indirect=True,
@@ -167,7 +166,6 @@ def test_doc_dynamic_functions(test_app, snapshot):
         {
             "buildername": "html",
             "srcdir": "doc_test/doc_df_calc_sum",
-            "no_plantuml": True,
         }
     ],
     indirect=True,
@@ -189,7 +187,6 @@ def test_doc_df_calc_sum(test_app):
         {
             "buildername": "html",
             "srcdir": "doc_test/doc_df_check_linked_values",
-            "no_plantuml": True,
         }
     ],
     indirect=True,
@@ -211,7 +208,6 @@ def test_doc_df_linked_values(test_app):
         {
             "buildername": "html",
             "srcdir": "doc_test/doc_df_links_from_content",
-            "no_plantuml": True,
         }
     ],
     indirect=True,
@@ -240,7 +236,6 @@ def test_doc_df_links_from_content(test_app, snapshot):
         {
             "buildername": "html",
             "srcdir": "doc_test/doc_df_user_functions",
-            "no_plantuml": True,
         }
     ],
     indirect=True,

--- a/packages/sphinx-needs/tests/test_external.py
+++ b/packages/sphinx-needs/tests/test_external.py
@@ -166,7 +166,6 @@ needs_builder_filter = ''
                  """,
                 ),
             ],
-            "no_plantuml": True,
         }
     ],
     indirect=True,
@@ -226,7 +225,6 @@ needs_builder_filter = ''
                  """,
                 ),
             ],
-            "no_plantuml": True,
         }
     ],
     indirect=True,
@@ -282,7 +280,6 @@ needs_build_json = True
                  """,
                 ),
             ],
-            "no_plantuml": True,
         }
     ],
     indirect=True,

--- a/packages/sphinx-needs/tests/test_extra_options.py
+++ b/packages/sphinx-needs/tests/test_extra_options.py
@@ -9,7 +9,7 @@ from syrupy.filters import props
 
 @pytest.mark.parametrize(
     "test_app",
-    [{"buildername": "html", "srcdir": "doc_test/extra_options", "no_plantuml": True}],
+    [{"buildername": "html", "srcdir": "doc_test/extra_options"}],
     indirect=True,
 )
 def test_custom_attributes_appear(test_app, snapshot):

--- a/packages/sphinx-needs/tests/test_field_defaults.py
+++ b/packages/sphinx-needs/tests/test_field_defaults.py
@@ -29,7 +29,6 @@ def snapshot(snapshot):
         {
             "buildername": "html",
             "srcdir": "doc_test/doc_global_options",
-            "no_plantuml": True,
         }
     ],
     indirect=True,
@@ -121,7 +120,6 @@ Test
     [
         {
             "buildername": "html",
-            "no_plantuml": True,
             "files": [
                 (Path("conf.py"), CONF_INVALID_PREDICATE),
                 (Path("index.rst"), INDEX_INVALID_PREDICATE),
@@ -182,7 +180,6 @@ def test_invalid_predicate_default(test_app):
         {
             "buildername": "html",
             "srcdir": "doc_test/doc_field_defaults",
-            "no_plantuml": True,
         }
     ],
     indirect=True,

--- a/packages/sphinx-needs/tests/test_filter.py
+++ b/packages/sphinx-needs/tests/test_filter.py
@@ -129,7 +129,6 @@ def test_filter_build_html(test_app):
         {
             "buildername": "html",
             "srcdir": "doc_test/doc_filter_this_doc",
-            "no_plantuml": True,
         }
     ],
     indirect=True,

--- a/packages/sphinx-needs/tests/test_github_issues.py
+++ b/packages/sphinx-needs/tests/test_github_issues.py
@@ -46,7 +46,13 @@ def test_doc_github_44(test_app):
 
 @pytest.mark.parametrize(
     "test_app",
-    [{"buildername": "html", "srcdir": "doc_test/doc_github_issue_61"}],
+    [
+        {
+            "buildername": "html",
+            "srcdir": "doc_test/doc_github_issue_61",
+            "plantuml": True,
+        }
+    ],
     indirect=True,
 )
 def test_doc_github_61(test_app):

--- a/packages/sphinx-needs/tests/test_layouts.py
+++ b/packages/sphinx-needs/tests/test_layouts.py
@@ -6,7 +6,7 @@ from tests.util import extract_needs_from_html
 
 @pytest.mark.parametrize(
     "test_app",
-    [{"buildername": "html", "srcdir": "doc_test/doc_layout", "no_plantuml": True}],
+    [{"buildername": "html", "srcdir": "doc_test/doc_layout"}],
     indirect=True,
 )
 def test_doc_build_html(test_app):

--- a/packages/sphinx-needs/tests/test_link_conditions.py
+++ b/packages/sphinx-needs/tests/test_link_conditions.py
@@ -14,7 +14,6 @@ from syrupy.filters import props
         {
             "buildername": "html",
             "srcdir": "doc_test/doc_link_conditions",
-            "no_plantuml": True,
         }
     ],
     indirect=True,
@@ -56,7 +55,6 @@ def test_link_conditions(test_app: Sphinx, snapshot):
         {
             "buildername": "html",
             "srcdir": "doc_test/doc_link_conditions",
-            "no_plantuml": True,
             "confoverrides": {"needs_json_include_link_conditions": False},
         }
     ],
@@ -77,7 +75,6 @@ def test_json_excludes_link_conditions_when_disabled(test_app: Sphinx, snapshot)
         {
             "buildername": "html",
             "srcdir": "doc_test/doc_link_conditions",
-            "no_plantuml": True,
         }
     ],
     indirect=True,

--- a/packages/sphinx-needs/tests/test_links.py
+++ b/packages/sphinx-needs/tests/test_links.py
@@ -7,7 +7,7 @@ from sphinx.util.console import strip_colors
 
 @pytest.mark.parametrize(
     "test_app",
-    [{"buildername": "html", "srcdir": "doc_test/doc_links", "no_plantuml": False}],
+    [{"buildername": "html", "srcdir": "doc_test/doc_links"}],
     indirect=True,
 )
 def test_links_html(test_app):
@@ -44,7 +44,7 @@ def test_links_html(test_app):
 
 @pytest.mark.parametrize(
     "test_app",
-    [{"buildername": "latex", "srcdir": "doc_test/doc_links", "no_plantuml": False}],
+    [{"buildername": "latex", "srcdir": "doc_test/doc_links"}],
     indirect=True,
 )
 def test_links_latex(test_app):

--- a/packages/sphinx-needs/tests/test_list2need_behaviour.py
+++ b/packages/sphinx-needs/tests/test_list2need_behaviour.py
@@ -71,7 +71,6 @@ def params(body: str, conf: str = CONF, **extra: str) -> dict[str, object]:
     return {
         "buildername": "html",
         "files": project(body, conf, **extra),
-        "no_plantuml": True,
     }
 
 
@@ -962,7 +961,6 @@ def myst_params(index: str) -> dict[str, object]:
     return {
         "buildername": "html",
         "files": [(Path("conf.py"), MYST_CONF), (Path("index.md"), index)],
-        "no_plantuml": True,
     }
 
 

--- a/packages/sphinx-needs/tests/test_need_constraints.py
+++ b/packages/sphinx-needs/tests/test_need_constraints.py
@@ -14,7 +14,6 @@ from syrupy.filters import props
         {
             "buildername": "html",
             "srcdir": "doc_test/need_constraints",
-            "no_plantuml": True,
         }
     ],
     indirect=True,
@@ -106,7 +105,6 @@ def test_need_constraints(test_app, snapshot):
         {
             "buildername": "html",
             "srcdir": "doc_test/need_constraints_failed",
-            "no_plantuml": True,
         }
     ],
     indirect=True,

--- a/packages/sphinx-needs/tests/test_need_lineno.py
+++ b/packages/sphinx-needs/tests/test_need_lineno.py
@@ -99,7 +99,7 @@ def params(conf: str = CONF, index: str = INDEX, **extra: str) -> dict[str, obje
     """Build the :func:`test_app` parameters for a single case."""
     files = [(Path("conf.py"), conf), (Path("index.rst"), index)]
     files.extend((Path(name), text) for name, text in extra.items())
-    return {"buildername": "html", "files": files, "no_plantuml": True}
+    return {"buildername": "html", "files": files}
 
 
 def needs(app: SphinxTestApp) -> dict[str, dict[str, Any]]:
@@ -188,7 +188,6 @@ requires_myst = pytest.mark.skipif(
         {
             "buildername": "html",
             "files": [(Path("conf.py"), MYST_CONF), (Path("index.md"), MYST_INDEX)],
-            "no_plantuml": True,
         }
     ],
     indirect=True,

--- a/packages/sphinx-needs/tests/test_need_parts.py
+++ b/packages/sphinx-needs/tests/test_need_parts.py
@@ -17,7 +17,7 @@ def snapshot_json(snapshot):
 
 @pytest.mark.parametrize(
     "test_app",
-    [{"buildername": "html", "srcdir": "doc_test/doc_need_parts", "no_plantuml": True}],
+    [{"buildername": "html", "srcdir": "doc_test/doc_need_parts"}],
     indirect=True,
 )
 def test_doc_need_parts(test_app: Sphinx, snapshot_json):

--- a/packages/sphinx-needs/tests/test_needarch.py
+++ b/packages/sphinx-needs/tests/test_needarch.py
@@ -58,7 +58,13 @@ def test_doc_needarch_jinja_import(test_app, snapshot):
 
 @pytest.mark.parametrize(
     "test_app",
-    [{"buildername": "html", "srcdir": "doc_test/doc_needarch_jinja_func_need"}],
+    [
+        {
+            "buildername": "html",
+            "srcdir": "doc_test/doc_needarch_jinja_func_need",
+            "plantuml": True,
+        }
+    ],
     indirect=True,
 )
 def test_needarch_jinja_func_need(test_app, snapshot):

--- a/packages/sphinx-needs/tests/test_needbar.py
+++ b/packages/sphinx-needs/tests/test_needbar.py
@@ -36,7 +36,6 @@ def _x_tick_labels(svg: str) -> list[str]:
         {
             "buildername": "html",
             "srcdir": "doc_test/doc_needbar_from_data",
-            "no_plantuml": True,
         }
     ],
     indirect=True,
@@ -78,7 +77,6 @@ def test_needbar_label_defaults(test_app):
         {
             "buildername": "html",
             "srcdir": "doc_test/doc_needbar_from_data",
-            "no_plantuml": True,
         }
     ],
     indirect=True,

--- a/packages/sphinx-needs/tests/test_needextend.py
+++ b/packages/sphinx-needs/tests/test_needextend.py
@@ -10,7 +10,7 @@ from syrupy.filters import props
 
 @pytest.mark.parametrize(
     "test_app",
-    [{"buildername": "html", "srcdir": "doc_test/doc_needextend", "no_plantuml": True}],
+    [{"buildername": "html", "srcdir": "doc_test/doc_needextend"}],
     indirect=True,
 )
 def test_doc_needextend_html(test_app: Sphinx, snapshot):
@@ -52,7 +52,6 @@ def test_doc_needextend_html(test_app: Sphinx, snapshot):
         {
             "buildername": "html",
             "srcdir": "doc_test/doc_needextend_warnings",
-            "no_plantuml": True,
         }
     ],
     indirect=True,

--- a/packages/sphinx-needs/tests/test_needextract.py
+++ b/packages/sphinx-needs/tests/test_needextract.py
@@ -25,7 +25,6 @@ def build_warnings(app) -> list[str]:
         {
             "buildername": "html",
             "srcdir": "doc_test/doc_needextract",
-            "no_plantuml": True,
         }
     ],
     indirect=True,
@@ -75,7 +74,6 @@ def test_needextract_basic(test_app):
         {
             "buildername": "html",
             "srcdir": "doc_test/needextract_with_nested_needs",
-            "no_plantuml": True,
         }
     ],
     indirect=True,
@@ -184,7 +182,6 @@ Extract
         pytest.param(
             {
                 "buildername": "html",
-                "no_plantuml": True,
                 "files": [
                     (Path("conf.py"), CONF),
                     (Path("index.rst"), UNKNOWN_ID_INDEX),
@@ -200,7 +197,6 @@ Extract
         pytest.param(
             {
                 "buildername": "html",
-                "no_plantuml": True,
                 "files": [
                     (Path("conf.py"), CONF),
                     (Path("index.rst"), ARG_AND_FILTER_INDEX),
@@ -216,7 +212,6 @@ Extract
         pytest.param(
             {
                 "buildername": "html",
-                "no_plantuml": True,
                 "files": [
                     (Path("conf.py"), CONF_NEEDS_HIDDEN),
                     (Path("index.rst"), PLAIN_EXTRACT_INDEX),
@@ -369,7 +364,6 @@ def extract_doc(need_id: str) -> str:
         pytest.param(
             {
                 "buildername": "html",
-                "no_plantuml": True,
                 "files": [
                     (Path("conf.py"), CONF),
                     (Path("index.rst"), VIEW_IN_CONTENT_INDEX),
@@ -386,7 +380,6 @@ def extract_doc(need_id: str) -> str:
         pytest.param(
             {
                 "buildername": "html",
-                "no_plantuml": True,
                 "files": [
                     (Path("conf.py"), CONF),
                     (Path("index.rst"), NESTED_EXTRACT_INDEX),
@@ -403,7 +396,6 @@ def extract_doc(need_id: str) -> str:
         pytest.param(
             {
                 "buildername": "html",
-                "no_plantuml": True,
                 "files": [
                     (Path("conf.py"), CONF),
                     (Path("index.rst"), NEEDPIE_IN_CONTENT_INDEX),
@@ -420,7 +412,6 @@ def extract_doc(need_id: str) -> str:
         pytest.param(
             {
                 "buildername": "html",
-                "no_plantuml": True,
                 "files": [
                     (Path("conf.py"), CONF),
                     (Path("index.rst"), NEEDBAR_IN_CONTENT_INDEX),
@@ -437,7 +428,6 @@ def extract_doc(need_id: str) -> str:
         pytest.param(
             {
                 "buildername": "html",
-                "no_plantuml": True,
                 "files": [
                     (Path("conf.py"), CONF),
                     (Path("index.rst"), NEEDUML_IN_CONTENT_INDEX),
@@ -462,7 +452,6 @@ def extract_doc(need_id: str) -> str:
         pytest.param(
             {
                 "buildername": "html",
-                "no_plantuml": True,
                 "files": [
                     (Path("conf.py"), CONF),
                     (Path("index.rst"), NEEDTABLE_IN_CHILD_INDEX),
@@ -540,7 +529,6 @@ Index
     [
         {
             "buildername": "html",
-            "no_plantuml": True,
             "files": [
                 (Path("conf.py"), CONF),
                 (Path("index.rst"), REFERENCE_CONTRACT_INDEX),
@@ -620,7 +608,6 @@ Index
     [
         {
             "buildername": "html",
-            "no_plantuml": True,
             "files": [
                 (Path("conf.py"), RECORDING_CONF),
                 (Path("index.rst"), RECORDING_INDEX),
@@ -682,7 +669,6 @@ Index
     [
         {
             "buildername": "html",
-            "no_plantuml": True,
             "files": [
                 (Path("conf.py"), CONF),
                 (Path("index.rst"), FOOTNOTE_INDEX),
@@ -764,7 +750,6 @@ def setup(app):
     [
         {
             "buildername": "html",
-            "no_plantuml": True,
             "files": [
                 (Path("conf.py"), LEAK_PROBE_CONF),
                 # a need with a reference in it, so the post-transforms have

--- a/packages/sphinx-needs/tests/test_needflow.py
+++ b/packages/sphinx-needs/tests/test_needflow.py
@@ -74,6 +74,7 @@ def _get_svg(config: Config, outdir: Path, file: str, id: str) -> str:
             "buildername": "html",
             "srcdir": "doc_test/doc_needflow",
             "confoverrides": {"needs_flow_engine": "plantuml"},
+            "plantuml": True,
         },
         {
             "buildername": "html",
@@ -165,6 +166,7 @@ def test_doc_build_html(test_app):
             "buildername": "html",
             "srcdir": "doc_test/doc_needflow_incl_child_needs",
             "confoverrides": {"needs_flow_engine": "plantuml"},
+            "plantuml": True,
         },
         {
             "buildername": "html",

--- a/packages/sphinx-needs/tests/test_needimport.py
+++ b/packages/sphinx-needs/tests/test_needimport.py
@@ -15,7 +15,7 @@ from sphinx_needs.needsfile import SphinxNeedsFileException
 
 @pytest.mark.parametrize(
     "test_app",
-    [{"buildername": "html", "srcdir": "doc_test/import_doc", "no_plantuml": True}],
+    [{"buildername": "html", "srcdir": "doc_test/import_doc"}],
     indirect=True,
 )
 def test_import_json(test_app):
@@ -92,7 +92,6 @@ needs_json = """
                 ("needs.json", needs_json),
                 ("nested/needs.json", needs_json),
             ],
-            "no_plantuml": True,
         }
     ],
     indirect=True,
@@ -123,7 +122,6 @@ def test_import_rel_abs_sphinx_paths(test_app, index_content):
                 ("conf.py", 'extensions = ["sphinx_needs"]'),
                 ("needs.json", needs_json),
             ],
-            "no_plantuml": True,
         }
     ],
     indirect=True,
@@ -156,7 +154,6 @@ def test_import_abs_paths_win(test_app, path_sep):
                 ("conf.py", 'extensions = ["sphinx_needs"]'),
                 ("needs.json", needs_json),
             ],
-            "no_plantuml": True,
         }
     ],
     indirect=True,
@@ -187,7 +184,6 @@ def test_import_abs_paths_lin_mac(test_app):
             "files": [
                 ("conf.py", 'extensions = ["sphinx_needs"]\nneeds_build_json = True'),
             ],
-            "no_plantuml": True,
         }
     ],
     indirect=True,
@@ -236,7 +232,6 @@ def test_import_allow_type_coercion_true(test_app):
             "files": [
                 ("conf.py", 'extensions = ["sphinx_needs"]\nneeds_build_json = True'),
             ],
-            "no_plantuml": True,
         }
     ],
     indirect=True,
@@ -283,7 +278,6 @@ def test_import_allow_type_coercion_false(test_app):
         {
             "buildername": "html",
             "srcdir": "doc_test/import_doc_invalid",
-            "no_plantuml": True,
         }
     ],
     indirect=True,
@@ -305,7 +299,6 @@ def test_json_schema_check(test_app):
         {
             "buildername": "html",
             "srcdir": "doc_test/import_doc_warnings",
-            "no_plantuml": True,
         }
     ],
     indirect=True,
@@ -333,7 +326,6 @@ def test_need_schema_warnings(test_app, snapshot):
         {
             "buildername": "html",
             "srcdir": "doc_test/import_doc_empty",
-            "no_plantuml": True,
         }
     ],
     indirect=True,
@@ -352,7 +344,6 @@ def test_empty_file_check(test_app):
         {
             "buildername": "html",
             "srcdir": "doc_test/non_exists_file_import",
-            "no_plantuml": True,
         }
     ],
     indirect=True,
@@ -375,7 +366,7 @@ def test_import_non_exists_json(test_app):
 
 @pytest.mark.parametrize(
     "test_app",
-    [{"buildername": "needs", "srcdir": "doc_test/import_doc", "no_plantuml": True}],
+    [{"buildername": "needs", "srcdir": "doc_test/import_doc"}],
     indirect=True,
 )
 def test_import_builder(test_app, snapshot):
@@ -392,7 +383,6 @@ def test_import_builder(test_app, snapshot):
         {
             "buildername": "needs",
             "srcdir": "doc_test/doc_needimport_download_needs_json",
-            "no_plantuml": True,
         }
     ],
     indirect=True,
@@ -469,7 +459,6 @@ def test_needimport_needs_json_download(test_app, snapshot):
         {
             "buildername": "needs",
             "srcdir": "doc_test/doc_needimport_download_needs_json_negative",
-            "no_plantuml": True,
         }
     ],
     indirect=True,
@@ -489,7 +478,6 @@ def test_needimport_needs_json_download_negative(test_app):
         {
             "buildername": "latex",
             "srcdir": "doc_test/doc_needimport_noindex",
-            "no_plantuml": True,
         }
     ],
     indirect=True,
@@ -521,7 +509,6 @@ def test_doc_needimport_noindex(test_app):
                 ("conf.py", 'extensions = ["sphinx_needs"]'),
                 ("needs.json", needs_json),  # reuse the existing needs_json string
             ],
-            "no_plantuml": True,
         }
     ],
     indirect=True,

--- a/packages/sphinx-needs/tests/test_needreport.py
+++ b/packages/sphinx-needs/tests/test_needreport.py
@@ -48,7 +48,7 @@ def build_warnings(app) -> list[str]:
 
 @pytest.mark.parametrize(
     "test_app",
-    [{"buildername": "html", "srcdir": "doc_test/doc_needreport", "no_plantuml": True}],
+    [{"buildername": "html", "srcdir": "doc_test/doc_needreport"}],
     indirect=True,
 )
 def test_doc_needreport(test_app):
@@ -111,7 +111,6 @@ Never rendered.
         pytest.param(
             {
                 "buildername": "html",
-                "no_plantuml": True,
                 "files": [
                     (Path("conf.py"), RENDER_FAIL_CONF),
                     (Path("index.rst"), REPORT_INDEX),
@@ -124,7 +123,6 @@ Never rendered.
         pytest.param(
             {
                 "buildername": "html",
-                "no_plantuml": True,
                 "files": [
                     (Path("conf.py"), RENDER_FAIL_CONF),
                     (Path("index.rst"), REPORT_INDEX),
@@ -181,7 +179,6 @@ needs_render_context = {
     [
         {
             "buildername": "html",
-            "no_plantuml": True,
             "files": [
                 (Path("conf.py"), RESERVED_KEY_CONF),
                 (Path("index.rst"), REPORT_INDEX),
@@ -247,7 +244,6 @@ TYPES_TEMPLATE = """\
     [
         {
             "buildername": "html",
-            "no_plantuml": True,
             "files": [
                 (Path("conf.py"), ABS_TEMPLATE_CONF),
                 (Path("index.rst"), REPORT_INDEX),
@@ -332,7 +328,6 @@ def test_report_template_join_semantics(srcdir, configured, expected):
         {
             "buildername": "html",
             "srcdir": "doc_test/doc_needreport_no_dropdown",
-            "no_plantuml": True,
         }
     ],
     indirect=True,
@@ -409,7 +404,6 @@ def setup(app):
     [
         {
             "buildername": "html",
-            "no_plantuml": True,
             "files": [
                 (Path("conf.py"), STUB_DROPDOWN_CONF),
                 (Path("index.rst"), REPORT_INDEX),
@@ -441,7 +435,6 @@ def test_dropdown_provider_is_left_alone(test_app):
     [
         {
             "buildername": "html",
-            "no_plantuml": True,
             "files": [
                 (
                     Path("conf.py"),
@@ -477,7 +470,6 @@ needs_render_context = {"report_directive": "dropdown"}
     [
         {
             "buildername": "html",
-            "no_plantuml": True,
             "files": [
                 (Path("conf.py"), EXPLICIT_DROPDOWN_CONF),
                 (Path("index.rst"), REPORT_INDEX),
@@ -528,7 +520,6 @@ The project defines {{ types|length }} need types:
     [
         {
             "buildername": "html",
-            "no_plantuml": True,
             "files": [
                 (Path("conf.py"), CUSTOM_TEMPLATE_CONF),
                 (Path("index.rst"), REPORT_INDEX),
@@ -611,7 +602,6 @@ PROSE_MENTION_TEMPLATE = """\
         pytest.param(
             {
                 "buildername": "html",
-                "no_plantuml": True,
                 "files": [
                     (Path("conf.py"), NO_PROVIDER_CONF),
                     (Path("index.rst"), REPORT_INDEX),
@@ -660,7 +650,6 @@ HARDCODED_DROPDOWN_TEMPLATE = """\
     [
         {
             "buildername": "html",
-            "no_plantuml": True,
             "files": [
                 (Path("conf.py"), NO_PROVIDER_CONF),
                 (Path("index.rst"), REPORT_INDEX),
@@ -704,7 +693,6 @@ Never rendered.
     [
         {
             "buildername": "html",
-            "no_plantuml": True,
             "files": [
                 (Path("conf.py"), NO_PROVIDER_CONF),
                 (Path("index.rst"), REPORT_INDEX),
@@ -763,7 +751,6 @@ NASTY_DETAIL_TEMPLATE = "{{ explode() }}\n"
     [
         {
             "buildername": "html",
-            "no_plantuml": True,
             "files": [
                 (Path("conf.py"), NASTY_DETAIL_CONF),
                 (Path("index.rst"), REPORT_INDEX),
@@ -853,7 +840,6 @@ Report
     [
         {
             "buildername": "html",
-            "no_plantuml": True,
             "files": [
                 (Path("conf.py"), RESERVED_KEY_CONF),
                 (Path("index.rst"), MANY_REPORTS_INDEX),
@@ -908,7 +894,6 @@ LITERAL_BLOCK_SECOND_RENDER_FAILS_TEMPLATE = """\
     [
         {
             "buildername": "html",
-            "no_plantuml": True,
             "files": [
                 (Path("conf.py"), NO_PROVIDER_CONF),
                 (Path("index.rst"), REPORT_INDEX),
@@ -942,7 +927,6 @@ def test_example_markup_in_a_literal_block_is_substituted(test_app):
     [
         {
             "buildername": "html",
-            "no_plantuml": True,
             "files": [
                 (Path("conf.py"), NO_PROVIDER_CONF),
                 (Path("index.rst"), REPORT_INDEX),
@@ -993,7 +977,6 @@ REAL_USE_SECOND_RENDER_FAILS_TEMPLATE = """\
     [
         {
             "buildername": "html",
-            "no_plantuml": True,
             "files": [
                 (Path("conf.py"), NO_PROVIDER_CONF),
                 (Path("index.rst"), REPORT_INDEX),

--- a/packages/sphinx-needs/tests/test_needs_external_needs_build.py
+++ b/packages/sphinx-needs/tests/test_needs_external_needs_build.py
@@ -84,7 +84,13 @@ def test_doc_build_html(test_app: SphinxTestApp, plantuml_command: str):
 )
 @pytest.mark.parametrize(
     "test_app",
-    [{"buildername": "html", "srcdir": "doc_test/doc_needs_external_needs"}],
+    [
+        {
+            "buildername": "html",
+            "srcdir": "doc_test/doc_needs_external_needs",
+            "plantuml": True,
+        }
+    ],
     indirect=True,
 )
 def test_external_needs_base_url_relative_path(test_app):

--- a/packages/sphinx-needs/tests/test_needs_external_needs_build.py
+++ b/packages/sphinx-needs/tests/test_needs_external_needs_build.py
@@ -14,7 +14,7 @@ from sphinx.util.console import strip_colors
     [{"buildername": "html", "srcdir": "doc_test/doc_needs_external_needs"}],
     indirect=True,
 )
-def test_doc_build_html(test_app: SphinxTestApp, plantuml_command: str):
+def test_doc_build_html(test_app: SphinxTestApp, plantuml_subprocess_args: list[str]):
     import subprocess
 
     src_dir = Path(test_app.srcdir)
@@ -24,8 +24,7 @@ def test_doc_build_html(test_app: SphinxTestApp, plantuml_command: str):
             "sphinx-build",
             "-b",
             "html",
-            "-D",
-            f"plantuml={plantuml_command}",
+            *plantuml_subprocess_args,
             src_dir,
             out_dir,
         ],
@@ -43,8 +42,7 @@ def test_doc_build_html(test_app: SphinxTestApp, plantuml_command: str):
             "sphinx-build",
             "-b",
             "html",
-            "-D",
-            f"plantuml={plantuml_command}",
+            *plantuml_subprocess_args,
             src_dir,
             out_dir,
         ],

--- a/packages/sphinx-needs/tests/test_needs_from_toml.py
+++ b/packages/sphinx-needs/tests/test_needs_from_toml.py
@@ -11,7 +11,6 @@ from syrupy.filters import props
         {
             "buildername": "html",
             "srcdir": "doc_test/needs_from_toml",
-            "no_plantuml": True,
         }
     ],
     indirect=True,
@@ -32,7 +31,6 @@ def test_needs_from_toml(test_app, snapshot):
         {
             "buildername": "html",
             "srcdir": "doc_test/needs_from_toml",
-            "no_plantuml": True,
             "confoverrides": {"needs_reproducible_json": False},
         }
     ],

--- a/packages/sphinx-needs/tests/test_needs_warning.py
+++ b/packages/sphinx-needs/tests/test_needs_warning.py
@@ -12,7 +12,6 @@ from sphinx.util.console import strip_colors
         {
             "buildername": "html",
             "srcdir": "doc_test/doc_needs_warnings",
-            "no_plantuml": True,
         }
     ],
     indirect=True,
@@ -154,7 +153,6 @@ needs_warnings = {"unknown_filter": 42}
 """,
                 ),
             ],
-            "no_plantuml": True,
         }
     ],
     indirect=True,

--- a/packages/sphinx-needs/tests/test_needuml.py
+++ b/packages/sphinx-needs/tests/test_needuml.py
@@ -517,7 +517,6 @@ def test_needumls_builder_rerun_keeps_saved_files(test_app):
         {
             "buildername": "html",
             "srcdir": "doc_test/doc_needuml_save_no_plantuml",
-            "no_plantuml": True,
         }
     ],
     indirect=True,

--- a/packages/sphinx-needs/tests/test_needuml.py
+++ b/packages/sphinx-needs/tests/test_needuml.py
@@ -88,16 +88,22 @@ def test_needuml_option_key_forbidden(test_app):
     [{"buildername": "html", "srcdir": "doc_test/doc_needuml_diagram_allowmixing"}],
     indirect=True,
 )
-def test_needuml_diagram_allowmixing(test_app):
+def test_needuml_diagram_allowmixing(test_app, plantuml_subprocess_args):
     app = test_app
 
     srcdir = Path(app.srcdir)
     out_dir = srcdir / "_build"
 
     out = subprocess.run(
-        ["sphinx-build", "-M", "html", srcdir, out_dir], capture_output=True
+        ["sphinx-build", "-M", "html", srcdir, out_dir, *plantuml_subprocess_args],
+        capture_output=True,
     )
     assert out.returncode == 0
+    # the subprocess renders eight diagrams, and a failed render is only a WARNING to
+    # sphinxcontrib-plantuml -- so without this the test is green on a renderer that
+    # cannot run, which is how it spent years drawing with whatever `plantuml` the
+    # machine carried
+    assert "error while running plantuml" not in out.stderr.decode("utf-8")
 
 
 @pytest.mark.parametrize(

--- a/packages/sphinx-needs/tests/test_needuml.py
+++ b/packages/sphinx-needs/tests/test_needuml.py
@@ -177,7 +177,13 @@ def test_needumls_builder(test_app, snapshot):
 
 @pytest.mark.parametrize(
     "test_app",
-    [{"buildername": "html", "srcdir": "doc_test/doc_needuml_filter"}],
+    [
+        {
+            "buildername": "html",
+            "srcdir": "doc_test/doc_needuml_filter",
+            "plantuml": True,
+        }
+    ],
     indirect=True,
 )
 def test_needuml_filter(test_app, snapshot):
@@ -201,7 +207,13 @@ def test_needuml_filter(test_app, snapshot):
 
 @pytest.mark.parametrize(
     "test_app",
-    [{"buildername": "html", "srcdir": "doc_test/doc_needuml_jinja_func_flow"}],
+    [
+        {
+            "buildername": "html",
+            "srcdir": "doc_test/doc_needuml_jinja_func_flow",
+            "plantuml": True,
+        }
+    ],
     indirect=True,
 )
 def test_needuml_jinja_func_flow(test_app, snapshot):
@@ -275,7 +287,13 @@ def test_doc_needarch_jinja_import_negative(test_app):
 
 @pytest.mark.parametrize(
     "test_app",
-    [{"buildername": "html", "srcdir": "doc_test/doc_needuml_jinja_func_ref"}],
+    [
+        {
+            "buildername": "html",
+            "srcdir": "doc_test/doc_needuml_jinja_func_ref",
+            "plantuml": True,
+        }
+    ],
     indirect=True,
 )
 def test_needuml_jinja_func_ref(test_app, snapshot):
@@ -308,7 +326,13 @@ def test_needuml_jinja_func_ref(test_app, snapshot):
 
 @pytest.mark.parametrize(
     "test_app",
-    [{"buildername": "html", "srcdir": "doc_test/doc_needuml_option_warnings"}],
+    [
+        {
+            "buildername": "html",
+            "srcdir": "doc_test/doc_needuml_option_warnings",
+            "plantuml": True,
+        }
+    ],
     indirect=True,
 )
 def test_needuml_option_warnings(test_app):

--- a/packages/sphinx-needs/tests/test_needuml.py
+++ b/packages/sphinx-needs/tests/test_needuml.py
@@ -104,6 +104,10 @@ def test_needuml_diagram_allowmixing(test_app, plantuml_subprocess_args):
     # cannot run, which is how it spent years drawing with whatever `plantuml` the
     # machine carried
     assert "error while running plantuml" not in out.stderr.decode("utf-8")
+    # ...and a renderer that cannot even be STARTED is a different message ("plantuml
+    # command ... cannot be run"), also a WARNING: the positive assertion is that the
+    # diagrams exist. Eight on a good build; none under either failure (measured)
+    assert list((out_dir / "html" / "_images").glob("plantuml-*"))
 
 
 @pytest.mark.parametrize(

--- a/packages/sphinx-needs/tests/test_parallel_execution.py
+++ b/packages/sphinx-needs/tests/test_parallel_execution.py
@@ -13,7 +13,6 @@ from sphinx.util.parallel import parallel_available
             "buildername": "html",
             "srcdir": "doc_test/parallel_doc",
             "parallel": 4,
-            "no_plantuml": True,
         }
     ],
     indirect=True,

--- a/packages/sphinx-needs/tests/test_plantuml.py
+++ b/packages/sphinx-needs/tests/test_plantuml.py
@@ -5,7 +5,13 @@ import pytest
 
 @pytest.mark.parametrize(
     "test_app",
-    [{"buildername": "html", "srcdir": "doc_test/plantuml_from_ext_list"}],
+    [
+        {
+            "buildername": "html",
+            "srcdir": "doc_test/plantuml_from_ext_list",
+            "plantuml": True,
+        }
+    ],
     indirect=True,
 )
 def test_plantuml_from_ext_list(test_app, get_warnings_list):
@@ -19,7 +25,13 @@ def test_plantuml_from_ext_list(test_app, get_warnings_list):
 
 @pytest.mark.parametrize(
     "test_app",
-    [{"buildername": "html", "srcdir": "doc_test/plantuml_from_app_extension"}],
+    [
+        {
+            "buildername": "html",
+            "srcdir": "doc_test/plantuml_from_app_extension",
+            "plantuml": True,
+        }
+    ],
     indirect=True,
 )
 def test_plantuml_from_app_extension(test_app, get_warnings_list):

--- a/packages/sphinx-needs/tests/test_plantuml.py
+++ b/packages/sphinx-needs/tests/test_plantuml.py
@@ -52,9 +52,18 @@ def test_plantuml_unconfigured(test_app, get_warnings_list):
     test_app.build()
     assert test_app.statuscode == 0
 
+    # ONE warning now, where there used to be two. The fixture injected a `plantuml`
+    # confoverride into EVERY build, and this project deliberately does not load the
+    # extension, so the build also collected "unknown config value 'plantuml' in
+    # override, ignoring" -- a warning about the test fixture rather than about
+    # sphinx-needs. Rendering is opt in now and this test does not opt in, so nothing is
+    # injected and that warning is gone.
+    #
+    # Still two ENTRIES, though: `get_warnings_list` splits the stream on "WARNING: ", so
+    # a located warning arrives as its bare location followed by its message.
     warnings = get_warnings_list(test_app)
     assert len(warnings) == 2
-    assert "unknown config value 'plantuml' in override, ignoring" in warnings[0]
+    assert "index.rst" in warnings[0]
     # the page says so, but a build nobody reads the output of said nothing at all
     assert (
         "PlantUML is not available, so the diagram was not rendered. "

--- a/packages/sphinx-needs/tests/test_proper_warning.py
+++ b/packages/sphinx-needs/tests/test_proper_warning.py
@@ -8,7 +8,7 @@ from sphinx.util.console import strip_colors
 
 @pytest.mark.parametrize(
     "test_app",
-    [{"buildername": "html", "srcdir": "doc_test/doc_warning", "no_plantuml": True}],
+    [{"buildername": "html", "srcdir": "doc_test/doc_warning"}],
     indirect=True,
 )
 def test_proper_warning(test_app: Sphinx):
@@ -36,7 +36,6 @@ def test_proper_warning(test_app: Sphinx):
         {
             "buildername": "html",
             "srcdir": "doc_test/doc_warning",
-            "no_plantuml": True,
             "confoverrides": {"rst_prolog": ".. |drift| replace:: drift\n"},
         }
     ],

--- a/packages/sphinx-needs/tests/test_service_github.py
+++ b/packages/sphinx-needs/tests/test_service_github.py
@@ -15,7 +15,6 @@ from syrupy.filters import props
         {
             "buildername": "html",
             "srcdir": "doc_test/doc_service_github",
-            "no_plantuml": True,
         }
     ],
     indirect=True,

--- a/packages/sphinx-needs/tests/test_sn_collapse_button.py
+++ b/packages/sphinx-needs/tests/test_sn_collapse_button.py
@@ -161,7 +161,6 @@ def test_collapse_button_in_doc_basic(test_app: SphinxTestApp, page: Page) -> No
         {
             "buildername": "html",
             "srcdir": "doc_test/import_doc",
-            "no_plantuml": True,
         }
     ],
     indirect=True,

--- a/packages/sphinx-needs/tests/test_styles/test_style_unknown.py
+++ b/packages/sphinx-needs/tests/test_styles/test_style_unknown.py
@@ -10,7 +10,6 @@ from sphinx.util.console import strip_colors
         {
             "buildername": "html",
             "srcdir": "doc_test/doc_style_unknown",
-            "no_plantuml": True,
         }
     ],
     indirect=True,

--- a/packages/sphinx-needs/tests/test_variant_data_integration.py
+++ b/packages/sphinx-needs/tests/test_variant_data_integration.py
@@ -20,7 +20,6 @@ from sphinx_needs.exceptions import NeedsConfigException
         {
             "buildername": "html",
             "srcdir": "doc_test/doc_variant_data",
-            "no_plantuml": True,
         }
     ],
     indirect=True,
@@ -60,7 +59,6 @@ def test_variant_data_html(test_app):
         {
             "buildername": "html",
             "srcdir": "doc_test/doc_variant_data_file",
-            "no_plantuml": True,
         }
     ],
     indirect=True,
@@ -97,7 +95,6 @@ def snapshot_json(snapshot):
         {
             "buildername": "html",
             "srcdir": "doc_test/doc_variant_data_fields",
-            "no_plantuml": True,
         }
     ],
     indirect=True,
@@ -122,7 +119,6 @@ def test_variant_data_fields_html(test_app, snapshot_json):
         {
             "buildername": "html",
             "srcdir": "doc_test/doc_variant_data_field_errors",
-            "no_plantuml": True,
         }
     ],
     indirect=True,
@@ -159,7 +155,6 @@ def test_variant_data_field_errors_html(test_app, snapshot_json):
         {
             "buildername": "html",
             "srcdir": "doc_test/doc_variant_data_config_inited",
-            "no_plantuml": True,
         }
     ],
     indirect=True,
@@ -190,7 +185,6 @@ def test_variant_data_resolved_at_config_inited(test_app):
         {
             "buildername": "html",
             "srcdir": "doc_test/doc_variant_data_config_inited",
-            "no_plantuml": True,
         }
     ],
     indirect=True,
@@ -342,7 +336,6 @@ def test_variant_data_file_confoverride_wins_over_toml(
         {
             "buildername": "html",
             "srcdir": "doc_test/doc_variant_data_extension_write",
-            "no_plantuml": True,
         }
     ],
     indirect=True,

--- a/packages/sphinx-needs/tests/test_variant_role.py
+++ b/packages/sphinx-needs/tests/test_variant_role.py
@@ -15,7 +15,6 @@ from sphinx.util.console import strip_colors
         {
             "buildername": "html",
             "srcdir": "doc_test/doc_variant_role",
-            "no_plantuml": True,
         }
     ],
     indirect=True,
@@ -62,7 +61,6 @@ def test_variant_role_html(test_app):
         {
             "buildername": "html",
             "srcdir": "doc_test/doc_variant_role_no_data",
-            "no_plantuml": True,
         }
     ],
     indirect=True,
@@ -91,7 +89,6 @@ def test_variant_role_no_data_html(test_app):
         {
             "buildername": "html",
             "srcdir": "doc_test/doc_variant_role_file",
-            "no_plantuml": True,
         }
     ],
     indirect=True,

--- a/packages/sphinx-needs/tests/test_views_max_items.py
+++ b/packages/sphinx-needs/tests/test_views_max_items.py
@@ -222,8 +222,6 @@ def params(
         "buildername": "html",
         "files": files(view, needs=needs, conf=PLANTUML_CONF if plantuml else conf),
     }
-    if not plantuml:
-        param["no_plantuml"] = True
     if overrides:
         param["confoverrides"] = overrides
     return param

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -409,10 +409,10 @@ cwd = "packages/sphinx-needs"
 
 [tool.poe.tasks.test-needs-js]
 help = "Run only the browser tests; run `poe install-browser` once first"
-# yes, these need a jar too, although they render no diagram anyone looks at: two of the
-# three cases build through the `test_app` fixture, which takes `plantuml_command`, and
-# that fixture RAISES when it can find no renderer rather than skipping
-deps = ["fetch-plantuml"]
+# NO `deps = ["fetch-plantuml"]`, and no jar: none of the three cases opts into rendering
+# (their projects -- variant_doc, doc_basic, import_doc -- draw nothing), and `test_app` only
+# resolves `plantuml_command` for a build that asked for one. It used to need the jar because
+# the fixture took that fixture unconditionally and it RAISES rather than skipping
 cmd = "pytest --ignore=performance --ignore=tests/benchmarks -m jstest"
 cwd = "packages/sphinx-needs"
 

--- a/tools/tests/test_ci_plantuml_steps.py
+++ b/tools/tests/test_ci_plantuml_steps.py
@@ -50,8 +50,8 @@ import yaml
 REPO = Path(__file__).resolve().parents[2]
 SCRIPT = "tools/src/sn_tools/fetch_plantuml.py"
 
-# The eight sites, counted by hand on this head and asserted below. Seven CAPTURE the jar's
-# path into `PLANTUML_JAR`; the eighth is CI's Lint job, which runs the same `--verify` with
+# The seven sites, counted by hand on this head and asserted below. Six CAPTURE the jar's
+# path into `PLANTUML_JAR`; the seventh is CI's Lint job, which runs the same `--verify` with
 # no pipe and no capture — so it needs neither `shell: bash` nor the `tr`, and a plain `run:`
 # under `bash -e` already carries the script's exit status.
 #
@@ -59,7 +59,6 @@ SCRIPT = "tools/src/sn_tools/fetch_plantuml.py"
 #                                                                  tests-extensions x4)
 #   .github/workflows/benchmark.yaml         benchmarks           capture
 #   .github/workflows/ci.yaml                bazel                capture
-#   .github/workflows/ci.yaml                tests-js             capture
 #   .github/workflows/ci.yaml                tests-no-mpl         capture
 #   .github/workflows/docs.yaml              linkcheck            capture
 #   .github/workflows/release.yaml           build                capture
@@ -67,8 +66,8 @@ SCRIPT = "tools/src/sn_tools/fetch_plantuml.py"
 #
 # Adding a job that renders means adding a site and raising these numbers — deliberately, so
 # that the addition is a decision someone made rather than a step nobody checked.
-EXPECTED_SITES = 8
-EXPECTED_CAPTURES = 7
+EXPECTED_SITES = 7
+EXPECTED_CAPTURES = 6
 
 
 @dataclass(frozen=True)

--- a/vendor/plantuml/README.md
+++ b/vendor/plantuml/README.md
@@ -136,9 +136,11 @@ success on exactly the mistake the fence is for. Lint runs it (`pytest tools/tes
    from a git ref with no checkout as its build context, so it downloads its own copy; this
    is the one place the version is repeated, and it is repeated deliberately.)
 5. `uv run poe verify-plantuml` — the check Lint will make — and re-run the renderer-heavy
-   suites — every sphinx-needs test that actually renders is in these five paths:
-   `uv run poe test-needs tests/conformance tests/test_plantuml.py tests/test_plantuml_incdir.py tests/test_needuml.py tests/test_needflow.py`,
-   `uv run poe docs-needs`, `uv run poe test-mounts`.
+   suites: `uv run poe test-needs`, `uv run poe docs-needs`, `uv run poe test-mounts`. **The
+   whole sphinx-needs suite, not a path list**: rendering is opt in now, so the suite is
+   cheap (280 s serial, ~100 s at `-n 4`) and it is the only check that cannot miss a
+   renderer — the 102 rendering cases are spread over nine files, and a hand-written path
+   list is precisely the thing a jar bump would be trusted with and get wrong.
 
 **Pushing a bump may need `http.postBuffer`.** Over an HTTPS remote, git buffers a push body
 up to `http.postBuffer` (1 MB by default) and switches to chunked transfer above it, which

--- a/vendor/plantuml/README.md
+++ b/vendor/plantuml/README.md
@@ -5,7 +5,9 @@ for every package in this repository. `pin.toml` names the version and its sha25
 `plantuml-<version>.jar` beside it is that file. Nothing downloads it — a checkout has it.
 
 Everything that renders a diagram in this repository reads this one pin — sphinx-needs' test
-suite (`tests/conftest.py`) and its documentation (`docs/conf.py`), the performance project,
+suite (`tests/conftest.py`, for the builds that opt into rendering: the dozen `test_app`
+parameter dicts that say `"plantuml": True`, plus the tests that call `make_app` and take the
+`plantuml_command` fixture themselves) and its documentation (`docs/conf.py`), the performance project,
 the sphinx-mounts suite (through `PLANTUML_JAR`, which CI and the poe tasks set from here),
 `ci.yaml`, `release.yaml`, `benchmark.yaml`, `docs.yaml` and Read the Docs. The docker image
 is the one exception it cannot be: a `Dockerfile` cannot read TOML, so `docker/Dockerfile`
@@ -32,9 +34,11 @@ without a commit.
   1.2022.5, and sat four years and ~46 releases behind without anyone noticing, because
   nothing in the tree said what it was.
 - **Zero network.** A checkout renders. That is the whole point of committing it, and it is
-  worth more than the ~30 MB: 22 of a CI run's 26 jobs render (counted on run 34057129950,
-  on `a3aebf1f`: the four that do not are `Lint`, the smoke test, `Docs codelinks` and the
-  `check` aggregator), Read the Docs builds on every pull request, developers work offline,
+  worth more than the ~30 MB: 20 of a CI run's 26 jobs render (counted on run 34057129950,
+  on `a3aebf1f`, minus the two `Needs JS` cells that stopped needing a renderer when
+  rendering became opt in: the six that do not are `Lint`, the smoke test, `Docs codelinks`,
+  the `check` aggregator and those two), Read the Docs builds on every pull request,
+  developers work offline,
   and a sandboxed agent session's network allowlist is set
   on the environment rather than in this repository (this repository's own `CLAUDE.md` records
   `api.github.com` having to be added to it by hand).
@@ -132,7 +136,8 @@ success on exactly the mistake the fence is for. Lint runs it (`pytest tools/tes
    from a git ref with no checkout as its build context, so it downloads its own copy; this
    is the one place the version is repeated, and it is repeated deliberately.)
 5. `uv run poe verify-plantuml` — the check Lint will make — and re-run the renderer-heavy
-   suites: `uv run poe test-needs tests/test_plantuml.py tests/test_plantuml_incdir.py tests/test_needuml.py tests/test_needflow.py`,
+   suites — every sphinx-needs test that actually renders is in these five paths:
+   `uv run poe test-needs tests/conformance tests/test_plantuml.py tests/test_plantuml_incdir.py tests/test_needuml.py tests/test_needflow.py`,
    `uv run poe docs-needs`, `uv run poe test-mounts`.
 
 **Pushing a bump may need `http.postBuffer`.** Over an HTTPS remote, git buffers a push body


### PR DESCRIPTION
`test_app` injected a `plantuml` command into **every** build it made, so all 266 of the
suite's parameter dicts rendered unless they opted **out** with `"no_plantuml": True` — and
127 did, one line at a time, over years. The default was backwards: 12 tests assert on a
rendered diagram; the rest paid ~2 s of JVM start per diagram for output nobody looks at.
This inverts it — a build renders only if its parameter dict says `"plantuml": True`.

## Not opted in means the renderer is *inert*, not unset

Leaving a project on sphinxcontrib's own default — the bare word `plantuml` — means "render
with whatever unpinned renderer this machine carries, and say nothing"; here that is homebrew
PlantUML 1.2026.1 against the pinned 1.2026.8. So `make_plantuml_inert` puts three layers on a
non-opted build, each covering what the one before it cannot:

1. every node visitor sphinxcontrib registers is replaced with one that raises `SkipNode` —
   the directive still parses and the node still reaches the doctree, so every test that
   inspects the emitted *source* keeps passing, but no JVM starts;
2. **this app's own** `PlantumlBuilder` gets its two render entry points replaced with one
   that raises, naming the parameter that would have enabled rendering;
3. the `plantuml` config value is pointed at a command that cannot be run.

(2) is on the app, not on `outdir`, because ten test functions run a real `sphinx-build`
subprocess — two into `app.outdir` — and a rendered file there is not the fixture's doing.
(3) is a *sentinel* rather than a fence: its protection is that the token cannot be `exec`-ed,
and sphinxcontrib turns the error it provokes into a warning. The docstring says so.

**The fence is a property of this app object**, and the prose now says what goes round it. A
`sphinx-build` **subprocess** reads the project's own `conf.py`, where sphinxcontrib's default
is that bare word. Measured with a logging `plantuml`/`java` shim on `PATH`,
`test_needuml.py::test_needuml_diagram_allowmixing` was drawing **eight diagrams with homebrew
1.2026.1** — long before this branch. A `plantuml_subprocess_args` fixture now passes the
suite's resolved command in: the same measurement goes from **225 pinned-jar / 14 unpinned
starts to 233 / 6**. The six left are `test_needpie.py`'s two `make_app` callers, which take
no renderer fixture at all — named in `AGENTS.md`, and the shared-test-layer slice's to close.

All three happen after the app exists, not through `confoverrides`: 88 of the 138 test
projects do not load the extension, and injecting the config value into those is what earned
"unknown config value 'plantuml' in override, ignoring" — the one warning
`test_plantuml_unconfigured` loses here. `plantuml_command` also stops being named in
`test_app`'s signature: it *raises* when it finds no renderer, and a fixture named in a
signature is resolved whether or not the body uses it, which is why a machine with no jar used
to see 478 errors and now sees 157.

## What this buys

`poe test-needs`, serial, back to back on one warm machine: **387.04 s → 280.58 s, −27.5 %**,
at an unchanged 1757 passed / 12 skipped / 3 deselected. No test is skipped, deselected or
weakened; the twelve that need a renderer say so.

The browser lane drops its renderer entirely: `test-needs-js` loses
`deps = ["fetch-plantuml"]` and the `tests-js` lane loses its `PLANTUML_JAR` step. Proved, not
assumed — with `PLANTUML_JAR` naming a file that does not exist and `PATH` cut to the system
directories the three browser cases pass, while the same environment turns `test_arch.py` into
`RuntimeError: PLANTUML_JAR names … which is not a file`.

A latent bug goes with it: `test_app` used to `.update()` the `confoverrides` dict **in
place** — the object inside the test module's own `@pytest.mark.parametrize` list, evaluated
once at collection and shared by every use of that parameter. It is copied now.
`plantuml_batch_size = 100` also rides along for opted-in builds; the gain is small
(178.9 → 171.8 s over the seven opt-in modules), because this lever and the inversion are
substitutes, and the conformance corpus is measurably not worth batching (45.5 → 44.4 s).

## Commits

Ten, each reviewable on its own: the mechanical deletion of all 130 `no_plantuml` sites
(deletions only) · the twelve opt-ins · the fixture inversion · the render fence · the poe/CI
simplification · the batch size · the prose — then, after review, the subprocess fix above ·
the 45 `doc_test/*/conf.py` comments claiming the suite sets their command (true of 10 of
them; now true of all 45) · and four prose corrections. The one that mattered:
`vendor/plantuml/README.md`'s bump checklist claimed every rendering test was in five named
paths, and four files with 20 jar starts were outside them. It is a plain
`uv run poe test-needs` now — affordable exactly because of this PR.

No changelog entry: nothing here changes sphinx-needs' behaviour for anyone who installs it
(the diff touches no file under any package's `src/`).

Slice 1 of a four-slice arc ending in one shared test layer for sphinx-needs, sphinx-mounts
and sphinx-codelinks. It stands alone and moves no code between packages.