### PR TITLE
‼️ Remove the 4.0 deprecation of `[[...]]` in need content, and the `need_func` role

### DIFF
--- a/packages/sphinx-needs/docs/dynamic_functions.rst
+++ b/packages/sphinx-needs/docs/dynamic_functions.rst
@@ -35,7 +35,7 @@ To refer to a dynamic function, you can use the following syntax:
 
       This need has id :ndf:`copy("id")` and status :ndf:`copy("status")`.
 
-Dynamic functions can be used for the following directive options:
+The ``[[...]]`` syntax applies to directive **options** only; the following are supported:
 
 - ``status``
 - ``tags``
@@ -45,9 +45,12 @@ Dynamic functions can be used for the following directive options:
 - :ref:`extra fields <needs_fields>`
 - :ref:`needs_links`
 
-.. deprecated:: 3.1.0
+Inside a need's **content**, the :ref:`ndf` role is the way to call a dynamic function.
 
-   The :ref:`ndf` role replaces the use of the ``[[...]]`` syntax in need content.
+.. versionchanged:: 9.0.0
+
+   The ``[[...]]`` syntax is no longer interpreted in a need's content, where it is now
+   plain text as in any other Sphinx document; use the :ref:`ndf` role instead.
 
 Built-in functions
 -------------------

--- a/packages/sphinx-needs/docs/roles.rst
+++ b/packages/sphinx-needs/docs/roles.rst
@@ -189,15 +189,15 @@ To calculate the ratio of one filter to another filter, you can define two filte
 
 need_func
 ---------
-.. deprecated:: 3.1.0
+.. versionchanged:: 9.0.0
 
-   Use :ref:`ndf` instead.
+   The ``need_func`` role is removed; use :ref:`ndf` instead.
 
 .. _ndf:
 
 ndf
 ---
-.. versionadded:: 3.1.0
+.. versionadded:: 4.0.0
 
 Executes a :ref:`need dynamic function <dynamic_functions>` and uses the return values as content.
 

--- a/packages/sphinx-needs/src/sphinx_needs/functions/functions.py
+++ b/packages/sphinx-needs/src/sphinx_needs/functions/functions.py
@@ -421,31 +421,6 @@ def check_and_get_content(
     return content
 
 
-def _detect_and_execute_field(
-    content: Any, need: NeedItem, needs: NeedsMutable, app: Sphinx
-) -> tuple[
-    str | None,
-    str | int | float | list[str] | list[int] | list[float] | list[NeedLink] | None,
-]:
-    """Detects if given need field value is a function call and executes it."""
-    content = str(content)
-
-    func_match = FUNC_RE.search(content)
-    if func_match is None:
-        return None, None
-
-    func_call = func_match.group(1)  # Extract function call
-    func_return = execute_func(
-        app,
-        need,
-        needs,
-        func_call,
-        (need["docname"], need["lineno"]) if need["docname"] else None,
-    )  # Execute function call and get return value
-
-    return func_call, func_return
-
-
 @dataclass(frozen=True, slots=True)
 class NeedAttribute:
     """A reference to a need field."""

--- a/packages/sphinx-needs/src/sphinx_needs/functions/functions.py
+++ b/packages/sphinx-needs/src/sphinx_needs/functions/functions.py
@@ -205,82 +205,33 @@ def find_and_replace_node_content(
     node: nodes.Node, env: BuildEnvironment, need: NeedItem
 ) -> nodes.Node:
     """
-    Search inside a given node and its children for nodes of type Text,
-    if found, check if it contains a function string and run/replace it.
+    Search inside a given node and its children for ``NeedFunc`` nodes,
+    created by the ``ndf`` role, and replace each with the text its function returns.
+
+    Literal blocks, inline literals and nested needs are not descended into;
+    a nested need runs this pass itself, for its own need data.
 
     :param node: Node to analyse
     :param env: Sphinx environment
     :param need: Need data
     """
-    new_children = []
     if isinstance(node, NeedFunc):
         return node.get_text(env, need)
-    elif (not node.children and isinstance(node, nodes.Text)) or isinstance(
-        node, nodes.reference
-    ):
-        if isinstance(node, nodes.reference):
-            try:
-                new_text = node.attributes["refuri"]
-            except KeyError:
-                # If no refuri is set, we don't need to modify anything.
-                # So stop here and return the untouched node.
-                return node
-        else:
-            new_text = node
-        func_match = FUNC_RE.findall(new_text)
-        for func_string in func_match:
-            # sphinx is replacing ' and " with language specific quotation marks (up and down), which makes
-            # it impossible for the later used AST render engine to detect a python function call in the given
-            # string. Therefor a replacement is needed for the execution of the found string.
-            func_string_org = func_string[:]
-            func_string = func_string.replace("„", '"')
-            func_string = func_string.replace("“", '"')
-            func_string = func_string.replace("”", '"')
-            func_string = func_string.replace("”", '"')
 
-            func_string = func_string.replace("‘", "'")  # noqa: RUF001
-            func_string = func_string.replace("’", "'")  # noqa: RUF001
-
-            msg = f"The [[{func_string}]] syntax in need content is deprecated. Replace with :ndf:`{func_string}` instead."
-            log_warning(logger, msg, "deprecated", location=node)
-
-            func_return = execute_func(
-                env.app, need, SphinxNeedsData(env).get_needs_view(), func_string, node
-            )
-
-            if isinstance(func_return, list):
-                func_return = ", ".join(str(el) for el in func_return)
-
-            new_text = new_text.replace(
-                f"[[{func_string_org}]]",
-                "" if func_return is None else str(func_return),
-            )
-
-        if isinstance(node, nodes.reference):
-            node.attributes["refuri"] = new_text
-            # Call normal handling for children of reference node (will contain related Text node with link-text)
-            for child in node.children:
-                new_child = find_and_replace_node_content(child, env, need)
-                new_children.append(new_child)
-
-            node.children = new_children
-            for subchild in node.children:
-                node.setup_child(subchild)
-        else:
-            node = nodes.Text(new_text)
+    if not node.children:
         return node
-    else:
-        for child in node.children:
-            if isinstance(child, nodes.literal_block | nodes.literal | Need):
-                # Do not parse literal blocks or nested needs
-                new_children.append(child)
-                continue
-            new_child = find_and_replace_node_content(child, env, need)
-            new_children.append(new_child)
 
-        node.children = new_children
-        for subchild in node.children:
-            node.setup_child(subchild)
+    new_children = []
+    for child in node.children:
+        if isinstance(child, nodes.literal_block | nodes.literal | Need):
+            # Do not parse literal blocks or nested needs
+            new_children.append(child)
+            continue
+        new_children.append(find_and_replace_node_content(child, env, need))
+
+    node.children = new_children
+    for subchild in node.children:
+        node.setup_child(subchild)
     return node
 
 
@@ -440,6 +391,10 @@ def check_and_get_content(
     Checks if the given content is a function call.
     If not, content is returned.
     If it is, the functions gets executed and its returns value replaces the related part in content.
+
+    This is the ``[[...]]`` syntax as written in a directive option
+    (``:style:``, ``needtable``'s ``:style_row:``); it is not applied to a need's content,
+    where the ``ndf`` role is the way to call a dynamic function.
 
     :param content: option content string
     :param need: need

--- a/packages/sphinx-needs/src/sphinx_needs/functions/functions.py
+++ b/packages/sphinx-needs/src/sphinx_needs/functions/functions.py
@@ -208,8 +208,10 @@ def find_and_replace_node_content(
     Search inside a given node and its children for ``NeedFunc`` nodes,
     created by the ``ndf`` role, and replace each with the text its function returns.
 
-    Literal blocks, inline literals and nested needs are not descended into;
-    a nested need runs this pass itself, for its own need data.
+    A nested need is not descended into, because it runs this pass itself, for its own
+    need data -- that skip is observable. Literal blocks and inline literals are skipped
+    to state the intent: RST cannot put a role inside either, so no ``NeedFunc`` can be
+    there to find.
 
     :param node: Node to analyse
     :param env: Sphinx environment

--- a/packages/sphinx-needs/src/sphinx_needs/needs.py
+++ b/packages/sphinx-needs/src/sphinx_needs/needs.py
@@ -312,8 +312,7 @@ def setup(app: Sphinx) -> dict[str, Any]:
         ),
     )
 
-    app.add_role("need_func", NeedFuncRole(with_brackets=True))  # deprecrated
-    app.add_role("ndf", NeedFuncRole(with_brackets=False))
+    app.add_role("ndf", NeedFuncRole())
 
     # Resolves :variant:`a.b` immediately to the value from needs_variant_data.
     app.add_role("variant", VariantRole())

--- a/packages/sphinx-needs/src/sphinx_needs/roles/need_func.py
+++ b/packages/sphinx-needs/src/sphinx_needs/roles/need_func.py
@@ -1,5 +1,5 @@
 """
-Provide a role which executes a dynamic function.
+Provide the ``ndf`` role, which executes a dynamic function and renders its return value.
 """
 
 from __future__ import annotations
@@ -10,72 +10,40 @@ from sphinx.environment import BuildEnvironment
 from sphinx.util.docutils import SphinxRole
 
 from sphinx_needs.data import SphinxNeedsData
-from sphinx_needs.logging import get_logger, log_warning
 from sphinx_needs.need_item import NeedItem
 from sphinx_needs.utils import add_doc
-
-LOGGER = get_logger(__name__)
 
 
 class NeedFuncRole(SphinxRole):
     """Role for creating ``NeedFunc`` node."""
-
-    def __init__(self, *, with_brackets: bool = False) -> None:
-        """Initialize the role.
-
-        :param with_brackets: If True, the function is expected to be wrapped in brackets ``[[]]``.
-        """
-        self.with_brackets = with_brackets
-        super().__init__()
 
     def run(self) -> tuple[list[nodes.Node], list[nodes.system_message]]:
         add_doc(self.env, self.env.docname)
         node = NeedFunc(
             self.rawtext,
             nodes.literal(self.rawtext, self.text),
-            with_brackets=self.with_brackets,
             **self.options,
         )
         self.set_source_info(node)
-        if self.with_brackets:
-            from sphinx_needs.functions.functions import FUNC_RE
-
-            msg = "The `need_func` role is deprecated. "
-            if func_match := FUNC_RE.search(node.astext()):
-                func_call = func_match.group(1)
-                msg += f"Replace with :ndf:`{func_call}` instead."
-            else:
-                msg += "Replace with ndf role instead."
-            log_warning(LOGGER, msg, "deprecated", location=node)
         return [node], []
 
 
 class NeedFunc(nodes.Inline, nodes.Element):
-    @property
-    def with_brackets(self) -> bool:
-        """Return the function with brackets."""
-        return self.get("with_brackets", False)
-
     def get_text(self, env: BuildEnvironment, need: NeedItem | None) -> nodes.Text:
         """Execute function and return result."""
-        from sphinx_needs.functions.functions import check_and_get_content, execute_func
+        from sphinx_needs.functions.functions import execute_func
 
-        if not self.with_brackets:
-            func_return = execute_func(
-                env.app,
-                need,
-                SphinxNeedsData(env).get_needs_view(),
-                self.astext(),
-                self,
-            )
-            if isinstance(func_return, list):
-                func_return = ", ".join(str(el) for el in func_return)
+        func_return = execute_func(
+            env.app,
+            need,
+            SphinxNeedsData(env).get_needs_view(),
+            self.astext(),
+            self,
+        )
+        if isinstance(func_return, list):
+            func_return = ", ".join(str(el) for el in func_return)
 
-            return nodes.Text("" if func_return is None else str(func_return))
-
-        result = check_and_get_content(self.astext(), need, env, self)
-
-        return nodes.Text(str(result))
+        return nodes.Text("" if func_return is None else str(func_return))
 
 
 def process_need_func(

--- a/packages/sphinx-needs/tests/__snapshots__/test_dynamic_functions.ambr
+++ b/packages/sphinx-needs/tests/__snapshots__/test_dynamic_functions.ambr
@@ -667,8 +667,6 @@
             'content': '''
               This is id [[copy("id")]]
               
-              This is also id :need_func:`[[copy("id")]]`
-              
               This is the best id :ndf:`copy("id")`
             ''',
             'docname': 'index',
@@ -692,7 +690,7 @@
             'docname': 'index',
             'external_css': 'external_link',
             'id': 'TEST_2',
-            'lineno': 15,
+            'lineno': 13,
             'section_name': 'DYNAMIC FUNCTIONS',
             'sections': list([
               'DYNAMIC FUNCTIONS',
@@ -710,7 +708,7 @@
             'docname': 'index',
             'external_css': 'external_link',
             'id': 'TEST_3',
-            'lineno': 19,
+            'lineno': 17,
             'section_name': 'DYNAMIC FUNCTIONS',
             'sections': list([
               'DYNAMIC FUNCTIONS',
@@ -729,14 +727,12 @@
               
                   nested id [[copy('id')]]
               
-                  nested id also :need_func:`[[copy("id")]]`
-              
                   nested id best :ndf:`copy("id")`
             ''',
             'docname': 'index',
             'external_css': 'external_link',
             'id': 'TEST_5',
-            'lineno': 29,
+            'lineno': 27,
             'parent_needs_back': list([
               'TEST_6',
             ]),
@@ -755,14 +751,12 @@
             'content': '''
               nested id [[copy('id')]]
               
-              nested id also :need_func:`[[copy("id")]]`
-              
               nested id best :ndf:`copy("id")`
             ''',
             'docname': 'index',
             'external_css': 'external_link',
             'id': 'TEST_6',
-            'lineno': 35,
+            'lineno': 33,
             'parent_need': 'TEST_5',
             'parent_needs': list([
               'TEST_5',
@@ -779,7 +773,7 @@
             'docname': 'index',
             'external_css': 'external_link',
             'id': 'TEST_9',
-            'lineno': 56,
+            'lineno': 52,
             'non_func': '[[test(need.unknown)]]',
             'section_name': 'DYNAMIC FUNCTIONS',
             'sections': list([

--- a/packages/sphinx-needs/tests/__snapshots__/test_dynamic_functions.ambr
+++ b/packages/sphinx-needs/tests/__snapshots__/test_dynamic_functions.ambr
@@ -668,6 +668,11 @@
               This is id [[copy("id")]]
               
               This is the best id :ndf:`copy("id")`
+              
+              via an internal link: |intsub|_
+              
+              .. |intsub| replace:: :ndf:`copy("id")`
+              .. _intsub: `DYNAMIC FUNCTIONS`_
             ''',
             'docname': 'index',
             'external_css': 'external_link',
@@ -690,7 +695,7 @@
             'docname': 'index',
             'external_css': 'external_link',
             'id': 'TEST_2',
-            'lineno': 13,
+            'lineno': 18,
             'section_name': 'DYNAMIC FUNCTIONS',
             'sections': list([
               'DYNAMIC FUNCTIONS',
@@ -708,7 +713,7 @@
             'docname': 'index',
             'external_css': 'external_link',
             'id': 'TEST_3',
-            'lineno': 17,
+            'lineno': 22,
             'section_name': 'DYNAMIC FUNCTIONS',
             'sections': list([
               'DYNAMIC FUNCTIONS',
@@ -732,7 +737,7 @@
             'docname': 'index',
             'external_css': 'external_link',
             'id': 'TEST_5',
-            'lineno': 27,
+            'lineno': 32,
             'parent_needs_back': list([
               'TEST_6',
             ]),
@@ -756,7 +761,7 @@
             'docname': 'index',
             'external_css': 'external_link',
             'id': 'TEST_6',
-            'lineno': 33,
+            'lineno': 38,
             'parent_need': 'TEST_5',
             'parent_needs': list([
               'TEST_5',
@@ -773,7 +778,7 @@
             'docname': 'index',
             'external_css': 'external_link',
             'id': 'TEST_9',
-            'lineno': 52,
+            'lineno': 57,
             'non_func': '[[test(need.unknown)]]',
             'section_name': 'DYNAMIC FUNCTIONS',
             'sections': list([

--- a/packages/sphinx-needs/tests/doc_test/doc_df_user_functions/index.rst
+++ b/packages/sphinx-needs/tests/doc_test/doc_df_user_functions/index.rst
@@ -5,17 +5,19 @@ DYNAMIC FUNCTIONS
     :id: TEST_1
     :status: [[my_own_function()]]
 
-    [[my_own_function()]]
+    :ndf:`my_own_function()`
+
+    [[my_own_function()]] is not a dynamic function here
 
 .. spec:: TEST_2
     :id: TEST_2
     :status: [[bad_function()]]
 
-    [[bad_function()]]
+    :ndf:`bad_function()`
 
-    [[invalid]]
+    :ndf:`invalid`
 
-    [[unknown()]]
+    :ndf:`unknown()`
 
     .. code-block:: toml
 

--- a/packages/sphinx-needs/tests/doc_test/doc_dynamic_functions/index.rst
+++ b/packages/sphinx-needs/tests/doc_test/doc_dynamic_functions/index.rst
@@ -10,6 +10,11 @@ DYNAMIC FUNCTIONS
 
     This is the best id :ndf:`copy("id")`
 
+    via an internal link: |intsub|_
+
+    .. |intsub| replace:: :ndf:`copy("id")`
+    .. _intsub: `DYNAMIC FUNCTIONS`_
+
 .. spec:: TEST_2
    :id: TEST_2
    :tags: my_tag; [[copy("tags", "SP_TOO_001")]]

--- a/packages/sphinx-needs/tests/doc_test/doc_dynamic_functions/index.rst
+++ b/packages/sphinx-needs/tests/doc_test/doc_dynamic_functions/index.rst
@@ -8,8 +8,6 @@ DYNAMIC FUNCTIONS
 
     This is id [[copy("id")]]
 
-    This is also id :need_func:`[[copy("id")]]`
-
     This is the best id :ndf:`copy("id")`
 
 .. spec:: TEST_2
@@ -37,11 +35,9 @@ DYNAMIC FUNCTIONS
 
         nested id [[copy('id')]]
 
-        nested id also :need_func:`[[copy("id")]]`
-
         nested id best :ndf:`copy("id")`
 
-These should warn since they have no associated need: :need_func:`[[copy("id")]]`, :ndf:`copy("id")`
+This should warn since it has no associated need: :ndf:`copy("id")`
 
 .. spec:: TEST_7
    :id: TEST_7

--- a/packages/sphinx-needs/tests/test_dynamic_functions.py
+++ b/packages/sphinx-needs/tests/test_dynamic_functions.py
@@ -139,18 +139,23 @@ def test_doc_dynamic_functions(test_app, snapshot):
 
     warning_records = build_warnings(app)
     assert warning_records == [
-        '<srcdir>/index.rst:11: WARNING: The `need_func` role is deprecated. Replace with :ndf:`copy("id")` instead. [needs.deprecated]',
-        "<srcdir>/index.rst:23: WARNING: Need could not be created: 'tags' value is invalid: only one string, dynamic function or variant function allowed per array item. [needs.create_need]",
-        '<srcdir>/index.rst:40: WARNING: The `need_func` role is deprecated. Replace with :ndf:`copy("id")` instead. [needs.deprecated]',
-        '<srcdir>/index.rst:44: WARNING: The `need_func` role is deprecated. Replace with :ndf:`copy("id")` instead. [needs.deprecated]',
-        "<srcdir>/index.rst:46: WARNING: Need could not be created: Field 'test_func' is invalid: Error parsing dynamic function 'test': Unsupported arg 0 value type [needs.create_need]",
-        "<srcdir>/index.rst:52: WARNING: Need could not be created: Field 'test_func' is invalid: Error parsing dynamic function 'test': Unsupported arg 0 value type [needs.create_need]",
-        '<srcdir>/index.rst:9: WARNING: The [[copy("id")]] syntax in need content is deprecated. Replace with :ndf:`copy("id")` instead. [needs.deprecated]',
-        "<srcdir>/index.rst:33: WARNING: The [[copy('id')]] syntax in need content is deprecated. Replace with :ndf:`copy('id')` instead. [needs.deprecated]",
-        "<srcdir>/index.rst:38: WARNING: The [[copy('id')]] syntax in need content is deprecated. Replace with :ndf:`copy('id')` instead. [needs.deprecated]",
-        "<srcdir>/index.rst:44: WARNING: Error while executing function 'copy': Need not found [needs.dynamic_function]",
-        "<srcdir>/index.rst:44: WARNING: Error while executing function 'copy': Need not found [needs.dynamic_function]",
+        "<srcdir>/index.rst:21: WARNING: Need could not be created: 'tags' value is invalid: only one string, dynamic function or variant function allowed per array item. [needs.create_need]",
+        "<srcdir>/index.rst:42: WARNING: Need could not be created: Field 'test_func' is invalid: Error parsing dynamic function 'test': Unsupported arg 0 value type [needs.create_need]",
+        "<srcdir>/index.rst:48: WARNING: Need could not be created: Field 'test_func' is invalid: Error parsing dynamic function 'test': Unsupported arg 0 value type [needs.create_need]",
+        "<srcdir>/index.rst:40: WARNING: Error while executing function 'copy': Need not found [needs.dynamic_function]",
     ]
+
+    html = Path(app.outdir, "index.html").read_text()
+    # since 9.0.0 ``[[...]]`` in a need's CONTENT is plain text, and only the ``ndf`` role runs
+    # a dynamic function there.  Sphinx's smartquotes transform has already curled the quotes by
+    # the time the text is rendered -- which is what the removed scan used to undo before it ran
+    # the call, and one of the reasons the syntax was surprising.
+    assert "This is id [[copy(\u201cid\u201d)]]" in html
+    assert "This is the best id SP_TOO_001" in html
+    assert "nested id [[copy(\u2018id\u2019)]]" in html
+    assert "nested id best TEST_6" in html
+    # a link's URI is left alone too
+    assert "href=\"http://www.[[copy('id')]]\"" in html
 
     json_data = Path(app.outdir, "needs.json").read_text()
     needs = json.loads(json_data)
@@ -240,14 +245,10 @@ def test_doc_df_user_functions(test_app):
     warning_records = build_warnings(app)
     # print(warnings)
     expected = [
-        "<srcdir>/index.rst:10: WARNING: Error while resolving dynamic values for field 'status', of need 'TEST_2': dynamic function value <class 'object'> is not of type 'string' [needs.dynamic_function]",
-        "<srcdir>/index.rst:8: WARNING: The [[my_own_function()]] syntax in need content is deprecated. Replace with :ndf:`my_own_function()` instead. [needs.deprecated]",
-        "<srcdir>/index.rst:14: WARNING: The [[bad_function()]] syntax in need content is deprecated. Replace with :ndf:`bad_function()` instead. [needs.deprecated]",
-        "<srcdir>/index.rst:14: WARNING: Return value of function 'bad_function' is of type <class 'object'>. Allowed are str, int, float, list [needs.dynamic_function]",
-        "<srcdir>/index.rst:16: WARNING: The [[invalid]] syntax in need content is deprecated. Replace with :ndf:`invalid` instead. [needs.deprecated]",
-        "<srcdir>/index.rst:16: WARNING: Error parsing dynamic function: Not a function call [needs.dynamic_function]",
-        "<srcdir>/index.rst:18: WARNING: The [[unknown()]] syntax in need content is deprecated. Replace with :ndf:`unknown()` instead. [needs.deprecated]",
-        "<srcdir>/index.rst:18: WARNING: Unknown function 'unknown' [needs.dynamic_function]",
+        "<srcdir>/index.rst:12: WARNING: Error while resolving dynamic values for field 'status', of need 'TEST_2': dynamic function value <class 'object'> is not of type 'string' [needs.dynamic_function]",
+        "<srcdir>/index.rst:16: WARNING: Return value of function 'bad_function' is of type <class 'object'>. Allowed are str, int, float, list [needs.dynamic_function]",
+        "<srcdir>/index.rst:18: WARNING: Error parsing dynamic function: Not a function call [needs.dynamic_function]",
+        "<srcdir>/index.rst:20: WARNING: Unknown function 'unknown' [needs.dynamic_function]",
     ]
     if version_info >= (7, 3):
         warn = "WARNING: cannot cache unpickable configuration value: 'needs_functions' (because it contains a function, class, or module object)"
@@ -260,3 +261,48 @@ def test_doc_df_user_functions(test_app):
 
     html = Path(app.outdir, "index.html").read_text()
     assert "Awesome" in html
+    # the same call written as ``[[...]]`` in the content is plain text since 9.0.0
+    assert "[[my_own_function()]] is not a dynamic function here" in html
+
+
+# -- the ``need_func`` role, removed in 9.0.0 --------------------------------
+#
+# It was deprecated in 4.0.0 together with ``[[...]]`` in a need's content, and
+# ``ndf`` replaces both.  Nothing registers it any more, so a document that still
+# writes it gets docutils' own diagnostic for a role that does not exist.
+
+NEED_FUNC_CONF = """\
+extensions = ["sphinx_needs"]
+"""
+
+NEED_FUNC_INDEX = """\
+Removed role
+============
+
+.. req:: One
+   :id: R_ONE
+
+   This is id :need_func:`[[copy("id")]]`
+"""
+
+
+@pytest.mark.parametrize(
+    "test_app",
+    [
+        {
+            "buildername": "html",
+            "files": [
+                (Path("conf.py"), NEED_FUNC_CONF),
+                (Path("index.rst"), NEED_FUNC_INDEX),
+            ],
+        }
+    ],
+    indirect=True,
+)
+def test_need_func_role_removed(test_app):
+    app = test_app
+    app.build()
+
+    warning_records = build_warnings(app)
+    assert len(warning_records) == 1, warning_records
+    assert 'Unknown interpreted text role "need_func"' in warning_records[0]

--- a/packages/sphinx-needs/tests/test_dynamic_functions.py
+++ b/packages/sphinx-needs/tests/test_dynamic_functions.py
@@ -139,10 +139,10 @@ def test_doc_dynamic_functions(test_app, snapshot):
 
     warning_records = build_warnings(app)
     assert warning_records == [
-        "<srcdir>/index.rst:21: WARNING: Need could not be created: 'tags' value is invalid: only one string, dynamic function or variant function allowed per array item. [needs.create_need]",
-        "<srcdir>/index.rst:42: WARNING: Need could not be created: Field 'test_func' is invalid: Error parsing dynamic function 'test': Unsupported arg 0 value type [needs.create_need]",
-        "<srcdir>/index.rst:48: WARNING: Need could not be created: Field 'test_func' is invalid: Error parsing dynamic function 'test': Unsupported arg 0 value type [needs.create_need]",
-        "<srcdir>/index.rst:40: WARNING: Error while executing function 'copy': Need not found [needs.dynamic_function]",
+        "<srcdir>/index.rst:26: WARNING: Need could not be created: 'tags' value is invalid: only one string, dynamic function or variant function allowed per array item. [needs.create_need]",
+        "<srcdir>/index.rst:47: WARNING: Need could not be created: Field 'test_func' is invalid: Error parsing dynamic function 'test': Unsupported arg 0 value type [needs.create_need]",
+        "<srcdir>/index.rst:53: WARNING: Need could not be created: Field 'test_func' is invalid: Error parsing dynamic function 'test': Unsupported arg 0 value type [needs.create_need]",
+        "<srcdir>/index.rst:45: WARNING: Error while executing function 'copy': Need not found [needs.dynamic_function]",
     ]
 
     html = Path(app.outdir, "index.html").read_text()
@@ -156,6 +156,16 @@ def test_doc_dynamic_functions(test_app, snapshot):
     assert "nested id best TEST_6" in html
     # a link's URI is left alone too
     assert "href=\"http://www.[[copy('id')]]\"" in html
+    # an ``ndf`` reached through a substitution used as an INTERNAL hyperlink reference
+    # (``|intsub|_``): the reference node carries a refid and NO refuri, and the walk this
+    # PR replaced returned early on exactly that, never visiting the reference's children.
+    # It rendered ``??``; here it resolves.  The other half of this assertion is the
+    # expected-warnings list above, which is exact and holds a single "Need not found" --
+    # the one from the need-less ``:ndf:`` at index.rst:45, not a second, spurious one.
+    assert (
+        'via an internal link: <a class="reference internal" '
+        'href="#dynamic-functions">SP_TOO_001</a>' in html
+    )
 
     json_data = Path(app.outdir, "needs.json").read_text()
     needs = json.loads(json_data)

--- a/packages/sphinx-needs/tests/test_dynamic_functions.py
+++ b/packages/sphinx-needs/tests/test_dynamic_functions.py
@@ -145,7 +145,7 @@ def test_doc_dynamic_functions(test_app, snapshot):
         "<srcdir>/index.rst:45: WARNING: Error while executing function 'copy': Need not found [needs.dynamic_function]",
     ]
 
-    html = Path(app.outdir, "index.html").read_text()
+    html = Path(app.outdir, "index.html").read_text(encoding="utf-8")
     # since 9.0.0 ``[[...]]`` in a need's CONTENT is plain text, and only the ``ndf`` role runs
     # a dynamic function there.  Sphinx's smartquotes transform has already curled the quotes by
     # the time the text is rendered -- which is what the removed scan used to undo before it ran
@@ -167,7 +167,7 @@ def test_doc_dynamic_functions(test_app, snapshot):
         'href="#dynamic-functions">SP_TOO_001</a>' in html
     )
 
-    json_data = Path(app.outdir, "needs.json").read_text()
+    json_data = Path(app.outdir, "needs.json").read_text(encoding="utf-8")
     needs = json.loads(json_data)
     assert needs == snapshot(exclude=props("created", "project", "creator"))
 
@@ -186,7 +186,7 @@ def test_doc_df_calc_sum(test_app):
     app = test_app
     app.build()
     assert_no_warnings(app)
-    html = Path(app.outdir, "index.html").read_text()
+    html = Path(app.outdir, "index.html").read_text(encoding="utf-8")
     assert "43210" in html  # all hours
     assert "3210" in html  # hours of linked needs
     assert "210" in html  # hours of filtered needs
@@ -206,7 +206,7 @@ def test_doc_df_linked_values(test_app):
     app = test_app
     app.build()
     assert_no_warnings(app)
-    html = Path(app.outdir, "index.html").read_text()
+    html = Path(app.outdir, "index.html").read_text(encoding="utf-8")
     assert "all_good" in html
     assert "all_bad" not in html
     assert "all_awesome" in html
@@ -233,7 +233,7 @@ def test_doc_df_links_from_content(test_app, snapshot):
         "WARNING: links_from_content: no stored node for need 'unknown3' [needs.dynamic_function]",
     ]
 
-    json_data = Path(app.outdir, "needs.json").read_text()
+    json_data = Path(app.outdir, "needs.json").read_text(encoding="utf-8")
     needs = json.loads(json_data)
     assert needs == snapshot(exclude=props("created", "project", "creator"))
 
@@ -269,7 +269,7 @@ def test_doc_df_user_functions(test_app):
         expected.insert(0, warn)
     assert warning_records == expected
 
-    html = Path(app.outdir, "index.html").read_text()
+    html = Path(app.outdir, "index.html").read_text(encoding="utf-8")
     assert "Awesome" in html
     # the same call written as ``[[...]]`` in the content is plain text since 9.0.0
     assert "[[my_own_function()]] is not a dynamic function here" in html

--- a/packages/sphinx-needs/tests/test_needextract.py
+++ b/packages/sphinx-needs/tests/test_needextract.py
@@ -61,7 +61,7 @@ def test_needextract_basic(test_app):
     ]
     run_checks(checks, "subfolder/check_images_2.html")
 
-    index_html = Path(app.outdir, "check_need_refs.html").read_text()
+    index_html = Path(app.outdir, "check_need_refs.html").read_text(encoding="utf-8")
     assert "Awesome Sphinx-Needs" in index_html
 
 
@@ -80,7 +80,7 @@ def test_needextract_with_nested_needs(test_app):
     app.build()
     assert_no_warnings(app)
 
-    needextract_html = Path(app.outdir, "needextract.html").read_text()
+    needextract_html = Path(app.outdir, "needextract.html").read_text(encoding="utf-8")
 
     # ensure that the needs exist and that their hrefs point to the correct location
     assert (

--- a/packages/sphinx-needs/tests/test_needextract.py
+++ b/packages/sphinx-needs/tests/test_needextract.py
@@ -78,15 +78,7 @@ def test_needextract_basic(test_app):
 def test_needextract_with_nested_needs(test_app):
     app = test_app
     app.build()
-    warning_records = warning_lines(app)
-    # print(warnings)
-    # note these warnings are emitted twice because they are resolved twice: once when first specified and once when copied with needextract
-    assert warning_records == [
-        '<srcdir>/index.rst:13: WARNING: The [[copy("id")]] syntax in need content is deprecated. Replace with :ndf:`copy("id")` instead. [needs.deprecated]',
-        '<srcdir>/index.rst:33: WARNING: The [[copy("id")]] syntax in need content is deprecated. Replace with :ndf:`copy("id")` instead. [needs.deprecated]',
-        '<srcdir>/index.rst:13: WARNING: The [[copy("id")]] syntax in need content is deprecated. Replace with :ndf:`copy("id")` instead. [needs.deprecated]',
-        '<srcdir>/index.rst:33: WARNING: The [[copy("id")]] syntax in need content is deprecated. Replace with :ndf:`copy("id")` instead. [needs.deprecated]',
-    ]
+    assert_no_warnings(app)
 
     needextract_html = Path(app.outdir, "needextract.html").read_text()
 
@@ -110,9 +102,14 @@ def test_needextract_with_nested_needs(test_app):
         in needextract_html
     )
 
-    # dynamic functions should be executed
-    assert "This is id SPEC_1 SPEC_1" in needextract_html
-    assert "This is grandchild id SPEC_1_1_2 SPEC_1_1_2" in needextract_html
+    # the extracted copy runs the ``ndf`` role against the need it was copied from, and
+    # leaves ``[[...]]`` in the content alone, exactly as the original does.  (The copy is
+    # taken before docutils' smartquotes transform, so its quotes are still straight ones,
+    # where the original page renders them curled.)
+    assert "This is id [[copy(&quot;id&quot;)]] SPEC_1" in needextract_html
+    assert (
+        "This is grandchild id [[copy(&quot;id&quot;)]] SPEC_1_1_2" in needextract_html
+    )
 
 
 # -- inputs that used to end the build ---------------------------------------

--- a/packages/sphinx-needs/tests/test_needtable.py
+++ b/packages/sphinx-needs/tests/test_needtable.py
@@ -26,7 +26,7 @@ def test_doc_build_html(test_app):
     assert warnings.count("The 'style_col' option has never had any effect") == 1
     assert "test_styles.rst" in warnings
 
-    html = Path(app.outdir, "index.html").read_text()
+    html = Path(app.outdir, "index.html").read_text(encoding="utf-8")
     assert "SP_TOO_001" in html
     assert 'id="needtable-index-0"' in html
 
@@ -58,7 +58,9 @@ def test_doc_build_html(test_app):
     assert "another_test_class" in html
 
     # Test colwidths
-    colwidths_html_path = Path(app.outdir, "test_colwidths.html").read_text()
+    colwidths_html_path = Path(app.outdir, "test_colwidths.html").read_text(
+        encoding="utf-8"
+    )
 
     if int(doc_ver.split(".")[1]) >= 18:
         assert '<col style="width: 50.0%" />' in colwidths_html_path
@@ -78,7 +80,7 @@ def test_doc_build_html(test_app):
 def test_doc_needtable_options(test_app):
     app = test_app
     app.build()
-    html = Path(app.outdir, "test_options.html").read_text()
+    html = Path(app.outdir, "test_options.html").read_text(encoding="utf-8")
     assert "SP_TOO_003" in html
     assert 'id="needtable-test_options-0"' in html
     assert 'id="needtable-test_options-1"' in html
@@ -126,7 +128,7 @@ def test_string_links_no_trailing_separator(test_app):
     """Test that single-value string_links fields don't get a trailing separator."""
     app = test_app
     app.build()
-    html = Path(app.outdir, "test_options.html").read_text()
+    html = Path(app.outdir, "test_options.html").read_text(encoding="utf-8")
 
     # Find the SINGLE_STRING_LINK need's github cell content
     assert "SINGLE_STRING_LINK" in html
@@ -168,7 +170,7 @@ def test_string_links_no_trailing_separator(test_app):
 def test_doc_needtable_styles(test_app):
     app = test_app
     app.build()
-    html = Path(app.outdir, "test_styles.html").read_text()
+    html = Path(app.outdir, "test_styles.html").read_text(encoding="utf-8")
     assert "style_1" in html
     assert "NEEDS_TABLE" in html
     assert "NEEDS_DATATABLES" in html
@@ -182,7 +184,7 @@ def test_doc_needtable_styles(test_app):
 def test_doc_needtable_parts(test_app):
     app = test_app
     app.build()
-    html = Path(app.outdir, "test_parts.html").read_text()
+    html = Path(app.outdir, "test_parts.html").read_text(encoding="utf-8")
     assert "table_001.1" in html
     assert "table_001.2" in html
     assert "table_001.3" in html
@@ -197,7 +199,7 @@ def test_doc_needtable_parts(test_app):
 def test_doc_needtable_titles(test_app):
     app = test_app
     app.build()
-    html = Path(app.outdir, "test_titles.html").read_text()
+    html = Path(app.outdir, "test_titles.html").read_text(encoding="utf-8")
     assert '<th class="head"><p>Headline</p></th>' in html
     assert '<th class="head"><p>To this need123</p></th>' in html
     assert '<th class="head"><p>Special Characters!</p></th>' in html
@@ -248,6 +250,6 @@ def test_needtable_style_row_dynamic_function(test_app):
 
     assert_no_warnings(app)
 
-    html = Path(app.outdir, "index.html").read_text()
+    html = Path(app.outdir, "index.html").read_text(encoding="utf-8")
     assert '<tr class="need needs_open' in html
     assert "[[copy(" not in html

--- a/packages/sphinx-needs/tests/test_needtable.py
+++ b/packages/sphinx-needs/tests/test_needtable.py
@@ -3,6 +3,8 @@ from pathlib import Path
 import pytest
 from docutils import __version__ as doc_ver
 
+from sphinx_needs_testkit import assert_no_warnings
+
 
 @pytest.mark.parametrize(
     "test_app",
@@ -200,3 +202,52 @@ def test_doc_needtable_titles(test_app):
     assert '<th class="head"><p>To this need123</p></th>' in html
     assert '<th class="head"><p>Special Characters!</p></th>' in html
     assert '<td class="needs_special-chars!"><p>special-chars value</p></td>' in html
+
+
+# -- the option-level ``[[...]]`` path ---------------------------------------
+#
+# ``needtable``'s ``style_row`` is the one live consumer of
+# ``check_and_get_content``: ``:style:`` is itself a dynamic-function FIELD, so the
+# field path has already resolved it before ``need.py`` re-runs the option parser over
+# ``classes``.  Nothing else in this suite writes ``[[...]]`` in an option, so a break in
+# that path shows up only as a silently wrong row class -- no warning, no failing build.
+
+STYLE_ROW_CONF = """\
+extensions = ["sphinx_needs"]
+"""
+
+STYLE_ROW_INDEX = """\
+Style row
+=========
+
+.. req:: One
+   :id: R_ONE
+   :status: open
+
+.. needtable::
+   :style_row: needs_[[copy("status")]]
+"""
+
+
+@pytest.mark.parametrize(
+    "test_app",
+    [
+        {
+            "buildername": "html",
+            "files": [
+                (Path("conf.py"), STYLE_ROW_CONF),
+                (Path("index.rst"), STYLE_ROW_INDEX),
+            ],
+        }
+    ],
+    indirect=True,
+)
+def test_needtable_style_row_dynamic_function(test_app):
+    app = test_app
+    app.build()
+
+    assert_no_warnings(app)
+
+    html = Path(app.outdir, "index.html").read_text()
+    assert '<tr class="need needs_open' in html
+    assert "[[copy(" not in html


### PR DESCRIPTION
Since 4.0.0 (#1269, #1266) every `[[...]]` inside a need's **content** has been executed
*and* warned about under `[needs.deprecated]`, with the `:ndf:` role as its replacement;
the `need_func` role was deprecated in the same round. Four majors have carried the
warning, and 9.0.0 is the release that drops it.

After this PR:

- `[[...]]` in a need's **content** is plain text, as it is in any other Sphinx document.
- `:ndf:` is the one way to run a dynamic function inline.
- a document that still writes `:need_func:` gets docutils' own
  `Unknown interpreted text role "need_func"`. No stub role warns: the point of the major
  is that the old syntax is gone.
- the private `_detect_and_execute_field` goes too — a pure deletion in its own commit; it
  has been uncalled since #1516 replaced its two call sites with the parsed
  `DynamicFunctionParsed` path, and it was never re-exported.
- `[[...]]` in **fields** is untouched — `:tags:`, `:status:`, `:links:`, `:style:`,
  `needtable`'s `:style_row:`, extra fields, `needs_global_options` defaults. That is still
  the documented way to write a dynamic function in an option, and `FUNC_RE` and
  `check_and_get_content` are exactly as they were.

`find_and_replace_node_content` now does one thing: replace every `NeedFunc` node with the
text its function returns, skipping nested needs as before — and a `reference`'s children
are now walked like everything else's, which resolves an `:ndf:` reached through a
substitution used as an internal hyperlink (`|sub|_` with ``.. _sub: `Section`_``), where
the old code returned early on the missing `refuri` and left `??` plus a spurious
`Error while executing function 'copy': Need not found`. Gone with the scan are the quote
normalisation it needed (sphinx's smartquotes transform had already curled `"` to `“` by
the time it ran) and the rewrite of a link's `refuri`, so
`` `link <http://www.[[copy('id')]]>`_ `` is now an ordinary URL.

Beyond the deprecation itself, the scan intercepted `[[...]]` in a need's body before roles
were resolved, so the `:need:` role's own `[[field]]` template syntax could not be written
inside a need at all. That is what blocks #1201, which can be updated and merged once this
lands.

## Tests

`doc_dynamic_functions` and `needextract_with_nested_needs` keep their `[[copy("id")]]`
content lines, and the tests now assert positively that they render as written rather than
only that the warning is absent; the `:ndf:` lines beside them still resolve. In
`doc_df_user_functions` the four content calls become `:ndf:` roles, which keeps every
error path that project exists to cover (bad return type, "Not a function call", unknown
function), with one plain `[[...]]` line added for the literal assertion.
`test_need_func_role_removed` is new, and so are fences for two paths that had none: the
`|sub|_`-into-an-internal-link shape above, and `needtable`'s
`:style_row: needs_[[copy("status")]]` — the one live consumer of `check_and_get_content`,
which until now could be reduced to a pass-through with the whole suite and the docs build
still green.

## For the 9.0.0 changelog

**BREAKING**: `[[...]]` inside a need's content is no longer interpreted as a dynamic
function, and the `need_func` role is removed; both were deprecated in 4.0.0. Use the
`:ndf:` role. Dynamic functions in fields (`[[...]]` in options and links) are unchanged.

Closes #1906
