### PR TITLE
🧪 sphinx-codelinks: one fixture for the worker-local dcdc copy

### DIFF
--- a/packages/sphinx-codelinks/tests/conftest.py
+++ b/packages/sphinx-codelinks/tests/conftest.py
@@ -48,31 +48,20 @@ ONELINE_COMMENT_STYLE_DEFAULT = OneLineCommentStyle()
 
 @pytest.fixture(scope="session")
 def source_directory(tmp_path_factory: pytest.TempPathFactory) -> Path:
-    tests_dir = Path(__file__).parent
-    source_fixture = tests_dir / "data" / "dcdc"
-    source_directory = tmp_path_factory.getbasetemp() / "dcdc"
-    shutil.copytree(source_fixture, source_directory)
+    """A worker-local copy of ``tests/data/dcdc``: a git repository whose ``.gitignore``
+    hides ``demo_1.cpp``.
+
+    The copy lives under pytest's base temp directory -- one per xdist worker -- so no test
+    writes into the checkout and no worker can remove another's ``.gitignore``. The
+    ``git init`` is load-bearing: the ``ignore`` crate discovery walks with honours a
+    ``.gitignore`` only inside a repository, so without it the ``--gitignore`` cases see all
+    four files.
+    """
+    source_directory = tmp_path_factory.mktemp("dcdc")
+    shutil.copytree(TEST_DIR / "data" / "dcdc", source_directory, dirs_exist_ok=True)
     subprocess.run(["git", "init", "--quiet"], cwd=source_directory, check=True)
+    (source_directory / ".gitignore").write_text("demo_1.cpp\n", encoding="utf-8")
     return source_directory
-
-
-@pytest.fixture(scope="session")
-def source_paths(source_directory: Path) -> list[Path]:
-    source_paths = [
-        source_directory / "charge" / "demo_1.cpp",
-        source_directory / "charge" / "demo_2.cpp",
-        source_directory / "discharge" / "demo_3.cpp",
-        source_directory / "supercharge.cpp",
-    ]
-    return source_paths
-
-
-@pytest.fixture(scope="session", autouse=True)
-def temporary_gitignore(source_directory: Path):
-    gitignore_path = source_directory / ".gitignore"
-    gitignore_path.write_text("demo_1.cpp\n", encoding="utf-8")
-    yield
-    gitignore_path.unlink()
 
 
 # `DoctreeSnapshotExtension` and `snapshot_doctree` are NOT here any more: they were a

--- a/packages/sphinx-codelinks/tests/test_source_discover.py
+++ b/packages/sphinx-codelinks/tests/test_source_discover.py
@@ -15,11 +15,14 @@ from sphinx_codelinks.source_discover.source_discover import SourceDiscover
 FIXTURES_PATH = Path(__file__).parent / "data" / "discover_fixtures.json"
 
 
-def test_source_directory_is_worker_local(source_directory: Path) -> None:
-    checkout_fixture = Path(__file__).parent / "data" / "dcdc"
-
-    assert source_directory != checkout_fixture
+def test_source_directory_is_worker_local(
+    source_directory: Path, tmp_path_factory: pytest.TempPathFactory
+) -> None:
+    assert source_directory.is_relative_to(tmp_path_factory.getbasetemp())
     assert (source_directory / "charge" / "demo_1.cpp").is_file()
+    assert (source_directory / ".gitignore").read_text(
+        encoding="utf-8"
+    ) == "demo_1.cpp\n"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Follow-up to #1912, which stopped the sphinx-codelinks suite writing a `.gitignore` into the checked-in `tests/data/dcdc` fixture by copying it under pytest's temp directory once per xdist worker. This tightens what that left behind; tests only, no behaviour change.

- **One fixture instead of two.** The autouse, session-scoped `temporary_gitignore` fixture wrote the `.gitignore` into the copy and unlinked it at teardown. `source_directory` now writes it right after the copy: the directory is pytest's to clean up, so the teardown goes, and tests that never touch the copy no longer trigger the copy plus `git init` just because an autouse fixture depended on it.
- **`tmp_path_factory.mktemp("dcdc")`** rather than a path composed under `getbasetemp()` by hand.
- **The `git init` says why it is there.** The `ignore` crate discovery walks with honours a `.gitignore` only inside a git repository (`require_git`, its default), so without the `git init` the `--gitignore` cases see all four files instead of three. The fixture's docstring now records that, since the line reads like an accident otherwise.
- **A stronger worker-locality fence.** `test_source_directory_is_worker_local` asserted the fixture was not the checkout path; it now asserts the copy is under `tmp_path_factory.getbasetemp()` (per worker under xdist) and that the `.gitignore` the discovery cases rely on is in place.
- **The session-scoped `source_paths` fixture goes**: nothing requested it (every other `source_paths` in the suite is the `SourceDiscover` attribute).

Measured on the branch, in the order the change was made: `poe test-codelinks` serial and `-n 4` both 360 passed; `poe lint`, `poe typecheck` green. Four mutations, each reverted with a clean tree between:

| mutation | red |
|---|---|
| drop the `git init` | `test_discover[True-3 files discovered]`, `test_source_discover[config1-3-]` (4 files, not 3) |
| drop the `.gitignore` write | the two above plus the worker-locality test |
| return the checkout path from the fixture | the same three |
| copy to a sibling of the base temp directory | the worker-locality test alone |
