### PR TITLE
🔧 Read the Docs installs the workspace sibling from the checkout before the member

### DIFF
--- a/packages/sphinx-codelinks/.readthedocs.yaml
+++ b/packages/sphinx-codelinks/.readthedocs.yaml
@@ -64,6 +64,15 @@ sphinx:
 
 python:
   install:
+    # The workspace sibling FIRST, from this checkout. Read the Docs runs these entries in
+    # order with pip, and a member installed on its own would resolve `sphinx-needs` from
+    # PyPI -- the released version, not the one beside it -- so a docs build here could
+    # pass or fail on code the workspace does not have. With the sibling already installed
+    # the member's requirement is satisfied and pip fetches nothing (tight tracking keeps
+    # the checkout's version inside the member's floor and cap). CI's docs job builds from
+    # the workspace lock and needs none of this.
+    - method: pip
+      path: packages/sphinx-needs
     - method: pip
       path: packages/sphinx-codelinks
       extra_requirements:

--- a/packages/sphinx-mounts/.readthedocs.yaml
+++ b/packages/sphinx-mounts/.readthedocs.yaml
@@ -60,15 +60,6 @@ sphinx:
 
 python:
   install:
-    # The workspace sibling FIRST, from this checkout. Read the Docs runs these entries in
-    # order with pip, and a member installed on its own would resolve `sphinx-needs` from
-    # PyPI -- the released version, not the one beside it -- so a docs build here could
-    # pass or fail on code the workspace does not have. With the sibling already installed
-    # the member's requirement is satisfied and pip fetches nothing (tight tracking keeps
-    # the checkout's version inside the member's floor and cap). CI's docs job builds from
-    # the workspace lock and needs none of this.
-    - method: pip
-      path: packages/sphinx-needs
     - method: pip
       path: packages/sphinx-mounts
       extra_requirements:

--- a/packages/sphinx-mounts/.readthedocs.yaml
+++ b/packages/sphinx-mounts/.readthedocs.yaml
@@ -60,6 +60,15 @@ sphinx:
 
 python:
   install:
+    # The workspace sibling FIRST, from this checkout. Read the Docs runs these entries in
+    # order with pip, and a member installed on its own would resolve `sphinx-needs` from
+    # PyPI -- the released version, not the one beside it -- so a docs build here could
+    # pass or fail on code the workspace does not have. With the sibling already installed
+    # the member's requirement is satisfied and pip fetches nothing (tight tracking keeps
+    # the checkout's version inside the member's floor and cap). CI's docs job builds from
+    # the workspace lock and needs none of this.
+    - method: pip
+      path: packages/sphinx-needs
     - method: pip
       path: packages/sphinx-mounts
       extra_requirements:


### PR DESCRIPTION
## Why

`packages/sphinx-codelinks/.readthedocs.yaml` pip-installs the member directory alone, so the member's `sphinx-needs>=8.5.0,<9` resolves from PyPI: the **released** sphinx-needs, not the one beside the member in the same checkout. Today the two are the same version and nothing shows. The first extension change that relies on unreleased sphinx-needs code would be green in CI, whose docs jobs build from the workspace lock, and red on Read the Docs — or wrongly green, because the released version happens to still work.

## What changes

The codelinks config gains one `python.install` entry ahead of the member: `packages/sphinx-needs`, plain, from the checkout. Read the Docs runs the entries in order with pip, so by the time the member is installed its sphinx-needs requirement is already satisfied and pip fetches nothing. Tight tracking is what makes this safe: the workspace's version literal is always inside the member's floor and cap, and the bump tool keeps it there.

The root `.readthedocs.yml` (sphinx-needs' own project) is unchanged: it has no workspace dependency. sphinx-mounts' config is unchanged too: it does not depend on sphinx-needs, and a first draft of this change that gave it the same entry was reverted after its build log showed the sibling installed and never resolved. CI's docs jobs are unchanged: they already build from the lock.

## What proves it

This pull request's own Read the Docs build for sphinx-codelinks. Measured on build 34425440: the sibling step ends `Successfully built sphinx-needs` (wheel `sphinx_needs-8.5.0` from the checkout), and the member step reports `Requirement already satisfied: sphinx-needs<9,>=8.5.0` from the build's own site-packages — no download.
