### PR TITLE
🔧 Stop shipping the test suite in the sphinx-needs sdist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,8 +138,9 @@ one renderer — as does an offline machine with `plantuml` installed from its p
 is declared there), then re-run the renderer-heavy suites — `vendor/plantuml/README.md` has
 the recipe, including the `http.postBuffer` a 30 MB push over HTTPS needs. An sdist carries
 neither the jar nor the pin — `vendor/` is outside the directory flit builds the tarball from
-— so a distribution packager building from it takes the `PLANTUML_JAR` or `plantuml`-on-`PATH`
-route, and the sdist is ≈8 MB rather than 28.
+— so a docs build out of the tarball takes the `PLANTUML_JAR` or `plantuml`-on-`PATH` route,
+and a packager who runs the suite does so from a repository snapshot, where the jar, the pin
+and the testkit all are. The sdist is ≈7.4 MB rather than 28.
 
 **sphinx-codelinks needs NEITHER renderer**: nothing in that package draws a diagram, its
 docs build installs no `apt_packages` and its CI cell asks for graphviz only because it
@@ -262,10 +263,15 @@ uv pip install|uninstall …       # NOT project-scoped: it targets the activate
 **The sdist's contents come from `[tool.flit.sdist]`, not from git.** `uv build` runs
 `flit_core.buildapi`, which never consults git: measured, the sdist built in a worktree and
 the one built in a `git clone --depth 1` of it have identical entry lists *and* identical
-entry sizes. So what decides whether `tests/`, `docs/` and `performance/` ship
-is the `include`/`exclude` table in `packages/sphinx-needs/pyproject.toml`, and
-`uv run poe smoke-needs` asserts on every run that those trees are in the tarball and that
-nothing a docs or test run left behind is. (Until flit 4 this was a worktree hazard rather
+entry sizes. So the `include`/`exclude` table in `packages/sphinx-needs/pyproject.toml` is
+the whole story, and it now says `docs/` alone: `tests/` and `performance/` stopped shipping
+when the suite moved its fixtures into `packages/sphinx-needs-testkit`, a private member no
+index carries and no tarball can, which made the shipped suite unrunnable rather than merely
+large (1380 files / 7.72 MB before, 817 / 7.37 MB after — the count, not the bytes: test rst
+compresses to nothing). A packager who runs the suite does so from a repository snapshot,
+where the jar, the pin and the testkit all are. `uv run poe smoke-needs` asserts both
+directions on every run — `docs/` present, `tests/` and `performance/` absent — plus that
+nothing a docs build left behind is there. (Until flit 4 this was a worktree hazard rather
 than a manifest one: `flit build --use-vcs` tested `.git` for a *directory*, and in a
 worktree it is a file, so the sdist silently fell back to the module alone — no warning, a
 tenth of the size. Nothing runs `flit` directly any more.)

--- a/packages/sphinx-needs-testkit/src/sphinx_needs_testkit/_plantuml.py
+++ b/packages/sphinx-needs-testkit/src/sphinx_needs_testkit/_plantuml.py
@@ -80,8 +80,10 @@ def resolve_plantuml_command(workspace_jar: Path | None) -> str:
 
     1. ``PLANTUML_JAR``, run through ``java``. Naming a jar is an explicit choice, so it
        wins: it is how sphinx-mounts' suite is already pointed at a renderer, and it is
-       the only route open to someone running these tests from an sdist -- which ships no
-       jar at all now that the workspace keeps one. A variable that is set but names no
+       the only route open to someone running a suite from a tree with no ``vendor/`` above
+       it -- a package directory copied out of the repository, or the ``site-packages`` the
+       release workflow's compat cell installs this member into. No sdist this workspace
+       builds ships a suite at all. A variable that is set but names no
        file is a mistake worth a red run rather than a silent fall-through: falling through
        would render with a renderer the caller did not ask for and say nothing.
     2. The workspace's committed jar, ``vendor/plantuml/plantuml-<pinned version>.jar``.

--- a/packages/sphinx-needs/docs/contributing.rst
+++ b/packages/sphinx-needs/docs/contributing.rst
@@ -186,6 +186,29 @@ it with Playwright's ``expect``:
 Register ``page.on("pageerror", ...)`` before ``page.goto`` if the test should also assert
 that the page raised nothing.
 
+The tests are not in the source distribution
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The sdist on PyPI carries the package and its documentation, and nothing else. The suite
+lives in this repository: it loads its fixtures from ``sphinx-needs-testkit``, a workspace
+member classified ``Private :: Do Not Upload`` that is on no index, so a copy of ``tests/``
+inside a tarball could not be run from it anyway — shipping one would only look runnable.
+
+Run it from a repository checkout instead — ``uv sync --frozen``, then ``uv run poe
+test-needs``, which installs the testkit out of the workspace for you. From a source
+snapshot with no uv (a GitHub tag tarball, or a distribution's own copy of one) install the
+package and the testkit from the tree itself, then add the rest of the root's ``test``
+dependency group by name; that group lists the testkit as a bare requirement, so
+``pip install --group test`` on its own would go looking for it on an index and fail.
+Either way the machine needs graphviz's ``dot`` and a PlantUML renderer — the pinned jar is
+committed at ``vendor/plantuml/``, so a repository snapshot already carries it — because
+the tests that need them assert rather than skip:
+
+.. code-block:: bash
+
+   pip install ./packages/sphinx-needs ./packages/sphinx-needs-testkit
+   pytest packages/sphinx-needs/tests
+
 Benchmarks
 ----------
 

--- a/packages/sphinx-needs/pyproject.toml
+++ b/packages/sphinx-needs/pyproject.toml
@@ -68,25 +68,36 @@ theme-rtd = ["sphinx_rtd_theme>=3.0.2,<4"]
 # The sdist. flit 3 inferred its contents from git (`flit build --use-vcs`, which is what
 # CI ran until this workflow was rewritten); flit 4 flipped that default off, and
 # `uv build` -- which resolves `flit_core >=3.4,<5` to 4.x -- never had it at all. Without
-# this table the sdist silently drops from ~28 MB / ~1400 files to ~2.5 MB / ~700: module
-# only, no warning, exit 0. (Approximate on purpose -- the exact counts move with every
-# test file added; measured 2026-09.) Declaring the contents makes the sdist independent of
-# which flit_core is resolved and of whether the build ran in a git checkout at all.
+# this table the sdist is the module alone, with no warning and exit 0. Declaring the
+# contents makes it independent of which flit_core is resolved and of whether the build ran
+# in a git checkout at all.
 #
-# `tests/`, `docs/` and `performance/` ship on purpose, and the two downstream cases were
-# checked rather than assumed: conda-forge builds from this sdist (its test step is an
-# import check), and Debian runs the suite -- out of the GitHub tag tarball its
-# `debian/watch` fetches, not out of this file. `scripts/smoke_needs.py` asserts the trees
-# are here (and that none of the junk below is), so losing them would be a red gate rather
-# than a discovery on PyPI.
+# `docs/` ships; `tests/` and `performance/` deliberately do NOT, which reverses what this
+# table said until 9.0.0. The suite loads its fixtures from `sphinx-needs-testkit`, a
+# workspace member classified `Private :: Do Not Upload` that is on no index, so a `tests/`
+# tree in a tarball is a suite nobody can run from it -- worse than shipping none, because
+# it looks runnable. Neither downstream consumer loses anything, and both were checked
+# rather than assumed: conda-forge builds from this sdist and its test step is an import
+# check plus `pip check`, and Debian does run the suite but out of the GitHub tag tarball
+# its `debian/watch` fetches -- a repository snapshot, which carries the testkit, the
+# vendored PlantUML jar and its pin, none of which any sdist can. `docs/` stays as the
+# offline documentation source, which is also the mature-library convention (sphinx,
+# docutils, pytest, attrs, jinja2 and click all ship docs). `scripts/smoke_needs.py`
+# asserts both halves -- `docs/` present, `tests/` and `performance/` absent -- so putting
+# an unrunnable suite back is a red gate rather than a discovery on PyPI. Measured 2026-09:
+# 1380 files / 7.72 MB before this change and 817 / 7.37 MB after -- the tarball barely
+# moves because 554 files of test rst and python compress to a third of a megabyte; the
+# point is the 554 files, not the bytes.
 [tool.flit.sdist]
-include = ["docs/", "tests/", "performance/"]
-# Whatever a *used* checkout leaves lying under those three trees. flit reads the working
-# directory, not git, so anything a docs build or a test run wrote is a candidate: measured
-# on a tree where `poe docs-needs` and part of the suite had run, the docs build alone adds
-# 456 files (`docs/_build/`) plus the two generated artefacts named below. The `__pycache__`
-# and `.pyc` patterns are belt and braces -- flit_core 4 already drops those -- and they
-# cost nothing to state next to the ones it does not.
+include = ["docs/"]
+# Whatever a *used* checkout leaves lying under that tree. flit reads the working directory,
+# not git, so anything a docs build wrote is a candidate: measured on a tree where
+# `poe docs-needs` had run, the build alone adds 456 files (`docs/_build/`) plus the two
+# generated artefacts named below. The `__pycache__` and `.pyc` patterns are belt and braces
+# -- flit_core 4 already drops those -- and they cost nothing to state next to the ones it
+# does not. The `**/.pytest_cache/` entry went with the test tree: pytest writes that
+# directory at its rootdir, never inside `docs/`, and `smoke_needs.py` still asserts no
+# tarball carries one.
 exclude = [
   "docs/_build/",
   "docs/github_images/",
@@ -94,5 +105,4 @@ exclude = [
   "**/_build/",
   "**/__pycache__/",
   "**/*.pyc",
-  "**/.pytest_cache/",
 ]

--- a/packages/sphinx-needs/tests/test_plantuml_command.py
+++ b/packages/sphinx-needs/tests/test_plantuml_command.py
@@ -13,8 +13,12 @@ colour if it changed:
   renders for real and a developer machine carrying a homebrew ``plantuml`` must not
   silently swap the renderer version out from under it;
 * the executable is reached only when that jar is gone -- a checkout somebody deleted it
-  from, or an sdist, which carries neither the jar nor the pin because ``vendor/`` is
-  outside the package directory flit builds the tarball from.
+  from, or a package directory copied out of the repository, which has no ``vendor/``
+  above it because ``vendor/`` sits at the repository root and flit's ``include`` patterns
+  cannot escape the package directory. That used to describe the sdist as well; from 9.0.0
+  the tarball ships neither this suite nor the testkit it imports, so nobody reaches this
+  chain from one -- but ``docs/conf.py``, which the sdist does ship, resolves a renderer
+  the same way, and its copy of the message says the same two things in the same order.
 
 The command it returns is a *string*, which sphinxcontrib-plantuml splits for itself, so
 two of the cases below assert through that real split rather than on the string -- what has
@@ -107,8 +111,8 @@ def test_the_workspace_jar_is_the_default(
 def test_an_executable_is_the_fallback(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """With the jar gone -- a checkout somebody deleted it from, or an sdist --
-    ``plantuml`` on ``PATH`` is used."""
+    """With the jar gone -- a checkout somebody deleted it from, or a package directory
+    copied out of the repository -- ``plantuml`` on ``PATH`` is used."""
     monkeypatch.setattr(shutil, "which", lambda _name: "/usr/local/bin/plantuml")
 
     assert (
@@ -287,12 +291,15 @@ def test_a_missing_utils_directory_is_not_an_error(tmp_path: Path) -> None:
 def test_no_pin_at_all_falls_through_to_the_executable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """``None`` -- the sdist shape -- skips route (2) instead of crashing on it.
+    """``None`` -- a tree with no ``vendor/`` above it -- skips route (2) instead of
+    crashing on it.
 
-    ``vendor/`` is at the repository root and flit's sdist ``include`` patterns cannot
-    escape the package directory, so a tarball carries neither the jar nor the pin that
-    names it. :func:`sphinx_needs_testkit.workspace_plantuml_jar` returns ``None`` there, and the
-    chain has to read that as "no workspace jar" rather than looking up a path on it.
+    ``vendor/`` is at the repository root and flit's ``include`` patterns cannot escape the
+    package directory, so nothing this repository builds carries the jar or the pin that
+    names it: the sdist (whose ``docs/conf.py`` resolves a renderer this way), the wheel,
+    and a package directory somebody copied out of the tree.
+    :func:`sphinx_needs_testkit.workspace_plantuml_jar` returns ``None`` in all of them, and
+    the chain has to read that as "no workspace jar" rather than looking up a path on it.
     """
     monkeypatch.setattr(shutil, "which", lambda _name: "/usr/local/bin/plantuml")
 
@@ -302,14 +309,15 @@ def test_no_pin_at_all_falls_through_to_the_executable(
 def test_no_pin_and_no_executable_says_which_tree_this_is(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """An sdist with no renderer at all gets a message about an sdist.
+    """A pinless tree with no renderer at all gets a message about a pinless tree.
 
     ``None does not exist`` would be the obvious way to write this and the wrong one: the
-    reader is in a tree where ``poe fetch-plantuml`` does not exist either -- the tarball
-    ships no ``vendor/``, no root ``pyproject.toml`` and no poe -- so the message has to say
-    that no pin was found rather than name a path that never was one, and it must not LEAD
-    with a command that cannot be run there. The two routes that do work come first; the task
-    is mentioned last and only for "a checkout of the repository".
+    reader is in a tree where ``poe fetch-plantuml`` does not exist either -- an sdist
+    building its shipped ``docs/`` ships no ``vendor/``, no root ``pyproject.toml`` and no
+    poe, and neither does a copied-out package directory -- so the message has to say that
+    no pin was found rather than name a path that never was one, and it must not LEAD with
+    a command that cannot be run there. The two routes that do work come first; the task is
+    mentioned last and only for "a checkout of the repository".
     """
     monkeypatch.setattr(shutil, "which", lambda _name: None)
 
@@ -331,11 +339,16 @@ def test_the_workspace_jar_is_read_from_the_pin() -> None:
     Two facts at once: the version comes out of ``vendor/plantuml/pin.toml`` rather than a
     literal, and the filename carries it -- which is exactly what the four-year-old
     ``plantuml.jar`` this replaced could not say for itself. Skipped rather than failed
-    when there is no pin, because that is the sdist the two cases above describe.
+    when there is no pin, which is the pinless tree the two cases above describe -- no
+    longer an sdist, which stopped shipping this suite in 9.0.0, but still a package
+    directory copied out of the repository. The guard stays because what it protects is the
+    assertion below, which is about the pin and not about how the tree was obtained.
     """
     jar = workspace_plantuml_jar()
     if jar is None:
-        pytest.skip("no vendor/plantuml/pin.toml: this is an sdist, not a checkout")
+        pytest.skip(
+            "no vendor/plantuml/pin.toml: this tree is not a repository checkout"
+        )
 
     version = tomllib.loads((jar.parent / "pin.toml").read_text(encoding="utf-8"))[
         "version"

--- a/scripts/smoke_needs.py
+++ b/scripts/smoke_needs.py
@@ -7,10 +7,14 @@ invisible to all of them (issue #1829).  This script closes that gap:
 
 1. build the sdist + wheel with the *same* ``uv build`` invocation the release workflow
    runs (``--package <dist> --no-sources -o dist/<dist>``);
-2. assert the sdist still carries the trees it is meant to ship, and none of the rubbish a
-   used checkout leaves behind. flit 4 does not infer sdist contents from git, so those
-   trees are in the sdist only because ``[tool.flit.sdist] include`` says so -- and the
-   failure mode of losing them is an 11x smaller tarball, no warning and exit 0;
+2. assert the sdist carries the trees it is meant to ship, does *not* carry the ones it is
+   meant to have stopped shipping, and holds none of the rubbish a used checkout leaves
+   behind. Both directions are silent failures. flit 4 does not infer sdist contents from
+   git, so ``docs/`` is in the tarball only because ``[tool.flit.sdist] include`` says so;
+   and since 9.0.0 ``tests/`` and ``performance/`` must stay out of it, because the suite
+   loads its fixtures from ``sphinx-needs-testkit``, a private workspace member that is on
+   no index -- a shipped suite nobody can run is worse than none, and re-adding one to
+   ``include`` is a two-word edit that no other gate would notice;
 3. create a throwaway virtual environment *outside* the project;
 4. install the wheel into it with ``uv pip install``, which reads the wheel's own
    ``Requires-Dist`` and resolves it from the index (measured on uv 0.12.9: ``uv pip
@@ -159,13 +163,22 @@ def build(dist_name: str) -> tuple[Path, Path]:
     return wheels[0], sdists[0]
 
 
-def check_sdist_contents(sdist: Path, wanted: list[str], checks: Checks) -> None:
-    """The sdist ships the declared trees, and nothing a used checkout left behind.
+def check_sdist_contents(
+    sdist: Path, wanted: list[str], unwanted: list[str], checks: Checks
+) -> None:
+    """The sdist ships the declared trees, not the withdrawn ones, and no leftovers.
 
     `uv build` runs `flit_core.buildapi`, and flit 4 dropped flit 3's "infer the sdist from
-    git" behaviour -- so `tests/` and `docs/` are in the tarball only while
-    `[tool.flit.sdist] include` names them. Losing them costs 11x the size and warns about
-    nothing, which is exactly why it is asserted here and not left to review.
+    git" behaviour -- so `docs/` is in the tarball only while `[tool.flit.sdist] include`
+    names it, and losing it warns about nothing.
+
+    The `unwanted` half is the same assertion pointed the other way, and it is the one that
+    matters now: `tests/` and `performance/` were shipped until 9.0.0, the suite has since
+    moved its fixtures into `sphinx-needs-testkit` -- a member classified
+    `Private :: Do Not Upload`, which no sdist can carry -- and a tarball that ships the
+    suite anyway ships something that cannot be run. Debian, the one downstream that runs
+    these tests, runs them from the GitHub tag tarball `debian/watch` fetches, so nothing
+    is lost by keeping them out and nothing warns if they come back.
     """
     with tarfile.open(sdist) as tar:
         names = tar.getnames()
@@ -179,6 +192,18 @@ def check_sdist_contents(sdist: Path, wanted: list[str], checks: Checks) -> None
             f"{len(entries)} entries"
             if entries
             else "none -- is it in [tool.flit.sdist] include?",
+        )
+    for tree in unwanted:
+        entries = sorted(name for name in inner if name.startswith(f"{tree}/"))
+        shown = ", ".join(entries[:3]) + (" ..." if len(entries) > 3 else "")
+        checks.check(
+            not entries,
+            f"the sdist does NOT ship {tree}/",
+            f"{len(entries)} entries: {shown} -- drop {tree}/ from "
+            "[tool.flit.sdist] include; the suite needs sphinx-needs-testkit, "
+            "which is on no index"
+            if entries
+            else "",
         )
     junk = sorted(name for name in inner if any(bad in name for bad in SDIST_JUNK))
     shown = ", ".join(junk[:3]) + (" ..." if len(junk) > 3 else "")
@@ -383,9 +408,16 @@ def main() -> int:
     parser.add_argument(
         "--sdist-dirs",
         nargs="*",
-        default=["tests", "docs"],
+        default=["docs"],
         metavar="DIR",
-        help="directories the sdist must ship (default: tests docs); pass none to skip",
+        help="directories the sdist must ship (default: docs); pass none to skip",
+    )
+    parser.add_argument(
+        "--sdist-absent-dirs",
+        nargs="*",
+        default=["tests", "performance"],
+        metavar="DIR",
+        help="directories the sdist must NOT ship (default: tests performance); pass none to skip",
     )
     parser.add_argument(
         "--python",
@@ -409,7 +441,7 @@ def main() -> int:
     wheel, sdist = build(args.dist_name)
     print(f"built {wheel.name} and {sdist.name}")
     check_wheel_contents(wheel, module, package_dir, checks)
-    check_sdist_contents(sdist, args.sdist_dirs, checks)
+    check_sdist_contents(sdist, args.sdist_dirs, args.sdist_absent_dirs, checks)
 
     tmp = Path(tempfile.mkdtemp(prefix=f"smoke-{args.dist_name}-"))
     try:

--- a/vendor/plantuml/README.md
+++ b/vendor/plantuml/README.md
@@ -22,9 +22,9 @@ unpinned `releases/latest` download in the docker image, a fourth version that c
 without a commit.
 
 - **The sdist.** Moving the jar *here* is what takes it out of the tarball, and that is true
-  whether or not it is committed: `[tool.flit.sdist]` ships `tests/` and `docs/`, and flit's
-  `include` patterns cannot escape the package directory, so a repository-root directory
-  cannot enter the sdist at all. The two jars were 21,421,383 bytes on disk, and dropping
+  whether or not it is committed: `[tool.flit.sdist]` ships `docs/` (and shipped `tests/`
+  too, at the time), and flit's `include` patterns cannot escape the package directory, so a
+  repository-root directory cannot enter the sdist at all. The two jars were 21,421,383 bytes on disk, and dropping
   them takes the 28,050,184-byte sphinx-needs sdist down by 19,962,751 bytes — **71 %**, to
   ≈8.1 MB against a 2.8 MB wheel. A distribution packager building from the sdist takes the
   `PLANTUML_JAR` or `plantuml`-on-`PATH` route below.


### PR DESCRIPTION
`[tool.flit.sdist] include` drops `tests/` and `performance/` and keeps `docs/`.

## Why

Since #1904 the suite loads its fixtures from `sphinx-needs-testkit`, a workspace member
classified `Private :: Do Not Upload` that no index carries and no sdist can — the shipped
`tests/conftest.py` line 29 is `from sphinx_needs_testkit import make_plantuml_inert`, so
`pytest` in an unpacked tarball dies at collection. A suite that cannot run is worse than
none, because it looks runnable.

Both downstream consumers were checked rather than assumed, and neither loses anything.
**conda-forge** builds from this sdist and its test step (`recipe.yaml`) is an import check
plus `pip check` — it never ran these tests. **Debian** (`sphinx-needs` 5.1.0+dfsg-8, sid)
*does* run the suite, but from the GitHub tag tarball its `debian/watch` fetches — a
repository snapshot, which from 9.0.0 on carries the testkit at
`packages/sphinx-needs-testkit/`, the vendored PlantUML jar and its pin. Unaffected.

`docs/` stays: the offline documentation source, and what mature libraries ship (sphinx,
docutils, pytest, attrs, jinja2 and click all ship docs; myst-parser, sphinx-design,
sphinx-mounts and sphinx-codelinks ship the module alone).

## Measured — `uv build --package sphinx-needs --no-sources`, same tree, flit_core 4

| | files | tarball |
|---|---|---|
| before | 1380 | 8,090,950 B (7.72 MB) |
| after | 817 | 7,723,432 B (7.37 MB) |

563 files leave and the tarball moves 0.35 MB — test rst and python compress to almost
nothing. **The point is the 554 unrunnable files, not the bytes**, and the manifest comment
says so rather than claiming a size win it does not have. `tar tzf … | grep -c
'^[^/]*/tests/'` is 0; `src/` (702 files) and `docs/` (110) are unchanged.

## The fence, flipped

`scripts/smoke_needs.py` asserted the three trees were present; the failure mode is now the
reverse, so `check_sdist_contents` takes an `unwanted` list beside `wanted`, `--sdist-dirs`
defaults to `docs` and a new `--sdist-absent-dirs` to `tests performance`. The junk check
and step 7 (build a wheel *from* the sdist) are unchanged; `poe smoke-needs` passes neither
list, so the defaults are the policy. Mutation-tested — `tests/` back in `include`:

```
FAIL  the sdist does NOT ship tests/  -- 554 entries: tests/__init__.py, … -- drop tests/
      from [tool.flit.sdist] include; the suite needs sphinx-needs-testkit, on no index
```

## Documentation

`docs/contributing.rst` gains a short subsection: the sdist carries the package and its
documentation only, and the suite runs from a checkout (`uv sync --frozen`,
`uv run poe test-needs`) or from a source snapshot with the testkit installed from the tree.
Root `AGENTS.md`'s two sdist paragraphs are rewritten to the new truth. The "this is an
sdist" prose in `tests/test_plantuml_command.py` now says "a package directory copied out of
the repository" — **no logic change**: that path is still real, the shipped `docs/conf.py`
resolves a renderer through it, and the error strings (asserted word for word, duplicated in
three other files) are untouched.

**For the 9.0.0 changelog: the sdist no longer carries the test suite.** No entry here —
sphinx-needs' changelog is stamped at release time by `poe bump` plus a hand-written
paragraph, so the release PR should pick that line up.
