### PR TITLE
🔧 A theme-screenshot instrument for the needtable examples

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,8 @@ uv run poe typecheck                  # ty over both packages, against the oldes
 uv run poe docs-needs                 # the furo docs build
 uv run poe docs-mounts                # the sphinx-mounts docs build
 uv run poe docs-codelinks             # the sphinx-codelinks docs build
+uv run poe docs-needs-themes          # the docs in all five themes, one after another
+uv run poe docs-needs-shots           # screenshot the needtable examples in every theme built
 uv run poe smoke-needs                # build the wheel and test the built package
 uv run poe verify-plantuml            # the committed PlantUML jar is the one its pin names
 uv run poe fetch-plantuml             # download it -- a bump step; otherwise a hash check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -356,6 +356,10 @@ allowed-unresolved-imports = [
   "clang.**",
   "matplotlib",
   "matplotlib.**",
+  # `theme_shots.py` imports playwright lazily, inside the one function that drives a
+  # browser, so that its tests and `--help` run without it. The driver lives in the root
+  # `js` group, which the typing floor deliberately does not install
+  "playwright.**",
   "requests_file",
   "sphinx_data_viewer.**",
   "sphinxcontrib.plantuml",
@@ -819,3 +823,35 @@ executor = { type = "uv", frozen = true, no-group = "dev", extra = [
   "theme-rtd",
 ] }
 env = { UV_PROJECT_ENVIRONMENT = ".venvs/docs-rtd", DOCS_THEME = "sphinx_rtd_theme" }
+
+# --- Theme screenshots ---
+# `docs-needs-shots` reads the five theme builds above; `docs-needs-themes` produces them. They
+# are two tasks rather than one on purpose: the builds are ~2 minutes each, and putting ten
+# minutes of `deps` in front of every re-shoot would make the instrument too expensive to use
+# the way it is meant to be used -- shoot, look, change one CSS rule, shoot again.
+
+[tool.poe.tasks.docs-needs-themes]
+help = "Build the HTML docs in all five themes, one after another (~10 min), for docs-needs-shots"
+# `deps` and nothing else: poe runs a task's dependencies in order and one at a time, which is
+# the requirement here rather than a convenience -- AGENTS.md's "do not run two docs builds
+# concurrently" is about plantuml, which is load-sensitive across processes. The `expr` is the
+# task's body only because a task needs one; it prints where the builds went
+deps = [
+  "docs-needs",
+  "docs-needs-alabaster",
+  "docs-needs-im",
+  "docs-needs-pds",
+  "docs-needs-rtd",
+]
+expr = "'built into packages/sphinx-needs/docs/_build/html/; `poe docs-needs-shots` next'"
+
+[tool.poe.tasks.docs-needs-shots]
+help = "Screenshot the needtable examples in every EXISTING theme build (docs-needs, docs-needs-alabaster, docs-needs-im, docs-needs-pds, docs-needs-rtd -- or docs-needs-themes for all five), light and dark, into docs/_build/shots"
+# NO `deps` on the five builds: see the comment above. A theme that was not built is reported
+# and skipped, so this is useful with one build present as well as five.
+#
+# No `executor` override either, exactly like `test-needs-js`: playwright comes from the root
+# `js` group, `dev` includes `js`, and `dev` is what a bare `uv sync` installs -- so the
+# default `.venv` already has the driver. The BROWSER is not a package: `poe install-browser`
+# once per machine, and the script's error message says so if it is missing.
+cmd = "python tools/src/sn_tools/theme_shots.py"

--- a/tools/src/sn_tools/theme_shots.py
+++ b/tools/src/sn_tools/theme_shots.py
@@ -180,10 +180,12 @@ class Target:
 
     label: str
     page: str
-    #: A CSS selector for the section to search inside, or None for the whole document. This
-    #: is how "the widget in the #style-row example section" is said without naming an element
-    #: that a theme or a rewrite might rename.
-    scope: str | None = None
+    #: A CSS selector for the thing that starts the section to search in, or None for the
+    #: whole document. NOT necessarily a container: sphinx emits `<section id="style-row">`,
+    #: but sphinx-immaterial unwraps sections and moves the id onto the `<h3>`, so
+    #: `#style-row table.NEEDS_DATATABLES` matches nothing in that one build. See
+    #: `scope_strategies`, which is why this is an anchor rather than a scope.
+    anchor: str | None = None
     #: The element to find (inside `scope`). The FIRST match wins -- "the first widget on the
     #: page" is a target, not an accident.
     element: str = WIDGET_TABLE
@@ -205,9 +207,10 @@ DEFAULT_TARGETS: tuple[Target, ...] = (
     Target(
         label="style-row",
         page=NEEDTABLE_PAGE,
-        # the section's own id, which sphinx derives from the `style_row` heading; the
-        # `needtable_style_row` label above it becomes a bare anchor, not the section id
-        scope="section#style-row",
+        # the id sphinx derives from the `style_row` heading -- which lands on the section in
+        # four of the five themes and on the heading itself in sphinx-immaterial, so it is
+        # written bare and `scope_strategies` copes with both
+        anchor="#style-row",
         wrappers=WIDGET_WRAPPERS,
         help="the widget in the style_row example, whose rows carry theme-fighting colours",
     ),
@@ -264,9 +267,21 @@ def closest_wrapper(
     return resolve_selector(wrappers, has_ancestor)
 
 
-def scoped(scope: str | None, element: str) -> str:
-    """The CSS the page is actually queried with."""
-    return element if scope is None else f"{scope} {element}"
+def scope_strategies(anchor: str | None, element: str) -> list[tuple[str, str]]:
+    """The ways to find `element` "in the `anchor` section", in order: `(strategy, argument)`.
+
+    Two, because the five theme builds do not agree on what an anchor IS. sphinx writes
+    `<section id="style-row">` and the element is a descendant, so a descendant selector finds
+    it -- in furo, alabaster, pydata-sphinx-theme and sphinx_rtd_theme. sphinx-immaterial
+    unwraps sections and moves the id onto the `<h3>`, where nothing is a descendant of the
+    anchor at all and `#style-row table.NEEDS_DATATABLES` silently matches nothing. (Measured:
+    that is exactly the shot this instrument dropped on its first full run.) So the fallback is
+    document order -- the first match that FOLLOWS the anchor -- which is what "the widget in
+    that example section" means in both DOMs. The strategy that fired is recorded.
+    """
+    if anchor is None:
+        return [("selector", element)]
+    return [("selector", f"{anchor} {element}"), ("after", anchor)]
 
 
 def select_targets(
@@ -355,34 +370,81 @@ def is_dark(colour: str | None) -> bool | None:
 def dark_verdict(light: Json, dark: Json) -> tuple[bool, str, list[str]]:
     """Does this theme have a dark mode? `(supported, reason, labels that came out identical)`.
 
-    TWO signals, and both have to say "nothing changed" before a theme is called dark-less,
-    because either alone can lie. Byte equality alone would call a theme dark-less if a build
-    happened to render identically for some other reason; a background sample alone would miss
-    a theme that darkens its content area and not its page. Together they are the observable
-    difference between "the emulation did nothing" and "the theme responded".
+    TWO signals -- the theme's own page background, and byte equality of the WIDGET shots --
+    and both have to say "nothing moved" before a theme is called dark-less. Either alone can
+    lie: byte equality would call a theme dark-less if a build happened to render identically
+    for some other reason, and a background sample alone would miss a theme that darkened its
+    content area and not its page.
+
+    The whole-page shot is deliberately NOT one of the signals, and that is a measured
+    correction rather than a simplification. On master, alabaster's and sphinx_rtd_theme's
+    `full` shots DO differ between the two colour schemes while every widget shot is
+    byte-identical and the page background never moves: something on the page that is not the
+    theme -- the syntax-example extension's stylesheet -- answers `prefers-color-scheme` on its
+    own. Counting that as a dark mode put two duplicate rows in the gallery, which is the exact
+    thing this function exists to prevent. It is still reported in the reason, because a
+    reviewer looking at a light theme with dark code blocks in it wants to know.
     """
-    light_shots = {shot["label"]: shot for shot in light.get("shots", [])}
-    dark_shots = {shot["label"]: shot for shot in dark.get("shots", [])}
+
+    def widgets(entry: Json) -> dict[str, Json]:
+        return {
+            shot["label"]: shot
+            for shot in entry.get("shots", [])
+            if not shot.get("viewport")
+        }
+
+    light_shots, dark_shots = widgets(light), widgets(dark)
     shared = [label for label in light_shots if label in dark_shots]
     identical = [
-        label for label in shared if light_shots[label].get("sha") == dark_shots[label].get("sha")
+        label
+        for label in shared
+        if light_shots[label].get("sha") == dark_shots[label].get("sha")
     ]
     background_light = light.get("background")
     background_dark = dark.get("background")
-    if not shared:
-        return False, "no shots were captured in dark mode", identical
-    if len(identical) == len(shared) and background_light == background_dark:
+    moved = background_light != background_dark
+    changed = len(shared) - len(identical)
+    if moved:
         return (
-            False,
-            "every dark shot is byte-identical to its light counterpart and the page "
-            f"background is unchanged ({background_light})",
+            True,
+            f"the page background moved from {background_light} to {background_dark}",
             identical,
         )
-    if background_light != background_dark:
-        reason = f"the page background moved from {background_light} to {background_dark}"
-    else:
-        reason = f"{len(shared) - len(identical)} of {len(shared)} shots changed"
-    return True, reason, identical
+    if changed:
+        return True, f"{changed} of {len(shared)} widget shots changed", identical
+    if not shared:
+        return False, "no widget shots were captured in dark mode", identical
+    viewport_moved = _viewport_moved(light, dark)
+    aside = (
+        " (the whole-page shot does differ, so something on the page other than the theme "
+        "answers prefers-color-scheme)"
+        if viewport_moved
+        else ""
+    )
+    return (
+        False,
+        f"the page background is unchanged ({background_light}) and every widget shot is "
+        f"byte-identical to its light counterpart{aside}",
+        identical,
+    )
+
+
+def _viewport_moved(light: Json, dark: Json) -> bool:
+    """Whether the whole-page shots differ -- reported, never counted. See `dark_verdict`."""
+
+    def viewports(entry: Json) -> dict[str, Json]:
+        return {
+            shot["label"]: shot
+            for shot in entry.get("shots", [])
+            if shot.get("viewport")
+        }
+
+    left, right = viewports(light), viewports(dark)
+    return any(
+        left[label].get("sha") != right[label].get("sha")
+        for label in left
+        if label in right
+    )
 
 
 def sha256_of(path: Path) -> str:
@@ -476,6 +538,17 @@ BROWSER_MISSING = (
 
 #: `el.closest(selector) !== null`, for `closest_wrapper`.
 JS_HAS_ANCESTOR = "(el, selector) => el.closest(selector) !== null"
+
+#: The `after` scope strategy: the first `element` that FOLLOWS `anchor` in document order.
+#: What "the widget in that example section" means when the anchor is a heading rather than a
+#: container -- see `scope_strategies`.
+JS_AFTER_ANCHOR = """(args) => {
+  const anchor = document.querySelector(args.anchor);
+  if (!anchor) return null;
+  return Array.from(document.querySelectorAll(args.element)).find(
+    (el) => anchor.compareDocumentPosition(el) & Node.DOCUMENT_POSITION_FOLLOWING
+  ) || null;
+}"""
 
 #: The first non-transparent background walking up from `<body>`. A theme that paints the page
 #: on `<html>` and leaves `<body>` transparent is the common case for exactly the themes whose
@@ -619,9 +692,9 @@ def _capture_mode(
     page.on("pageerror", lambda error: log.add("pageerror", str(error)))
     page.on(
         "console",
-        lambda message: log.add("console.error", message.text)
-        if message.type == "error"
-        else None,
+        lambda message: (
+            log.add("console.error", message.text) if message.type == "error" else None
+        ),
     )
     directory = out / theme / mode
     directory.mkdir(parents=True, exist_ok=True)
@@ -686,18 +759,32 @@ def _capture_target(
 ) -> Json:
     """One screenshot, plus everything a reviewer needs in order to trust it."""
     path = directory / f"{target.label}.png"
-    selector = scoped(target.scope, target.element)
+    strategies = scope_strategies(target.anchor, target.element)
     record: Json = {
         "label": target.label,
         "theme": theme,
         "mode": mode,
         "page": target.page,
         "file": f"{theme}/{mode}/{target.label}.png",
-        "selector": selector,
+        "viewport": target.viewport,
     }
-    handle = page.query_selector(selector)
+    handle = None
+    for strategy, argument in strategies:
+        if strategy == "selector":
+            handle = page.query_selector(argument)
+        else:
+            handle = page.evaluate_handle(
+                JS_AFTER_ANCHOR, {"anchor": argument, "element": target.element}
+            ).as_element()
+        if handle is not None:
+            record["strategy"] = strategy
+            record["selector"] = argument
+            break
     if handle is None:
-        record["error"] = f"no element matched {selector!r}"
+        record["selector"] = strategies[0][1]
+        record["error"] = "nothing matched " + " or ".join(
+            f"{strategy}:{argument!r}" for strategy, argument in strategies
+        )
         return record
 
     if target.viewport:
@@ -983,7 +1070,9 @@ def write_gallery(manifest: Json, out: Path, before: Json | None = None) -> Path
                 if before is not None:
                     cell.append(_figure("before", before_shots.get(label)))
                 cell.append(
-                    _figure("after" if before is not None else label, after_shots.get(label))
+                    _figure(
+                        "after" if before is not None else label, after_shots.get(label)
+                    )
                 )
                 parts.append("<td>" + "".join(cell) + "</td>")
             parts.append("</tr>")
@@ -1043,7 +1132,10 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
-        "--root", type=Path, default=None, help="the repository root (default: this checkout)"
+        "--root",
+        type=Path,
+        default=None,
+        help="the repository root (default: this checkout)",
     )
     parser.add_argument(
         "--build-root",
@@ -1129,12 +1221,16 @@ def main(argv: Sequence[str] | None = None) -> int:
     for name in missing:
         task = tasks.get(name)
         hint = f" (build it with `uv run poe {task}`)" if task else ""
-        print(f"note: no build at {build_root / name} -- skipping{hint}", file=sys.stderr)
+        print(
+            f"note: no build at {build_root / name} -- skipping{hint}", file=sys.stderr
+        )
     if not themes:
         raise SystemExit(
             f"error: no theme build under {build_root}.\n"
             "Build them first -- `uv run poe docs-needs-themes`, or one at a time:\n"
-            + "\n".join(f"  uv run poe {task:24s} # {name}" for name, task in BUILD_TASKS)
+            + "\n".join(
+                f"  uv run poe {task:24s} # {name}" for name, task in BUILD_TASKS
+            )
         )
 
     out.mkdir(parents=True, exist_ok=True)

--- a/tools/src/sn_tools/theme_shots.py
+++ b/tools/src/sn_tools/theme_shots.py
@@ -1,0 +1,1173 @@
+"""Screenshot the needtable examples out of the theme docs builds, light and dark.
+
+sphinx-needs ships CSS that has to look right in five themes -- furo, alabaster,
+sphinx-immaterial, pydata-sphinx-theme and sphinx_rtd_theme -- each of which the docs can be
+built against (``poe docs-needs``, ``docs-needs-alabaster``, ``docs-needs-im``,
+``docs-needs-pds``, ``docs-needs-rtd``; each writes ``docs/_build/html/<theme>/``). Whether
+that CSS *integrates* with a theme is a judgement nobody can make from a diff, and re-making
+it by hand for five themes x two colour schemes x a handful of widget states is thirty
+screenshots somebody has to take the same way twice. So this takes them.
+
+It screenshots **existing** builds and never runs sphinx: the builds are ~2 minutes each and
+making them a dependency would put ten minutes in front of every re-shoot. ``poe
+docs-needs-themes`` is the task that produces them, so the recipe is two commands::
+
+    uv run poe docs-needs-themes      # ~10 min, the five builds one after another
+    uv run poe docs-needs-shots       # seconds per theme
+
+What comes out is ``<out>/<theme>/<mode>/<label>.png``, a ``manifest.json`` and a
+self-contained ``index.html`` gallery. With ``--compare <other out dir>`` the gallery puts a
+BEFORE next to every AFTER, which is what makes it a review instrument rather than an album:
+shoot the docs on master, shoot them on the branch with ``--compare``, and the regression is
+the pair that stopped matching.
+
+Four decisions in here are load-bearing, and each was made because the obvious alternative
+fails on this repository's actual DOM:
+
+* **The pages are served over HTTP, not opened as ``file://``.** Chromium gives every
+  ``file://`` document an opaque origin, so anything a theme loads as an ES module -- and
+  anything at all that a page ``fetch``es -- fails with a CORS error that has nothing to do
+  with the CSS under review. A ``ThreadingHTTPServer`` on a random port costs nothing and
+  makes the console-error list mean what it says.
+
+* **A widget is located by its TABLE and photographed by its WRAPPER.** The wrapper is created
+  by JavaScript at load time and its class differs between the DataTables DOM
+  (``div.dataTables_wrapper``) and an enhancer that replaces it (``div.needstable``), so
+  neither can be the thing that is searched for. ``table.NEEDS_DATATABLES`` is in the built
+  HTML either way; ``closest()`` from there finds whichever wrapper this build has, and falls
+  back to the table itself so a build whose JavaScript never ran still shoots. Which wrapper
+  fired is recorded -- when a comparison shows a widget change, that is the first thing a
+  reviewer wants to know.
+
+* **Interactions are lists of candidate selectors, not one selector.** "Click the second
+  column's sort control" is a stable *intent* across DOMs; ``thead th:nth-child(2)`` (the whole
+  header cell is the control in DataTables) and ``thead th:nth-child(2) button`` (a real button
+  in a modern one) are not the same selector. The first candidate that resolves wins and is
+  recorded, so a before/after gallery stays comparable even when the DOM underneath moved.
+
+* **A theme with no dark mode is detected, not assumed.** alabaster and sphinx_rtd_theme
+  ignore ``prefers-color-scheme``, so emulating it produces a "dark" shot byte-identical to the
+  light one -- a third of the gallery being the same picture twice. The test is evidential
+  rather than a hard-coded list of theme names: every shot's bytes, plus the sampled page
+  background. Both unchanged means no dark mode, the duplicate files are removed, and the
+  gallery says ``dark: n/a (theme has no dark mode)`` in their place.
+
+Everything else is a review aid, so **a page error is data, never a failure**: the exit code is
+non-zero only when the instrument itself cannot run (no builds to shoot, no playwright, no
+browser). Console errors are collected, printed as a summary line, and listed in both the
+manifest and the gallery.
+
+Usage::
+
+    uv run poe docs-needs-shots
+    uv run poe docs-needs-shots --themes furo,pydata_sphinx_theme --modes dark
+    uv run --group js python tools/src/sn_tools/theme_shots.py \\
+        --build-root /elsewhere/docs/_build/html --out /tmp/after --compare /tmp/before
+
+playwright is imported **lazily**, inside the one function that drives a browser, so
+``--help``, ``--list-targets`` and the whole of ``tools/tests/test_theme_shots.py`` run in an
+environment that has never heard of it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import functools
+import hashlib
+import html
+import json
+import re
+import shutil
+import subprocess
+import sys
+import threading
+from collections.abc import Callable, Iterator, Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+
+#: The manifest and everything in it is JSON-shaped, and every consumer of it here is a
+#: writer of HTML or a test. `Any` rather than a nest of TypedDicts: the shape is documented
+#: by `write_manifest`'s output, and a schema would be a second place to keep it correct.
+Json = dict[str, Any]
+
+#: Where the five theme tasks write, relative to the repository root. Each of them ends in a
+#: directory named for its `DOCS_THEME`, which is why one build root holds all five.
+DEFAULT_BUILD_ROOT = Path("packages/sphinx-needs/docs/_build/html")
+
+#: Beside the builds rather than inside one: `<build-root>/shots` would be served by the same
+#: HTTP server and swept away by `docs-needs-clean`.
+DEFAULT_OUT = Path("packages/sphinx-needs/docs/_build/shots")
+
+#: The tasks that produce the builds this reads, named in the "nothing to shoot" message and
+#: used to order the gallery. In task order.
+BUILD_TASKS = (
+    ("furo", "docs-needs"),
+    ("alabaster", "docs-needs-alabaster"),
+    ("sphinx_immaterial", "docs-needs-im"),
+    ("pydata_sphinx_theme", "docs-needs-pds"),
+    ("sphinx_rtd_theme", "docs-needs-rtd"),
+)
+
+#: A directory under the build root is a theme build if it has this in it. `_static`,
+#: `.doctrees` and this instrument's own output can be siblings of the theme directories, so
+#: "is a directory" is not enough.
+THEME_MARKER = "index.html"
+
+MODES = ("light", "dark")
+
+#: The page every default target is on.
+NEEDTABLE_PAGE = "directives/needtable.html"
+
+#: What is in the BUILT HTML for every needtable widget, in every build, whatever JavaScript
+#: later does to it. The search always starts here.
+WIDGET_TABLE = "table.NEEDS_DATATABLES"
+
+#: `closest()` candidates, in preference order: the DataTables wrapper as master builds it,
+#: then an enhancer's. Neither is in the built HTML -- both are created at load time -- so
+#: this is resolved in the browser, per shot, and the winner is recorded.
+WIDGET_WRAPPERS = ("div.dataTables_wrapper", "div.needstable")
+
+#: "The second column's header control, whatever it is." DataTables makes the whole `<th>` the
+#: control and marks it `.sorting`; a DOM with a real button puts one inside the cell. Most
+#: specific first, so a button is preferred to the cell that contains it.
+SORT_CONTROLS = (
+    "thead th:nth-child(2) button",
+    "thead th:nth-child(2) [role='button']",
+    "thead th:nth-child(2) a",
+    "thead th:nth-child(2)",
+)
+
+#: "The widget's search input, whatever it is." DataTables wraps it in `.dataTables_filter`;
+#: anything else is likely to type it as a search input or give it a class of its own.
+SEARCH_INPUTS = (
+    "div.dataTables_filter input",
+    ".needstable__search input",
+    "input[type='search']",
+    "input[type='text']",
+)
+
+#: Typed into the search input for the `filtered` shot, and it is chosen rather than obvious.
+#: The shot has to be recognisably *filtered*: `spec` matches 23 of the first table's 225 rows
+#: on master, which moves the first visible row (`ACT_ANALYSIS` -> `CON_SPEC_1`), leaves the
+#: body a full page so the row CSS is still what is being looked at, and shortens the
+#: pagination. A string matching everything on page one -- `ACT` does, the table being sorted
+#: by id -- produces a shot indistinguishable from a broken filter, and one matching a handful
+#: produces an empty widget. `--filter-text` overrides it.
+DEFAULT_FILTER_TEXT = "spec"
+
+
+@dataclass(frozen=True)
+class Interaction:
+    """One declarative act on a widget, said so that two different DOMs can satisfy it.
+
+    `selectors` are candidates searched **inside the resolved widget**, most specific first;
+    the first that resolves is used, and recorded. `kind` is `click` or `fill`.
+    """
+
+    kind: str
+    selectors: tuple[str, ...]
+    text: str | None = None
+
+
+@dataclass(frozen=True)
+class Target:
+    """One screenshot: where to look, what to photograph, and what to do to it first."""
+
+    label: str
+    page: str
+    #: A CSS selector for the section to search inside, or None for the whole document. This
+    #: is how "the widget in the #style-row example section" is said without naming an element
+    #: that a theme or a rewrite might rename.
+    scope: str | None = None
+    #: The element to find (inside `scope`). The FIRST match wins -- "the first widget on the
+    #: page" is a target, not an accident.
+    element: str = WIDGET_TABLE
+    #: `closest()` candidates for the wrapper actually photographed, in preference order.
+    wrappers: tuple[str, ...] = ()
+    interaction: Interaction | None = None
+    #: True for the whole-page shot: photograph the viewport rather than an element.
+    viewport: bool = False
+    help: str = ""
+
+
+DEFAULT_TARGETS: tuple[Target, ...] = (
+    Target(
+        label="first",
+        page=NEEDTABLE_PAGE,
+        wrappers=WIDGET_WRAPPERS,
+        help="the first needtable widget on the page, untouched",
+    ),
+    Target(
+        label="style-row",
+        page=NEEDTABLE_PAGE,
+        # the section's own id, which sphinx derives from the `style_row` heading; the
+        # `needtable_style_row` label above it becomes a bare anchor, not the section id
+        scope="section#style-row",
+        wrappers=WIDGET_WRAPPERS,
+        help="the widget in the style_row example, whose rows carry theme-fighting colours",
+    ),
+    Target(
+        label="sorted",
+        page=NEEDTABLE_PAGE,
+        wrappers=WIDGET_WRAPPERS,
+        interaction=Interaction("click", SORT_CONTROLS),
+        help="the first widget after clicking the second column's sort control",
+    ),
+    Target(
+        label="filtered",
+        page=NEEDTABLE_PAGE,
+        wrappers=WIDGET_WRAPPERS,
+        interaction=Interaction("fill", SEARCH_INPUTS),
+        help="the first widget after typing into its search input",
+    ),
+    Target(
+        label="full",
+        page=NEEDTABLE_PAGE,
+        element="body",
+        viewport=True,
+        help="the whole page above the fold, so the theme's own chrome is visible",
+    ),
+)
+
+
+# --- pure resolution, so the tests need no browser -----------------------------------------
+# Everything a browser is needed for arrives as a one-line callable. That is not test
+# scaffolding for its own sake: the selection rules ARE the contract this instrument makes
+# with two different DOMs, and a rule that can only be exercised by launching chromium at a
+# two-minute sphinx build is a rule nobody checks.
+
+
+def resolve_selector(
+    candidates: Sequence[str], exists: Callable[[str], bool]
+) -> str | None:
+    """The first candidate that resolves, or None. `exists` answers "is there one of these?"."""
+    for candidate in candidates:
+        if exists(candidate):
+            return candidate
+    return None
+
+
+def closest_wrapper(
+    wrappers: Sequence[str], has_ancestor: Callable[[str], bool]
+) -> str | None:
+    """The first wrapper the element sits inside, or None -- then the element itself is shot.
+
+    `has_ancestor` is `el.closest(selector) !== null` in the browser. None is a legitimate
+    answer rather than a failure: a build whose JavaScript did not run (or has none) still has
+    a table, and a photograph of the bare table is exactly the right evidence for that.
+    """
+    return resolve_selector(wrappers, has_ancestor)
+
+
+def scoped(scope: str | None, element: str) -> str:
+    """The CSS the page is actually queried with."""
+    return element if scope is None else f"{scope} {element}"
+
+
+def select_targets(
+    names: Sequence[str] | None, targets: Sequence[Target] = DEFAULT_TARGETS
+) -> list[Target]:
+    """`--targets` resolved against the table above, in the order the caller asked for.
+
+    An unknown label is a usage error naming what there is; a silent skip would produce a
+    gallery with a column missing and nothing to say why.
+    """
+    if names is None:
+        return list(targets)
+    by_label = {target.label: target for target in targets}
+    unknown = [name for name in names if name not in by_label]
+    if unknown:
+        raise SystemExit(
+            f"error: no such target: {', '.join(unknown)}. "
+            f"Known targets: {', '.join(by_label)}"
+        )
+    return [by_label[name] for name in names]
+
+
+def discover_themes(
+    build_root: Path, requested: Sequence[str] | None
+) -> tuple[list[str], list[str]]:
+    """`(present, missing)`. With no `--themes`, every theme build under the root, sorted.
+
+    A requested theme that was never built is **reported and skipped**, never an error: the
+    normal way to use this is to shoot whatever builds a machine happens to have, and a
+    reviewer looking at four themes because the fifth build was skipped is better served by a
+    gallery plus a note than by no gallery at all.
+    """
+
+    def is_build(name: str) -> bool:
+        return (build_root / name / THEME_MARKER).is_file()
+
+    if requested is None:
+        entries = sorted(build_root.iterdir()) if build_root.is_dir() else []
+        return [
+            path.name for path in entries if path.is_dir() and is_build(path.name)
+        ], []
+    present = [name for name in requested if is_build(name)]
+    missing = [name for name in requested if not is_build(name)]
+    return present, missing
+
+
+def theme_order(themes: Sequence[str]) -> list[str]:
+    """The five known themes in task order first, then anything else alphabetically."""
+    rank = {name: index for index, (name, _) in enumerate(BUILD_TASKS)}
+    return sorted(themes, key=lambda name: (rank.get(name, len(rank)), name))
+
+
+# --- what "is this actually dark?" means ---------------------------------------------------
+
+
+def parse_rgb(colour: str | None) -> tuple[int, int, int] | None:
+    """`rgb(r, g, b)` / `rgba(r, g, b, a)` as integers, or None for anything else."""
+    if not colour:
+        return None
+    numbers = re.findall(r"[\d.]+", colour)
+    if len(numbers) < 3:
+        return None
+    try:
+        red, green, blue = (int(float(value)) for value in numbers[:3])
+    except ValueError:
+        return None
+    return red, green, blue
+
+
+def is_dark(colour: str | None) -> bool | None:
+    """Whether a sampled background reads as dark. None when it could not be parsed.
+
+    Relative luminance with the sRGB coefficients, thresholded at the midpoint. This is the
+    check behind "verify each dark shot IS dark": furo, pydata-sphinx-theme and
+    sphinx-immaterial all honour `prefers-color-scheme`, and a dark gallery full of light
+    screenshots -- which is what a theme upgrade that dropped the media query would produce --
+    is otherwise invisible in a page of thumbnails.
+    """
+    parsed = parse_rgb(colour)
+    if parsed is None:
+        return None
+    red, green, blue = parsed
+    return (0.2126 * red + 0.7152 * green + 0.0722 * blue) / 255 < 0.5
+
+
+def dark_verdict(light: Json, dark: Json) -> tuple[bool, str, list[str]]:
+    """Does this theme have a dark mode? `(supported, reason, labels that came out identical)`.
+
+    TWO signals, and both have to say "nothing changed" before a theme is called dark-less,
+    because either alone can lie. Byte equality alone would call a theme dark-less if a build
+    happened to render identically for some other reason; a background sample alone would miss
+    a theme that darkens its content area and not its page. Together they are the observable
+    difference between "the emulation did nothing" and "the theme responded".
+    """
+    light_shots = {shot["label"]: shot for shot in light.get("shots", [])}
+    dark_shots = {shot["label"]: shot for shot in dark.get("shots", [])}
+    shared = [label for label in light_shots if label in dark_shots]
+    identical = [
+        label for label in shared if light_shots[label].get("sha") == dark_shots[label].get("sha")
+    ]
+    background_light = light.get("background")
+    background_dark = dark.get("background")
+    if not shared:
+        return False, "no shots were captured in dark mode", identical
+    if len(identical) == len(shared) and background_light == background_dark:
+        return (
+            False,
+            "every dark shot is byte-identical to its light counterpart and the page "
+            f"background is unchanged ({background_light})",
+            identical,
+        )
+    if background_light != background_dark:
+        reason = f"the page background moved from {background_light} to {background_dark}"
+    else:
+        reason = f"{len(shared) - len(identical)} of {len(shared)} shots changed"
+    return True, reason, identical
+
+
+def sha256_of(path: Path) -> str:
+    """The shot's bytes, as one comparable value. Comparing these IS the byte comparison."""
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+# --- where the build came from -------------------------------------------------------------
+
+
+def built_version(build_root: Path, theme: str) -> str | None:
+    """The sphinx-needs version, out of the build's own `documentation_options.js`.
+
+    `docs/conf.py` sets `version = release = sphinx_needs.__version__`, and sphinx writes that
+    into `_static/documentation_options.js` as `VERSION`. So this is derived from the built
+    HTML rather than from the checkout doing the screenshotting -- which is the whole point
+    when the build root is somebody else's worktree.
+    """
+    path = build_root / theme / "_static" / "documentation_options.js"
+    if not path.is_file():
+        return None
+    match = re.search(
+        r"VERSION:\s*['\"]([^'\"]+)['\"]", path.read_text(encoding="utf-8")
+    )
+    return match.group(1) if match else None
+
+
+def git_sha(path: Path) -> str | None:
+    """The HEAD of whatever checkout the build sits in, or None.
+
+    Not derivable from the HTML -- nothing sphinx writes carries it -- but the build root's own
+    checkout is the honest next best thing, and it is what tells two galleries apart. A linked
+    worktree answers correctly; a directory that is in no checkout answers None.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(path), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return None
+    return result.stdout.strip() or None
+
+
+# --- serving the build ---------------------------------------------------------------------
+
+
+class _QuietHandler(SimpleHTTPRequestHandler):
+    """`SimpleHTTPRequestHandler` without a request log on stderr."""
+
+    def log_message(self, format: str, *args: Any) -> None:
+        return
+
+
+@contextmanager
+def serve(directory: Path) -> Iterator[str]:
+    """Serve `directory` on a random loopback port for the life of the block.
+
+    Not `file://`: see the module docstring. One server covers every theme, because the theme
+    directories are siblings under the build root.
+    """
+    handler = functools.partial(_QuietHandler, directory=str(directory))
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+# --- the browser half ----------------------------------------------------------------------
+
+PLAYWRIGHT_MISSING = (
+    "error: playwright is not installed in this environment.\n"
+    "  uv sync --frozen --group js     # the driver (the root `js` dependency group)\n"
+    "  uv run poe install-browser      # the browser itself, once per machine\n"
+    "Or run `uv run poe docs-needs-shots`, which uses the default environment (`dev` "
+    "includes `js`)."
+)
+
+BROWSER_MISSING = (
+    "error: playwright has no browser to drive.\n"
+    "  uv run poe install-browser      # fetches exactly the chromium this playwright pins\n"
+    "A browser already on the machine is not necessarily the revision playwright looks for."
+)
+
+#: `el.closest(selector) !== null`, for `closest_wrapper`.
+JS_HAS_ANCESTOR = "(el, selector) => el.closest(selector) !== null"
+
+#: The first non-transparent background walking up from `<body>`. A theme that paints the page
+#: on `<html>` and leaves `<body>` transparent is the common case for exactly the themes whose
+#: dark mode matters, so stopping at `<body>` would sample nothing.
+JS_PAGE_BACKGROUND = """() => {
+  let el = document.body;
+  while (el) {
+    const colour = getComputedStyle(el).backgroundColor;
+    if (colour && colour !== 'transparent' && !/^rgba\\(0,\\s*0,\\s*0,\\s*0\\)$/.test(colour)) {
+      return colour;
+    }
+    el = el.parentElement;
+  }
+  return null;
+}"""
+
+#: Visible data rows, and the first one's text. Cheap evidence that an interaction did
+#: something: a `filtered` shot whose row count never moved is a broken selector, and a
+#: screenshot alone cannot say so.
+JS_ROW_EVIDENCE = """(el) => {
+  const rows = Array.from(el.querySelectorAll('tbody tr'))
+    .filter((row) => row.offsetParent !== null);
+  const first = rows[0];
+  return {
+    rows: rows.length,
+    first: first ? first.innerText.replace(/\\s+/g, ' ').trim().slice(0, 90) : null,
+  };
+}"""
+
+
+@dataclass
+class PageLog:
+    """Console errors and uncaught exceptions from one page, deduplicated."""
+
+    entries: list[dict[str, str]] = field(default_factory=list)
+
+    def add(self, kind: str, text: str) -> None:
+        record = {"kind": kind, "text": " ".join(text.split())[:400]}
+        if record not in self.entries:
+            self.entries.append(record)
+
+
+def _import_playwright() -> Any:
+    """Imported here and nowhere else, so `--help` and the tests never need the driver."""
+    try:
+        from playwright.sync_api import sync_playwright
+    except ImportError:
+        raise SystemExit(PLAYWRIGHT_MISSING) from None
+    return sync_playwright
+
+
+def capture(
+    *,
+    build_root: Path,
+    out: Path,
+    themes: Sequence[str],
+    targets: Sequence[Target],
+    modes: Sequence[str],
+    viewport: tuple[int, int],
+    filter_text: str,
+    settle_ms: int,
+) -> Json:
+    """Drive the browser over every theme x mode x target, and return the manifest."""
+    sync_playwright = _import_playwright()
+    width, height = viewport
+    version = next(
+        (v for theme in themes if (v := built_version(build_root, theme))), None
+    )
+    themes_entry: Json = {}
+    manifest: Json = {
+        "generated": datetime.now(UTC).isoformat(timespec="seconds"),
+        "build_root": str(build_root),
+        "out": str(out),
+        "viewport": {"width": width, "height": height},
+        "modes": list(modes),
+        "filter_text": filter_text,
+        "targets": [
+            {"label": target.label, "page": target.page, "help": target.help}
+            for target in targets
+        ],
+        "source": {
+            "sphinx_needs_version": version,
+            "git_sha": git_sha(build_root),
+        },
+        "themes": themes_entry,
+    }
+
+    with serve(build_root) as base_url, sync_playwright() as driver:
+        try:
+            browser = driver.chromium.launch()
+        except Exception as error:
+            if "Executable doesn't exist" in str(error):
+                raise SystemExit(BROWSER_MISSING) from None
+            raise
+        try:
+            for theme in theme_order(themes):
+                modes_entry: Json = {}
+                theme_entry: Json = {"modes": modes_entry}
+                themes_entry[theme] = theme_entry
+                for mode in modes:
+                    context = browser.new_context(
+                        viewport={"width": width, "height": height},
+                        color_scheme=mode,
+                        # the shots are for a reviewer's eye, not for pixel diffing across
+                        # machines, and 1x keeps thirty PNGs to a few MB
+                        device_scale_factor=1,
+                    )
+                    try:
+                        modes_entry[mode] = _capture_mode(
+                            context=context,
+                            base_url=base_url,
+                            theme=theme,
+                            mode=mode,
+                            out=out,
+                            targets=targets,
+                            filter_text=filter_text,
+                            settle_ms=settle_ms,
+                        )
+                    finally:
+                        context.close()
+                finish_dark(out, theme, theme_entry)
+        finally:
+            browser.close()
+    return manifest
+
+
+def _capture_mode(
+    *,
+    context: Any,
+    base_url: str,
+    theme: str,
+    mode: str,
+    out: Path,
+    targets: Sequence[Target],
+    filter_text: str,
+    settle_ms: int,
+) -> Json:
+    """Every target for one theme in one colour scheme, on one page object."""
+    log = PageLog()
+    page = context.new_page()
+    page.on("pageerror", lambda error: log.add("pageerror", str(error)))
+    page.on(
+        "console",
+        lambda message: log.add("console.error", message.text)
+        if message.type == "error"
+        else None,
+    )
+    directory = out / theme / mode
+    directory.mkdir(parents=True, exist_ok=True)
+    shots: list[Json] = []
+    background: str | None = None
+    loaded: str | None = None
+    dirty = False
+    try:
+        for target in targets:
+            url = f"{base_url}/{theme}/{target.page}"
+            # A load per target would be tidier but doubles the run; one is only actually
+            # needed when the page changes or the previous target left the DOM interacted-with
+            if loaded != url or dirty:
+                _load(page, url, settle_ms)
+                loaded, dirty = url, False
+                if background is None:
+                    background = page.evaluate(JS_PAGE_BACKGROUND)
+            shots.append(
+                _capture_target(
+                    page=page,
+                    target=target,
+                    directory=directory,
+                    theme=theme,
+                    mode=mode,
+                    filter_text=filter_text,
+                )
+            )
+            if target.interaction is not None:
+                dirty = True
+    finally:
+        page.close()
+    return {
+        "background": background,
+        "background_is_dark": is_dark(background),
+        "console_errors": log.entries,
+        "shots": shots,
+    }
+
+
+def _load(page: Any, url: str, settle_ms: int) -> None:
+    """Navigate, and wait for the widget's JavaScript to have had its turn."""
+    page.goto(url, wait_until="load")
+    # neither wait is a precondition for a shot: a page that never goes idle, or that has no
+    # needtable on it at all, is a thing this should photograph and report rather than skip
+    with contextlib.suppress(Exception):
+        page.wait_for_load_state("networkidle", timeout=15000)
+    with contextlib.suppress(Exception):
+        page.wait_for_selector(WIDGET_TABLE, timeout=15000)
+    # the enhancement is a `$(document).ready` handler on master, and will be something
+    # similar on any replacement: neither fires an event this could wait for instead
+    page.wait_for_timeout(settle_ms)
+
+
+def _capture_target(
+    *,
+    page: Any,
+    target: Target,
+    directory: Path,
+    theme: str,
+    mode: str,
+    filter_text: str,
+) -> Json:
+    """One screenshot, plus everything a reviewer needs in order to trust it."""
+    path = directory / f"{target.label}.png"
+    selector = scoped(target.scope, target.element)
+    record: Json = {
+        "label": target.label,
+        "theme": theme,
+        "mode": mode,
+        "page": target.page,
+        "file": f"{theme}/{mode}/{target.label}.png",
+        "selector": selector,
+    }
+    handle = page.query_selector(selector)
+    if handle is None:
+        record["error"] = f"no element matched {selector!r}"
+        return record
+
+    if target.viewport:
+        page.evaluate("() => window.scrollTo(0, 0)")
+        page.screenshot(path=str(path), animations="disabled", caret="hide")
+        record.update(bytes=path.stat().st_size, sha=sha256_of(path), wrapper=None)
+        return record
+
+    wrapper = closest_wrapper(
+        target.wrappers,
+        lambda candidate: bool(handle.evaluate(JS_HAS_ANCESTOR, candidate)),
+    )
+    record["wrapper"] = wrapper
+    element = handle
+    if wrapper is not None:
+        found = handle.evaluate_handle(
+            "(el, selector) => el.closest(selector)", wrapper
+        ).as_element()
+        if found is not None:
+            element = found
+
+    if target.interaction is not None:
+        record["interaction"] = _interact(
+            page, element, target.interaction, filter_text, record
+        )
+
+    element.scroll_into_view_if_needed()
+    element.screenshot(path=str(path), animations="disabled", caret="hide")
+    record.update(bytes=path.stat().st_size, sha=sha256_of(path))
+    return record
+
+
+def _interact(
+    page: Any,
+    element: Any,
+    interaction: Interaction,
+    filter_text: str,
+    record: Json,
+) -> Json:
+    """Run one declarative interaction; record which selector fired and what changed."""
+    selector = resolve_selector(
+        interaction.selectors,
+        lambda candidate: element.query_selector(candidate) is not None,
+    )
+    result: Json = {
+        "kind": interaction.kind,
+        "selector": selector,
+        "candidates": list(interaction.selectors),
+        "before": element.evaluate(JS_ROW_EVIDENCE),
+    }
+    if selector is None:
+        result["error"] = "none of the candidate selectors resolved"
+        record["error"] = f"no {interaction.kind} control found in the widget"
+        return result
+    control = element.query_selector(selector)
+    if interaction.kind == "click":
+        control.click()
+    else:
+        text = interaction.text if interaction.text is not None else filter_text
+        result["text"] = text
+        control.fill(text)
+        # DataTables filters on keyup; anything else will listen for `input`. `fill` fires
+        # `input` but no key events, so both are dispatched
+        control.evaluate(
+            "(el) => el.dispatchEvent(new KeyboardEvent('keyup', {bubbles: true}))"
+        )
+        # a blinking caret in the shot is noise, and it would also make the light/dark byte
+        # comparison that detects a theme with no dark mode flap
+        control.evaluate("(el) => el.blur()")
+    page.wait_for_timeout(600)
+    result["after"] = element.evaluate(JS_ROW_EVIDENCE)
+    return result
+
+
+def finish_dark(out: Path, theme: str, entry: Json) -> None:
+    """Decide whether this theme has a dark mode; drop the duplicate shots if it has not."""
+    modes = entry.get("modes", {})
+    light, dark = modes.get("light"), modes.get("dark")
+    if light is None or dark is None:
+        return
+    supported, reason, identical = dark_verdict(light, dark)
+    verdict: Json = {
+        "supported": supported,
+        "reason": reason,
+        "identical": identical,
+        "background_light": light.get("background"),
+        "background_dark": dark.get("background"),
+    }
+    entry["dark"] = verdict
+    if not supported:
+        shutil.rmtree(out / theme / "dark", ignore_errors=True)
+        verdict["files_removed"] = True
+
+
+# --- the outputs ---------------------------------------------------------------------------
+
+
+def import_before(compare: Path, out: Path) -> Json:
+    """Copy a BEFORE run's images into `<out>/_before/` and return its manifest, rebased.
+
+    The gallery has to survive being copied somewhere else -- which is most of the reason it is
+    written at all -- so it cannot reach its images through a relative path that climbs out of
+    its own directory. The before images are brought inside instead, and that manifest's `file`
+    entries are rewritten to match.
+    """
+    path = compare / "manifest.json"
+    if not path.is_file():
+        raise SystemExit(f"error: --compare {compare} has no manifest.json in it")
+    manifest: Json = json.loads(path.read_text(encoding="utf-8"))
+    destination = out / "_before"
+    shutil.rmtree(destination, ignore_errors=True)
+    for theme, entry in manifest.get("themes", {}).items():
+        for mode, mode_entry in entry.get("modes", {}).items():
+            for shot in mode_entry.get("shots", []):
+                relative = shot.get("file")
+                if not relative or not (compare / relative).is_file():
+                    shot["file"] = None
+                    continue
+                name = Path(relative).name
+                target = destination / theme / mode / name
+                target.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(compare / relative, target)
+                shot["file"] = f"_before/{theme}/{mode}/{name}"
+    return manifest
+
+
+GALLERY_CSS = """
+:root { color-scheme: light dark; --bg:#fff; --fg:#1b1b1d; --muted:#5c5c66;
+        --line:#d8d8e0; --card:#f6f6f9; --warn:#8a3b12; }
+@media (prefers-color-scheme: dark) {
+  :root { --bg:#131316; --fg:#e6e6ea; --muted:#a0a0ac; --line:#33333c;
+          --card:#1c1c21; --warn:#f0a879; }
+}
+* { box-sizing: border-box; }
+body { margin: 0; padding: 24px; background: var(--bg); color: var(--fg);
+       font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; }
+h1 { font-size: 20px; margin: 0 0 4px; }
+h2 { font-size: 16px; margin: 32px 0 8px; }
+p.meta { color: var(--muted); margin: 0 0 12px; }
+table.gallery { border-collapse: collapse; width: 100%; table-layout: fixed; }
+table.gallery th, table.gallery td { border: 1px solid var(--line); padding: 8px;
+       vertical-align: top; }
+table.gallery th { background: var(--card); text-align: left; font-size: 13px; }
+th.rowhead { width: 150px; }
+figure { margin: 0 0 10px; }
+figcaption { color: var(--muted); font-size: 12px; margin-bottom: 4px; }
+img { max-width: 100%; height: auto; display: block; border: 1px solid var(--line); }
+.na { color: var(--muted); font-style: italic; }
+.warn { color: var(--warn); }
+ul.errors { margin: 4px 0 0 16px; padding: 0; font-size: 12px; color: var(--warn); }
+code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; }
+details { margin-top: 6px; }
+summary { cursor: pointer; color: var(--muted); font-size: 12px; }
+"""
+
+DARK_NA = "dark: n/a (theme has no dark mode)"
+
+
+def _figure(caption: str, shot: Json | None) -> str:
+    """One image, or the reason there is not one."""
+    label = html.escape(caption)
+    if shot is None:
+        return f"<figure><figcaption>{label}</figcaption><p class='na'>not captured</p></figure>"
+    if shot.get("error") or not shot.get("file"):
+        reason = html.escape(str(shot.get("error", "not captured")))
+        return f"<figure><figcaption>{label}</figcaption><p class='warn'>{reason}</p></figure>"
+    file = html.escape(str(shot["file"]))
+    note = ""
+    interaction = shot.get("interaction")
+    if isinstance(interaction, dict):
+        before = interaction.get("before") or {}
+        after = interaction.get("after") or {}
+        note = (
+            f"<details><summary>{html.escape(str(interaction.get('selector')))}</summary>"
+            f"<code>rows {before.get('rows')} &rarr; {after.get('rows')}<br>"
+            f"first: {html.escape(str(after.get('first')))}</code></details>"
+        )
+    return (
+        f"<figure><figcaption>{label}</figcaption>"
+        f"<a href='{file}'><img src='{file}' alt='{label}'></a>{note}</figure>"
+    )
+
+
+def _shots_by_label(entry: Json | None) -> dict[str, Json]:
+    if not entry:
+        return {}
+    return {str(shot["label"]): shot for shot in entry.get("shots", [])}
+
+
+def _row_head(mode: str, mode_entry: Json | None) -> str:
+    """The left-hand cell: the mode, the background it sampled, and anything it logged."""
+    parts = [f"<th class='rowhead'>{mode}"]
+    entry = mode_entry or {}
+    background = entry.get("background")
+    if background:
+        flag = "dark" if entry.get("background_is_dark") else "light"
+        parts.append(
+            f"<br><code>{html.escape(str(background))}</code>"
+            f"<br><span class='meta'>reads as {flag}</span>"
+        )
+    errors = entry.get("console_errors") or []
+    if errors:
+        parts.append(
+            "<ul class='errors'>"
+            + "".join(
+                f"<li>{html.escape(str(error['kind']))}: {html.escape(str(error['text']))}</li>"
+                for error in errors
+            )
+            + "</ul>"
+        )
+    return "".join(parts) + "</th>"
+
+
+def write_gallery(manifest: Json, out: Path, before: Json | None = None) -> Path:
+    """`<out>/index.html`: one row per theme x mode, one column per label. Self-contained."""
+    labels = [str(target["label"]) for target in manifest.get("targets", [])]
+    themes = manifest.get("themes", {})
+    before_themes = (before or {}).get("themes", {})
+    source = manifest.get("source", {})
+    parts: list[str] = [
+        "<!doctype html><html><head><meta charset='utf-8'>",
+        "<meta name='viewport' content='width=device-width, initial-scale=1'>",
+        "<title>sphinx-needs needtable &mdash; theme shots</title>",
+        f"<style>{GALLERY_CSS}</style></head><body>",
+        "<h1>needtable widgets across the docs themes</h1>",
+    ]
+    viewport = manifest.get("viewport", {})
+    meta = [
+        f"generated {html.escape(str(manifest.get('generated')))}",
+        f"sphinx-needs {html.escape(str(source.get('sphinx_needs_version')))}",
+        f"build {html.escape(str(source.get('git_sha'))[:12])}",
+        f"viewport {viewport.get('width')}x{viewport.get('height')}",
+    ]
+    if before is not None:
+        before_source = before.get("source", {})
+        meta.append(
+            f"compared against {html.escape(str(before_source.get('git_sha'))[:12])} "
+            f"(sphinx-needs {html.escape(str(before_source.get('sphinx_needs_version')))})"
+        )
+    parts.append(f"<p class='meta'>{' &middot; '.join(meta)}</p>")
+    if before is not None:
+        parts.append(
+            "<p class='meta'>Every cell is <strong>before</strong> (the comparison run) "
+            "above <strong>after</strong> (this run).</p>"
+        )
+    for target in manifest.get("targets", []):
+        if target.get("help"):
+            parts.append(
+                f"<p class='meta'><code>{html.escape(str(target['label']))}</code> &mdash; "
+                f"{html.escape(str(target['help']))}</p>"
+            )
+
+    extra = [name for name in before_themes if name not in themes]
+    for theme in theme_order([*themes, *extra]):
+        entry = themes.get(theme, {})
+        before_entry = before_themes.get(theme, {}) if before else {}
+        dark = entry.get("dark", {})
+        no_dark = bool(dark) and not dark.get("supported")
+        parts.append(f"<h2>{html.escape(theme)}</h2>")
+        if no_dark:
+            parts.append(
+                f"<p class='meta'>{DARK_NA} &mdash; {html.escape(str(dark.get('reason')))}</p>"
+            )
+        parts.append("<table class='gallery'><tr><th class='rowhead'>mode</th>")
+        parts.extend(f"<th>{html.escape(label)}</th>" for label in labels)
+        parts.append("</tr>")
+        for mode in MODES:
+            mode_entry = entry.get("modes", {}).get(mode)
+            before_mode = before_entry.get("modes", {}).get(mode) if before else None
+            if mode == "dark" and no_dark:
+                parts.append(
+                    f"<tr><th class='rowhead'>dark</th>"
+                    f"<td class='na' colspan='{len(labels)}'>{DARK_NA}</td></tr>"
+                )
+                continue
+            if mode_entry is None and before_mode is None:
+                continue
+            parts.append("<tr>" + _row_head(mode, mode_entry))
+            after_shots = _shots_by_label(mode_entry)
+            before_shots = _shots_by_label(before_mode)
+            for label in labels:
+                cell = []
+                if before is not None:
+                    cell.append(_figure("before", before_shots.get(label)))
+                cell.append(
+                    _figure("after" if before is not None else label, after_shots.get(label))
+                )
+                parts.append("<td>" + "".join(cell) + "</td>")
+            parts.append("</tr>")
+        parts.append("</table>")
+
+    parts.append("</body></html>")
+    path = out / "index.html"
+    path.write_text("".join(parts), encoding="utf-8")
+    return path
+
+
+def write_manifest(manifest: Json, out: Path) -> Path:
+    path = out / "manifest.json"
+    path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+def console_summary(manifest: Json) -> list[str]:
+    """One line per (theme, mode) that logged anything. Printed; never an exit code."""
+    lines = []
+    for theme, entry in manifest.get("themes", {}).items():
+        for mode, mode_entry in entry.get("modes", {}).items():
+            errors = mode_entry.get("console_errors") or []
+            if errors:
+                lines.append(
+                    f"{theme}/{mode}: {len(errors)} console error(s) -- "
+                    + "; ".join(error["text"][:120] for error in errors)
+                )
+    return lines
+
+
+# --- CLI -----------------------------------------------------------------------------------
+
+
+def default_root() -> Path:
+    """The repository root, from this file's own location (the tooling is run by path)."""
+    return Path(__file__).resolve().parents[3]
+
+
+def parse_viewport(value: str) -> tuple[int, int]:
+    match = re.fullmatch(r"(\d+)x(\d+)", value.strip())
+    if match is None:
+        raise argparse.ArgumentTypeError(f"expected WIDTHxHEIGHT, got {value!r}")
+    return int(match.group(1)), int(match.group(2))
+
+
+def comma_list(value: str) -> list[str]:
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="theme_shots.py",
+        description=(
+            "Screenshot the needtable examples out of EXISTING theme docs builds, light and "
+            "dark, into a self-contained gallery. Build them first: `poe docs-needs-themes`."
+        ),
+    )
+    parser.add_argument(
+        "--root", type=Path, default=None, help="the repository root (default: this checkout)"
+    )
+    parser.add_argument(
+        "--build-root",
+        type=Path,
+        default=None,
+        help=f"where the theme builds are (default: <root>/{DEFAULT_BUILD_ROOT})",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help=f"where to write (default: <root>/{DEFAULT_OUT})",
+    )
+    parser.add_argument(
+        "--themes",
+        type=comma_list,
+        default=None,
+        help="comma-separated theme directory names (default: every build present)",
+    )
+    parser.add_argument(
+        "--targets",
+        type=comma_list,
+        default=None,
+        help="comma-separated target labels (default: all; see --list-targets)",
+    )
+    parser.add_argument(
+        "--modes",
+        type=comma_list,
+        default=list(MODES),
+        help="comma-separated colour schemes (default: light,dark)",
+    )
+    parser.add_argument(
+        "--viewport",
+        type=parse_viewport,
+        default=(1280, 900),
+        help="WIDTHxHEIGHT (default: 1280x900)",
+    )
+    parser.add_argument(
+        "--compare",
+        type=Path,
+        default=None,
+        help="another --out directory, shown as BEFORE beside this run",
+    )
+    parser.add_argument(
+        "--filter-text",
+        default=DEFAULT_FILTER_TEXT,
+        help=f"typed into the search input for the `filtered` shot (default: {DEFAULT_FILTER_TEXT})",
+    )
+    parser.add_argument(
+        "--settle",
+        type=int,
+        default=1200,
+        dest="settle_ms",
+        help="milliseconds to wait after load for the widget JavaScript (default: 1200)",
+    )
+    parser.add_argument(
+        "--list-targets",
+        action="store_true",
+        help="print the targets and exit (needs no browser)",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.list_targets:
+        for target in DEFAULT_TARGETS:
+            print(f"{target.label:12s} {target.page}  {target.help}")
+        return 0
+
+    root = args.root or default_root()
+    build_root = (args.build_root or root / DEFAULT_BUILD_ROOT).resolve()
+    out = (args.out or root / DEFAULT_OUT).resolve()
+    targets = select_targets(args.targets)
+    unknown = [mode for mode in args.modes if mode not in MODES]
+    if unknown:
+        raise SystemExit(
+            f"error: no such mode: {', '.join(unknown)}. Known: {', '.join(MODES)}"
+        )
+
+    themes, missing = discover_themes(build_root, args.themes)
+    tasks = dict(BUILD_TASKS)
+    for name in missing:
+        task = tasks.get(name)
+        hint = f" (build it with `uv run poe {task}`)" if task else ""
+        print(f"note: no build at {build_root / name} -- skipping{hint}", file=sys.stderr)
+    if not themes:
+        raise SystemExit(
+            f"error: no theme build under {build_root}.\n"
+            "Build them first -- `uv run poe docs-needs-themes`, or one at a time:\n"
+            + "\n".join(f"  uv run poe {task:24s} # {name}" for name, task in BUILD_TASKS)
+        )
+
+    out.mkdir(parents=True, exist_ok=True)
+    manifest = capture(
+        build_root=build_root,
+        out=out,
+        themes=themes,
+        targets=targets,
+        modes=args.modes,
+        viewport=args.viewport,
+        filter_text=args.filter_text,
+        settle_ms=args.settle_ms,
+    )
+    before = import_before(args.compare.resolve(), out) if args.compare else None
+    write_manifest(manifest, out)
+    gallery = write_gallery(manifest, out, before)
+
+    for theme in theme_order(themes):
+        entry = manifest["themes"][theme]
+        dark = entry.get("dark")
+        if dark is None:
+            state = "dark not captured"
+        elif dark.get("supported"):
+            state = f"dark ok ({dark['background_dark']})"
+        else:
+            state = DARK_NA
+        light = entry.get("modes", {}).get("light", {})
+        print(f"{theme:22s} {state:44s} light background {light.get('background')}")
+    for line in console_summary(manifest):
+        print(f"console: {line}", file=sys.stderr)
+    print(gallery)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_theme_shots.py
+++ b/tools/tests/test_theme_shots.py
@@ -49,7 +49,9 @@ PNG = base64.b64decode(
 LABELS = ("first", "style-row", "sorted", "filtered", "full")
 
 
-def write_shots(out: Path, theme: str, mode: str, *, payload: bytes = PNG) -> list[dict]:
+def write_shots(
+    out: Path, theme: str, mode: str, *, payload: bytes = PNG
+) -> list[dict]:
     """`<out>/<theme>/<mode>/<label>.png` for every label, and the manifest entries for them."""
     directory = out / theme / mode
     directory.mkdir(parents=True, exist_ok=True)
@@ -66,7 +68,8 @@ def write_shots(out: Path, theme: str, mode: str, *, payload: bytes = PNG) -> li
                 "file": f"{theme}/{mode}/{label}.png",
                 "bytes": len(payload),
                 "sha": theme_shots.sha256_of(path),
-                "wrapper": "div.dataTables_wrapper",
+                "wrapper": None if label == "full" else "div.dataTables_wrapper",
+                "viewport": label == "full",
             }
         )
     return shots
@@ -105,7 +108,11 @@ def fake_manifest(
         "modes": ["light", "dark"],
         "filter_text": "spec",
         "targets": [
-            {"label": label, "page": theme_shots.NEEDTABLE_PAGE, "help": f"the {label} shot"}
+            {
+                "label": label,
+                "page": theme_shots.NEEDTABLE_PAGE,
+                "help": f"the {label} shot",
+            }
             for label in LABELS
         ],
         "source": {"sphinx_needs_version": version, "git_sha": git_sha},
@@ -167,12 +174,21 @@ def test_closest_wrapper(ancestors: set[str], expected: str | None):
     )
 
 
-def test_scoped_narrows_to_a_section():
-    assert theme_shots.scoped(None, "table.NEEDS_DATATABLES") == "table.NEEDS_DATATABLES"
-    assert (
-        theme_shots.scoped("section#style-row", "table.NEEDS_DATATABLES")
-        == "section#style-row table.NEEDS_DATATABLES"
-    )
+def test_scope_strategies_without_an_anchor_is_just_the_element():
+    assert theme_shots.scope_strategies(None, "table.NEEDS_DATATABLES") == [
+        ("selector", "table.NEEDS_DATATABLES")
+    ]
+
+
+def test_scope_strategies_copes_with_both_shapes_of_section():
+    """sphinx puts the id on the section; sphinx-immaterial puts it on the heading."""
+    assert theme_shots.scope_strategies("#style-row", "table.NEEDS_DATATABLES") == [
+        # four of the five themes: the widget is a descendant of `<section id="style-row">`
+        ("selector", "#style-row table.NEEDS_DATATABLES"),
+        # sphinx-immaterial unwraps sections, so nothing is a descendant of the `<h3>` and
+        # the widget has to be found by document order instead
+        ("after", "#style-row"),
+    ]
 
 
 def test_default_targets_cover_the_documented_set():
@@ -180,9 +196,9 @@ def test_default_targets_cover_the_documented_set():
     assert labels == ["first", "style-row", "sorted", "filtered", "full"]
     by_label = {target.label: target for target in theme_shots.DEFAULT_TARGETS}
     # the two interaction states are the SAME widget as `first`, so they are comparable
-    assert by_label["sorted"].scope is None
-    assert by_label["filtered"].scope is None
-    assert by_label["style-row"].scope == "section#style-row"
+    assert by_label["sorted"].anchor is None
+    assert by_label["filtered"].anchor is None
+    assert by_label["style-row"].anchor == "#style-row"
     # every widget target starts from the table that IS in the built HTML
     assert all(
         target.element == theme_shots.WIDGET_TABLE
@@ -274,31 +290,53 @@ def test_is_dark(colour: str | None, expected: bool | None):
     assert theme_shots.is_dark(colour) is expected
 
 
-def shot(label: str, sha: str) -> dict[str, Any]:
-    return {"label": label, "sha": sha, "file": f"x/{label}.png"}
+def shot(label: str, sha: str, *, viewport: bool = False) -> dict[str, Any]:
+    return {
+        "label": label,
+        "sha": sha,
+        "file": f"x/{label}.png",
+        "viewport": viewport,
+    }
 
 
 def test_dark_verdict_calls_a_theme_dark_less_only_when_both_signals_agree():
     light = {
         "background": "rgb(255, 255, 255)",
-        "shots": [shot("first", "aa"), shot("full", "bb")],
+        "shots": [shot("first", "aa"), shot("full", "bb", viewport=True)],
     }
     dark = {
         "background": "rgb(255, 255, 255)",
-        "shots": [shot("first", "aa"), shot("full", "bb")],
+        "shots": [shot("first", "aa"), shot("full", "bb", viewport=True)],
     }
     supported, reason, identical = theme_shots.dark_verdict(light, dark)
     assert supported is False
     assert "byte-identical" in reason
-    assert identical == ["first", "full"]
+    # the whole-page shot is never one of the signals, so it is not one of the labels either
+    assert identical == ["first"]
 
 
-def test_dark_verdict_one_changed_shot_is_enough():
+def test_dark_verdict_ignores_a_whole_page_shot_that_moved_on_its_own():
+    """Measured on master: alabaster and rtd, whose code blocks are not the theme's doing."""
+    light = {
+        "background": "rgb(255, 255, 255)",
+        "shots": [shot("first", "aa"), shot("full", "bb", viewport=True)],
+    }
+    dark = {
+        "background": "rgb(255, 255, 255)",
+        "shots": [shot("first", "aa"), shot("full", "ZZ", viewport=True)],
+    }
+    supported, reason, _ = theme_shots.dark_verdict(light, dark)
+    assert supported is False
+    # ... and the reader is told about it anyway
+    assert "whole-page shot does differ" in reason
+
+
+def test_dark_verdict_one_changed_widget_shot_is_enough():
     light = {"background": "rgb(255, 255, 255)", "shots": [shot("first", "aa")]}
     dark = {"background": "rgb(255, 255, 255)", "shots": [shot("first", "zz")]}
     supported, reason, identical = theme_shots.dark_verdict(light, dark)
     assert supported is True
-    assert "1 of 1 shots changed" in reason
+    assert "1 of 1 widget shots changed" in reason
     assert identical == []
 
 
@@ -352,11 +390,17 @@ def test_manifest_and_gallery(tmp_path: Path):
         out,
         {
             "furo": {
-                "backgrounds": {"light": "rgb(255, 255, 255)", "dark": "rgb(19, 19, 22)"},
+                "backgrounds": {
+                    "light": "rgb(255, 255, 255)",
+                    "dark": "rgb(19, 19, 22)",
+                },
                 "errors": [{"kind": "pageerror", "text": "$ is not defined"}],
             },
             "alabaster": {
-                "backgrounds": {"light": "rgb(255, 255, 255)", "dark": "rgb(255, 255, 255)"}
+                "backgrounds": {
+                    "light": "rgb(255, 255, 255)",
+                    "dark": "rgb(255, 255, 255)",
+                }
             },
         },
     )
@@ -449,7 +493,7 @@ def test_compare_layout_brings_the_before_images_inside(tmp_path: Path):
 def test_compare_needs_a_manifest(tmp_path: Path):
     (tmp_path / "before").mkdir()
     (tmp_path / "after").mkdir()
-    with pytest.raises(SystemExit, match="manifest.json"):
+    with pytest.raises(SystemExit, match=r"manifest\.json"):
         theme_shots.import_before(tmp_path / "before", tmp_path / "after")
 
 

--- a/tools/tests/test_theme_shots.py
+++ b/tools/tests/test_theme_shots.py
@@ -1,0 +1,530 @@
+"""`theme_shots.py` without a browser: the resolution rules, the writers, the dark verdict.
+
+This instrument's job is to be re-runnable across two different DOMs -- the DataTables markup
+master builds, and whatever replaces it -- so its contract is not "it takes a screenshot", it
+is *which element it decides to photograph, and what it does to it first*. All of that is
+decided by pure functions taking a one-line callable for the browser's part, and this module
+exercises them with fakes: a chromium launch against a two-minute sphinx build is not a thing
+anybody runs often enough for it to be a check.
+
+Four of the tests below cover behaviour that only shows up on a real run, and each of them
+would otherwise be discovered as a broken gallery hours later:
+
+* **the wrapper fallback** -- the class of the widget wrapper differs between the two DOMs and
+  is absent from the built HTML in both, so the search starts at the table and walks up. A
+  build whose JavaScript never ran has neither wrapper, and must still produce a shot;
+* **the dark verdict** -- alabaster and sphinx_rtd_theme ignore `prefers-color-scheme`, so
+  emulating it yields a duplicate image. Two signals decide it, and the test pins that ONE
+  changing is enough to call the theme dark-capable;
+* **the `--compare` layout** -- before images are copied inside the output directory, because
+  the gallery's whole point is to be copied somewhere else and a relative path that climbs out
+  of it would arrive broken;
+* **the missing-theme skip** -- a theme that was never built is a note, not an error.
+
+Nothing here imports playwright, and one test asserts that it stays that way: the import is
+lazy, and its failure message has to name both halves of the fix.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+import pytest
+from sn_tools import theme_shots
+
+pytestmark = pytest.mark.filterwarnings("error")
+
+#: a real 1x1 PNG -- the writers only stat and hash it, but a file that is not an image would
+#: make a failing gallery look like a passing one when opened by hand
+PNG = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQ"
+    "AAAABJRU5ErkJggg=="
+)
+
+LABELS = ("first", "style-row", "sorted", "filtered", "full")
+
+
+def write_shots(out: Path, theme: str, mode: str, *, payload: bytes = PNG) -> list[dict]:
+    """`<out>/<theme>/<mode>/<label>.png` for every label, and the manifest entries for them."""
+    directory = out / theme / mode
+    directory.mkdir(parents=True, exist_ok=True)
+    shots = []
+    for label in LABELS:
+        path = directory / f"{label}.png"
+        path.write_bytes(payload)
+        shots.append(
+            {
+                "label": label,
+                "theme": theme,
+                "mode": mode,
+                "page": theme_shots.NEEDTABLE_PAGE,
+                "file": f"{theme}/{mode}/{label}.png",
+                "bytes": len(payload),
+                "sha": theme_shots.sha256_of(path),
+                "wrapper": "div.dataTables_wrapper",
+            }
+        )
+    return shots
+
+
+def fake_manifest(
+    out: Path,
+    themes: dict[str, dict[str, Any]],
+    *,
+    git_sha: str = "0123456789abcdef",
+    version: str = "5.2.0",
+) -> dict[str, Any]:
+    """A manifest of the shape `capture()` returns, over files actually on disk.
+
+    `themes` maps a theme name to `{"backgrounds": {mode: colour}, "errors": [...] }`.
+    """
+    entries: dict[str, Any] = {}
+    for theme, options in themes.items():
+        modes: dict[str, Any] = {}
+        for mode, background in options["backgrounds"].items():
+            modes[mode] = {
+                "background": background,
+                "background_is_dark": theme_shots.is_dark(background),
+                "console_errors": options.get("errors", []) if mode == "light" else [],
+                "shots": write_shots(out, theme, mode),
+            }
+        entry: dict[str, Any] = {"modes": modes}
+        if "light" in modes and "dark" in modes:
+            theme_shots.finish_dark(out, theme, entry)
+        entries[theme] = entry
+    return {
+        "generated": "2026-09-08T00:00:00+00:00",
+        "build_root": str(out.parent / "html"),
+        "out": str(out),
+        "viewport": {"width": 1280, "height": 900},
+        "modes": ["light", "dark"],
+        "filter_text": "spec",
+        "targets": [
+            {"label": label, "page": theme_shots.NEEDTABLE_PAGE, "help": f"the {label} shot"}
+            for label in LABELS
+        ],
+        "source": {"sphinx_needs_version": version, "git_sha": git_sha},
+        "themes": entries,
+    }
+
+
+# --- selector resolution: the contract with two DOMs ----------------------------------------
+
+
+def test_resolve_selector_takes_the_first_that_exists():
+    seen: list[str] = []
+
+    def exists(candidate: str) -> bool:
+        seen.append(candidate)
+        return candidate == "thead th:nth-child(2)"
+
+    assert (
+        theme_shots.resolve_selector(theme_shots.SORT_CONTROLS, exists)
+        == "thead th:nth-child(2)"
+    )
+    # every more specific candidate was tried first, and nothing after the winner was
+    assert seen == list(theme_shots.SORT_CONTROLS)
+
+
+def test_resolve_selector_prefers_a_real_button_to_the_header_cell():
+    """The branch's DOM and master's both satisfy "the second column's sort control"."""
+    both = {"thead th:nth-child(2) button", "thead th:nth-child(2)"}
+    assert (
+        theme_shots.resolve_selector(theme_shots.SORT_CONTROLS, both.__contains__)
+        == "thead th:nth-child(2) button"
+    )
+
+
+def test_resolve_selector_returns_none_when_nothing_matches():
+    assert theme_shots.resolve_selector(("a", "b"), lambda _: False) is None
+
+
+@pytest.mark.parametrize(
+    ("ancestors", "expected"),
+    [
+        # master: DataTables builds this wrapper at load time
+        ({"div.dataTables_wrapper"}, "div.dataTables_wrapper"),
+        # the enhancer that replaces it
+        ({"div.needstable"}, "div.needstable"),
+        # a page carrying both -- the preference order decides
+        (
+            {"div.dataTables_wrapper", "div.needstable"},
+            "div.dataTables_wrapper",
+        ),
+        # JavaScript never ran: there is no wrapper, and the bare table is the right shot
+        (set(), None),
+    ],
+)
+def test_closest_wrapper(ancestors: set[str], expected: str | None):
+    assert (
+        theme_shots.closest_wrapper(theme_shots.WIDGET_WRAPPERS, ancestors.__contains__)
+        == expected
+    )
+
+
+def test_scoped_narrows_to_a_section():
+    assert theme_shots.scoped(None, "table.NEEDS_DATATABLES") == "table.NEEDS_DATATABLES"
+    assert (
+        theme_shots.scoped("section#style-row", "table.NEEDS_DATATABLES")
+        == "section#style-row table.NEEDS_DATATABLES"
+    )
+
+
+def test_default_targets_cover_the_documented_set():
+    labels = [target.label for target in theme_shots.DEFAULT_TARGETS]
+    assert labels == ["first", "style-row", "sorted", "filtered", "full"]
+    by_label = {target.label: target for target in theme_shots.DEFAULT_TARGETS}
+    # the two interaction states are the SAME widget as `first`, so they are comparable
+    assert by_label["sorted"].scope is None
+    assert by_label["filtered"].scope is None
+    assert by_label["style-row"].scope == "section#style-row"
+    # every widget target starts from the table that IS in the built HTML
+    assert all(
+        target.element == theme_shots.WIDGET_TABLE
+        for target in theme_shots.DEFAULT_TARGETS
+        if not target.viewport
+    )
+    assert by_label["full"].viewport is True
+
+
+def test_select_targets_keeps_the_callers_order():
+    chosen = theme_shots.select_targets(["filtered", "first"])
+    assert [target.label for target in chosen] == ["filtered", "first"]
+
+
+def test_select_targets_names_what_there_is():
+    with pytest.raises(SystemExit) as error:
+        theme_shots.select_targets(["frist"])
+    assert "frist" in str(error.value)
+    assert "style-row" in str(error.value)
+
+
+# --- theme discovery ------------------------------------------------------------------------
+
+
+def make_build(root: Path, theme: str, *, version: str | None = "5.2.0") -> None:
+    directory = root / theme
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "index.html").write_text("<html></html>", encoding="utf-8")
+    if version is not None:
+        static = directory / "_static"
+        static.mkdir(exist_ok=True)
+        (static / "documentation_options.js").write_text(
+            f"const DOCUMENTATION_OPTIONS = {{VERSION: '{version}', LANGUAGE: 'en'}};",
+            encoding="utf-8",
+        )
+
+
+def test_discover_themes_finds_every_build_and_ignores_everything_else(tmp_path: Path):
+    make_build(tmp_path, "furo")
+    make_build(tmp_path, "alabaster")
+    # siblings of the theme directories that are not builds
+    (tmp_path / ".doctrees").mkdir()
+    (tmp_path / "shots").mkdir()
+    (tmp_path / "stray.txt").write_text("", encoding="utf-8")
+    assert theme_shots.discover_themes(tmp_path, None) == (["alabaster", "furo"], [])
+
+
+def test_discover_themes_reports_a_missing_theme_and_skips_it(tmp_path: Path):
+    """A theme nobody built is a note, never an error -- see the module docstring."""
+    make_build(tmp_path, "furo")
+    present, missing = theme_shots.discover_themes(
+        tmp_path, ["furo", "sphinx_rtd_theme"]
+    )
+    assert present == ["furo"]
+    assert missing == ["sphinx_rtd_theme"]
+
+
+def test_discover_themes_on_a_root_that_does_not_exist(tmp_path: Path):
+    assert theme_shots.discover_themes(tmp_path / "nope", None) == ([], [])
+
+
+def test_theme_order_is_task_order_then_the_rest():
+    assert theme_shots.theme_order(
+        ["zebra", "sphinx_rtd_theme", "alabaster", "furo"]
+    ) == ["furo", "alabaster", "sphinx_rtd_theme", "zebra"]
+
+
+def test_built_version_comes_from_the_build_not_the_checkout(tmp_path: Path):
+    make_build(tmp_path, "furo", version="9.0.0")
+    assert theme_shots.built_version(tmp_path, "furo") == "9.0.0"
+    make_build(tmp_path, "alabaster", version=None)
+    assert theme_shots.built_version(tmp_path, "alabaster") is None
+
+
+# --- the dark verdict -----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("colour", "expected"),
+    [
+        ("rgb(255, 255, 255)", False),
+        ("rgb(19, 19, 22)", True),
+        ("rgba(18, 18, 18, 1)", True),
+        ("transparent", None),
+        (None, None),
+    ],
+)
+def test_is_dark(colour: str | None, expected: bool | None):
+    assert theme_shots.is_dark(colour) is expected
+
+
+def shot(label: str, sha: str) -> dict[str, Any]:
+    return {"label": label, "sha": sha, "file": f"x/{label}.png"}
+
+
+def test_dark_verdict_calls_a_theme_dark_less_only_when_both_signals_agree():
+    light = {
+        "background": "rgb(255, 255, 255)",
+        "shots": [shot("first", "aa"), shot("full", "bb")],
+    }
+    dark = {
+        "background": "rgb(255, 255, 255)",
+        "shots": [shot("first", "aa"), shot("full", "bb")],
+    }
+    supported, reason, identical = theme_shots.dark_verdict(light, dark)
+    assert supported is False
+    assert "byte-identical" in reason
+    assert identical == ["first", "full"]
+
+
+def test_dark_verdict_one_changed_shot_is_enough():
+    light = {"background": "rgb(255, 255, 255)", "shots": [shot("first", "aa")]}
+    dark = {"background": "rgb(255, 255, 255)", "shots": [shot("first", "zz")]}
+    supported, reason, identical = theme_shots.dark_verdict(light, dark)
+    assert supported is True
+    assert "1 of 1 shots changed" in reason
+    assert identical == []
+
+
+def test_dark_verdict_a_changed_background_is_enough():
+    """A theme could in principle darken its page and not its widgets; that is still dark."""
+    light = {"background": "rgb(255, 255, 255)", "shots": [shot("first", "aa")]}
+    dark = {"background": "rgb(19, 19, 22)", "shots": [shot("first", "aa")]}
+    supported, reason, _ = theme_shots.dark_verdict(light, dark)
+    assert supported is True
+    assert "rgb(19, 19, 22)" in reason
+
+
+def test_finish_dark_removes_the_duplicate_images(tmp_path: Path):
+    light_shots = write_shots(tmp_path, "alabaster", "light")
+    dark_shots = write_shots(tmp_path, "alabaster", "dark")
+    entry: dict[str, Any] = {
+        "modes": {
+            "light": {"background": "rgb(255, 255, 255)", "shots": light_shots},
+            "dark": {"background": "rgb(255, 255, 255)", "shots": dark_shots},
+        }
+    }
+    assert (tmp_path / "alabaster" / "dark").is_dir()
+    theme_shots.finish_dark(tmp_path, "alabaster", entry)
+    assert entry["dark"]["supported"] is False
+    assert entry["dark"]["files_removed"] is True
+    assert not (tmp_path / "alabaster" / "dark").exists()
+    assert (tmp_path / "alabaster" / "light").is_dir()
+
+
+def test_finish_dark_keeps_a_real_dark_mode(tmp_path: Path):
+    light_shots = write_shots(tmp_path, "furo", "light")
+    dark_shots = write_shots(tmp_path, "furo", "dark", payload=PNG + b"\x00")
+    entry: dict[str, Any] = {
+        "modes": {
+            "light": {"background": "rgb(255, 255, 255)", "shots": light_shots},
+            "dark": {"background": "rgb(19, 19, 22)", "shots": dark_shots},
+        }
+    }
+    theme_shots.finish_dark(tmp_path, "furo", entry)
+    assert entry["dark"]["supported"] is True
+    assert (tmp_path / "furo" / "dark").is_dir()
+
+
+# --- the writers ----------------------------------------------------------------------------
+
+
+def test_manifest_and_gallery(tmp_path: Path):
+    out = tmp_path / "after"
+    out.mkdir()
+    manifest = fake_manifest(
+        out,
+        {
+            "furo": {
+                "backgrounds": {"light": "rgb(255, 255, 255)", "dark": "rgb(19, 19, 22)"},
+                "errors": [{"kind": "pageerror", "text": "$ is not defined"}],
+            },
+            "alabaster": {
+                "backgrounds": {"light": "rgb(255, 255, 255)", "dark": "rgb(255, 255, 255)"}
+            },
+        },
+    )
+    # the two themes were given identical shot bytes, so only the backgrounds separate them
+    assert manifest["themes"]["furo"]["dark"]["supported"] is True
+    assert manifest["themes"]["alabaster"]["dark"]["supported"] is False
+
+    theme_shots.write_manifest(manifest, out)
+    written = json.loads((out / "manifest.json").read_text(encoding="utf-8"))
+    assert written["source"]["sphinx_needs_version"] == "5.2.0"
+    assert written["themes"]["furo"]["modes"]["light"]["shots"][0]["bytes"] == len(PNG)
+
+    theme_shots.write_gallery(manifest, out)
+    page = (out / "index.html").read_text(encoding="utf-8")
+    # one column per label, one row per theme x mode
+    for label in LABELS:
+        assert f"<th>{label}</th>" in page
+        assert f"furo/light/{label}.png" in page
+        assert f"furo/dark/{label}.png" in page
+    # the theme with no dark mode says so instead of showing the same picture twice
+    assert theme_shots.DARK_NA in page
+    assert "alabaster/dark/first.png" not in page
+    assert "alabaster/light/first.png" in page
+    # console errors reach the reader
+    assert "$ is not defined" in page
+    # self-contained: no external resource of any kind
+    assert "http://" not in page and "https://" not in page
+    assert "<style>" in page and "<link" not in page
+    # the sampled background is on the page, and so is the verdict about it
+    assert "rgb(19, 19, 22)" in page
+    assert "reads as dark" in page
+
+
+def test_gallery_escapes_what_a_page_logged(tmp_path: Path):
+    out = tmp_path / "after"
+    out.mkdir()
+    manifest = fake_manifest(
+        out,
+        {
+            "furo": {
+                "backgrounds": {"light": "rgb(255, 255, 255)"},
+                "errors": [{"kind": "console.error", "text": "<script>oops</script>"}],
+            }
+        },
+    )
+    theme_shots.write_gallery(manifest, out)
+    page = (out / "index.html").read_text(encoding="utf-8")
+    assert "&lt;script&gt;oops&lt;/script&gt;" in page
+    assert "<script>" not in page
+
+
+def test_compare_layout_brings_the_before_images_inside(tmp_path: Path):
+    before_dir = tmp_path / "before"
+    before_dir.mkdir()
+    before = fake_manifest(
+        before_dir,
+        {"furo": {"backgrounds": {"light": "rgb(255, 255, 255)"}}},
+        git_sha="beef0000beef0000",
+        version="5.1.0",
+    )
+    theme_shots.write_manifest(before, before_dir)
+
+    after_dir = tmp_path / "after"
+    after_dir.mkdir()
+    after = fake_manifest(
+        after_dir,
+        {"furo": {"backgrounds": {"light": "rgb(255, 255, 255)"}}},
+        git_sha="cafe0000cafe0000",
+    )
+    rebased = theme_shots.import_before(before_dir, after_dir)
+    theme_shots.write_gallery(after, after_dir, rebased)
+    page = (after_dir / "index.html").read_text(encoding="utf-8")
+
+    # the before images live under the AFTER directory, so the gallery survives being copied
+    for label in LABELS:
+        copied = after_dir / "_before" / "furo" / "light" / f"{label}.png"
+        assert copied.is_file()
+        assert f"_before/furo/light/{label}.png" in page
+        assert f"furo/light/{label}.png" in page
+    assert "<figcaption>before</figcaption>" in page
+    assert "<figcaption>after</figcaption>" in page
+    # nothing climbs out of the output directory
+    assert "../" not in page
+    # both revisions are identified, so a reviewer knows what is being compared
+    assert "cafe0000cafe" in page
+    assert "beef0000beef" in page
+    assert "5.1.0" in page
+
+
+def test_compare_needs_a_manifest(tmp_path: Path):
+    (tmp_path / "before").mkdir()
+    (tmp_path / "after").mkdir()
+    with pytest.raises(SystemExit, match="manifest.json"):
+        theme_shots.import_before(tmp_path / "before", tmp_path / "after")
+
+
+def test_console_summary_lists_every_page_that_logged(tmp_path: Path):
+    out = tmp_path / "after"
+    out.mkdir()
+    manifest = fake_manifest(
+        out,
+        {
+            "furo": {
+                "backgrounds": {"light": "rgb(255, 255, 255)"},
+                "errors": [{"kind": "pageerror", "text": "boom"}],
+            },
+            "alabaster": {"backgrounds": {"light": "rgb(255, 255, 255)"}},
+        },
+    )
+    summary = theme_shots.console_summary(manifest)
+    assert len(summary) == 1
+    assert summary[0].startswith("furo/light: 1 console error(s)")
+    assert "boom" in summary[0]
+
+
+# --- the CLI, and staying browser-free ------------------------------------------------------
+
+
+def test_list_targets_needs_no_browser(capsys: pytest.CaptureFixture[str]):
+    assert theme_shots.main(["--list-targets"]) == 0
+    printed = capsys.readouterr().out
+    for label in LABELS:
+        assert label in printed
+    # nothing on this path touched the driver
+    assert "sync_playwright" not in printed
+
+
+def test_no_builds_names_the_tasks_that_make_them(tmp_path: Path):
+    with pytest.raises(SystemExit) as error:
+        theme_shots.main(["--build-root", str(tmp_path), "--out", str(tmp_path / "o")])
+    message = str(error.value)
+    assert "docs-needs-themes" in message
+    for _, task in theme_shots.BUILD_TASKS:
+        assert task in message
+
+
+def test_an_unknown_mode_is_a_usage_error(tmp_path: Path):
+    make_build(tmp_path, "furo")
+    with pytest.raises(SystemExit, match="sepia"):
+        theme_shots.main(["--build-root", str(tmp_path), "--modes", "sepia"])
+
+
+def test_viewport_parsing():
+    assert theme_shots.parse_viewport("1280x900") == (1280, 900)
+    with pytest.raises(Exception, match="WIDTHxHEIGHT"):
+        theme_shots.parse_viewport("wide")
+
+
+def test_playwright_is_imported_lazily_and_says_how_to_get_it(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The whole point of the lazy import: this module works in an environment without it."""
+    monkeypatch.setitem(sys.modules, "playwright.sync_api", None)
+    with pytest.raises(SystemExit) as error:
+        theme_shots._import_playwright()
+    message = str(error.value)
+    assert "--group js" in message
+    assert "install-browser" in message
+
+
+def test_serve_hands_out_the_build_over_http(tmp_path: Path):
+    """Not `file://`: an opaque origin breaks module scripts and every fetch a theme makes.
+
+    Loopback only -- nothing here leaves the machine.
+    """
+    (tmp_path / "furo").mkdir()
+    (tmp_path / "furo" / "index.html").write_bytes(b"<h1>needtable</h1>")
+    with theme_shots.serve(tmp_path) as base_url:
+        assert base_url.startswith("http://127.0.0.1:")
+        with urllib.request.urlopen(f"{base_url}/furo/index.html") as response:
+            assert response.read() == b"<h1>needtable</h1>"


### PR DESCRIPTION
A review instrument for the CSS that has to look right in five themes. It screenshots the needtable examples out of the existing theme docs builds — furo, alabaster, sphinx-immaterial, pydata-sphinx-theme and sphinx_rtd_theme, light and dark — and writes a self-contained gallery, so that "does this integrate with the themes" is thirty pictures taken the same way twice rather than a judgement made from a diff.

Two poe tasks, on purpose two:

```
uv run poe docs-needs-themes      # the five theme builds, one after another (~10 min)
uv run poe docs-needs-shots       # seconds per theme, from whatever builds exist
```

`docs-needs-shots` never runs sphinx and never depends on the builds: it shoots what is there, reports and skips a theme that was not built, and is meant to be used shoot–look–change one rule–shoot again. `--compare <other out dir>` puts a BEFORE next to every AFTER in the gallery, which is what turned it from an album into a review instrument on #1920, where it found the theme collisions the unit tests could not see (a disclosure styled as an admonition by one theme, 10 px inputs beside 14 px buttons in another, a stale build directory keeping the old stylesheet).

The decisions that matter, each made because the obvious alternative fails on this repository's real DOM, are recorded at the top of `tools/src/sn_tools/theme_shots.py`: pages are served over HTTP rather than `file://` so console errors mean what they say; a widget is found by its table and photographed by whichever wrapper the build's JavaScript created, falling back to the table itself; interactions are lists of candidate selectors so a before/after pair stays comparable when the DOM underneath moves; and a theme with no dark mode is detected from the bytes, not assumed from its name.

A page error is data, never a failure — the exit code is non-zero only when the instrument itself cannot run. Playwright is imported lazily inside the one function that drives a browser, so `--help` and the 39 tests run without the `js` group; the browser comes from `poe install-browser`, once per machine, as for `test-needs-js`.

Tests: `tools/tests/test_theme_shots.py` — target and selector resolution, the dark-mode verdict, the gallery and manifest writers, `--compare`, the missing-theme skip — all without a browser. Not a CI job: pixel output differs across platforms and browser builds, and the five theme environments plus a browser are a poor tax on every run; it is a local aid, run when a stylesheet moves.
