### PR TITLE
🧪 Type-check needstable.js in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,6 +79,26 @@ jobs:
             esac
             rm -f "$probe"
           done
+      - name: Type-check the needstable script
+        # tsc over `needstable.js`, the vendored browser script that is plain JavaScript
+        # typed through `// @ts-check` and JSDoc. The check is the one
+        # `packages/sphinx-needs/design/needstable-contract.md` §4 records; until now it was
+        # a by-hand step, so a JSDoc type could regress without anything going red (#1924).
+        # The command -- and the typescript version it pins -- lives in the
+        # `typecheck-js-needs` poe task and NOT here, so what a developer runs and what
+        # blocks a pull request cannot drift; the pin matters because `npx -p typescript`
+        # would otherwise resolve whatever compiler is newest that day.
+        #
+        # In LINT rather than in `tests-js`: this needs no browser, no sphinx and no
+        # interpreter matrix -- just node -- and Lint is a required status context on
+        # master, which `tests-js` is not. No `setup-node` either: `ubuntu-latest` ships
+        # node and npm, and `npx -y -p` fetches the pinned compiler into the runner's npm
+        # cache for the run (23 MB unpacked, ~2 s).
+        #
+        # After the prek step for the same reason as the probe above: `uv run --frozen`
+        # there has already built the default environment, which is where poe lives, so
+        # this step can be `--no-sync`
+        run: uv run --frozen --no-sync poe typecheck-js-needs
       - name: Check the sphinx groups are declared conflicting
         # if this sync ever succeeds, `[tool.uv] conflicts` has been dropped and the lock
         # holds one sphinx again, so every matrix cell below would test the same version

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -91,9 +91,9 @@ jobs:
         #
         # In LINT rather than in `tests-js`: this needs no browser, no sphinx and no
         # interpreter matrix -- just node -- and Lint is a required status context on
-        # master, which `tests-js` is not. No `setup-node` either: `ubuntu-latest` ships
-        # node and npm, and `npx -y -p` fetches the pinned compiler into the runner's npm
-        # cache for the run (23 MB unpacked, ~2 s).
+        # master in its own right, not only through `check`. No `setup-node` either:
+        # `ubuntu-latest` ships node and npm, and `npx -y -p` fetches the pinned compiler
+        # into the runner's npm cache for the run (23 MB unpacked, ~2 s).
         #
         # After the prek step for the same reason as the probe above: `uv run --frozen`
         # there has already built the default environment, which is where poe lives, so

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,7 @@ uv run poe test-mounts                # the sphinx-mounts suite (bazel tests des
 uv run poe test-codelinks             # the sphinx-codelinks suite (adds the libclang group)
 uv run poe lint                       # every prek hook over the whole tree
 uv run poe typecheck                  # ty over both packages, against the oldest supported sphinx
+uv run poe typecheck-js-needs         # tsc over the vendored needstable.js (needs node)
 uv run poe docs-needs                 # the furo docs build
 uv run poe docs-mounts                # the sphinx-mounts docs build
 uv run poe docs-codelinks             # the sphinx-codelinks docs build

--- a/packages/sphinx-needs/design/needstable-contract.md
+++ b/packages/sphinx-needs/design/needstable-contract.md
@@ -314,8 +314,10 @@ $ echo $?
 0
 ```
 
-It is not a CI gate here — this package's CI has no node — so run it by hand after editing
-the file. A consumer with a JavaScript toolchain can run the same check on its vendored copy.
+It IS a CI gate here: `uv run poe typecheck-js-needs` runs exactly that command with the
+typescript version pinned in the task, and the Lint job runs the task (#1924) — so run the
+task after editing the file, and bump the compiler by editing that one literal. A consumer
+with a JavaScript toolchain can run the unpinned command above on its vendored copy.
 
 Why not TypeScript source: it would need a node toolchain, committed compiled output and a
 re-compile fence in a Python repository — exactly the machinery rolling our own avoided —

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -627,6 +627,38 @@ cmd = "ty check packages/sphinx-needs/src/sphinx_needs packages/sphinx-mounts/sr
 executor = { type = "uv", frozen = true, no-group = "dev", group = ["typing"] }
 env = { UV_PROJECT_ENVIRONMENT = ".venvs/typing" }
 
+# The OTHER type gate, and the only one that is not Python: `needstable.js` is plain
+# ES2020 typed through `// @ts-check` and JSDoc, and tsc is what checks those types
+# (`packages/sphinx-needs/design/needstable-contract.md` §4 is the contract it enforces).
+# The name follows the naming rule -- this acts on ONE package, so it ends in `-needs`,
+# while `typecheck` above is bare because it covers all three. CI's Lint job runs this
+# task rather than its own copy of the command, so the gate a developer runs and the gate
+# that blocks a pull request cannot drift.
+#
+# The typescript version is PINNED, and that is the point of the task: `npx -p typescript`
+# resolves whatever is newest that day, so a compiler release could turn a pull request
+# red with nothing in this repository having changed. To bump it, edit the one literal
+# below and run the task (measured on 5.9.3; 7.0.2, the newest at the time of writing,
+# passes the same file).
+#
+# ONE PATH PER LINE, so adding a script to the gate is one line -- which is the whole
+# extension story. Only `needstable.js` is here for now: `sphinx_needs_collapse.js` beside
+# it is jQuery-era, carries no `// @ts-check` and does not pass `--strict`, so #1922, which
+# ports it, is the pull request that adds the second line.
+#
+# No `package.json`, no `node_modules` and no second lock file: `npx -y -p` fetches the
+# pinned compiler into npm's cache for the run (23 MB unpacked, ~2 s cold, then cached).
+# Node itself comes from the machine, which is why CI needs no `setup-node`: GitHub's
+# `ubuntu-latest` image ships node and npm.
+[tool.poe.tasks.typecheck-js-needs]
+help = "Type-check the JSDoc-typed browser scripts with tsc (needs node on PATH)"
+cmd = """
+npx -y -p typescript@5.9.3 tsc
+  --allowJs --checkJs --noEmit --strict --target es2020 --lib dom,es2020
+  src/sphinx_needs/libs/html/needstable.js
+"""
+cwd = "packages/sphinx-needs"
+
 [tool.poe.tasks.benchmark-needs]
 help = "Run the benchmark suite (time + memory); needs the docs extra for the corpus"
 deps = ["fetch-plantuml"]


### PR DESCRIPTION
`needstable.js` (#1920) is plain JavaScript typed through `// @ts-check` and JSDoc, and `design/needstable-contract.md` §4 records the single command that checks those types. It passes at the tip, but nothing ran it, so any later edit could regress a type silently. This makes it a gate.

- **A poe task, `typecheck-js-needs`**, holds the command with the typescript version **pinned** (`typescript@5.9.3`): an unpinned `npx -p typescript` resolves whatever compiler is newest that day, which would let a TypeScript release turn a pull request red with nothing here having changed. To bump it, edit that one literal and run the task. 5.9.3 is the newest 5.9.x; the file is also clean under 7.0.2, today's `latest`.
- **One Lint step runs the task**, not a copy of the command, so the gate a developer runs locally and the gate that blocks a pull request cannot drift, the same arrangement as the prek hooks and `poe lint`. Lint rather than the `tests-js` lane: it needs no browser, no sphinx and no interpreter matrix, and Lint is a required status context in its own right. No `setup-node`: `ubuntu-latest` ships node and npm, and `npx -y -p` fetches the pinned compiler into the runner's npm cache for the run (about 2.5 s cold on an empty cache, 23 MB unpacked).
- **Files checked**: `needstable.js` only. `sphinx_needs_collapse.js` is jQuery-era, carries no `// @ts-check` and does not pass `--strict`; #1922 ports it and is the pull request that adds the second line. The task lists one path per line, so that is a one-line change.
- **Docs**: §4's "It is not a CI gate here" sentence now says the opposite, and the root `AGENTS.md` commands block gains the task. No changelog entry: nothing user-visible changed.

Proof the fence bites: with `this.sortColumn = -1` (declared `@type {number}`) changed to a string, the task exits 2 with

```
src/sphinx_needs/libs/html/needstable.js(452,13): error TS2322: Type 'string' is not assignable to type 'number'.
```

Closes #1924
