### PR TITLE
🧪 The parallel build test follows whichever story kept STORY_PAGE_1

### DIFF
--- a/packages/sphinx-needs/tests/test_parallel_execution.py
+++ b/packages/sphinx-needs/tests/test_parallel_execution.py
@@ -75,11 +75,21 @@ def test_doc_build_html(test_app):
 
     page1_html = Path(app.outdir, "page_1.html").read_text()
     assert "Page 1" in page1_html
-    assert "page_1 Story" in page1_html
     assert "SPEC_PAGE_1" in page1_html
+    # The same scheduling decides which story holds STORY_PAGE_1 in the output: the one
+    # the warning above does NOT name. SPEC_PAGE_1 links to the id either way, so only
+    # the target page of that link, and which title renders, follow the winner.
+    if "page_1.rst" in warnings[1]:
+        assert "page_1 Story" not in page1_html
+        page5_html = Path(app.outdir, "page_5.html").read_text()
+        assert "duplicate" in page5_html
+        link_target = "page_5.html#STORY_PAGE_1"
+    else:
+        assert "page_1 Story" in page1_html
+        link_target = "#STORY_PAGE_1"
     assert (
         '<div class="line">links outgoing: <span '
-        'class="links"><span><a class="reference internal" href="#STORY_PAGE_1" '
+        f'class="links"><span><a class="reference internal" href="{link_target}" '
         'title="SPEC_PAGE_1">STORY_PAGE_1</a></span></span></div>' in page1_html
     )
     page2_html = Path(app.outdir, "page_2.html").read_text()


### PR DESCRIPTION
`tests/doc_test/parallel_doc` declares `STORY_PAGE_1` twice, on `page_1` and `page_5`, and a four-worker build decides by merge order which story is created and which is reported as the duplicate. #1904 made the warning assertion accept either outcome; the HTML assertions still assumed `page_1` had won, and on a CI cell where it lost (#1907's `py3.12 sphinx-7` run) `page_1.html` has no story card and `SPEC_PAGE_1`'s outgoing link points at `page_5.html#STORY_PAGE_1`.

The test now keys both on the page the duplicate warning names: if `page_1` lost, its title is absent, `page_5.html` carries the surviving story and the link crosses pages; otherwise the original assertions hold. The losing branch's three literals were checked against a real build of the fixture with only `page_5`'s story present, since the losing order cannot be forced locally. Debian disables this test as unstable (their bug 1117433); with this it should be stable for them too.
