### PR TITLE
🧪 Adopt the shared test layer in sphinx-mounts and sphinx-codelinks

### DIFF
--- a/.github/workflows/test-extensions.yaml
+++ b/.github/workflows/test-extensions.yaml
@@ -75,8 +75,8 @@ jobs:
           # sphinx-mounts' path directives render with `dot`; sphinx-codelinks renders
           # nothing at all, and pays for the install here because the two share a cell
           needs-graphviz: true
-          # sphinx-mounts' uml tests render for real and `_require_renderer` asserts
-          # rather than skips
+          # sphinx-mounts' uml tests render for real, and the shared resolution RAISES
+          # rather than skipping when it finds no renderer
           needs-plantuml: true
       - name: Check the libclang engine this cell asked for is really there
         # `extra-groups: codelinks-libclang` above is the ONLY executable place that wheel

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,10 +121,13 @@ against the pin (one sha256 of 30 MB, well under a second including `uv` and `po
 is what CI's Lint job runs; `uv run poe fetch-plantuml` downloads the jar the pin names, which
 is a **bump** step and otherwise the same hash check. **You will rarely run either by hand**:
 every task that renders declares `fetch-plantuml` through `deps` — the sphinx-needs suites,
-`docs-needs*`, `benchmark-needs` and the sphinx-mounts suites, all of which resolve the jar
-for themselves through the shared test layer; `test-mounts-bazel` is the one that still needs
-`uses = { PLANTUML_JAR = "fetch-plantuml" }`, because its build runs in a Bazel sandbox that
-cannot see `vendor/` — and `lint` declares `verify-plantuml`. `smoke-needs`, `test-needs-js` and the
+`docs-needs*`, `benchmark-needs` and the sphinx-mounts suites. The two SUITES resolve the jar
+for themselves through the shared test layer; `docs-needs*` and `benchmark-needs` keep their
+own hand-written copies of the same three-route chain in `packages/sphinx-needs/docs/conf.py`
+and `packages/sphinx-needs/performance/performance_test.py`, and have to: a docs build and a
+benchmark must not import a test-only member. `test-mounts-bazel` is the one task that still
+needs `uses = { PLANTUML_JAR = "fetch-plantuml" }`, because its build runs in a Bazel sandbox
+that cannot see `vendor/` — and `lint` declares `verify-plantuml`. `smoke-needs`, `test-needs-js` and the
 sphinx-mounts docs render nothing and declare neither.
 
 Both suites resolve a renderer through ONE function in the shared test layer, and **both

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,14 +120,15 @@ session whose allowlist this repository cannot set. `uv run poe verify-plantuml`
 against the pin (one sha256 of 30 MB, well under a second including `uv` and `poe` startup) and
 is what CI's Lint job runs; `uv run poe fetch-plantuml` downloads the jar the pin names, which
 is a **bump** step and otherwise the same hash check. **You will rarely run either by hand**:
-every task that renders declares `fetch-plantuml` — the sphinx-needs suites, `docs-needs*` and
-`benchmark-needs` through `deps`, the sphinx-mounts suites through
-`uses = { PLANTUML_JAR = "fetch-plantuml" }`, because that suite reads the variable and nothing
-else — and `lint` declares `verify-plantuml`. `smoke-needs`, `test-needs-js` and the
+every task that renders declares `fetch-plantuml` through `deps` — the sphinx-needs suites,
+`docs-needs*`, `benchmark-needs` and the sphinx-mounts suites, all of which resolve the jar
+for themselves through the shared test layer; `test-mounts-bazel` is the one that still needs
+`uses = { PLANTUML_JAR = "fetch-plantuml" }`, because its build runs in a Bazel sandbox that
+cannot see `vendor/` — and `lint` declares `verify-plantuml`. `smoke-needs`, `test-needs-js` and the
 sphinx-mounts docs render nothing and declare neither.
 
-Both suites resolve a renderer in the same order, and **both assert rather than skip** when
-they find none: `PLANTUML_JAR` (an explicit choice, and an error when it names no file) →
+Both suites resolve a renderer through ONE function in the shared test layer, and **both
+assert rather than skip** when it finds none: `PLANTUML_JAR` (an explicit choice, and an error when it names no file) →
 the committed jar under `vendor/plantuml/` → a `plantuml` executable on `PATH` (`plantumlc`
 first on Windows, whose chocolatey `plantuml` shim is a non-blocking `javaw` launcher). So
 `PLANTUML_JAR=/any/plantuml.jar uv run poe test-mounts` still works and points both suites at

--- a/packages/sphinx-codelinks/AGENTS.md
+++ b/packages/sphinx-codelinks/AGENTS.md
@@ -187,8 +187,9 @@ a file path: `poe test-codelinks -- --collect-only -q` collects **0 items**, whe
 ### Test Structure
 
 - Tests use `pytest` with fixtures from `conftest.py`, which also loads the workspace's
-  shared test layer, `packages/sphinx-needs-testkit` — the doctree snapshot extension comes
-  from there rather than from a copy here
+  shared test layer, `packages/sphinx-needs-testkit` — the doctree snapshot extension and
+  the warning normalisation a build assertion goes through both come from there rather than
+  from a copy here, so a warning means the same thing in this suite as in the other two
 - Snapshot testing uses `syrupy` for complex output comparisons
 - Test data is in `tests/data/`
 - Sphinx integration tests use real Sphinx projects in `tests/doc_test/`

--- a/packages/sphinx-codelinks/tests/conftest.py
+++ b/packages/sphinx-codelinks/tests/conftest.py
@@ -7,9 +7,11 @@ from syrupy.extensions.single_file import SingleFileSnapshotExtension, WriteMode
 from sphinx_codelinks.config import OneLineCommentStyle
 
 # The workspace's shared test layer, `packages/sphinx-needs-testkit`, which carries the
-# doctree snapshot extension this file used to hold a byte-for-byte copy of. A line that
-# resolves to nothing is a collection ERROR, not a silent loss of fixtures, which is what
-# makes this the fence that the kit is importable in every cell this suite runs in.
+# doctree snapshot extension this file used to hold a byte-for-byte copy of -- and, imported
+# by name in the test modules rather than through this line, the warning normalisation the
+# suite's build assertions go through. A line that resolves to nothing is a collection
+# ERROR, not a silent loss of fixtures, which is what makes this the fence that the kit is
+# importable in every cell this suite runs in.
 # The order matters where both plugins define a fixture -- see the note in the testkit's
 # `fixtures` module -- so the testkit always comes last.
 #

--- a/packages/sphinx-codelinks/tests/test_src_trace.py
+++ b/packages/sphinx-codelinks/tests/test_src_trace.py
@@ -15,6 +15,7 @@ from sphinx_codelinks.config import (
     check_configuration,
 )
 from sphinx_codelinks.sphinx_extension.source_tracing import set_config_to_sphinx
+from sphinx_needs_testkit import assert_no_warnings, build_warnings
 
 
 @pytest.mark.parametrize(
@@ -322,7 +323,7 @@ def test_default_ubproject_toml_is_loaded(
     app.build()
 
     assert "demo" in app.config.src_trace_projects
-    assert app.warning.getvalue() == ""
+    assert_no_warnings(app)
 
 
 def test_default_ubproject_toml_without_codelinks_section_is_silent(
@@ -338,7 +339,7 @@ def test_default_ubproject_toml_without_codelinks_section_is_silent(
     app.build()
 
     assert app.config.src_trace_projects == {}
-    assert app.warning.getvalue() == ""
+    assert_no_warnings(app)
 
 
 def test_missing_default_ubproject_toml_is_silent(
@@ -351,7 +352,7 @@ def test_missing_default_ubproject_toml_is_silent(
     app.build()
 
     assert app.config.src_trace_projects == {}
-    assert app.warning.getvalue() == ""
+    assert_no_warnings(app)
 
 
 def test_explicit_toml_config_missing_warns(
@@ -366,4 +367,6 @@ def test_explicit_toml_config_missing_warns(
     app = make_app(srcdir=minimal_sphinx_project, freshenv=True)
     app.build()
 
-    assert "does not exist" in app.warning.getvalue()
+    warnings = build_warnings(app)
+    assert len(warnings) == 1, warnings
+    assert "does not exist" in warnings[0]

--- a/packages/sphinx-mounts/AGENTS.md
+++ b/packages/sphinx-mounts/AGENTS.md
@@ -115,27 +115,23 @@ as a standalone repository cannot be built there at all. Do not reintroduce it.
 
 ## Testing Guidelines
 
-- Tests use `pytest` with `sphinx.testing.fixtures`.
+- Tests use `pytest` with `sphinx.testing.fixtures`, and the workspace's shared test
+  layer beside it — the warning normalisation this suite asserts through and the renderer
+  resolution its uml cases build with both come from there, so a warning count, a warning
+  type and a jar mean the same thing in every suite in this repository.
 - **Renderers are a prerequisite, not an optional extra.** The graphviz and PlantUML cases
-  in `tests/test_path_directives.py` render for real, and `_require_renderer` **asserts**
-  rather than skipping — the point of those tests is to exercise the whole mounts chain
-  including the render step. Two routes, and either satisfies them:
+  in `tests/test_path_directives.py` render for real and **assert** rather than skipping —
+  the point of those tests is to exercise the whole mounts chain including the render step.
+  Two routes, and either satisfies them:
   - `dot` (graphviz) on `PATH`, which is required and has no alternative; and
-  - PlantUML, from **either** a `plantuml` executable on `PATH` **or** a plantuml jar named
-    by `PLANTUML_JAR`, with `java` on `PATH`. This suite reads the variable and never a
-    path, which is what keeps it independent of the workspace's layout — so **the jar has
-    to be handed to it**, and `uv run poe test-mounts` does exactly that:
-    `uses = { PLANTUML_JAR = "fetch-plantuml" }` runs that task and captures the path it
-    prints. The jar is the one `vendor/plantuml/pin.toml` names and it is **committed** at
-    `vendor/plantuml/plantuml-<version>.jar`, so the task hashes a file the checkout already
-    has rather than downloading anything; CI and `release.yaml` run the same script (with
-    `--verify`) and write the same variable. Pointing it somewhere else is honoured ahead of
-    everything: `PLANTUML_JAR=/any/plantuml.jar uv run poe test-mounts` (poe hands back the
-    value you set, because the script short-circuits on it). Running `pytest` directly,
-    outside the task, is the one case where you have to export it yourself —
-    `PLANTUML_JAR=$PWD/vendor/plantuml/plantuml-1.2026.8.jar`, or whatever
-    `uv run poe verify-plantuml` prints. sphinx-needs' suite reads the same variable first,
-    so one export serves both packages.
+  - PlantUML, resolved exactly as every other suite here resolves it: `PLANTUML_JAR` (an
+    explicit choice, and an error when it names no file), then the jar **committed** at
+    `vendor/plantuml/plantuml-<version>.jar` that `vendor/plantuml/pin.toml` names, then a
+    `plantuml` executable on `PATH`. A checkout therefore needs nothing exported and no
+    network: `uv run poe test-mounts` hashes the committed jar against the pin and the
+    suite finds it, and a bare `pytest` finds it too. `PLANTUML_JAR=/any/plantuml.jar` is
+    still honoured ahead of everything, which is how CI, `release.yaml` and the Bazel lane
+    supply theirs.
 
   Mermaid uses `raw` output, so no `mmdc` binary is needed.
 - **The three sphinx-needs integration tests assert rather than skip too.** They are the

--- a/packages/sphinx-mounts/tests/conftest.py
+++ b/packages/sphinx-mounts/tests/conftest.py
@@ -11,7 +11,22 @@ import pytest
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
 
-pytest_plugins = ["sphinx.testing.fixtures"]
+# The workspace's shared test layer, `packages/sphinx-needs-testkit`. This suite takes two
+# things from it: the warning normalisation (`build_warnings` / `warning_count`, imported
+# by name in the test modules) and the renderer resolution, whose lazy half is the
+# `plantuml_command` fixture this line is what provides -- so a tree that lost the entry
+# fails at setup with `fixture 'plantuml_command' not found` rather than silently
+# collecting less.
+#
+# The ORDER of the list is load-bearing where both plugins define a fixture, and the kit
+# must come last; see the note in its `fixtures` module. **Nothing in this suite fences it,
+# and that is acceptable here**: the only fixture the two share is `sphinx_test_tempdir`,
+# which this suite never resolves -- it builds through sphinx's `make_app` into `tmp_path`
+# -- and could not resolve if it tried, because the kit's version needs a `tests_dir`
+# fixture that only sphinx-needs' conftest defines. The day a test here uses sphinx's `app`
+# fixture, that arrives as `fixture 'tests_dir' not found`, which is loud rather than
+# wrong. `--sn-build-dir`, which the kit also adds, does nothing in this suite.
+pytest_plugins = ["sphinx.testing.fixtures", "sphinx_needs_testkit.fixtures"]
 
 TESTS_DIR = Path(__file__).parent
 FIXTURES_DIR = TESTS_DIR / "fixtures"
@@ -131,22 +146,10 @@ def _toml_string(value: str) -> str:
     return f'"{escaped}"'
 
 
-def count_warnings(app) -> int:
-    """Total number of warning records in the captured Sphinx warning stream.
-
-    Each Sphinx warning is emitted as a single ``WARNING:`` record, so
-    counting them pins the *exact* number of warnings a scenario may emit.
-    """
-    return app._warning.getvalue().count("WARNING:")
-
-
-def count_mount_warnings(app) -> int:
-    """Number of sphinx-mounts warnings (``mounts.*`` types) captured.
-
-    Every sphinx-mounts warning carries the ``[mounts.<subtype>]`` type
-    suffix on Sphinx 8/9 natively and Sphinx 7 via the manual append, so
-    counting those occurrences pins exactly how many of *our* warnings a
-    scenario emits — independent of unrelated Sphinx toctree noise and
-    stable across supported Sphinx versions.
-    """
-    return app._warning.getvalue().count("[mounts.")
+# `count_warnings` and `count_mount_warnings` are NOT here any more. The first counted
+# occurrences of the substring ``WARNING:``; both are replaced by the workspace's one
+# normalisation, `sphinx_needs_testkit.warning_count`, which counts warning RECORDS and,
+# given a type, only those carrying exactly that ``[type]`` token -- so a scenario now
+# pins WHICH sphinx-mounts warning it emits rather than how many mounts warnings of any
+# kind. The two family assertions that genuinely mean "no mounts warning at all" spell
+# that out over `build_warnings` at their call sites.

--- a/packages/sphinx-mounts/tests/test_example.py
+++ b/packages/sphinx-mounts/tests/test_example.py
@@ -110,18 +110,19 @@ def test_example_pipeline_end_to_end(tmp_path: Path) -> None:
             "'dot' not on PATH — required to render the showcase graphviz "
             "bundle under -nW"
         )
-    # PlantUML comes either from an executable on PATH or, when PLANTUML_JAR
-    # names a jar, from java — the route CI takes; the example's conf.py reads
-    # the same variable.
-    if not (
-        (os.environ.get("PLANTUML_JAR") and shutil.which("java"))
-        or shutil.which("plantuml")
-    ):
+    # One condition, not a resolution chain: the example is built by Bazel in a
+    # sandbox that cannot see ``vendor/``, so ``PLANTUML_JAR`` (which its
+    # ``.bazelrc`` passes through ``--action_env`` and its ``docs/conf.py``
+    # reads) is the only route to a renderer it has. ``uv run poe
+    # test-mounts-bazel`` is the task that sets it -- it is the one sphinx-mounts
+    # task that kept ``uses``, for exactly this reason.
+    if not os.environ.get("PLANTUML_JAR"):
         pytest.skip(
-            "no PlantUML — run `uv run poe test-mounts`, which sets PLANTUML_JAR "
-            "from the pinned jar in vendor/plantuml/, or set "
-            "PLANTUML_JAR yourself (with java on PATH), or install a `plantuml` "
-            "executable, to render the showcase uml bundle under -nW"
+            "PLANTUML_JAR is unset, and the example's Bazel sandbox has no other "
+            "route to a renderer — run `uv run poe test-mounts-bazel`, which sets "
+            "it from the jar committed under vendor/plantuml/, or export it "
+            "yourself (with java on PATH), to render the showcase uml bundle "
+            "under -nW"
         )
 
     workspace = tmp_path / "ws"

--- a/packages/sphinx-mounts/tests/test_mounting.py
+++ b/packages/sphinx-mounts/tests/test_mounting.py
@@ -1404,8 +1404,9 @@ def test_docname_conflict_warning_is_suppressible(
     app.build()
 
     assert "docname conflict" not in app._warning.getvalue()
+    # `warning_count(app) == 0` is the whole claim: a typed count of zero passes for any
+    # type string, including one no version of this package has ever emitted.
     assert warning_count(app) == 0
-    assert warning_count(app, "mounts.docname_conflict") == 0
 
 
 def test_docname_conflict_warning_group_suppressible(
@@ -1429,8 +1430,9 @@ def test_docname_conflict_warning_group_suppressible(
     app.build()
 
     assert "docname conflict" not in app._warning.getvalue()
+    # `warning_count(app) == 0` is the whole claim: a typed count of zero passes for any
+    # type string, including one no version of this package has ever emitted.
     assert warning_count(app) == 0
-    assert warning_count(app, "mounts.docname_conflict") == 0
 
 
 def test_docname_conflict_fails_under_warningiserror(

--- a/packages/sphinx-mounts/tests/test_mounting.py
+++ b/packages/sphinx-mounts/tests/test_mounting.py
@@ -1305,6 +1305,7 @@ def test_include_on_a_file_list_mount_warns_that_it_is_ignored(
     warnings = app._warning.getvalue()
     assert "mounts.ignored_option" in warnings, warnings
     assert "include" in warnings, warnings
+    assert warning_count(app) == 1
     assert warning_count(app, "mounts.ignored_option") == 1, warnings
     # The filter really had no effect: both files are still mounted. The
     # warning describes the situation rather than changing it.
@@ -1340,6 +1341,7 @@ def test_exclude_on_a_file_list_mount_warns_that_it_is_ignored(
     warnings = app._warning.getvalue()
     assert "mounts.ignored_option" in warnings, warnings
     assert "include and exclude" in warnings, warnings
+    assert warning_count(app) == 1
     assert warning_count(app, "mounts.ignored_option") == 1, warnings
     # `exclude` did not drop the file either.
     assert (Path(app.outdir) / "_g" / "m" / "one.html").exists()
@@ -1367,9 +1369,11 @@ def test_directory_mount_with_include_does_not_warn(
     app = make_app(srcdir=host, freshenv=True)
     app.build()
 
-    # The FAMILY, not one type: the claim is that a directory mount stays silent, whatever
-    # it might have warned about. `warning_count` matches one warning type exactly and
-    # offers no prefix, deliberately, so a family assertion is spelled out here.
+    # The FAMILY, not one type: the claim is that a directory mount stays silent whatever
+    # it might have warned about, and `warning_count` matches one type exactly, offering no
+    # prefix, deliberately. The TOTAL is not available here -- excluding `details.rst` makes
+    # the bundle's own toctree dangle, so the build emits a `toc.not_readable` and a
+    # `ref.doc` that have nothing to do with the claim (measured: `warning_count(app)` is 2).
     assert [w for w in build_warnings(app) if "[mounts." in w] == [], (
         app._warning.getvalue()
     )
@@ -1723,6 +1727,7 @@ def test_top_level_mounts_table_warns_that_it_is_deprecated(
     warnings = app._warning.getvalue()
     assert "mounts.deprecated_location" in warnings, warnings
     assert "[[source.mounts]]" in warnings, warnings
+    assert warning_count(app) == 1
     assert warning_count(app, "mounts.deprecated_location") == 1, warnings
     # The mount itself is unaffected — deprecated, not broken.
     html = _read_html(Path(app.outdir), "_generated/api-foo/details")
@@ -2802,6 +2807,7 @@ def test_dangling_attach_to_does_not_announce_a_re_read(
     app = make_app(srcdir=host, freshenv=True)
     app.build()
     # Exactly one diagnostic, and it is the missing target.
+    assert warning_count(app) == 1
     assert warning_count(app, "mounts.attach_to_missing") == 1, app._warning.getvalue()
     assert "mounts.attach_to_missing" in app._warning.getvalue()
 

--- a/packages/sphinx-mounts/tests/test_mounting.py
+++ b/packages/sphinx-mounts/tests/test_mounting.py
@@ -27,12 +27,8 @@ from docutils import nodes
 from sphinx import addnodes
 from sphinx.testing.fixtures import SharedResult  # noqa: F401  (registers fixture)
 
-from tests.conftest import (
-    count_mount_warnings,
-    count_warnings,
-    patch_conf_py,
-    write_ubproject_toml,
-)
+from sphinx_needs_testkit import build_warnings, warning_count
+from tests.conftest import patch_conf_py, write_ubproject_toml
 
 if TYPE_CHECKING:
     pass
@@ -54,7 +50,7 @@ def _build_clean(make_app, host_dir: Path) -> Path:
     """
     app = make_app(srcdir=host_dir, freshenv=True)
     app.build()
-    assert count_warnings(app) == 0, app._warning.getvalue()
+    assert warning_count(app) == 0, app._warning.getvalue()
     return Path(app.outdir)
 
 
@@ -347,8 +343,8 @@ def test_root_mount_shadowing_host_doc_warns(
     assert "mounts.docname_conflict" in warnings
     # The whole mount was removed: no sibling docs were mounted.
     assert not (Path(app.outdir) / "intro.html").exists()
-    assert count_warnings(app) == 1  # only the docname conflict
-    assert count_mount_warnings(app) == 1
+    assert warning_count(app) == 1  # only the docname conflict
+    assert warning_count(app, "mounts.docname_conflict") == 1
 
 
 def test_root_mount_with_attach_to_wires_bare_entry_doc(
@@ -837,7 +833,7 @@ def test_attach_each_wires_every_file_without_entry_doc(
 
     app = make_app(srcdir=host, freshenv=True)
     app.build()
-    assert count_warnings(app) == 0
+    assert warning_count(app) == 0
 
     # Every listed file is wired into the host toctree, in files order, and
     # no phantom "index" entry doc is invented.
@@ -881,7 +877,7 @@ def test_attach_each_creates_toctree_when_absent(
 
     app = make_app(srcdir=host, freshenv=True)
     app.build()
-    assert count_warnings(app) == 0
+    assert warning_count(app) == 0
 
     doctree = app.env.get_doctree("index")
     toctrees = list(doctree.findall(addnodes.toctree))
@@ -912,8 +908,8 @@ def test_mount_files_unknown_suffix_warns(make_app, make_host_project, tmp_path)
     warnings = app._warning.getvalue()
     assert "source_suffix" in warnings
     assert "mounts.unknown_suffix" in warnings
-    assert count_warnings(app) == 1  # only the unknown_suffix warning
-    assert count_mount_warnings(app) == 1
+    assert warning_count(app) == 1  # only the unknown_suffix warning
+    assert warning_count(app, "mounts.unknown_suffix") == 1
 
 
 def test_mount_files_missing_file_warns(make_app, make_host_project, tmp_path):
@@ -938,8 +934,8 @@ def test_mount_files_missing_file_warns(make_app, make_host_project, tmp_path):
     warnings = app._warning.getvalue()
     assert "does not exist" in warnings
     assert "mounts.missing_path" in warnings
-    assert count_warnings(app) == 1  # only the missing_path warning
-    assert count_mount_warnings(app) == 1
+    assert warning_count(app) == 1  # only the missing_path warning
+    assert warning_count(app, "mounts.missing_path") == 1
 
 
 def test_missing_mount_dir_warns(make_app, make_host_project, tmp_path):
@@ -962,8 +958,8 @@ def test_missing_mount_dir_warns(make_app, make_host_project, tmp_path):
     assert "does not exist" in warnings
     assert "mounts.missing_path" in warnings
     assert (Path(app.outdir) / "index.html").exists()
-    assert count_warnings(app) == 1  # only the missing_path warning
-    assert count_mount_warnings(app) == 1
+    assert warning_count(app) == 1  # only the missing_path warning
+    assert warning_count(app, "mounts.missing_path") == 1
 
 
 def test_missing_mount_dir_with_attach_to_does_not_wire_dangling_ref(
@@ -997,8 +993,8 @@ def test_missing_mount_dir_with_attach_to_does_not_wire_dangling_ref(
     assert all("_generated/api-foo/index" not in t["includefiles"] for t in toctrees)
     warnings = app._warning.getvalue()
     assert "toc.not_readable" not in warnings
-    assert count_warnings(app) == 1  # only the mounts.missing_path warning
-    assert count_mount_warnings(app) == 1
+    assert warning_count(app) == 1  # only the mounts.missing_path warning
+    assert warning_count(app, "mounts.missing_path") == 1
 
 
 def test_exclude_filter_bundle_files(make_app, make_host_project, tmp_path):
@@ -1069,8 +1065,8 @@ def test_docname_conflict_warns_and_first_mount_wins(
     )
     assert "API Foo" in html
     assert "Dup" not in html
-    assert count_warnings(app) == 1  # only the docname conflict
-    assert count_mount_warnings(app) == 1
+    assert warning_count(app) == 1  # only the docname conflict
+    assert warning_count(app, "mounts.docname_conflict") == 1
 
 
 def test_intra_mount_basename_collision_warns_and_skips_the_mount(
@@ -1127,8 +1123,8 @@ def test_intra_mount_basename_collision_warns_and_skips_the_mount(
         warnings
     )
     assert "include / exclude" not in warnings, warnings
-    assert count_warnings(app) == 1, warnings
-    assert count_mount_warnings(app) == 1
+    assert warning_count(app) == 1, warnings
+    assert warning_count(app, "mounts.docname_conflict") == 1
     # Whole-mount skip: neither document was mounted.
     assert not (Path(app.outdir) / "_g/fl/notes.html").exists()
 
@@ -1180,8 +1176,8 @@ def test_intra_mount_suffix_collision_warns_and_skips_the_mount(
     # remedy to offer here.
     assert "include / exclude" in warnings, warnings
     assert "`files` list" not in warnings, warnings
-    assert count_warnings(app) == 1, warnings
-    assert count_mount_warnings(app) == 1
+    assert warning_count(app) == 1, warnings
+    assert warning_count(app, "mounts.docname_conflict") == 1
     assert not (Path(app.outdir) / "_g/dm/index.html").exists()
 
 
@@ -1244,8 +1240,8 @@ def test_listed_file_that_is_only_a_suffix_is_rejected(
     warnings = app._warning.getvalue()
     assert "mounts.empty_docname" in warnings, warnings
     assert "no name before its '.rst' suffix" in warnings, warnings
-    assert count_warnings(app) == 1, warnings
-    assert count_mount_warnings(app) == 1
+    assert warning_count(app) == 1, warnings
+    assert warning_count(app, "mounts.empty_docname") == 1
     # Whole-mount skip: nothing was mounted, and no dotfile page was written.
     assert "_g/b" not in app.env.project.docnames
     assert not (Path(app.outdir) / "_g" / "b" / ".html").exists()
@@ -1309,7 +1305,7 @@ def test_include_on_a_file_list_mount_warns_that_it_is_ignored(
     warnings = app._warning.getvalue()
     assert "mounts.ignored_option" in warnings, warnings
     assert "include" in warnings, warnings
-    assert count_mount_warnings(app) == 1, warnings
+    assert warning_count(app, "mounts.ignored_option") == 1, warnings
     # The filter really had no effect: both files are still mounted. The
     # warning describes the situation rather than changing it.
     assert (Path(app.outdir) / "_g" / "m" / "one.html").exists()
@@ -1344,7 +1340,7 @@ def test_exclude_on_a_file_list_mount_warns_that_it_is_ignored(
     warnings = app._warning.getvalue()
     assert "mounts.ignored_option" in warnings, warnings
     assert "include and exclude" in warnings, warnings
-    assert count_mount_warnings(app) == 1, warnings
+    assert warning_count(app, "mounts.ignored_option") == 1, warnings
     # `exclude` did not drop the file either.
     assert (Path(app.outdir) / "_g" / "m" / "one.html").exists()
 
@@ -1371,7 +1367,12 @@ def test_directory_mount_with_include_does_not_warn(
     app = make_app(srcdir=host, freshenv=True)
     app.build()
 
-    assert count_mount_warnings(app) == 0, app._warning.getvalue()
+    # The FAMILY, not one type: the claim is that a directory mount stays silent, whatever
+    # it might have warned about. `warning_count` matches one warning type exactly and
+    # offers no prefix, deliberately, so a family assertion is spelled out here.
+    assert [w for w in build_warnings(app) if "[mounts." in w] == [], (
+        app._warning.getvalue()
+    )
     # ...and the patterns genuinely applied.
     assert not (Path(app.outdir) / "_g" / "m" / "details.html").exists()
 
@@ -1399,8 +1400,8 @@ def test_docname_conflict_warning_is_suppressible(
     app.build()
 
     assert "docname conflict" not in app._warning.getvalue()
-    assert count_warnings(app) == 0
-    assert count_mount_warnings(app) == 0
+    assert warning_count(app) == 0
+    assert warning_count(app, "mounts.docname_conflict") == 0
 
 
 def test_docname_conflict_warning_group_suppressible(
@@ -1424,8 +1425,8 @@ def test_docname_conflict_warning_group_suppressible(
     app.build()
 
     assert "docname conflict" not in app._warning.getvalue()
-    assert count_warnings(app) == 0
-    assert count_mount_warnings(app) == 0
+    assert warning_count(app) == 0
+    assert warning_count(app, "mounts.docname_conflict") == 0
 
 
 def test_docname_conflict_fails_under_warningiserror(
@@ -1472,8 +1473,8 @@ def test_docname_conflict_fails_under_warningiserror(
         assert "docname conflict" in warnings
         assert "toc.not_readable" not in warnings
         assert "toc.not_included" not in warnings
-        assert count_warnings(app) == 1  # only the docname conflict
-        assert count_mount_warnings(app) == 1
+        assert warning_count(app) == 1  # only the docname conflict
+        assert warning_count(app, "mounts.docname_conflict") == 1
 
 
 def test_strict_mount_at_warns_on_preexisting_host_dir(
@@ -1506,8 +1507,8 @@ def test_strict_mount_at_warns_on_preexisting_host_dir(
     assert "mounts.mount_at_occupied" in warnings
     # The whole mount was removed: no bundle doc was mounted.
     assert not (Path(app.outdir) / "_generated" / "api-foo" / "index.html").exists()
-    assert count_warnings(app) == 1  # only the mount_at_occupied warning
-    assert count_mount_warnings(app) == 1
+    assert warning_count(app) == 1  # only the mount_at_occupied warning
+    assert warning_count(app, "mounts.mount_at_occupied") == 1
 
 
 def test_strict_mount_at_passes_when_no_host_dir(
@@ -1580,8 +1581,8 @@ def test_strict_mount_at_warns_on_preexisting_host_dir_in_files_mode(
     warnings = app._warning.getvalue()
     assert "strict_mount_at" in warnings
     assert "mounts.mount_at_occupied" in warnings
-    assert count_warnings(app) == 1  # only the mount_at_occupied warning
-    assert count_mount_warnings(app) == 1
+    assert warning_count(app) == 1  # only the mount_at_occupied warning
+    assert warning_count(app, "mounts.mount_at_occupied") == 1
 
 
 def test_toml_overrides_conf_py_mounts(
@@ -1722,7 +1723,7 @@ def test_top_level_mounts_table_warns_that_it_is_deprecated(
     warnings = app._warning.getvalue()
     assert "mounts.deprecated_location" in warnings, warnings
     assert "[[source.mounts]]" in warnings, warnings
-    assert count_mount_warnings(app) == 1, warnings
+    assert warning_count(app, "mounts.deprecated_location") == 1, warnings
     # The mount itself is unaffected — deprecated, not broken.
     html = _read_html(Path(app.outdir), "_generated/api-foo/details")
     assert "BUNDLE_SIMPLE_DETAILS_MARKER" in html
@@ -1744,7 +1745,7 @@ def test_namespaced_mounts_table_does_not_warn(
     app = make_app(srcdir=host, freshenv=True)
     app.build()
 
-    assert count_warnings(app) == 0, app._warning.getvalue()
+    assert warning_count(app) == 0, app._warning.getvalue()
 
 
 def test_deprecated_location_warning_is_suppressible(
@@ -1774,7 +1775,7 @@ def test_deprecated_location_warning_is_suppressible(
     app = make_app(srcdir=host, freshenv=True)
     app.build()
 
-    assert count_warnings(app) == 0, app._warning.getvalue()
+    assert warning_count(app) == 0, app._warning.getvalue()
 
 
 def test_conf_py_mounts_fallback_is_not_deprecated(
@@ -1797,7 +1798,7 @@ def test_conf_py_mounts_fallback_is_not_deprecated(
     app.build()
 
     assert "deprecated" not in app._warning.getvalue(), app._warning.getvalue()
-    assert count_warnings(app) == 0, app._warning.getvalue()
+    assert warning_count(app) == 0, app._warning.getvalue()
 
 
 def test_declaring_mounts_in_both_tables_fails_the_build(
@@ -1976,7 +1977,7 @@ def test_attach_to_targets_specific_toctree_by_index(
 
     app = make_app(srcdir=host, freshenv=True)
     app.build()
-    assert count_warnings(app) == 0
+    assert warning_count(app) == 0
 
     # Inspect the parsed doctree directly: the mount entry must be in
     # the *second* toctree node (index 1, the SecondCaption one), not
@@ -2025,8 +2026,8 @@ def test_attach_to_index_out_of_range_warns_and_skips(
     warnings = app._warning.getvalue()
     assert "toctree_index" in warnings
     assert "mounts.toctree_index" in warnings
-    assert count_warnings(app) == 1  # only the toctree_index warning
-    assert count_mount_warnings(app) == 1
+    assert warning_count(app) == 1  # only the toctree_index warning
+    assert warning_count(app, "mounts.toctree_index") == 1
     # The host toctree is untouched: still empty, nothing wired on top.
     doctree = app.env.get_doctree("index")
     toctrees = list(doctree.findall(addnodes.toctree))
@@ -2096,7 +2097,7 @@ def test_attach_to_appends_new_toctree_at_section_end(
 
     app = make_app(srcdir=host, freshenv=True)
     app.build()
-    assert count_warnings(app) == 0
+    assert warning_count(app) == 0
 
     doctree = app.env.get_doctree("index")
     first_section = next(doctree.findall(nodes.section))
@@ -2165,7 +2166,7 @@ def test_attach_to_idempotent_with_static_entry(
 
     app = make_app(srcdir=host, freshenv=True)
     app.build()
-    assert count_warnings(app) == 0
+    assert warning_count(app) == 0
 
     # Inspect the env's resolved toctree includes — the dedup guarantee is
     # that ``_generated/api-foo/index`` appears once for the host index doc,
@@ -2202,8 +2203,8 @@ def test_attach_to_warns_when_target_docname_missing(
     warnings = app._warning.getvalue()
     assert "nonexistent_host_doc" in warnings
     assert "attach_to" in warnings
-    assert count_warnings(app) == 1  # only the attach_to_missing warning
-    assert count_mount_warnings(app) == 1
+    assert warning_count(app) == 1  # only the attach_to_missing warning
+    assert warning_count(app, "mounts.attach_to_missing") == 1
 
 
 # ---------- helpers ----------
@@ -2317,12 +2318,12 @@ def test_incremental_skips_mount_when_nothing_changed(
 
     app = make_app(srcdir=host, freshenv=True)
     app.build()
-    assert count_warnings(app) == 0
+    assert warning_count(app) == 0
     offset = len(app._status.getvalue())
 
     # Rebuild without changing anything.
     app.build()
-    assert count_warnings(app) == 0
+    assert warning_count(app) == 0
     warm_log = app._status.getvalue()[offset:]
 
     read = _docs_read_in_log(warm_log)
@@ -2366,7 +2367,7 @@ def test_host_toctree_change_does_not_reparse_mount_files(
 
     app = make_app(srcdir=host, freshenv=True)
     app.build()
-    assert count_warnings(app) == 0
+    assert warning_count(app) == 0
     cold_html = (Path(app.outdir) / "index.html").read_text(encoding="utf-8")
     assert "_generated/m/foo.html" in cold_html
 
@@ -2378,7 +2379,7 @@ def test_host_toctree_change_does_not_reparse_mount_files(
     _bump_mtime(host / "index.rst")
 
     app.build()
-    assert count_warnings(app) == 0
+    assert warning_count(app) == 0
     warm_log = app._status.getvalue()[offset:]
     warm_html = (Path(app.outdir) / "index.html").read_text(encoding="utf-8")
 
@@ -2426,7 +2427,7 @@ def test_incremental_rereads_mount_doc_when_dependency_changes(
 
     app = make_app(srcdir=host, freshenv=True)
     app.build()
-    assert count_warnings(app) == 0
+    assert warning_count(app) == 0
 
     # Precondition: the include target is a recorded dependency of the
     # mounted doc, pointing at the external file (not into the host srcdir).
@@ -2449,7 +2450,7 @@ def test_incremental_rereads_mount_doc_when_dependency_changes(
     _bump_mtime(snippet)
 
     app.build()
-    assert count_warnings(app) == 0
+    assert warning_count(app) == 0
     warm_log = app._status.getvalue()[offset:]
     read = _docs_read_in_log(warm_log)
 
@@ -2486,14 +2487,14 @@ def test_incremental_rereads_changed_file_in_file_list_mount(
 
     app = make_app(srcdir=host, freshenv=True)
     app.build()
-    assert count_warnings(app) == 0
+    assert warning_count(app) == 0
     offset = len(app._status.getvalue())
 
     page_a.write_text("Page A\n======\n\nA_MARKER_MODIFIED\n", encoding="utf-8")
     _bump_mtime(page_a)
 
     app.build()
-    assert count_warnings(app) == 0
+    assert warning_count(app) == 0
     warm_log = app._status.getvalue()[offset:]
     read = _docs_read_in_log(warm_log)
 
@@ -2564,7 +2565,7 @@ def test_disappearing_mount_entry_unwires_host_toctree_incrementally(
 
     app = make_app(srcdir=host, freshenv=True)
     app.build()
-    assert count_warnings(app) == 0, app._warning.getvalue()
+    assert warning_count(app) == 0, app._warning.getvalue()
     index_html = (Path(app.outdir) / "index.html").read_text(encoding="utf-8")
     assert "_g/m/index.html" in index_html, "entry doc was not wired on build 1"
 
@@ -2573,7 +2574,7 @@ def test_disappearing_mount_entry_unwires_host_toctree_incrementally(
 
     app.build()
     removal_log = app._status.getvalue()[offset:]
-    assert count_warnings(app) == 0, app._warning.getvalue()
+    assert warning_count(app) == 0, app._warning.getvalue()
     index_html = (Path(app.outdir) / "index.html").read_text(encoding="utf-8")
     assert "_g/m/index.html" not in index_html, (
         "host page still links to the removed mount entry"
@@ -2593,7 +2594,7 @@ def test_disappearing_mount_entry_unwires_host_toctree_incrementally(
     # ...and the next build has genuinely nothing left to do.
     offset = len(app._status.getvalue())
     app.build()
-    assert count_warnings(app) == 0, app._warning.getvalue()
+    assert warning_count(app) == 0, app._warning.getvalue()
     assert "no targets are out of date" in app._status.getvalue()[offset:], (
         "removal did not converge — the build still finds outdated targets"
     )
@@ -2622,7 +2623,7 @@ def test_appearing_mount_entry_wires_host_toctree_incrementally(
 
     app = make_app(srcdir=host, freshenv=True)
     app.build()
-    assert count_warnings(app) == 0, app._warning.getvalue()
+    assert warning_count(app) == 0, app._warning.getvalue()
     index_html = (Path(app.outdir) / "index.html").read_text(encoding="utf-8")
     assert "_g/m/index.html" not in index_html, "nothing should be wired yet"
 
@@ -2635,7 +2636,7 @@ def test_appearing_mount_entry_wires_host_toctree_incrementally(
     )
 
     app.build()
-    assert count_warnings(app) == 0, app._warning.getvalue()
+    assert warning_count(app) == 0, app._warning.getvalue()
     index_html = (Path(app.outdir) / "index.html").read_text(encoding="utf-8")
     assert "_g/m/index.html" in index_html, (
         "appearing entry doc was not wired into the host toctree"
@@ -2643,7 +2644,7 @@ def test_appearing_mount_entry_wires_host_toctree_incrementally(
 
     offset = len(app._status.getvalue())
     app.build()
-    assert count_warnings(app) == 0, app._warning.getvalue()
+    assert warning_count(app) == 0, app._warning.getvalue()
     assert "no targets are out of date" in app._status.getvalue()[offset:], (
         "wiring did not converge — the build still finds outdated targets"
     )
@@ -2678,14 +2679,14 @@ def test_bundle_churn_without_attach_to_does_not_reread_host(
 
     app = make_app(srcdir=host, freshenv=True)
     app.build()
-    assert count_warnings(app) == 0, app._warning.getvalue()
+    assert warning_count(app) == 0, app._warning.getvalue()
     offset = len(app._status.getvalue())
 
     # A brand-new docname is reported as "added" without any mtime comparison.
     (bundle / "extra.rst").write_text(":orphan:\n\nExtra\n=====\n", encoding="utf-8")
 
     app.build()
-    assert count_warnings(app) == 0, app._warning.getvalue()
+    assert warning_count(app) == 0, app._warning.getvalue()
     churn_log = app._status.getvalue()[offset:]
     read = _docs_read_in_log(churn_log)
     assert read == {"_g/m/extra"}, (
@@ -2723,7 +2724,7 @@ def test_no_attach_to_mount_entry_doc_appearing_is_silent(
 
     app = make_app(srcdir=host, freshenv=True)
     app.build()
-    assert count_warnings(app) == 0, app._warning.getvalue()
+    assert warning_count(app) == 0, app._warning.getvalue()
     offset = len(app._status.getvalue())
 
     # The second mount gains its entry doc. It wires nothing, so nothing
@@ -2731,7 +2732,7 @@ def test_no_attach_to_mount_entry_doc_appearing_is_silent(
     (late / "index.rst").write_text(":orphan:\n\nLate\n====\n", encoding="utf-8")
 
     app.build()
-    assert count_warnings(app) == 0, app._warning.getvalue()
+    assert warning_count(app) == 0, app._warning.getvalue()
     appear_log = app._status.getvalue()[offset:]
     assert _docs_read_in_log(appear_log) == {"_g/l/index"}, appear_log
     assert "mount wiring changed" not in appear_log, (
@@ -2801,7 +2802,7 @@ def test_dangling_attach_to_does_not_announce_a_re_read(
     app = make_app(srcdir=host, freshenv=True)
     app.build()
     # Exactly one diagnostic, and it is the missing target.
-    assert count_mount_warnings(app) == 1, app._warning.getvalue()
+    assert warning_count(app, "mounts.attach_to_missing") == 1, app._warning.getvalue()
     assert "mounts.attach_to_missing" in app._warning.getvalue()
 
     # Removing the entry doc moves the wiring signature, which is what used to
@@ -2873,7 +2874,7 @@ def test_attach_each_rewires_when_the_listed_set_changes(
 
     app = make_app(srcdir=host, freshenv=True)
     app.build()
-    assert count_warnings(app) == 0, app._warning.getvalue()
+    assert warning_count(app) == 0, app._warning.getvalue()
     index_html = (Path(app.outdir) / "index.html").read_text(encoding="utf-8")
     assert "_g/m/page_a.html" in index_html
     assert "_g/m/page_b.html" in index_html
@@ -2974,17 +2975,18 @@ def test_restored_env_still_mounts_correctly(
 
     first = make_app(srcdir=host, freshenv=True)
     first.build()
-    assert count_warnings(first) == 0, first._warning.getvalue()
+    assert warning_count(first) == 0, first._warning.getvalue()
 
     # freshenv defaults to False, so this one loads environment.pickle.
     second = make_app(srcdir=host)
     second.build()
-    # Not ``count_warnings``: building a SECOND app in one process makes
-    # docutils re-register its nodes, directives and roles, which emits dozens
-    # of ``app.add_node`` / ``app.add_directive`` warnings that have nothing to
-    # do with mounting. Assert on the categories this test is about instead.
+    # Not the total: building a SECOND app in one process makes docutils re-register its
+    # nodes, directives and roles, which emits dozens of ``app.add_node`` /
+    # ``app.add_directive`` warnings that have nothing to do with mounting. Assert on the
+    # categories this test is about instead -- and on the whole mounts family, since the
+    # claim is that a restored env warns about nothing at all.
     warnings = second._warning.getvalue()
-    assert count_mount_warnings(second) == 0, warnings
+    assert [w for w in build_warnings(second) if "[mounts." in w] == [], warnings
     assert "toc.not_readable" not in warnings, warnings
     assert "toc.not_included" not in warnings, warnings
 
@@ -3017,7 +3019,7 @@ def test_mounted_path_type_matches_host_path_type(
 
     app = make_app(srcdir=host, freshenv=True)
     app.build()
-    assert count_warnings(app) == 0
+    assert warning_count(app) == 0
 
     stored = app.project._docname_to_path
     host_type = type(stored["index"])
@@ -3047,7 +3049,7 @@ def test_doc2path_result_is_usable_as_a_string(
 
     app = make_app(srcdir=host, freshenv=True)
     app.build()
-    assert count_warnings(app) == 0
+    assert warning_count(app) == 0
 
     docname = "_g/m/index"
     path = app.env.doc2path(docname, False)
@@ -3087,7 +3089,7 @@ def test_path2doc_round_trips_a_mounted_source_path(
 
     app = make_app(srcdir=host, freshenv=True)
     app.build()
-    assert count_warnings(app) == 0
+    assert warning_count(app) == 0
 
     source = bundle_simple / "intro.rst"
     assert app.env.path2doc(str(source)) == "_g/m/intro"

--- a/packages/sphinx-mounts/tests/test_path_directives.py
+++ b/packages/sphinx-mounts/tests/test_path_directives.py
@@ -671,6 +671,7 @@ def test_escape_at_the_default_path_check_warns_and_builds(
     warnings = app._warning.getvalue()
     assert "mounts.path_escape" in warnings, warnings
     assert "outside its bundle root" in warnings, warnings
+    assert warning_count(app) == 1
     assert warning_count(app, "mounts.path_escape") == 1, warnings
     # The build really completed: the page exists, unlike under "error".
     assert (Path(app.outdir) / "_g" / "api" / "index.html").exists()
@@ -918,6 +919,7 @@ def test_files_mode_disjoint_branches_do_not_widen_to_the_filesystem_root(
 
     warnings = app._warning.getvalue()
     assert "mounts.path_escape" in warnings, warnings
+    assert warning_count(app) == 1
     assert warning_count(app, "mounts.path_escape") == 1, warnings
 
 

--- a/packages/sphinx-mounts/tests/test_path_directives.py
+++ b/packages/sphinx-mounts/tests/test_path_directives.py
@@ -1379,10 +1379,10 @@ def _plantuml_extra_conf(
     launcher. This suite used to write that chain out for itself, without the vendored
     step, which is why the jar had to be handed to it in an environment variable.
 
-    ``renders`` is the lazy half, and it matters for the one parametrised test whose eight
+    ``renders`` is the lazy half, and it matters for the one parametrised test whose nine
     cases include a single uml one: a parameter that draws no PlantUML diagram must not
     make the session resolve a renderer, or a machine with none could not run the other
-    seven.
+    eight.
 
     ``repr`` of the command string, so a path containing a space — or a Windows path's
     backslashes — survives into the conf.py as one literal.
@@ -1536,7 +1536,7 @@ def test_changed_include_target_rereads_mounted_doc(
         _add_extensions(host, *extensions)
     # only the `uml` parameter draws a PlantUML diagram, and only it may make the
     # session resolve a renderer -- otherwise a machine with none could run none of
-    # the eight
+    # the nine
     for line in conf_lines + _plantuml_extra_conf(
         request, requires == "sphinxcontrib.plantuml"
     ):

--- a/packages/sphinx-mounts/tests/test_path_directives.py
+++ b/packages/sphinx-mounts/tests/test_path_directives.py
@@ -32,7 +32,10 @@ import pytest
 import sphinx
 from sphinx.errors import ExtensionError
 
-from tests.conftest import count_mount_warnings, count_warnings, write_ubproject_toml
+from sphinx_needs_testkit import (
+    warning_count,
+)
+from tests.conftest import write_ubproject_toml
 
 if TYPE_CHECKING:
     from sphinx.testing.util import SphinxTestApp
@@ -337,7 +340,7 @@ def test_graphviz_file_resolves_within_bundle(make_app, make_host_project, tmp_p
     app = _build(make_app, host)
 
     assert (bundle / "g.dot").resolve() in _resolved_deps(app, "_g/api/index")
-    assert count_warnings(app) == 0, app._warning.getvalue()
+    assert warning_count(app) == 0, app._warning.getvalue()
 
 
 def test_uml_file_resolves_within_bundle(make_app, make_host_project, tmp_path):
@@ -360,7 +363,7 @@ def test_uml_file_resolves_within_bundle(make_app, make_host_project, tmp_path):
     app = _build(make_app, host)
 
     assert (bundle / "d.puml").resolve() in _resolved_deps(app, "_g/api/index")
-    assert count_warnings(app) == 0, app._warning.getvalue()
+    assert warning_count(app) == 0, app._warning.getvalue()
 
 
 def test_mermaid_file_resolves_within_bundle(make_app, make_host_project, tmp_path):
@@ -659,7 +662,7 @@ def test_escape_at_the_default_path_check_warns_and_builds(
     warnings = app._warning.getvalue()
     assert "mounts.path_escape" in warnings, warnings
     assert "outside its bundle root" in warnings, warnings
-    assert count_mount_warnings(app) == 1, warnings
+    assert warning_count(app, "mounts.path_escape") == 1, warnings
     # The build really completed: the page exists, unlike under "error".
     assert (Path(app.outdir) / "_g" / "api" / "index.html").exists()
 
@@ -683,7 +686,7 @@ def test_escape_at_the_default_path_check_is_suppressible(
 
     app = _build(make_app, host)
 
-    assert count_warnings(app) == 0, app._warning.getvalue()
+    assert warning_count(app) == 0, app._warning.getvalue()
 
 
 def test_path_check_warn_emits_warning_not_error(make_app, make_host_project, tmp_path):
@@ -699,8 +702,8 @@ def test_path_check_warn_emits_warning_not_error(make_app, make_host_project, tm
 
     assert "outside its bundle root" in app._warning.getvalue()
     assert "mounts.path_escape" in app._warning.getvalue()
-    assert count_warnings(app) == 1  # only the path_escape warning
-    assert count_mount_warnings(app) == 1
+    assert warning_count(app) == 1  # only the path_escape warning
+    assert warning_count(app, "mounts.path_escape") == 1
 
 
 def test_path_check_off_allows_escape(make_app, make_host_project, tmp_path):
@@ -715,7 +718,7 @@ def test_path_check_off_allows_escape(make_app, make_host_project, tmp_path):
     app = _build(make_app, host)
 
     assert "outside its bundle root" not in app._warning.getvalue()
-    assert count_warnings(app) == 0
+    assert warning_count(app) == 0
     # The leaked host file content really did render (documents the leak).
     html = (Path(app.outdir) / "_g" / "api" / "index.html").read_text(encoding="utf-8")
     assert "HOST_SECRET" in html
@@ -804,7 +807,7 @@ def test_files_mode_sibling_reference_within_the_mounts_roots_is_allowed(
 
     app = _build(make_app, host)
 
-    assert count_warnings(app) == 0, app._warning.getvalue()
+    assert warning_count(app) == 0, app._warning.getvalue()
     html = (Path(app.outdir) / "_g" / "rn" / "2026-q1.html").read_text(encoding="utf-8")
     assert "SHARED_TEXT" in html
 
@@ -906,7 +909,7 @@ def test_files_mode_disjoint_branches_do_not_widen_to_the_filesystem_root(
 
     warnings = app._warning.getvalue()
     assert "mounts.path_escape" in warnings, warnings
-    assert count_mount_warnings(app) == 1, warnings
+    assert warning_count(app, "mounts.path_escape") == 1, warnings
 
 
 def test_files_mode_escape_above_every_root_still_fails(
@@ -1141,7 +1144,7 @@ def test_symlinked_bundle_root_is_not_an_escape(make_app, make_host_project, tmp
 
     app = _build(make_app, host)  # must NOT raise
 
-    assert count_warnings(app) == 0, app._warning.getvalue()
+    assert warning_count(app) == 0, app._warning.getvalue()
     html = (Path(app.outdir) / "_g" / "api" / "index.html").read_text(encoding="utf-8")
     assert "IN_BUNDLE" in html
 
@@ -1546,7 +1549,7 @@ def test_changed_include_target_rereads_mounted_doc(
 
     app = make_app(srcdir=host, freshenv=True)
     app.build()
-    assert count_warnings(app) == 0, app._warning.getvalue()
+    assert warning_count(app) == 0, app._warning.getvalue()
 
     # Precondition (teeth): the directive recorded its target as a dependency
     # of the mounted doc, pointing at the external file. Without this, a later
@@ -1564,7 +1567,7 @@ def test_changed_include_target_rereads_mounted_doc(
     _bump_mtime(bundle / target_name)
 
     app.build()
-    assert count_warnings(app) == 0, app._warning.getvalue()
+    assert warning_count(app) == 0, app._warning.getvalue()
     read = _docs_read_in_log(app._status.getvalue()[offset:])
 
     assert "_generated/m/index" in read, (

--- a/packages/sphinx-mounts/tests/test_path_directives.py
+++ b/packages/sphinx-mounts/tests/test_path_directives.py
@@ -7,10 +7,10 @@ doc-relative path (needimport, needreport, needuml), plus the path_check
 enforcement. The graphviz/uml cases render for real and **hard-require**
 their renderers — the full mounts chain, render included, must be
 exercised rather than silently skipped when one is missing. ``dot`` has to be
-on ``PATH``; PlantUML is taken either from a ``plantuml`` executable on
-``PATH`` or, when ``PLANTUML_JAR`` names one, from a plantuml jar run through
-``java`` (which is how CI supplies it — see ``.github/workflows/ci.yaml`` and
-the package's ``AGENTS.md``). Mermaid uses 'raw'
+on ``PATH``; PlantUML comes from the workspace's shared resolution
+(``PLANTUML_JAR``, then the jar committed under ``vendor/plantuml/``, then a
+``plantuml`` executable on ``PATH``), which raises rather than falling back to a
+renderer nobody chose. Mermaid uses 'raw'
 output, so no mmdc is needed. The needuml ``!include`` case renders for
 real too, since PlantUML resolves that path itself and records no Sphinx
 dependency.
@@ -33,6 +33,8 @@ import sphinx
 from sphinx.errors import ExtensionError
 
 from sphinx_needs_testkit import (
+    plantuml_conf,
+    resolve_plantuml_command,
     warning_count,
 )
 from tests.conftest import write_ubproject_toml
@@ -343,7 +345,9 @@ def test_graphviz_file_resolves_within_bundle(make_app, make_host_project, tmp_p
     assert warning_count(app) == 0, app._warning.getvalue()
 
 
-def test_uml_file_resolves_within_bundle(make_app, make_host_project, tmp_path):
+def test_uml_file_resolves_within_bundle(
+    request, make_app, make_host_project, tmp_path
+):
     pytest.importorskip("sphinxcontrib.plantuml")
     _require_renderer(".. uml:: d.puml\n")
     bundle = tmp_path / "bundle"
@@ -355,7 +359,7 @@ def test_uml_file_resolves_within_bundle(make_app, make_host_project, tmp_path):
 
     host = make_host_project()
     _add_extensions(host, "sphinxcontrib.plantuml")
-    for line in _plantuml_extra_conf():
+    for line in _plantuml_extra_conf(request):
         _append_conf(host, line)
     write_ubproject_toml(host, [{"dir": str(bundle), "mount_at": "_g/api"}])
     _replace_index_toctree(host, "_g/api/index")
@@ -503,7 +507,9 @@ def test_needreport_resolves_template_within_bundle(
     assert not (Path(app.outdir) / "_g" / "api" / "report-template.html").exists()
 
 
-def test_needuml_include_resolves_within_bundle(make_app, make_host_project, tmp_path):
+def test_needuml_include_resolves_within_bundle(
+    request, make_app, make_host_project, tmp_path
+):
     """``needuml``'s PlantUML ``!include`` resolves against the bundle root.
 
     The reference case for sphinx-needs
@@ -535,7 +541,10 @@ def test_needuml_include_resolves_within_bundle(make_app, make_host_project, tmp
         "sphinxcontrib.plantuml",
         # The SVG path applies no scaling, so Pillow is not needed for the
         # ``scale`` attribute sphinx-needs stamps onto every diagram node.
-        conf_lines=("plantuml_output_format = 'svg_img'", *_plantuml_extra_conf()),
+        conf_lines=(
+            "plantuml_output_format = 'svg_img'",
+            *_plantuml_extra_conf(request),
+        ),
     )
     write_ubproject_toml(host, [{"dir": str(bundle), "mount_at": "_g/api"}])
     _replace_index_toctree(host, "_g/api/index")
@@ -1313,92 +1322,72 @@ def _require_sphinx_needs() -> None:
         ) from exc
 
 
-def _plantuml_jar_command() -> tuple[str, ...] | None:
-    """The ``plantuml`` configuration value for a jar named by ``PLANTUML_JAR``.
-
-    The second of the two ways this suite can reach PlantUML, and the one CI
-    uses: no ``plantuml`` package is installed anywhere, and the workflows
-    point this variable at the jar the workspace commits at
-    ``vendor/plantuml/`` (at the version ``vendor/plantuml/pin.toml`` names,
-    which the workflows verify before pointing at it). ``java`` has to be on ``PATH`` for
-    it, which it is on every GitHub runner image.
-
-    Returns ``None`` when the variable is unset, so the ``plantuml``-on-PATH
-    route is used instead; a variable that names a file which is not there is
-    a mistake worth failing on rather than falling back from, so it returns
-    the command regardless and lets the render fail loudly.
-    """
-    jar = os.environ.get("PLANTUML_JAR")
-    if not jar:
-        return None
-    # A TUPLE, not a string: sphinxcontrib-plantuml's ``_split_cmdargs`` passes a
-    # list or tuple through untouched and ``shlex``-splits anything else, which
-    # would break on a checkout under a path containing a space (and, on posix,
-    # on a Windows path's backslashes). Headless, like the sphinx-needs fixture
-    # that supplies the same jar: a CI runner has no windowing toolkit.
-    return ("java", "-Djava.awt.headless=true", "-jar", jar)
-
-
 def test_an_empty_plantuml_jar_is_treated_as_unset(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """An empty ``PLANTUML_JAR`` means "no jar", not "a jar named nothing".
 
     That is how the variable arrives from a developer shell with ``PLANTUML_JAR=``
     exported, and from a workflow that computes the value with an expression rather than
     deciding whether to set it at all. Read the other way, every cell that does not want
-    a jar would go red. sphinx-needs' suite agrees, and pins it in
-    ``tests/test_plantuml_command.py``; this is the same four lines on this side, because
-    the two implementations are separate and nothing else links them.
+    a jar would go red — and a value that is set but names no file is refused outright,
+    which is the mistake this one must not be mistaken for.
+
+    The resolution is the workspace's shared one now, so this asserts against it directly
+    rather than against a copy of it. It is worth keeping on this side because this suite
+    reaches the variable by three routes the sphinx-needs suite does not — its own poe
+    tasks, its CI cells, and the release workflow's compat cell — and because a jar handed
+    to it explicitly is what all three do.
     """
     monkeypatch.setenv("PLANTUML_JAR", "")
+    workspace_jar = tmp_path / "plantuml-0.0.0.jar"
+    workspace_jar.write_bytes(b"")
 
-    assert _plantuml_jar_command() is None
+    assert str(workspace_jar) in resolve_plantuml_command(workspace_jar)
 
 
 def _require_renderer(directive_rst: str) -> None:
     """Fail the test when a diagram directive's renderer is not available.
 
-    The graphviz/uml cases must exercise the full mounts chain *including*
-    the real renderer — tolerating a missing one would silently skip the
-    render step, which is the whole point of those tests. So this asserts; it
-    never skips.
+    ``dot`` only, and it asserts rather than skipping: the graphviz cases must exercise
+    the full mounts chain *including* the real renderer, and tolerating a missing one
+    would silently drop the render step, which is the whole point of them.
+
+    PlantUML is not checked here any more. :func:`_plantuml_extra_conf` resolves it
+    through the workspace's shared layer, which raises — with the one message every suite
+    in this repository gives — rather than falling back to a renderer nobody chose, so the
+    uml cases assert by construction and one fewer copy of the chain exists.
     """
     if "graphviz" in directive_rst:
         assert shutil.which("dot"), (
             "graphviz (the `dot` binary) is required to run this test — "
             "install it (e.g. `apt install graphviz`)"
         )
-    elif "uml" in directive_rst:
-        assert _plantuml_jar_command() or shutil.which("plantuml"), (
-            "PlantUML is required to run this test. Either set PLANTUML_JAR to "
-            "a plantuml jar and have `java` on PATH (this repository commits the "
-            "pinned one at vendor/plantuml/, and `uv run poe test-mounts` points "
-            "the variable at it for you, which is what CI does too), or install "
-            "a `plantuml` executable (e.g. "
-            "`apt install plantuml`, `brew install plantuml`, "
-            "`choco install plantuml`)"
-        )
 
 
-def _plantuml_extra_conf() -> tuple[str, ...]:
-    """Extra conf.py lines for the uml tests.
+def _plantuml_extra_conf(
+    request: pytest.FixtureRequest, renders: bool = True
+) -> tuple[str, ...]:
+    """Extra conf.py lines pointing a build at the workspace's PlantUML renderer.
 
-    ``PLANTUML_JAR`` wins when it is set: it is an explicit choice, and it is
-    the one CI makes on every runner including Windows.
+    The shared resolution, rendered as source: ``PLANTUML_JAR`` (an explicit choice, and
+    an error when it names no file), then the jar this repository commits under
+    ``vendor/plantuml/``, then a ``plantuml`` executable on ``PATH`` — ``plantumlc``
+    first on Windows, whose chocolatey ``plantuml`` shim is a non-blocking ``javaw``
+    launcher. This suite used to write that chain out for itself, without the vendored
+    step, which is why the jar had to be handed to it in an environment variable.
 
-    Otherwise sphinxcontrib.plantuml invokes the ``plantuml`` command
-    synchronously; on Windows the chocolatey package's ``plantuml`` shim is
-    non-blocking (javaw), so its ``plantumlc`` (java) shim must be used there.
+    ``renders`` is the lazy half, and it matters for the one parametrised test whose eight
+    cases include a single uml one: a parameter that draws no PlantUML diagram must not
+    make the session resolve a renderer, or a machine with none could not run the other
+    seven.
+
+    ``repr`` of the command string, so a path containing a space — or a Windows path's
+    backslashes — survives into the conf.py as one literal.
     """
-    jar_command = _plantuml_jar_command()
-    if jar_command is not None:
-        # `repr` of the tuple, so both a Windows path's backslashes and any
-        # space in it survive into the conf.py as one argument
-        return (f"plantuml = {jar_command!r}",)
-    if os.name == "nt":
-        return ("plantuml = 'plantumlc'",)
-    return ()
+    return tuple(
+        f"{key} = {value!r}" for key, value in plantuml_conf(request, renders).items()
+    )
 
 
 _RED_PNG = _tiny_png((0xFF, 0x00, 0x00))
@@ -1508,6 +1497,7 @@ REREAD_CASES = [
     REREAD_CASES,
 )
 def test_changed_include_target_rereads_mounted_doc(
+    request,
     make_app,
     make_host_project,
     tmp_path,
@@ -1542,7 +1532,12 @@ def test_changed_include_target_rereads_mounted_doc(
     host = make_host_project()
     if extensions:
         _add_extensions(host, *extensions)
-    for line in conf_lines + _plantuml_extra_conf():
+    # only the `uml` parameter draws a PlantUML diagram, and only it may make the
+    # session resolve a renderer -- otherwise a machine with none could run none of
+    # the eight
+    for line in conf_lines + _plantuml_extra_conf(
+        request, requires == "sphinxcontrib.plantuml"
+    ):
         _append_conf(host, line)
     write_ubproject_toml(host, [{"dir": str(bundle), "mount_at": "_generated/m"}])
     _replace_index_toctree(host, "_generated/m/index")

--- a/packages/sphinx-needs/tests/test_plantuml_command.py
+++ b/packages/sphinx-needs/tests/test_plantuml_command.py
@@ -177,7 +177,8 @@ def test_an_empty_variable_is_treated_as_unset(
     ``PLANTUML_JAR=`` exported, and from a workflow that computes the value with an
     expression rather than deciding whether to set it. Read as "set but names no file"
     it would instead raise, which is a red run for every cell that does not want a jar.
-    sphinx-mounts' `_plantuml_jar_command` agrees, and its own suite pins it too.
+    sphinx-mounts' suite pins the same reading of the variable, against this same
+    function -- it has no copy of the chain to disagree with any more.
     """
     monkeypatch.setenv("PLANTUML_JAR", "")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -511,17 +511,21 @@ env = { UV_PROJECT_ENVIRONMENT = ".venvs/sphinx-9" }
 # collects the working directory, and the root's `norecursedirs` is what keeps it out of
 # `docs/_build` and the `bazel-*` symlinks.
 
-# `uses`, not `deps`, for every sphinx-mounts task: that suite reads PLANTUML_JAR and
-# nothing else -- it has no notion of this repository's layout, which is the part it got
-# right -- so the task has to hand it the path, not merely rely on the file being there.
-# poe runs the named task and captures its STDOUT into the variable, which is why
-# `fetch_plantuml.py` prints the path there and everything else to stderr. A developer who
-# already exports PLANTUML_JAR gets that same value back, because the script short-circuits
-# on it: `uses` overwrites the variable with what it printed, not with a different jar.
+# `deps`, like the sphinx-needs tasks: this suite RESOLVES the jar for itself now
+# (PLANTUML_JAR, then the committed jar under `vendor/plantuml/`, then a `plantuml`
+# executable), through the same shared layer, so the task only has to hash the file
+# against the pin rather than hand the path over.
+#
+# `test-mounts-bazel` is the exception and keeps `uses`: its build runs inside a Bazel
+# sandbox whose `.bazelrc` passes PLANTUML_JAR through `--action_env`, and the example's
+# own `conf.py` reads the variable -- neither of them can see `vendor/`. poe runs the named
+# task and captures its STDOUT into the variable, which is why `fetch_plantuml.py` prints
+# the path there and everything else to stderr; a developer who already exports
+# PLANTUML_JAR gets that same value back, because the script short-circuits on it.
 
 [tool.poe.tasks.test-mounts]
 help = "Run the sphinx-mounts suite against the default (newest) sphinx; trailing args go to pytest"
-uses = { PLANTUML_JAR = "fetch-plantuml" }
+deps = ["fetch-plantuml"]
 cmd = "pytest -m 'not bazel'"
 cwd = "packages/sphinx-mounts"
 
@@ -533,7 +537,7 @@ cwd = "packages/sphinx-mounts"
 
 [tool.poe.tasks.test-mounts-sphinx7]
 help = "Run the sphinx-mounts suite against sphinx 7.4 (set UV_PYTHON to pick the interpreter)"
-uses = { PLANTUML_JAR = "fetch-plantuml" }
+deps = ["fetch-plantuml"]
 cmd = "pytest -m 'not bazel'"
 cwd = "packages/sphinx-mounts"
 executor = { type = "uv", frozen = true, no-group = "dev", group = [
@@ -544,7 +548,7 @@ env = { UV_PROJECT_ENVIRONMENT = ".venvs/sphinx-7" }
 
 [tool.poe.tasks.test-mounts-sphinx8]
 help = "Run the sphinx-mounts suite against sphinx 8.2 (set UV_PYTHON to pick the interpreter)"
-uses = { PLANTUML_JAR = "fetch-plantuml" }
+deps = ["fetch-plantuml"]
 cmd = "pytest -m 'not bazel'"
 cwd = "packages/sphinx-mounts"
 executor = { type = "uv", frozen = true, no-group = "dev", group = [
@@ -555,7 +559,7 @@ env = { UV_PROJECT_ENVIRONMENT = ".venvs/sphinx-8" }
 
 [tool.poe.tasks.test-mounts-sphinx9]
 help = "Run the sphinx-mounts suite against sphinx 9.1 (python >= 3.12; set UV_PYTHON to pick the interpreter)"
-uses = { PLANTUML_JAR = "fetch-plantuml" }
+deps = ["fetch-plantuml"]
 cmd = "pytest -m 'not bazel'"
 cwd = "packages/sphinx-mounts"
 executor = { type = "uv", frozen = true, no-group = "dev", group = [

--- a/tools/src/sn_tools/check_workspace.py
+++ b/tools/src/sn_tools/check_workspace.py
@@ -581,10 +581,18 @@ def check_private_classifier(
                 f"is declared only in the root's `{group}` dependency group, so it is "
                 "part of no product and nothing downstream could want it from an index"
             )
-        elif member.private:
+        elif group == "" and member.private:
             # the converse, and it is a contradiction rather than a nicety: the member is
             # in the list that says "this is one of the things this repository ships", and
-            # it carries the one classifier that guarantees it can never be shipped
+            # it carries the one classifier that guarantees it can never be shipped.
+            #
+            # `group == ""` and not merely a falsy `group`: check (1) returns `""` for a
+            # member reached through `[project] dependencies` and NOTHING AT ALL for one
+            # declared in neither place, and only the first is the contradiction this
+            # branch describes. Read as falsy, a member the root never declares would be
+            # told "the root depends on it in [project] dependencies", which is the one
+            # thing that is not true of it -- and check (1) has already named that tree's
+            # real fault.
             report.error(
                 member.relative,
                 f"{member.name} declares the classifier `{member.private}`, so PyPI will "

--- a/tools/tests/test_check_workspace.py
+++ b/tools/tests/test_check_workspace.py
@@ -234,8 +234,7 @@ def test_a_member_declared_nowhere_is_not_told_the_root_depends_on_it(
     assert run(root) == 1
     out = capsys.readouterr().out
     assert (
-        "`acme-testkit` is a workspace member but the root neither depends on it"
-        in (out)
+        "`acme-testkit` is a workspace member but the root neither depends on it" in out
     )
     assert "the root depends on it in [project] dependencies" not in out
 

--- a/tools/tests/test_check_workspace.py
+++ b/tools/tests/test_check_workspace.py
@@ -216,6 +216,30 @@ def test_a_published_member_may_not_carry_a_private_classifier(
     assert "the root depends on it in [project] dependencies" in out
 
 
+def test_a_member_declared_nowhere_is_not_told_the_root_depends_on_it(
+    workspace, capsys
+) -> None:
+    """Check (6)'s converse describes ONE tree: a member in `[project] dependencies` that
+    carries the classifier. A member the root declares in neither place is check (1)'s
+    fault to report, and saying it here too would tell the reader the root depends on it
+    -- the one thing that is not true of it. Red either way; this is about which sentence
+    the reader acts on."""
+    root = workspace(
+        {
+            "acme-core": {"version": "1.0.0"},
+            "acme-testkit": {"version": "0", "private": True},
+        },
+        root_dependencies=["acme-core"],
+    )
+    assert run(root) == 1
+    out = capsys.readouterr().out
+    assert (
+        "`acme-testkit` is a workspace member but the root neither depends on it"
+        in (out)
+    )
+    assert "the root depends on it in [project] dependencies" not in out
+
+
 def test_a_runtime_dependency_on_a_private_member_is_an_error(
     workspace, capsys
 ) -> None:


### PR DESCRIPTION
Fourth and last slice of the shared-test-layer arc (#1899, #1900, #1902, #1904): the member
`packages/sphinx-needs-testkit` exists and sphinx-needs' suite uses it, and this retires the copies of
the same ideas in the other two suites. **Tests and prose only** — no published package's `src/` is
touched, no `[project]` dependencies change, counts hold: **sphinx-needs 1781/12, sphinx-mounts 943,
sphinx-codelinks 359**.

## sphinx-mounts — the warnings

`count_warnings` counted occurrences of the substring `WARNING:`; `count_mount_warnings` counted
occurrences of `[mounts.` — the warning *family*, not a type. Both are gone; the 82 assertion sites go
through `warning_count`, which counts warning **records** and, given a type, only those carrying exactly
that `[type]` token. The 25 family sites land as **21 typed `== 1` + 2 family + 2 dropped** (a typed
count of zero passes for any type string, and `warning_count(app) == 0` was already beside them). Each
type was read off an assertion the same test already made on the raw stream where one existed — 18 of
the 21 — and otherwise off the source that emits it. An exact-type count says nothing about the *other*
warnings, so at the six sites where the family count was the only "how many" claim the swap would have
been a step down: all six builds are clean apart from the warning they are about, so each gained
`warning_count(app) == 1`. The two survivors say why the total is unavailable to them.

## sphinx-mounts — the renderer

`_plantuml_jar_command` / `_plantuml_extra_conf` were a copy of the resolution chain, and the short one:
`PLANTUML_JAR`, then `plantuml` on `PATH`, with **no step for the jar this repository commits** — the
whole reason the jar had to be handed to this suite in an environment variable. Both are now
`plantuml_conf` rendered as `conf.py` lines, so a checkout needs nothing exported: `poe test-mounts`,
and a bare `pytest`, find `vendor/plantuml/plantuml-<pinned>.jar` themselves. The lazy half earns its
keep on the one parametrised test whose nine cases include a single uml one — only that parameter
resolves a renderer. So `test-mounts` and its three matrix tasks take `deps = ["fetch-plantuml"]` like
every other rendering task; **`test-mounts-bazel` keeps `uses`**, its build running in a Bazel sandbox
that cannot see `vendor/` and reads the variable through `--action_env`. CI is unaffected either way: it
runs `pytest` directly with the variable set by the composite action — route 1 of the same chain.
`test_example.py`'s guard was another copy whose message named the wrong task; it is now one condition
naming `test-mounts-bazel`. Two copies remain on purpose — `docs/conf.py` and `performance_test.py`,
which must not import a test-only member — and the root `AGENTS.md` now says which is which.

## sphinx-codelinks, and one tooling fix

Three of its assertions were `app.warning.getvalue() == ""`, which fails with a bare `assert '' == '<the
whole stream>'`; `assert_no_warnings` says how many were emitted and prints each. A fourth grepped the
raw stream and would have passed on any number of warnings. Nothing else there duplicates the layer: it
renders no diagrams, and its `copytree` calls copy fixture trees into pytest's `tmpdir`. Separately,
`check_workspace.py` check (6) reports a contradiction when a member the root *publishes* carries a
`Private ::` classifier; it read the route as falsy rather than as the empty string, so a member
declared in neither place — already condemned by check (1) — was told "the root depends on it in
`[project]` dependencies". One test; 309.

## Mutations

| mutation | result |
|---|---|
| `PLANTUML_JAR=/nonexistent/plantuml.jar` | red with the **same message from the same line** in sphinx-mounts and sphinx-needs alike, and a third time from `fetch_plantuml.py` through the task |
| the source emits `docname_conflict` under another topic | the exact-type assertion red (`assert 0 == 1`); the family count it replaced, restored on the same tree, green |
| mounts loses the testkit from `pytest_plugins` | 3 failed + 940 passed = the same 943, `fixture 'plantuml_command' not found` — nothing silently collects less |
| `test_example.py` reached with no jar and no `plantuml` | the skip now names `test-mounts-bazel`, the task that sets the variable; with it set, the guard passes and the test proceeds into Bazel |

The plugin **order** is fenced by nothing here, and the conftest says so: reversing it is 943 passed,
because the only fixture both define is `sphinx_test_tempdir`, which this suite never resolves. Gates:
the three suites `-rs`, `pytest tools/tests`, `lint`, `typecheck`, `check-workspace`, `release-plan`.
