### PR TITLE
🧪 Every test in the sphinx-needs suite builds in process

### DIFF
--- a/packages/sphinx-needs-testkit/src/sphinx_needs_testkit/_plantuml.py
+++ b/packages/sphinx-needs-testkit/src/sphinx_needs_testkit/_plantuml.py
@@ -181,10 +181,9 @@ def make_plantuml_inert(app: SphinxTestApp) -> None:
       starts, and a JVM start is 2.04 s of every 2.13 s render, measured.
     * THIS APP'S OWN ``PlantumlBuilder`` has its two render entry points replaced with one
       that raises. That is the assertion that nothing renders, and it is made on the app
-      rather than on the output directory because 23 test functions in the sphinx-needs
-      suite run a real ``sphinx-build`` SUBPROCESS, four of them into ``app.outdir``
-      itself: a rendered file found in that directory cannot be attributed to the
-      fixture's app, while a call reaching this object can only have come from it.
+      rather than on the output directory because a rendered file found in a directory
+      cannot be attributed to any particular application, while a call reaching this
+      object can only have come from this one.
     * the ``plantuml`` configuration is pointed at :data:`_INERT_PLANTUML_COMMAND`. This one
       is a SENTINEL rather than a fence, and the difference is worth stating: its whole
       protection is that the token cannot be ``exec``-ed, and when sphinxcontrib does try it
@@ -205,9 +204,9 @@ def make_plantuml_inert(app: SphinxTestApp) -> None:
     if a future release dropped it, the import below raises ``ImportError`` at fixture setup
     rather than quietly restoring rendering.
 
-    **What this does NOT cover**: anything that is not this app object. A test that runs
-    ``sphinx-build`` as a subprocess gets a process with its own config (see
-    ``plantuml_subprocess_args``).
+    **What this does NOT cover**: anything that is not this app object. A build spawned as
+    a subprocess is a process with its own config, which no patch made here can reach --
+    which is one reason no test in the sphinx-needs suite spawns one.
 
     All of it happens after the app exists rather than through ``confoverrides``, because a
     project that does not load ``sphinxcontrib.plantuml`` -- 88 of the sphinx-needs suite's

--- a/packages/sphinx-needs-testkit/src/sphinx_needs_testkit/_subprocess.py
+++ b/packages/sphinx-needs-testkit/src/sphinx_needs_testkit/_subprocess.py
@@ -2,9 +2,9 @@
 
 The argv, because there is one right answer to a question each suite had been answering
 for itself -- and answering the same way, wrongly, at every site -- and the fence that
-keeps it that way, because two suites here spawn builds and both must be walked, and the
-third consumer of this module should get the fence with the helper rather than a file to
-copy.
+keeps it that way, because the tree that must never spawn a build and the one that
+legitimately does are both walked, and the third consumer of this module should get the
+fence with the helper rather than a file to copy.
 """
 
 from __future__ import annotations
@@ -69,9 +69,10 @@ def assert_no_bare_sphinx_build(tests_dir: Path) -> None:
     job in this workspace runs where that environment is the right one. Nothing else would
     ever report the regression.
 
-    It lives here rather than in one suite because two suites in this workspace spawn
-    builds and both must be walked -- and because the third consumer of this module,
-    sphinx-test-reports, gets the fence with the helper rather than a file to copy.
+    It lives here rather than in one suite because the tree that must never spawn a build
+    and the one that legitimately does are both walked -- and because the third consumer
+    of this module, sphinx-test-reports, gets the fence with the helper rather than a file
+    to copy.
 
     An explicit ``AssertionError`` rather than a bare ``assert``: pytest rewrites
     assertions in test modules and plugins, not in a package imported by name, so a bare

--- a/packages/sphinx-needs-testkit/src/sphinx_needs_testkit/fixtures.py
+++ b/packages/sphinx-needs-testkit/src/sphinx_needs_testkit/fixtures.py
@@ -125,24 +125,6 @@ def plantuml_command() -> str:
     return resolve_plantuml_command(workspace_plantuml_jar())
 
 
-@pytest.fixture(scope="session")
-def plantuml_subprocess_args(plantuml_command: str) -> list[str]:
-    """``sphinx-build`` arguments pointing a SUBPROCESS build at this suite's renderer.
-
-    :func:`make_plantuml_inert` patches an app object, and a test that shells out to
-    ``sphinx-build`` gets a process the fixture cannot reach: it reads the project's own
-    ``conf.py``, where sphinxcontrib-plantuml's default is the bare word ``plantuml``. Such
-    a build therefore renders with whatever renderer the machine happens to carry, unpinned
-    and silently -- measured, before this fixture existed, as eight diagrams drawn by a
-    developer's homebrew PlantUML 1.2026.1 against the 1.2026.8 ``vendor/plantuml/pin.toml``
-    names. Passing these in makes a subprocess build render with the same command every
-    in-process build uses, and raise on a machine that has no renderer at all.
-
-    :return: ``["-D", "plantuml=<command>"]``, to splat into a ``sphinx-build`` argv.
-    """
-    return ["-D", f"plantuml={plantuml_command}"]
-
-
 @pytest.fixture(scope="function")
 def test_app(
     make_app,

--- a/packages/sphinx-needs/AGENTS.md
+++ b/packages/sphinx-needs/AGENTS.md
@@ -108,12 +108,14 @@ No build in this suite renders with sphinxcontrib-plantuml's own default command
 word `plantuml`, i.e. whatever unpinned renderer the machine happens to carry. `test_app` says
 that for its own builds, and this suite's `make_app` fixture says it for every application
 made by calling `make_app` directly: one that has not chosen a renderer, in its
-`confoverrides` or in the `conf.py` its project writes, is made inert too. A test that runs
-`sphinx-build` as a SUBPROCESS is the one route neither can reach, and it passes the
-`plantuml_subprocess_args` fixture into its argv instead. It builds that argv with
-`sphinx_build_command(...)` from the shared test layer and never with the bare word, which
-`PATH` resolves to whatever Sphinx comes first there — another checkout's, or none at all —
-rather than to the interpreter running the tests.
+`confoverrides` or in the `conf.py` its project writes, is made inert too. That is total
+because **no test in this suite spawns a Sphinx build**: the in-process application carries
+the warnings (`build_warnings(app)`), the status text (`app._status`), the exceptions
+(`pytest.raises`) and the exit code (`app.statuscode`) a subprocess used to be needed for,
+and a subprocess is the one route the inert renderer cannot reach. The fence
+`assert_no_bare_sphinx_build`, from `tests/test_testkit_subprocess.py`, keeps it that way; a
+suite that genuinely must spawn one — sphinx-mounts' bazel tests — builds its argv with
+`sphinx_build_command(...)` rather than with the bare word.
 
 Choose a renderer with `plantuml_conf(request)`, which resolves the suite-wide command only
 when the build will actually draw — never by naming `plantuml_command` in a test's signature,

--- a/packages/sphinx-needs/AGENTS.md
+++ b/packages/sphinx-needs/AGENTS.md
@@ -110,12 +110,13 @@ that for its own builds, and this suite's `make_app` fixture says it for every a
 made by calling `make_app` directly: one that has not chosen a renderer, in its
 `confoverrides` or in the `conf.py` its project writes, is made inert too. That is total
 because **no test in this suite spawns a Sphinx build**: the in-process application carries
-the warnings (`build_warnings(app)`), the status text (`app._status`), the exceptions
-(`pytest.raises`) and the exit code (`app.statuscode`) a subprocess used to be needed for,
-and a subprocess is the one route the inert renderer cannot reach. The fence
-`assert_no_bare_sphinx_build`, from `tests/test_testkit_subprocess.py`, keeps it that way; a
-suite that genuinely must spawn one — sphinx-mounts' bazel tests — builds its argv with
-`sphinx_build_command(...)` rather than with the bare word.
+the warnings (`build_warnings(app)`), the status text (`app._status`) and the failures
+(`pytest.raises`) a subprocess used to be needed for, and a subprocess is the one route the
+inert renderer cannot reach. Two tests in `tests/test_testkit_subprocess.py` keep it so, and
+it takes both — one walks the tree for the bare word `sphinx-build`, the other for
+`sphinx_build_command(`, which is what an argv built the right way looks like and what every
+converted site used to spell. A suite that genuinely must spawn a build — sphinx-mounts'
+bazel tests — builds its argv with `sphinx_build_command(...)` rather than with the bare word.
 
 Choose a renderer with `plantuml_conf(request)`, which resolves the suite-wide command only
 when the build will actually draw — never by naming `plantuml_command` in a test's signature,

--- a/packages/sphinx-needs/tests/test_github_issues.py
+++ b/packages/sphinx-needs/tests/test_github_issues.py
@@ -1,15 +1,10 @@
 import re
-import subprocess
 from pathlib import Path
 
 import pytest
 from lxml import html as html_parser
 
-from sphinx_needs_testkit import (
-    assert_no_warnings,
-    build_warnings,
-    sphinx_build_command,
-)
+from sphinx_needs_testkit import assert_no_warnings, build_warnings
 
 
 @pytest.mark.parametrize(
@@ -21,19 +16,10 @@ def test_doc_github_44(test_app):
     """
     https://github.com/useblocks/sphinxcontrib-needs/issues/44
     """
-    # Ugly workaround to get the sphinx build output.
-    # I have no glue how to get it from an app.build(), because stdout redirecting does not work. Maybe because
-    # nosetest is doing something similar for each test.
-    # So we call the needed command directly, but still use the sphinx_testing app to create the outdir for us.
     app = test_app
+    app.build()
+    assert app.statuscode == 0
 
-    output = subprocess.run(
-        sphinx_build_command("-a", "-E", "-b", "html", app.srcdir, app.outdir),
-        check=True,
-        capture_output=True,
-    )
-
-    # app.build() Uncomment, if build should stop on breakpoints
     html = Path(app.outdir, "index.html").read_text()
     assert "<h1>Github Issue 44 test" in html
     assert "Test 1" in html
@@ -45,10 +31,7 @@ def test_doc_github_44(test_app):
         "'test_123_broken' in field 'links' [needs.link_outgoing]"
     ]
 
-    assert (
-        build_warnings(output.stderr.decode("utf-8"), srcdir=app.srcdir)
-        == expected_warnings
-    )
+    assert build_warnings(app) == expected_warnings
 
 
 @pytest.mark.parametrize(

--- a/packages/sphinx-needs/tests/test_github_issues.py
+++ b/packages/sphinx-needs/tests/test_github_issues.py
@@ -18,7 +18,6 @@ def test_doc_github_44(test_app):
     """
     app = test_app
     app.build()
-    assert app.statuscode == 0
 
     html = Path(app.outdir, "index.html").read_text()
     assert "<h1>Github Issue 44 test" in html

--- a/packages/sphinx-needs/tests/test_measure_time.py
+++ b/packages/sphinx-needs/tests/test_measure_time.py
@@ -2,7 +2,39 @@ from pathlib import Path
 
 import pytest
 
+from sphinx_needs import debug
 from sphinx_needs_testkit import build_warnings
+
+
+@pytest.fixture(autouse=True)
+def _restore_time_measurement_globals():
+    """Put ``sphinx_needs.debug``'s module-level switches back after this build.
+
+    ``needs.py`` sets ``debug.EXECUTE_TIME_MEASUREMENTS`` to ``True`` for a project that
+    asks for timings and never sets it back, so every later build in the same process runs
+    the ``measure_time`` wrappers too. That is invisible until one of them measures a
+    filter function loaded from a test project's own directory: the wrapper calls
+    ``inspect.getsourcelines`` the first time it sees a function, the directory the
+    function came from was removed with the test that created it, and the build dies with
+    ``OSError: could not get source code``. Ordering decides whether that ever happens, so
+    the suite was green in file order and red under ``--random-order-seed=1911``.
+
+    The leak is production code's -- the reset belongs in ``debug.process_timing``, which
+    is already connected to ``build-finished`` -- and closing it there is a change to
+    ``src/``. This is the test-side half: the one test that flips the switch puts it back.
+    """
+    saved = (
+        debug.EXECUTE_TIME_MEASUREMENTS,
+        debug.START_TIME,
+        dict(debug.TIME_MEASUREMENTS),
+    )
+    yield
+    (
+        debug.EXECUTE_TIME_MEASUREMENTS,
+        debug.START_TIME,
+    ) = saved[:2]
+    debug.TIME_MEASUREMENTS.clear()
+    debug.TIME_MEASUREMENTS.update(saved[2])
 
 
 @pytest.mark.parametrize(

--- a/packages/sphinx-needs/tests/test_need_constraints.py
+++ b/packages/sphinx-needs/tests/test_need_constraints.py
@@ -20,7 +20,6 @@ from sphinx_needs_testkit import build_warnings
 def test_need_constraints(test_app, snapshot):
     app = test_app
     app.build()
-    assert app.statuscode == 0
 
     warning_records = build_warnings(test_app)
 

--- a/packages/sphinx-needs/tests/test_need_constraints.py
+++ b/packages/sphinx-needs/tests/test_need_constraints.py
@@ -1,11 +1,10 @@
 import json
-import subprocess
 from pathlib import Path
 
 import pytest
 from syrupy.filters import props
 
-from sphinx_needs_testkit import build_warnings, sphinx_build_command
+from sphinx_needs_testkit import build_warnings
 
 
 @pytest.mark.parametrize(
@@ -21,6 +20,7 @@ from sphinx_needs_testkit import build_warnings, sphinx_build_command
 def test_need_constraints(test_app, snapshot):
     app = test_app
     app.build()
+    assert app.statuscode == 0
 
     warning_records = build_warnings(test_app)
 
@@ -63,21 +63,6 @@ def test_need_constraints(test_app, snapshot):
     json_text = Path(app.outdir, "needs.json").read_text()
     needs_data = json.loads(json_text)
     assert needs_data == snapshot(exclude=props("created", "project", "creator"))
-
-    srcdir = Path(app.srcdir)
-    out_dir = srcdir / "_build"
-
-    # Check return code when "-W --keep-going" not used
-    out_normal = subprocess.run(
-        sphinx_build_command("-M", "html", srcdir, out_dir), capture_output=True
-    )
-    assert out_normal.returncode == 0
-
-    # Check return code when only "-W" is used
-    out_w = subprocess.run(
-        sphinx_build_command("-M", "html", srcdir, out_dir, "-W"), capture_output=True
-    )
-    assert out_w.returncode >= 1
 
     # test if constraints_results / constraints_passed is properly set
     html = Path(app.outdir, "index.html").read_text()

--- a/packages/sphinx-needs/tests/test_needarch.py
+++ b/packages/sphinx-needs/tests/test_needarch.py
@@ -72,5 +72,4 @@ def test_needarch_jinja_func_need(test_app, snapshot):
     html = Path(app.outdir, "index.html").read_text(encoding="utf8")
     assert "as INT_001 [[../index.html#INT_001]]" in html
 
-    assert app.statuscode == 0
     assert_no_warnings(app)

--- a/packages/sphinx-needs/tests/test_needarch.py
+++ b/packages/sphinx-needs/tests/test_needarch.py
@@ -1,9 +1,11 @@
+import re
 from pathlib import Path
 
 import pytest
 from syrupy.filters import props
 
-from sphinx_needs_testkit import sphinx_build_command
+from sphinx_needs.directives.needuml import NeedArchException
+from sphinx_needs_testkit import assert_no_warnings
 
 
 @pytest.mark.parametrize(
@@ -24,22 +26,13 @@ def test_doc_needarch(test_app):
     indirect=True,
 )
 def test_doc_needarch_negative(test_app):
-    import subprocess
-
     app = test_app
 
-    srcdir = Path(app.srcdir)
-    out_dir = srcdir / "_build"
-
-    out = subprocess.run(
-        sphinx_build_command("-M", "html", srcdir, out_dir), capture_output=True
-    )
-
-    assert out.returncode == 1
-    assert (
-        "sphinx_needs.directives.needuml.NeedArchException: Directive needarch "
-        "can only be used inside a need." in out.stderr.decode("utf-8")
-    )
+    with pytest.raises(
+        NeedArchException,
+        match=re.escape("Directive needarch can only be used inside a need."),
+    ):
+        app.build()
 
 
 @pytest.mark.parametrize(
@@ -79,12 +72,5 @@ def test_needarch_jinja_func_need(test_app, snapshot):
     html = Path(app.outdir, "index.html").read_text(encoding="utf8")
     assert "as INT_001 [[../index.html#INT_001]]" in html
 
-    import subprocess
-
-    srcdir = Path(app.srcdir)
-    out_dir = srcdir / "_build"
-
-    out = subprocess.run(
-        sphinx_build_command("-M", "html", srcdir, out_dir), capture_output=True
-    )
-    assert out.returncode == 0
+    assert app.statuscode == 0
+    assert_no_warnings(app)

--- a/packages/sphinx-needs/tests/test_needs_builder.py
+++ b/packages/sphinx-needs/tests/test_needs_builder.py
@@ -1,12 +1,11 @@
 import json
 import os
-import subprocess
 from pathlib import Path
 
 import pytest
 from syrupy.filters import props
 
-from sphinx_needs_testkit import sphinx_build_command
+from sphinx_needs_testkit import assert_no_warnings
 
 
 @pytest.mark.parametrize(
@@ -67,17 +66,12 @@ def test_doc_needs_builder_remove_defaults(test_app, snapshot):
 )
 def test_doc_needs_build_without_needs_file(test_app):
     app = test_app
+    app.build()
 
-    srcdir = Path(app.srcdir)
-    out_dir = os.path.join(srcdir, "_build")
-
-    out = subprocess.run(
-        sphinx_build_command("-b", "needs", srcdir, out_dir), capture_output=True
-    )
-    assert not out.stderr
+    assert_no_warnings(app)
     assert (
         "needs.json found, but will not be used because needs_file not configured."
-        in out.stdout.decode("utf-8")
+        in app._status.getvalue()
     )
 
 
@@ -86,7 +80,7 @@ def test_doc_needs_build_without_needs_file(test_app):
     [{"buildername": "html", "srcdir": "doc_test/doc_needs_builder_parallel"}],
     indirect=True,
 )
-def test_needs_html_and_json(test_app):
+def test_needs_html_and_json(test_app, make_app):
     """
     Build html output and needs.json in one sphinx-build
     """
@@ -96,15 +90,17 @@ def test_needs_html_and_json(test_app):
     needs_json_path = os.path.join(app.outdir, "needs.json")
     assert os.path.exists(needs_json_path)
 
-    srcdir = app.srcdir
-    build_dir = os.path.join(app.outdir, "../needs")
-    print(build_dir)
-    output = subprocess.run(
-        sphinx_build_command("-b", "needs", srcdir, build_dir),
-        capture_output=True,
+    # the same source, a second time, through the needs builder: its own build
+    # directory, so it reads the sources afresh rather than the html build's doctrees
+    needs_app = make_app(
+        buildername="needs",
+        srcdir=app.srcdir,
+        builddir=Path(app.srcdir).parent / "needs_build",
     )
-    print(output)
-    needs_json_path_2 = os.path.join(build_dir, "needs.json")
+    needs_app.build()
+    assert needs_app.statuscode == 0
+
+    needs_json_path_2 = os.path.join(needs_app.outdir, "needs.json")
     assert os.path.exists(needs_json_path_2)
 
     # Check if the needs.json files from html/parallel build and builder are the same

--- a/packages/sphinx-needs/tests/test_needs_builder.py
+++ b/packages/sphinx-needs/tests/test_needs_builder.py
@@ -98,7 +98,6 @@ def test_needs_html_and_json(test_app, make_app):
         builddir=Path(app.srcdir).parent / "needs_build",
     )
     needs_app.build()
-    assert needs_app.statuscode == 0
 
     needs_json_path_2 = os.path.join(needs_app.outdir, "needs.json")
     assert os.path.exists(needs_json_path_2)

--- a/packages/sphinx-needs/tests/test_needs_external_needs_build.py
+++ b/packages/sphinx-needs/tests/test_needs_external_needs_build.py
@@ -8,7 +8,7 @@ from sphinx import version_info
 from sphinx.testing.util import SphinxTestApp
 from sphinx.util.console import strip_colors
 
-from sphinx_needs_testkit import build_warnings, sphinx_build_command
+from sphinx_needs_testkit import build_warnings
 
 
 @pytest.mark.parametrize(
@@ -16,50 +16,52 @@ from sphinx_needs_testkit import build_warnings, sphinx_build_command
     [{"buildername": "html", "srcdir": "doc_test/doc_needs_external_needs"}],
     indirect=True,
 )
-def test_doc_build_html(test_app: SphinxTestApp, plantuml_subprocess_args: list[str]):
-    import subprocess
+def test_doc_build_html(test_app: SphinxTestApp):
+    app = test_app
 
-    src_dir = Path(test_app.srcdir)
-    out_dir = Path(test_app.outdir)
-    output = subprocess.run(
-        sphinx_build_command("-b", "html", *plantuml_subprocess_args, src_dir, out_dir),
-        capture_output=True,
-    )
+    # BOTH streams accumulate across builds, so the second build's share of each is
+    # sliced off the end: the status text at the length the first build left it, the
+    # warnings at the count it left them
+    app.build()
+    first_status_length = len(app._status.getvalue())
+    first_warnings = build_warnings(app)
+
     expected_warnings = [
         "WARNING: http://my_company.com/docs/v1/index.html#TEST_01: Need 'EXT_TEST_01' has unknown outgoing link 'SPEC_1' in field 'links' [needs.external_link_outgoing]",
         "WARNING: ../../_build/html/index.html#TEST_01: Need 'EXT_REL_PATH_TEST_01' has unknown outgoing link 'SPEC_1' in field 'links' [needs.external_link_outgoing]",
     ]
-    assert build_warnings(output.stderr.decode("utf-8")) == expected_warnings
+    assert first_warnings == expected_warnings
 
     # run second time and check
-    output_second = subprocess.run(
-        sphinx_build_command("-b", "html", *plantuml_subprocess_args, src_dir, out_dir),
-        capture_output=True,
-    )
+    app.build()
+    second_warnings = build_warnings(app)[len(first_warnings) :]
 
     # Sphinx 8.2 removed an early return in case no documents were updated in
     # https://github.com/sphinx-doc/sphinx/pull/13236
     # which leads to some SN warnings not being emitted for incremental builds
     if version_info < (8, 2):
         expected_warnings = []
-    assert build_warnings(output_second.stderr.decode("utf-8")) == expected_warnings
+    assert second_warnings == expected_warnings
 
     # check if incremental build used
+    first_status = strip_colors(app._status.getvalue()[:first_status_length])
+    second_status = strip_colors(app._status.getvalue()[first_status_length:])
     # first build output
     assert (
         "updating environment: [new config] 3 added, 0 changed, 0 removed"
-        in strip_colors(output.stdout.decode("utf-8"))
+        in first_status
     )
-    # second build output
+    # second build output. The subprocess build this replaced looked for "loading
+    # pickled environment" here, which is how a NEW process gets an environment it did
+    # not build; in process the environment is simply still there, so what says the
+    # build was incremental is that it re-read nothing and rewrote nothing
     # TODO(Marco) check why 3 added configs are expected, should be 0 for incremental builds without changes
-    assert "loading pickled environment" in output_second.stdout.decode("utf-8")
     assert (
         "updating environment: [new config] 3 added, 0 changed, 0 removed"
-        not in strip_colors(output_second.stdout.decode("utf-8"))
+        not in second_status
     )
-    assert "updating environment: 0 added, 0 changed, 0 removed" in strip_colors(
-        output_second.stdout.decode("utf-8")
-    )
+    assert "updating environment: 0 added, 0 changed, 0 removed" in second_status
+    assert "no targets are out of date." in second_status
 
 
 @pytest.mark.skipif(

--- a/packages/sphinx-needs/tests/test_needs_warning.py
+++ b/packages/sphinx-needs/tests/test_needs_warning.py
@@ -1,9 +1,7 @@
-from pathlib import Path
-
 import pytest
 from sphinx import version_info
 
-from sphinx_needs_testkit import build_warnings, sphinx_build_command
+from sphinx_needs_testkit import build_warnings
 
 
 @pytest.mark.parametrize(
@@ -69,59 +67,44 @@ def test_needs_warnings(test_app):
     indirect=True,
 )
 def test_needs_warnings_return_status_code(test_app):
-    import subprocess
+    """Every check this project fails is reported through Sphinx's warning logger.
 
+    That is the sphinx-needs claim, and it is what makes ``-W`` fail such a build. The
+    exit codes ``-W`` and ``--keep-going`` produce are Sphinx's own contract -- they
+    changed in 8.1 -- so they are not asserted here.
+    """
     app = test_app
+    app.build()
 
-    srcdir = Path(app.srcdir)
-    out_dir = srcdir / "_build"
+    # nothing is reported through the status stream instead
+    assert "WARNING" not in app._status.getvalue()
 
-    # Check return code when "-W --keep-going" not used
-    out_normal = subprocess.run(
-        sphinx_build_command("-M", "html", srcdir, out_dir), capture_output=True
-    )
-    assert out_normal.returncode == 0
+    expected = [
+        "WARNING: invalid_status: failed\n"
+        "\t\tfailed needs: 2 (SP_TOO_001, US_63252)\n"
+        "\t\tused filter: status not in ['open', 'closed', 'done', 'example_2', 'example_3'] [needs.warnings]",
+        "WARNING: type_match: failed\n"
+        "\t\tfailed needs: 1 (TC_001)\n"
+        "\t\tused filter: my_custom_warning_check [needs.warnings]",
+    ]
 
-    # Check return code when only "-W" is used
-    out_w = subprocess.run(
-        sphinx_build_command("-M", "html", srcdir, out_dir, "-W"), capture_output=True
-    )
-    assert out_w.returncode >= 1
+    if version_info >= (8, 2):
+        expected.insert(
+            0,
+            "WARNING: cannot cache unpickleable configuration value: 'needs_warnings' (because it contains a function, class, or module object) [config.cache]",
+        )
+    elif version_info >= (8, 0):
+        expected.insert(
+            0,
+            "WARNING: cannot cache unpickable configuration value: 'needs_warnings' (because it contains a function, class, or module object) [config.cache]",
+        )
+    elif version_info >= (7, 3):
+        expected.insert(
+            0,
+            "WARNING: cannot cache unpickable configuration value: 'needs_warnings' (because it contains a function, class, or module object)",
+        )
 
-    # Check return code when only "--keep-going" is used
-    out_keep_going = subprocess.run(
-        sphinx_build_command("-M", "html", srcdir, out_dir, "--keep-going"),
-        capture_output=True,
-    )
-    assert out_keep_going.returncode == 0
-
-    # Check return code when "-W --keep-going" is used
-    out_w_keep_going = subprocess.run(
-        sphinx_build_command("-M", "html", srcdir, out_dir, "-W", "--keep-going"),
-        capture_output=True,
-    )
-    assert out_w_keep_going.returncode == 1
-
-    # Check no Sphinx raised warnings
-    assert "WARNING" not in out_w_keep_going.stdout.decode("utf-8")
-
-    warnings = out_w_keep_going.stderr.decode("utf-8")
-
-    # Check Sphinx-needs raised warnings amount
-    assert warnings.count("WARNING: ") == 2
-
-    # Check warnings contents
-    assert "WARNING: invalid_status: failed" in warnings
-    assert "failed needs: 2 (SP_TOO_001, US_63252)" in warnings
-    assert (
-        "used filter: status not in ['open', 'closed', 'done', 'example_2', 'example_3']"
-        in warnings
-    )
-
-    # Check needs warning from custom defined filter code
-    assert "WARNING: type_match: failed" in warnings
-    assert "failed needs: 1 (TC_001)" in warnings
-    assert "used filter: my_custom_warning_check" in warnings
+    assert build_warnings(app) == expected
 
 
 @pytest.mark.parametrize(

--- a/packages/sphinx-needs/tests/test_needuml.py
+++ b/packages/sphinx-needs/tests/test_needuml.py
@@ -79,7 +79,6 @@ def test_needuml_option_key_forbidden(test_app):
 def test_needuml_diagram_allowmixing(test_app):
     app = test_app
     app.build()
-    assert app.statuscode == 0
     # this build renders eight diagrams, and a failed render is only a WARNING to
     # sphinxcontrib-plantuml -- so without this the test is green on a renderer that
     # cannot run, which is how it spent years drawing with whatever `plantuml` the
@@ -182,7 +181,6 @@ def test_needuml_filter(test_app, snapshot):
     html = Path(app.outdir, "index.html").read_text(encoding="utf8")
     assert "as ST_002 [[../index.html#ST_002]]" in html
 
-    assert app.statuscode == 0
     assert_no_warnings(app)
 
 
@@ -207,7 +205,6 @@ def test_needuml_jinja_func_flow(test_app, snapshot):
     html = Path(app.outdir, "index.html").read_text(encoding="utf8")
     assert "as ST_001 [[../index.html#ST_001]]" in html
 
-    assert app.statuscode == 0
     assert_no_warnings(app)
 
 
@@ -280,7 +277,6 @@ def test_needuml_jinja_func_ref(test_app, snapshot):
         in html
     )
 
-    assert app.statuscode == 0
     assert_no_warnings(app)
 
 
@@ -354,8 +350,10 @@ def test_needuml_jinja_func_uml_missing_key(test_app):
     ) as caught:
         app.build()
 
-    # the guard, not a KeyError caught after the fact: nothing is chained to it
+    # the guard, not a KeyError caught or wrapped after the fact: nothing is chained
+    # to it, either way
     assert not isinstance(caught.value.__context__, KeyError)
+    assert not isinstance(caught.value.__cause__, KeyError)
 
 
 @pytest.mark.parametrize(
@@ -475,7 +473,6 @@ def test_needumls_builder_rerun_keeps_saved_files(test_app, make_app):
             )
         )
         current.build()
-        assert current.statuscode == 0, current._warning.getvalue()
 
         saved = [
             Path(current.outdir, "_build", "my_needuml.puml"),

--- a/packages/sphinx-needs/tests/test_needuml.py
+++ b/packages/sphinx-needs/tests/test_needuml.py
@@ -1,4 +1,4 @@
-import subprocess
+import re
 from pathlib import Path
 
 import pytest
@@ -6,8 +6,11 @@ from docutils import nodes
 from syrupy.filters import props
 
 from sphinx_needs.data import SphinxNeedsData
-from sphinx_needs.directives.needuml import get_debug_node_from_puml_node
-from sphinx_needs_testkit import build_warnings, sphinx_build_command
+from sphinx_needs.directives.needuml import (
+    NeedumlException,
+    get_debug_node_from_puml_node,
+)
+from sphinx_needs_testkit import assert_no_warnings, build_warnings
 
 
 @pytest.mark.parametrize(
@@ -38,19 +41,13 @@ def test_doc_build_html(test_app, snapshot):
 def test_needuml_option_key_duplicate(test_app):
     app = test_app
 
-    srcdir = Path(app.srcdir)
-    out_dir = srcdir / "_build"
-
-    out = subprocess.run(
-        sphinx_build_command("-M", "html", srcdir, out_dir), capture_output=True
-    )
-    assert out.returncode == 1
-
-    assert (
-        "sphinx_needs.directives.needuml.NeedumlException: Inside need: INT_001, "
-        "found duplicate Needuml option key name: sequence"
-        in out.stderr.decode("utf-8")
-    )
+    with pytest.raises(
+        NeedumlException,
+        match=re.escape(
+            "Inside need: INT_001, found duplicate Needuml option key name: sequence"
+        ),
+    ):
+        app.build()
 
 
 @pytest.mark.parametrize(
@@ -61,45 +58,38 @@ def test_needuml_option_key_duplicate(test_app):
 def test_needuml_option_key_forbidden(test_app):
     app = test_app
 
-    srcdir = Path(app.srcdir)
-    out_dir = srcdir / "_build"
-
-    out = subprocess.run(
-        sphinx_build_command("-M", "html", srcdir, out_dir), capture_output=True
-    )
-    assert out.returncode == 1
-
-    assert (
-        "sphinx_needs.directives.needuml.NeedumlException: Needuml option key name can't be: diagram"
-        in out.stderr.decode("utf-8")
-    )
+    with pytest.raises(
+        NeedumlException,
+        match=re.escape("Needuml option key name can't be: diagram"),
+    ):
+        app.build()
 
 
 @pytest.mark.parametrize(
     "test_app",
-    [{"buildername": "html", "srcdir": "doc_test/doc_needuml_diagram_allowmixing"}],
+    [
+        {
+            "buildername": "html",
+            "srcdir": "doc_test/doc_needuml_diagram_allowmixing",
+            "plantuml": True,
+        }
+    ],
     indirect=True,
 )
-def test_needuml_diagram_allowmixing(test_app, plantuml_subprocess_args):
+def test_needuml_diagram_allowmixing(test_app):
     app = test_app
-
-    srcdir = Path(app.srcdir)
-    out_dir = srcdir / "_build"
-
-    out = subprocess.run(
-        sphinx_build_command("-M", "html", srcdir, out_dir, *plantuml_subprocess_args),
-        capture_output=True,
-    )
-    assert out.returncode == 0
-    # the subprocess renders eight diagrams, and a failed render is only a WARNING to
+    app.build()
+    assert app.statuscode == 0
+    # this build renders eight diagrams, and a failed render is only a WARNING to
     # sphinxcontrib-plantuml -- so without this the test is green on a renderer that
     # cannot run, which is how it spent years drawing with whatever `plantuml` the
-    # machine carried
-    assert "error while running plantuml" not in out.stderr.decode("utf-8")
-    # ...and a renderer that cannot even be STARTED is a different message ("plantuml
-    # command ... cannot be run"), also a WARNING: the positive assertion is that the
-    # diagrams exist. Eight on a good build; none under either failure (measured)
-    assert list((out_dir / "html" / "_images").glob("plantuml-*"))
+    # machine carried. A renderer that cannot even be STARTED is a different message
+    # ("plantuml command ... cannot be run"), also a WARNING: both are covered by
+    # asserting the build emitted nothing at all
+    assert_no_warnings(app)
+    # the positive assertion is that the diagrams exist. Eight on a good build; none
+    # under either failure (measured)
+    assert list(Path(app.outdir, "_images").glob("plantuml-*"))
 
 
 @pytest.mark.parametrize(
@@ -136,20 +126,14 @@ def test_needuml_save(test_app, snapshot):
 def test_needuml_save_with_abs_path(test_app):
     app = test_app
 
-    srcdir = Path(app.srcdir)
-    out_dir = srcdir / "_build"
-
-    # this fails before plantuml is required, so the plantuml path is not provided
-    out = subprocess.run(
-        sphinx_build_command("-M", "html", srcdir, out_dir), capture_output=True
-    )
-    assert out.returncode == 1
-
-    assert (
-        "sphinx_needs.directives.needuml.NeedumlException: "
-        "Given save path: /_out/my_needuml.puml, is not a relative posix path."
-        in out.stderr.decode("utf-8")
-    )
+    # this fails before plantuml is required, so the build never renders
+    with pytest.raises(
+        NeedumlException,
+        match=re.escape(
+            "Given save path: /_out/my_needuml.puml, is not a relative posix path."
+        ),
+    ):
+        app.build()
 
 
 @pytest.mark.parametrize(
@@ -198,13 +182,8 @@ def test_needuml_filter(test_app, snapshot):
     html = Path(app.outdir, "index.html").read_text(encoding="utf8")
     assert "as ST_002 [[../index.html#ST_002]]" in html
 
-    srcdir = Path(app.srcdir)
-    out_dir = srcdir / "_build"
-
-    out = subprocess.run(
-        sphinx_build_command("-M", "html", srcdir, out_dir), capture_output=True
-    )
-    assert out.returncode == 0
+    assert app.statuscode == 0
+    assert_no_warnings(app)
 
 
 @pytest.mark.parametrize(
@@ -228,13 +207,8 @@ def test_needuml_jinja_func_flow(test_app, snapshot):
     html = Path(app.outdir, "index.html").read_text(encoding="utf8")
     assert "as ST_001 [[../index.html#ST_001]]" in html
 
-    srcdir = Path(app.srcdir)
-    out_dir = srcdir / "_build"
-
-    out = subprocess.run(
-        sphinx_build_command("-M", "html", srcdir, out_dir), capture_output=True
-    )
-    assert out.returncode == 0
+    assert app.statuscode == 0
+    assert_no_warnings(app)
 
 
 @pytest.mark.parametrize(
@@ -245,18 +219,13 @@ def test_needuml_jinja_func_flow(test_app, snapshot):
 def test_needuml_jinja_func_need_removed(test_app):
     app = test_app
 
-    srcdir = Path(app.srcdir)
-    out_dir = srcdir / "_build"
-
-    out = subprocess.run(
-        sphinx_build_command("-M", "html", srcdir, out_dir), capture_output=True
-    )
-    assert out.returncode == 1
-    assert (
-        "sphinx_needs.directives.needuml.NeedumlException: "
-        "Jinja function 'need()' is not supported in needuml directive."
-        in out.stderr.decode("utf-8")
-    )
+    with pytest.raises(
+        NeedumlException,
+        match=re.escape(
+            "Jinja function 'need()' is not supported in needuml directive."
+        ),
+    ):
+        app.build()
 
 
 @pytest.mark.parametrize(
@@ -272,19 +241,13 @@ def test_needuml_jinja_func_need_removed(test_app):
 def test_doc_needarch_jinja_import_negative(test_app):
     app = test_app
 
-    srcdir = Path(app.srcdir)
-    out_dir = srcdir / "_build"
-
-    out = subprocess.run(
-        sphinx_build_command("-M", "html", srcdir, out_dir), capture_output=True
-    )
-
-    assert out.returncode == 1
-    assert (
-        "sphinx_needs.directives.needuml.NeedumlException: "
-        "Jinja function 'import()' is not supported in needuml directive."
-        in out.stderr.decode("utf-8")
-    )
+    with pytest.raises(
+        NeedumlException,
+        match=re.escape(
+            "Jinja function 'import()' is not supported in needuml directive."
+        ),
+    ):
+        app.build()
 
 
 @pytest.mark.parametrize(
@@ -317,13 +280,8 @@ def test_needuml_jinja_func_ref(test_app, snapshot):
         in html
     )
 
-    srcdir = Path(app.srcdir)
-    out_dir = srcdir / "_build"
-
-    out = subprocess.run(
-        sphinx_build_command("-M", "html", srcdir, out_dir), capture_output=True
-    )
-    assert out.returncode == 0
+    assert app.statuscode == 0
+    assert_no_warnings(app)
 
 
 @pytest.mark.parametrize(
@@ -390,20 +348,14 @@ def test_needuml_jinja_func_uml_missing_key(test_app):
     """
     app = test_app
 
-    srcdir = Path(app.srcdir)
-    out_dir = srcdir / "_build"
+    with pytest.raises(
+        NeedumlException,
+        match=re.escape("Option key name: nosuchkey does not exist in need SP_001."),
+    ) as caught:
+        app.build()
 
-    out = subprocess.run(
-        sphinx_build_command("-M", "html", srcdir, out_dir), capture_output=True
-    )
-    assert out.returncode == 1
-
-    stderr = out.stderr.decode("utf-8")
-    assert (
-        "sphinx_needs.directives.needuml.NeedumlException: "
-        "Option key name: nosuchkey does not exist in need SP_001." in stderr
-    )
-    assert "KeyError: 'nosuchkey'" not in stderr
+    # the guard, not a KeyError caught after the fact: nothing is chained to it
+    assert not isinstance(caught.value.__context__, KeyError)
 
 
 @pytest.mark.parametrize(
@@ -419,20 +371,14 @@ def test_needuml_jinja_func_import_string_option(test_app):
     """
     app = test_app
 
-    srcdir = Path(app.srcdir)
-    out_dir = srcdir / "_build"
+    with pytest.raises(
+        NeedumlException,
+        match=re.escape("Option value for 'status' is not a list of need ids: 'open'."),
+    ) as caught:
+        app.build()
 
-    out = subprocess.run(
-        sphinx_build_command("-M", "html", srcdir, out_dir), capture_output=True
-    )
-    assert out.returncode == 1
-
-    stderr = out.stderr.decode("utf-8")
-    assert (
-        "sphinx_needs.directives.needuml.NeedumlException: "
-        "Option value for 'status' is not a list of need ids: 'open'." in stderr
-    )
-    assert "undefined need_id: 'o'" not in stderr
+    # not the old message, which reported the string's first character as a need id
+    assert "undefined need_id: 'o'" not in str(caught.value)
 
 
 @pytest.mark.parametrize(
@@ -502,7 +448,7 @@ def test_get_debug_node_from_puml_node_figure():
     [{"buildername": "needumls", "srcdir": "doc_test/doc_needuml_save"}],
     indirect=True,
 )
-def test_needumls_builder_rerun_keeps_saved_files(test_app):
+def test_needumls_builder_rerun_keeps_saved_files(test_app, make_app):
     """A second build must not truncate the ``.puml`` files the first one wrote.
 
     ``content_calculated`` is filled in while a document is written, after the
@@ -512,21 +458,29 @@ def test_needumls_builder_rerun_keeps_saved_files(test_app):
     """
     app = test_app
 
-    srcdir = Path(app.srcdir)
-    out_dir = srcdir / "_build_rerun"
-    saved = [
-        out_dir / "_build" / "my_needuml.puml",
-        out_dir / "_out" / "sub_folder" / "my_needs.puml",
-    ]
-
     first: list[str] = []
     for run in range(2):
-        out = subprocess.run(
-            sphinx_build_command("-b", "needumls", str(srcdir), str(out_dir)),
-            capture_output=True,
+        # the SECOND run is a second application over the first one's build directory,
+        # not a second `app.build()`: it has to load the environment the first run
+        # pickled, because that is where `content_calculated` is empty. An application
+        # that never let go of its environment still holds the values its own write
+        # phase put there, and would not exercise this at all
+        current = (
+            app
+            if run == 0
+            else make_app(
+                buildername="needumls",
+                srcdir=app.srcdir,
+                builddir=Path(app.outdir).parent,
+            )
         )
-        assert out.returncode == 0, out.stderr.decode("utf-8")
+        current.build()
+        assert current.statuscode == 0, current._warning.getvalue()
 
+        saved = [
+            Path(current.outdir, "_build", "my_needuml.puml"),
+            Path(current.outdir, "_out", "sub_folder", "my_needs.puml"),
+        ]
         contents = [path.read_text() for path in saved]
         assert all(content.strip() for content in contents), (
             f"a saved .puml file is empty after run {run + 1}: {contents}"

--- a/packages/sphinx-needs/tests/test_report_dead_links.py
+++ b/packages/sphinx-needs/tests/test_report_dead_links.py
@@ -1,9 +1,6 @@
-import subprocess
-from pathlib import Path
-
 import pytest
 
-from sphinx_needs_testkit import build_warnings, sphinx_build_command
+from sphinx_needs_testkit import assert_no_warnings, build_warnings
 
 
 @pytest.mark.parametrize(
@@ -13,15 +10,10 @@ from sphinx_needs_testkit import build_warnings, sphinx_build_command
 )
 def test_needs_dead_links_warnings(test_app):
     app = test_app
-
-    src_dir = Path(app.srcdir)
-    out_dir = Path(app.outdir)
-    output = subprocess.run(
-        sphinx_build_command("-M", "html", src_dir, out_dir), capture_output=True
-    )
+    app.build()
 
     # check there are expected warnings
-    emitted = build_warnings(output.stderr.decode("utf-8"), srcdir=app.srcdir)
+    emitted = build_warnings(app)
     expected_warnings = [
         "<srcdir>/index.rst:17: WARNING: Need 'REQ_004' has unknown outgoing link 'ANOTHER_DEAD_LINK' in field 'links' [needs.link_outgoing]",
         "<srcdir>/index.rst:45: WARNING: Need 'TEST_004' has unknown outgoing link 'REQ_005.invalid' in field 'tests' [needs.link_outgoing]",
@@ -38,15 +30,10 @@ def test_needs_dead_links_warnings(test_app):
 )
 def test_needs_dead_links_warnings_needs_builder(test_app):
     app = test_app
-
-    src_dir = Path(app.srcdir)
-    out_dir = Path(app.outdir)
-    output = subprocess.run(
-        sphinx_build_command("-M", "needs", src_dir, out_dir), capture_output=True
-    )
+    app.build()
 
     # check there are expected warnings
-    emitted = build_warnings(output.stderr.decode("utf-8"), srcdir=app.srcdir)
+    emitted = build_warnings(app)
     expected_warnings = [
         "<srcdir>/index.rst:17: WARNING: Need 'REQ_004' has unknown outgoing link 'ANOTHER_DEAD_LINK' in field 'links' [needs.link_outgoing]",
         "<srcdir>/index.rst:45: WARNING: Need 'TEST_004' has unknown outgoing link 'REQ_005.invalid' in field 'tests' [needs.link_outgoing]",
@@ -63,12 +50,7 @@ def test_needs_dead_links_warnings_needs_builder(test_app):
 )
 def test_needs_dead_links_suppress_warnings(test_app):
     app = test_app
-
-    src_dir = Path(app.srcdir)
-    out_dir = Path(app.outdir)
-    output = subprocess.run(
-        sphinx_build_command("-M", "html", src_dir, out_dir), capture_output=True
-    )
+    app.build()
 
     # check there are no warnings
-    assert not output.stderr
+    assert_no_warnings(app)

--- a/packages/sphinx-needs/tests/test_testkit_subprocess.py
+++ b/packages/sphinx-needs/tests/test_testkit_subprocess.py
@@ -95,3 +95,27 @@ def test_a_tests_dir_that_is_no_directory_is_loud(tmp_path: Path) -> None:
 
 def test_no_test_in_this_tree_spawns_the_bare_command() -> None:
     assert_no_bare_sphinx_build(Path(__file__).parent)
+
+
+def test_no_test_in_this_tree_builds_in_a_subprocess() -> None:
+    """The other half: the kit's argv helper is not for THIS suite either.
+
+    ``assert_no_bare_sphinx_build`` guards the bare word, which a site built with
+    ``sphinx_build_command`` never contains -- and that argv is exactly the shape all 28
+    converted sites had. This walk is what makes "no test in this suite spawns a build" a
+    fenced claim rather than a description of today.
+    """
+    here = Path(__file__).resolve()
+    offenders = [
+        f"{path.relative_to(here.parent)}:{number}"
+        for path in sorted(here.parent.rglob("*.py"))
+        if path.resolve() != here
+        for number, line in enumerate(path.read_text(encoding="utf8").splitlines(), 1)
+        if "sphinx_build_command(" in line
+    ]
+    assert not offenders, (
+        "this suite builds in process: `test_app` / `make_app` for the build, "
+        "`build_warnings(app)` for the warnings, `app._status` for the status text, "
+        "`pytest.raises` for the failures -- see the 'Rendering PlantUML is opt in' "
+        "paragraph in packages/sphinx-needs/AGENTS.md:\n" + "\n".join(offenders)
+    )

--- a/packages/sphinx-needs/tests/test_testkit_subprocess.py
+++ b/packages/sphinx-needs/tests/test_testkit_subprocess.py
@@ -1,17 +1,19 @@
 """Tests for the testkit's subprocess argv (``sphinx_needs_testkit._subprocess``).
 
 Two of these pin the argv helper's contract, three pin the fence's, and the sixth points
-the fence at this tree -- the one that matters after the conversion. A site that spells the
-build command as the bare word again is not a failing test: it passes, out of whatever
-environment the machine's ``PATH`` points at, so nothing would report it. The fence does.
+the fence at this tree -- the one that matters now that no test in it spawns a build at
+all. A site that spells the build command as the bare word again is not a failing test: it
+passes, out of whatever environment the machine's ``PATH`` points at, so nothing would
+report it. The fence does.
 
 The fence's three are here because it is a published kit function now, and its two call
 sites only ever assert that it does NOT fire -- which a fence-shaped no-op would satisfy
 too. They pin the three halves nothing else can see: that it raises at all, that the walk
 is recursive, and that a ``tests_dir`` naming no directory is loud rather than green.
 
-The walk itself is the kit's (``assert_no_bare_sphinx_build``) because two suites here
-spawn builds and both are walked; sphinx-mounts calls it from a module of its own. These
+The walk itself is the kit's (``assert_no_bare_sphinx_build``) because the tree that must
+never spawn a build and the one that legitimately does are both walked; sphinx-mounts calls
+it from a module of its own. These
 unit tests live in THIS suite for the same reason the warning tests do, and the note at the
 top of ``test_testkit_warnings.py`` is that reason: sphinx-needs' is the only one of the
 three suites a test of the kit can join without a fourth suite, task and CI cell.

--- a/packages/sphinx-needs/tests/test_testkit_subprocess.py
+++ b/packages/sphinx-needs/tests/test_testkit_subprocess.py
@@ -110,7 +110,9 @@ def test_no_test_in_this_tree_builds_in_a_subprocess() -> None:
         f"{path.relative_to(here.parent)}:{number}"
         for path in sorted(here.parent.rglob("*.py"))
         if path.resolve() != here
-        for number, line in enumerate(path.read_text(encoding="utf8").splitlines(), 1)
+        for number, line in enumerate(
+            path.read_text(encoding="utf8", errors="replace").splitlines(), 1
+        )
         if "sphinx_build_command(" in line
     ]
     assert not offenders, (


### PR DESCRIPTION
> *"Ugly workaround to get the sphinx build output. I have no glue how to get it from an
> `app.build()`, because stdout redirecting does not work."*

That comment has sat above `test_doc_github_44` since 2018, and 27 further subprocess builds
grew from it. All it could not reach, the in-process application exposes; all 28 sites are
converted, in eight modules. **No test in sphinx-needs' suite spawns a Sphinx build any more** —
two tree tests in `test_testkit_subprocess.py` keep it so, one against the bare word and one
against `sphinx_build_command(`. sphinx-mounts' bazel tests are untouched.

| the subprocess proved | the in-process assertion |
|---|---|
| warnings on stderr | `build_warnings(app)` compared to the exact list |
| `not out.stderr` | `assert_no_warnings(app)`, which names what it found |
| exit 1 + a class name in a traceback | `pytest.raises(<the class>, match=re.escape(<the full message>))` |
| exit 0 | the build not raising, plus the exact (usually empty) warning list |
| `-W` / `--keep-going` exit codes | dropped: Sphinx's contract, changed in 8.1. What they stood for is the warning list, now asserted directly |
| status text on stdout | `app._status.getvalue()` |
| a second builder over the same source | `make_app(buildername=…, srcdir=app.srcdir, builddir=…)` |
| a rendered diagram | `"plantuml": True` in the parameter dict; `-a -E` becomes nothing at all |

No site loses what it asserted about sphinx-needs; one stdout check narrowed to Sphinx's status
stream, the only channel a Sphinx warning could leak into in process; a stray `print` in
`src/` is no longer seen, and no test in this suite claims it is. Where the in-process form
asserts more, the ledger says so — a class asserted as a type rather than matched in a
traceback; an exact three-record list where a `"WARNING: "` count said two (it read the
*fourth* build into one output directory, where Sphinx had nothing left to re-pickle).

| | before | after |
|---|---|---|
| the eight modules, best of 2 | 48 passed in **43.20 s** | 48 passed in **21.94 s** |
| `git grep -c subprocess tests/` | 51 hits in 11 files | 9 in 4, none a Sphinx build |
| `needuml.py` lines covered by `test_needarch.py` (a subprocess contributes none) | 223 / 317 | 225 / 317 |

**Isolation.** A subprocess was hermetic by accident, so `sphinx_needs`' module-level state was censused: 35
containers, 12 caches, 0 `global`s. `config._NEEDS_CONFIG`, the one large mutable singleton,
is cleared at the end of every `setup(app)`, and nothing else a converted test writes outlives
its application — the eight sites that abort a build half-way included, since `pytest.raises`
keeps the exception in the test body and `cleanup()` still runs.

| proof | result |
|---|---|
| full suite, default / reversed / random seed 1911 | 1787 passed in each at `141ac75f`; 1788 at the head, which adds one test |
| each exception site immediately before `test_basic_doc.py` | 8 × 9 passed |
| all eight as one battery, then three clean modules | 31 passed |

The random order did find one order-dependence, and it is **not** this PR's — reproduced
identically on `master`. `test_measure_time` sets `debug.EXECUTE_TIME_MEASUREMENTS` and never
resets it, so a later build measures a filter function whose test directory has been deleted
and dies in `inspect.getsourcelines`. A commit here closes it test-side; the production half
(`debug.process_timing` should reset it, which matters for esbonio) is a follow-up.

**Also retired:** `plantuml_subprocess_args` (the testkit fixture that pointed a spawned build
at the pinned renderer; no consumer left), the two imports in the eight modules, and the stale
prose. Tests only; nothing shipped changes. No changelog entry.
