### PR TITLE
🧪 fix: make sphinx-codelinks fixtures xdist-safe

### DIFF
--- a/packages/sphinx-codelinks/tests/conftest.py
+++ b/packages/sphinx-codelinks/tests/conftest.py
@@ -1,4 +1,6 @@
 import json
+import shutil
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -45,9 +47,12 @@ ONELINE_COMMENT_STYLE_DEFAULT = OneLineCommentStyle()
 
 
 @pytest.fixture(scope="session")
-def source_directory() -> Path:
+def source_directory(tmp_path_factory: pytest.TempPathFactory) -> Path:
     tests_dir = Path(__file__).parent
-    source_directory = tests_dir / "data" / "dcdc"
+    source_fixture = tests_dir / "data" / "dcdc"
+    source_directory = tmp_path_factory.getbasetemp() / "dcdc"
+    shutil.copytree(source_fixture, source_directory)
+    subprocess.run(["git", "init", "--quiet"], cwd=source_directory, check=True)
     return source_directory
 
 

--- a/packages/sphinx-codelinks/tests/test_cmd.py
+++ b/packages/sphinx-codelinks/tests/test_cmd.py
@@ -142,19 +142,15 @@ def test_analyse_logs_per_project_summary_and_gates_detail(tmp_path: Path) -> No
 
 
 @pytest.mark.parametrize(
-    ("options", "stdout"),
+    ("gitignore", "stdout"),
     [
-        (
-            ["discover", str(TEST_DIR / "data" / "dcdc"), "--no-gitignore"],
-            "4 files discovered",
-        ),
-        (
-            ["discover", str(TEST_DIR / "data" / "dcdc"), "--gitignore"],
-            "3 files discovered",
-        ),
+        (False, "4 files discovered"),
+        (True, "3 files discovered"),
     ],
 )
-def test_discover(options, stdout):
+def test_discover(gitignore: bool, stdout: str, source_directory: Path) -> None:
+    options = ["discover", str(source_directory)]
+    options.append("--gitignore" if gitignore else "--no-gitignore")
     result = runner.invoke(app, options)
     assert result.exit_code == 0
     assert stdout in result.stdout

--- a/packages/sphinx-codelinks/tests/test_source_discover.py
+++ b/packages/sphinx-codelinks/tests/test_source_discover.py
@@ -15,6 +15,13 @@ from sphinx_codelinks.source_discover.source_discover import SourceDiscover
 FIXTURES_PATH = Path(__file__).parent / "data" / "discover_fixtures.json"
 
 
+def test_source_directory_is_worker_local(source_directory: Path) -> None:
+    checkout_fixture = Path(__file__).parent / "data" / "dcdc"
+
+    assert source_directory != checkout_fixture
+    assert (source_directory / "charge" / "demo_1.cpp").is_file()
+
+
 @pytest.mark.parametrize(
     ("config", "msgs"),
     [


### PR DESCRIPTION
## Summary

Fix xdist races in the sphinx-codelinks test fixtures.

The `temporary_gitignore` fixture previously wrote and removed `tests/data/dcdc/.gitignore`, a checked-in fixture path shared by xdist workers. Parallel workers could remove each other's file and fail during teardown.

The fixture now copies `tests/data/dcdc` into each worker's temporary directory, initializes a temporary Git root so `.gitignore` discovery remains covered, and updates the discovery tests to use the isolated fixture.

## Testing

- `uv run poe test-codelinks -n 4` — 360 passed
- `uv run poe lint`
- `uv run poe typecheck`
- `uv run poe docs-codelinks`

closes #1909
