### PR TITLE
👌 register common CSS files deterministically

### DIFF
--- a/packages/sphinx-needs/src/sphinx_needs/environment.py
+++ b/packages/sphinx-needs/src/sphinx_needs/environment.py
@@ -57,7 +57,12 @@ def install_styles_static_files(app: Sphinx, env: BuildEnvironment) -> None:
         str(dest_dir.joinpath("common_css")),
         lambda path: not path.endswith(".css"),
     )
-    for common_path in dest_dir.joinpath("common_css").glob("*.css"):
+    # Sphinx preserves registration order for stylesheets with the same priority.
+    # Sort by filename to keep generated HTML and the CSS cascade deterministic.
+    common_css_files = sorted(
+        dest_dir.joinpath("common_css").glob("*.css"), key=lambda path: path.name
+    )
+    for common_path in common_css_files:
         _add_css_file(app, common_path.relative_to(statics_dir))
 
     # Add theme css file

--- a/packages/sphinx-needs/tests/test_styles/test_style_css_js_registration.py
+++ b/packages/sphinx-needs/tests/test_styles/test_style_css_js_registration.py
@@ -45,6 +45,14 @@ def test_file_registration(tmp_path: Path, make_app: type[SphinxTestApp]):
     css_run_1 = len(css_files)
     script_run_1 = len(script_files)
 
+    common_css_files = [
+        x.filename.rsplit("/", maxsplit=1)[-1]
+        for x in css_files
+        if "/common_css/" in x.filename
+    ]
+    # Sphinx emits stylesheets with the same priority in registration order.
+    assert common_css_files == sorted(common_css_files)
+
     # Check for duplicates
     assert css_run_1 == len(set(css_files))
     assert script_run_1 == len(set(script_files))


### PR DESCRIPTION
## Why

Common CSS files are discovered with `Path.glob()`, whose iteration order is not guaranteed. Because Sphinx emits same-priority stylesheets in registration order, this can make generated HTML and the CSS cascade vary between otherwise identical builds.

## What changed

- Sort common CSS paths by filename before registering them.
- Add regression coverage asserting that registered common CSS files are ordered deterministically.

Fixes #1913