### PR TITLE
♻️ Port sphinx_needs_collapse.js off jQuery, and defer it

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,11 +79,12 @@ jobs:
             esac
             rm -f "$probe"
           done
-      - name: Type-check the needstable script
-        # tsc over `needstable.js`, the vendored browser script that is plain JavaScript
-        # typed through `// @ts-check` and JSDoc. The check is the one
-        # `packages/sphinx-needs/design/needstable-contract.md` §4 records; until now it was
-        # a by-hand step, so a JSDoc type could regress without anything going red (#1924).
+      - name: Type-check the browser scripts
+        # tsc over `needstable.js` and `sphinx_needs_collapse.js`, the two browser scripts
+        # this package ships, both plain JavaScript typed through `// @ts-check` and JSDoc.
+        # The check is the one `packages/sphinx-needs/design/needstable-contract.md` §4
+        # records; until now it was a by-hand step, so a JSDoc type could regress without
+        # anything going red (#1924). The collapse script joined the task with #1922.
         # The command -- and the typescript version it pins -- lives in the
         # `typecheck-js-needs` poe task and NOT here, so what a developer runs and what
         # blocks a pull request cannot drift; the pin matters because `npx -p typescript`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,7 @@ uv run poe test-mounts                # the sphinx-mounts suite (bazel tests des
 uv run poe test-codelinks             # the sphinx-codelinks suite (adds the libclang group)
 uv run poe lint                       # every prek hook over the whole tree
 uv run poe typecheck                  # ty over both packages, against the oldest supported sphinx
-uv run poe typecheck-js-needs         # tsc over the vendored needstable.js (needs node)
+uv run poe typecheck-js-needs         # tsc over the two browser scripts (needs node)
 uv run poe docs-needs                 # the furo docs build
 uv run poe docs-mounts                # the sphinx-mounts docs build
 uv run poe docs-codelinks             # the sphinx-codelinks docs build

--- a/packages/sphinx-needs/design/needstable-contract.md
+++ b/packages/sphinx-needs/design/needstable-contract.md
@@ -314,8 +314,9 @@ $ echo $?
 0
 ```
 
-It IS a CI gate here: `uv run poe typecheck-js-needs` runs exactly that command with the
-typescript version pinned in the task, and the Lint job runs the task (#1924) — so run the
+It IS a CI gate here: `uv run poe typecheck-js-needs` runs that command over every browser
+script the package ships (this file and `sphinx_needs_collapse.js`), with the typescript
+version pinned in the task, and the Lint job runs the task (#1924) — so run the
 task after editing the file, and bump the compiler by editing that one literal. A consumer
 with a JavaScript toolchain can run the unpinned command above on its vendored copy.
 

--- a/packages/sphinx-needs/docs/changelog.rst
+++ b/packages/sphinx-needs/docs/changelog.rst
@@ -4,6 +4,25 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+- ♻️ The need's collapse button is plain JavaScript, and no longer blocks the parser
+  (:issue:`1922`, :pr:`TBD`)
+
+  ``sphinx_needs_collapse.js`` -- the control that hides and shows a need's meta rows --
+  was written against jQuery. It is now plain ES2020 with no dependencies, type-checked
+  through JSDoc as ``needstable.js`` is, and registered with ``defer``, so it runs after
+  the page is parsed instead of blocking it. What it does is unchanged: the same initial
+  state, the same toggle on click, the same classes.
+
+  ``sphinxcontrib-jquery`` **remains a dependency**, so a project whose own scripts rely
+  on Sphinx-Needs putting jQuery on the page still works. It can go once
+  `sphinx-data-viewer <https://github.com/useblocks/sphinx-data-viewer>`__ -- which
+  Sphinx-Needs sets up for :ref:`needservice`'s debug output, and which adds a jQuery
+  loader script to every page while declaring no jQuery dependency of its own -- no
+  longer needs it.
+
 .. _`release:8.5.0`:
 
 8.5.0

--- a/packages/sphinx-needs/docs/changelog.rst
+++ b/packages/sphinx-needs/docs/changelog.rst
@@ -4,25 +4,6 @@
 Changelog
 =========
 
-Unreleased
-----------
-
-- ♻️ The need's collapse button is plain JavaScript, and no longer blocks the parser
-  (:issue:`1922`, :pr:`TBD`)
-
-  ``sphinx_needs_collapse.js`` -- the control that hides and shows a need's meta rows --
-  was written against jQuery. It is now plain ES2020 with no dependencies, type-checked
-  through JSDoc as ``needstable.js`` is, and registered with ``defer``, so it runs after
-  the page is parsed instead of blocking it. What it does is unchanged: the same initial
-  state, the same toggle on click, the same classes.
-
-  ``sphinxcontrib-jquery`` **remains a dependency**, so a project whose own scripts rely
-  on Sphinx-Needs putting jQuery on the page still works. It can go once
-  `sphinx-data-viewer <https://github.com/useblocks/sphinx-data-viewer>`__ -- which
-  Sphinx-Needs sets up for :ref:`needservice`'s debug output, and which adds a jQuery
-  loader script to every page while declaring no jQuery dependency of its own -- no
-  longer needs it.
-
 .. _`release:8.5.0`:
 
 8.5.0

--- a/packages/sphinx-needs/pyproject.toml
+++ b/packages/sphinx-needs/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
   "requests~=2.32",                # external links
   "jsonschema-rs>=0.37.1,<0.54.0", # schema validation
   "sphinx-data-viewer~=0.1.5",     # needservice debug output
-  "sphinxcontrib-jquery~=4.0",     # sphinx_needs_collapse.js is still jQuery
+  "sphinxcontrib-jquery~=4.0",     # sphinx-data-viewer's loader; nothing of ours (#1922)
   "typing-extensions>=4.14.0",     # for `**kwargs: Unpack[...]` (PEP 692), which typing supports from 3.12
   "minijinja~=2.15",               # lightweight jinja2-compatible template engine
 ]

--- a/packages/sphinx-needs/src/sphinx_needs/environment.py
+++ b/packages/sphinx-needs/src/sphinx_needs/environment.py
@@ -136,8 +136,13 @@ def install_lib_static_files(app: Sphinx, env: BuildEnvironment) -> None:
     copy_asset(str(source_dir), str(destination_dir), **_overwrite())
 
     lib_path = Path("sphinx-needs") / "libs" / "html"
-    # the needtable pair is registered per page, in `install_needtable_assets` below
-    _add_js_file(app, lib_path.joinpath("sphinx_needs_collapse.js"))
+    # the needtable pair is registered per page, in `install_needtable_assets` below.
+    # `loading_method="defer"`, not `defer="defer"`: this route goes through
+    # `Sphinx.add_js_file`, which translates the keyword -- writing the attribute itself
+    # would leave `loading_method` in the tag as well
+    _add_js_file(
+        app, lib_path.joinpath("sphinx_needs_collapse.js"), loading_method="defer"
+    )
 
 
 def install_needtable_assets(

--- a/packages/sphinx-needs/src/sphinx_needs/environment.py
+++ b/packages/sphinx-needs/src/sphinx_needs/environment.py
@@ -137,9 +137,10 @@ def install_lib_static_files(app: Sphinx, env: BuildEnvironment) -> None:
 
     lib_path = Path("sphinx-needs") / "libs" / "html"
     # the needtable pair is registered per page, in `install_needtable_assets` below.
-    # `loading_method="defer"`, not `defer="defer"`: this route goes through
-    # `Sphinx.add_js_file`, which translates the keyword -- writing the attribute itself
-    # would leave `loading_method` in the tag as well
+    # `loading_method="defer"`: this route goes through `Sphinx.add_js_file`, which
+    # translates the keyword into the `defer` attribute (passing `defer="defer"` would
+    # write the same tag). `install_needtable_assets` below has to spell the attribute out
+    # because the builder-level `add_js_file` has no such keyword
     _add_js_file(
         app, lib_path.joinpath("sphinx_needs_collapse.js"), loading_method="defer"
     )

--- a/packages/sphinx-needs/src/sphinx_needs/libs/html/sphinx_needs_collapse.js
+++ b/packages/sphinx-needs/src/sphinx_needs/libs/html/sphinx_needs_collapse.js
@@ -18,11 +18,10 @@
  *           <span class="needs visible"> ... </span>     the other carries HIDE_CLASS
  *
  * The `id` on the control is NOT an identifier: docutils writes the same one on every
- * need of a page (`target__show__meta`, forty-four times over in one of the test
- * projects), and what it actually carries is the state the page was written in plus the
- * row classes, joined by `__`. So every lookup here is scoped to the control's own
- * `SNCB-` container instead, which is what the `#<container id> table ...` selectors this
- * file used to build did.
+ * need in the same state -- `target__show__meta`, thirty-one times over on one test
+ * project's index page -- and what it carries is that state plus the row classes, joined
+ * by `__`. So every lookup here is scoped to the control's own `SNCB-` container instead,
+ * which is what the `#<container id> table ...` selectors this file used to build did.
  *
  * The server already hides the right ICON, so on load the only state this script has to
  * establish is the metadata ROWS'. A click then flips all three.

--- a/packages/sphinx-needs/src/sphinx_needs/libs/html/sphinx_needs_collapse.js
+++ b/packages/sphinx-needs/src/sphinx_needs/libs/html/sphinx_needs_collapse.js
@@ -1,60 +1,147 @@
-// This JS function ensures the metadata of a need table is hidden or shown when a document is loaded
-// and it also ensures that when a user clicks on the collapse button, the metadata is hidden or shown.
+// @ts-check
+/*!
+ * sphinx_needs_collapse.js -- the collapse control on a need's meta box.
+ *
+ * Copyright (c) useblocks GmbH. MIT licence.
+ *
+ * Plain ES2020, no dependencies -- it drove jQuery until #1922, which was the last thing
+ * in this extension that did. Type-checked through `// @ts-check` and JSDoc with the
+ * one-line `tsc` recipe in `design/needstable-contract.md` (section 4).
+ *
+ * The markup it drives is written by `layout.py`, one block per need:
+ *
+ *     <div id="SNCB-1a2b3c4d" class="need_container">
+ *       <table class="need">
+ *         <tr class="meta"> ... </tr>            the rows the control governs
+ *         <span class="needs needs_collapse" id="target__<show|hide>__<row class>...">
+ *           <span class="needs collapsed"> ... </span>   one of the two is displayed;
+ *           <span class="needs visible"> ... </span>     the other carries HIDE_CLASS
+ *
+ * The `id` on the control is NOT an identifier: docutils writes the same one on every
+ * need of a page (`target__show__meta`, forty-four times over in one of the test
+ * projects), and what it actually carries is the state the page was written in plus the
+ * row classes, joined by `__`. So every lookup here is scoped to the control's own
+ * `SNCB-` container instead, which is what the `#<container id> table ...` selectors this
+ * file used to build did.
+ *
+ * The server already hides the right ICON, so on load the only state this script has to
+ * establish is the metadata ROWS'. A click then flips all three.
+ */
 
-const HIDE_CLASS = "collapse_is_hidden";
+(function () {
+    "use strict";
 
-$(document).ready(function() {
-    $("table.need span.needs.needs_collapse").each(function() {
-        var id = $(this).attr("id");
-        var parts = id.split("__");
-        var rows = parts.slice(2);
+    /** The class that hides an icon or a metadata row; `css/common/need_core.css` styles it. */
+    const HIDE_CLASS = "collapse_is_hidden";
 
-        var table = $(this).closest('table');
-        var need_table_id = table.closest("div[id^=SNCB-]").attr("id");
-
-        // initialise the correct collapse state
-        if (parts[1] == "show") {
-            var visible_icon = document.querySelector(`#${need_table_id} table span.needs.visible`);
-            visible_icon.classList.add(HIDE_CLASS);
-            var collapse_icon = document.querySelector(`#${need_table_id} table span.needs.collapsed`);
-            collapse_icon.classList.remove(HIDE_CLASS);
-            for (var row in rows) {
-                var collapse_row = document.querySelector(`#${need_table_id} table tr.${rows[row]}`);
-                collapse_row.classList.remove(HIDE_CLASS);
+    /**
+     * The elements one control governs, inside the need's own container.
+     *
+     * Each lookup takes the FIRST match, as the selectors it replaces did -- a need has one
+     * table, with one icon of each kind and one row per named class.
+     *
+     * @param {Element} container the `div[id^=SNCB-]` around one need
+     * @param {string[]} rowClasses the metadata row classes named in the control's id
+     * @returns {{collapsedIcon: Element | null, visibleIcon: Element | null, rows: Element[]}}
+     */
+    function governed(container, rowClasses) {
+        /** @type {Element[]} */
+        const rows = [];
+        for (const rowClass of rowClasses) {
+            if (!rowClass) {
+                continue; // an empty `target` would build the invalid selector `table tr.`
             }
-        } else {
-            var visible_icon = document.querySelector(`#${need_table_id} table span.needs.visible`);
-            visible_icon.classList.remove(HIDE_CLASS);
-            var collapse_icon = document.querySelector(`#${need_table_id} table span.needs.collapsed`);
-            collapse_icon.classList.add(HIDE_CLASS);
-            for (var row in rows) {
-                var collapse_row = document.querySelector(`#${need_table_id} table tr.${rows[row]}`);
-                collapse_row.classList.add(HIDE_CLASS);
+            const row = container.querySelector("table tr." + rowClass);
+            if (row) {
+                rows.push(row);
             }
         }
+        return {
+            collapsedIcon: container.querySelector("table span.needs.collapsed"),
+            visibleIcon: container.querySelector("table span.needs.visible"),
+            rows: rows,
+        };
+    }
 
-        // Func to execute when collapse buttons get clicked ()
-        $(this).find("span.needs.collapsed, span.needs.visible").click(function() {
-            var table = $(this).closest('table');
-            var need_table_id = table.closest("div[id^=SNCB-]").attr("id");
-            for (var row in rows) {
-                var collapse_row = document.querySelector(`#${need_table_id} table tr.${rows[row]}`);
-                collapse_row.classList.toggle(HIDE_CLASS);
-            }
-            var collapse_icon = document.querySelector(`#${need_table_id} table span.needs.collapsed`);
-            var visible_icon = document.querySelector(`#${need_table_id} table span.needs.visible`);
+    /**
+     * @param {Element | null} element
+     * @param {boolean} hidden
+     */
+    function setHidden(element, hidden) {
+        if (element) {
+            element.classList.toggle(HIDE_CLASS, hidden);
+        }
+    }
 
-            collapse_icon.classList.toggle(HIDE_CLASS);
-            visible_icon.classList.toggle(HIDE_CLASS);
-        })
-    });
-});
+    /** @param {Element | null} element */
+    function flipHidden(element) {
+        if (element) {
+            element.classList.toggle(HIDE_CLASS);
+        }
+    }
 
-$(document).ready(function() {
-    $('a.no_link').click(function (e) {
-        e.preventDefault();
-    });
-});
+    /**
+     * Give one control the state its page was written in, and the click that flips it.
+     *
+     * @param {Element} control a `span.needs.needs_collapse` inside a `table.need`
+     */
+    function initControl(control) {
+        const id = control.getAttribute("id");
+        if (!id) {
+            return;
+        }
+        const [, mode, ...rowClasses] = id.split("__");
+        const table = control.closest("table");
+        const container = table && table.closest('div[id^="SNCB-"]');
+        if (!container) {
+            return;
+        }
 
+        const showRows = mode === "show";
+        const parts = governed(container, rowClasses);
+        setHidden(parts.visibleIcon, showRows);
+        setHidden(parts.collapsedIcon, !showRows);
+        for (const row of parts.rows) {
+            setHidden(row, !showRows);
+        }
 
+        const icons = control.querySelectorAll(
+            "span.needs.collapsed, span.needs.visible",
+        );
+        for (const icon of Array.from(icons)) {
+            icon.addEventListener("click", function () {
+                // looked up again on every click, as before, so that the control still
+                // governs whatever is in the container at that moment
+                const current = governed(container, rowClasses);
+                for (const row of current.rows) {
+                    flipHidden(row);
+                }
+                flipHidden(current.collapsedIcon);
+                flipHidden(current.visibleIcon);
+            });
+        }
+    }
 
+    function run() {
+        const controls = document.querySelectorAll(
+            "table.need span.needs.needs_collapse",
+        );
+        for (const control of Array.from(controls)) {
+            initControl(control);
+        }
+
+        // an anchor that must not navigate. The extension's own layouts do not emit one
+        // today, but a project's `needs_layouts` may, and this has always been here
+        for (const anchor of Array.from(document.querySelectorAll("a.no_link"))) {
+            anchor.addEventListener("click", function (event) {
+                event.preventDefault();
+            });
+        }
+    }
+
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", run);
+    } else {
+        run();
+    }
+})();

--- a/packages/sphinx-needs/src/sphinx_needs/needs.py
+++ b/packages/sphinx-needs/src/sphinx_needs/needs.py
@@ -230,6 +230,10 @@ def setup(app: Sphinx) -> dict[str, Any]:
     LOGGER.debug("Starting setup of Sphinx-Needs")
     LOGGER.debug("Load Sphinx-Data-Viewer for Sphinx-Needs")
     app.setup_extension("sphinx_data_viewer")
+    # nothing of ours has needed jQuery since #1922 made `sphinx_needs_collapse.js` plain
+    # JavaScript. sphinx-data-viewer's `jsonview_loader.js` still does, and that extension
+    # adds it to EVERY page while declaring no jQuery dependency of its own -- so dropping
+    # this line puts `$ is not defined` on every page of every project
     app.setup_extension("sphinxcontrib.jquery")
     app.setup_extension("sphinx.ext.graphviz")
 

--- a/packages/sphinx-needs/tests/doc_test/doc_collapse_no_link/conf.py
+++ b/packages/sphinx-needs/tests/doc_test/doc_collapse_no_link/conf.py
@@ -1,0 +1,5 @@
+project = "needs"
+version = "0.1.0"
+copyright = "2024"
+
+extensions = ["sphinx_needs"]

--- a/packages/sphinx-needs/tests/doc_test/doc_collapse_no_link/index.rst
+++ b/packages/sphinx-needs/tests/doc_test/doc_collapse_no_link/index.rst
@@ -1,0 +1,19 @@
+TEST DOCUMENT
+=============
+
+A need, so that the page carries a collapse control, and an ``a.no_link`` anchor, which
+``sphinx_needs_collapse.js`` keeps from navigating.
+
+Nothing in sphinx-needs' own layouts writes that class today: ``no_link=True`` on the
+layout's ``image()`` function produces ``no-scaled-link`` on the image, not ``no_link`` on
+an anchor. A project's own ``needs_layouts`` or raw markup can, though, which is what the
+block below stands in for -- without it the branch has no page to run on.
+
+.. req:: Test requirement
+   :id: RQ_001
+
+   Some content.
+
+.. raw:: html
+
+   <p><a class="no_link" href="#nowhere">an anchor that must not navigate</a></p>

--- a/packages/sphinx-needs/tests/test_basic_doc.py
+++ b/packages/sphinx-needs/tests/test_basic_doc.py
@@ -74,17 +74,22 @@ def test_html_head_files(test_app: SphinxTestApp):
     script_nodes = root_tree.xpath("/html/head/script")
     script_files = [x.attrib["src"].rsplit("?", 1)[0] for x in script_nodes]
     assert script_files.count("_static/sphinx-needs/libs/html/needstable.js") == 1
+    assert (
+        script_files.count("_static/sphinx-needs/libs/html/sphinx_needs_collapse.js")
+        == 1
+    )
 
-    # the tag has to be DEFERRED, and `loading_method` is not an HTML attribute: only
+    # both tags have to be DEFERRED, and `loading_method` is not an HTML attribute: only
     # `Sphinx.add_js_file` translates that keyword, and the per-page registration has to
     # go through the builder, which writes every keyword into the tag verbatim
-    script = next(
-        node
-        for node in script_nodes
-        if "libs/html/needstable.js" in node.attrib.get("src", "")
-    )
-    assert script.attrib.get("defer") is not None, dict(script.attrib)
-    assert "loading_method" not in script.attrib, dict(script.attrib)
+    for asset in ("needstable.js", "sphinx_needs_collapse.js"):
+        script = next(
+            node
+            for node in script_nodes
+            if f"libs/html/{asset}" in node.attrib.get("src", "")
+        )
+        assert script.attrib.get("defer") is not None, dict(script.attrib)
+        assert "loading_method" not in script.attrib, dict(script.attrib)
 
     link_nodes = root_tree.xpath("/html/head/link")
     link_files = [x.attrib["href"].rsplit("?", 1)[0] for x in link_nodes]
@@ -101,9 +106,14 @@ def test_html_head_files(test_app: SphinxTestApp):
     # whole 2.26 MB DataTables bundle
     for pagename in ("search.html", "genindex.html"):
         tree = html_parser.parse(str(Path(app.outdir, pagename)))
-        assets = [
-            node.attrib["src" if node.tag == "script" else "href"].rsplit("?", 1)[0]
-            for node in tree.xpath("/html/head/script") + tree.xpath("/html/head/link")
+        page_scripts = [
+            node.attrib["src"].rsplit("?", 1)[0]
+            for node in tree.xpath("/html/head/script")
+            if "src" in node.attrib
+        ]
+        assets = page_scripts + [
+            node.attrib["href"].rsplit("?", 1)[0]
+            for node in tree.xpath("/html/head/link")
         ]
         assert "_static/sphinx-needs/libs/html/needstable.js" not in assets, pagename
         assert "_static/sphinx-needs/libs/html/needstable.css" not in assets, pagename

--- a/packages/sphinx-needs/tests/test_basic_doc.py
+++ b/packages/sphinx-needs/tests/test_basic_doc.py
@@ -106,14 +106,9 @@ def test_html_head_files(test_app: SphinxTestApp):
     # whole 2.26 MB DataTables bundle
     for pagename in ("search.html", "genindex.html"):
         tree = html_parser.parse(str(Path(app.outdir, pagename)))
-        page_scripts = [
-            node.attrib["src"].rsplit("?", 1)[0]
-            for node in tree.xpath("/html/head/script")
-            if "src" in node.attrib
-        ]
-        assets = page_scripts + [
-            node.attrib["href"].rsplit("?", 1)[0]
-            for node in tree.xpath("/html/head/link")
+        assets = [
+            node.attrib["src" if node.tag == "script" else "href"].rsplit("?", 1)[0]
+            for node in tree.xpath("/html/head/script") + tree.xpath("/html/head/link")
         ]
         assert "_static/sphinx-needs/libs/html/needstable.js" not in assets, pagename
         assert "_static/sphinx-needs/libs/html/needstable.css" not in assets, pagename

--- a/packages/sphinx-needs/tests/test_sn_collapse_button.py
+++ b/packages/sphinx-needs/tests/test_sn_collapse_button.py
@@ -4,7 +4,8 @@ The page under test is built by the ordinary ``test_app`` fixture and then opene
 off disk over ``file://`` -- nothing in it fetches, so no server is involved. What is
 asserted is ``src/sphinx_needs/libs/html/sphinx_needs_collapse.js``: on load it hides one of
 the two icons (and, in ``hide`` mode, the metadata rows) by adding ``collapse_is_hidden``,
-and a click on the control toggles all of them.
+and a click on the control toggles all of them. The last case covers its other half, the
+``a.no_link`` anchor whose click it prevents.
 """
 
 from __future__ import annotations
@@ -176,3 +177,41 @@ def test_collapse_button_in_import_doc(test_app: SphinxTestApp, page: Page) -> N
     assert {"show", "hide"} <= modes, (
         f"expected both collapse modes, met {sorted(modes)}"
     )
+
+
+@pytest.mark.jstest
+@pytest.mark.parametrize(
+    "test_app",
+    [
+        {
+            "buildername": "html",
+            "srcdir": "doc_test/doc_collapse_no_link",
+        }
+    ],
+    indirect=True,
+)
+def test_no_link_anchor_does_not_navigate(test_app: SphinxTestApp, page: Page) -> None:
+    """The script's second, older half: a click on ``a.no_link`` is prevented.
+
+    It is the one branch the three cases above never reach, because no layout of this
+    extension emits that class any more -- ``no_link=True`` on the layout's ``image()``
+    writes ``no-scaled-link`` on the image. The project's page carries a raw-HTML anchor so
+    that the branch has markup to run on; without the ``preventDefault``, the click would
+    put the anchor's fragment in the URL.
+    """
+    app = test_app
+    app.build()
+
+    page_errors: list[str] = []
+    page.on("pageerror", lambda error: page_errors.append(error.message))
+
+    url = Path(app.outdir, "index.html").as_uri()
+    page.goto(url)
+
+    anchor = page.locator("a.no_link")
+    assert anchor.count() == 1, "the built page has no `a.no_link` to test"
+    assert anchor.get_attribute("href") == "#nowhere"
+
+    anchor.click()
+    assert page.url == url, "the click navigated"
+    assert not page_errors, f"the page raised: {page_errors}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -656,6 +656,7 @@ cmd = """
 npx -y -p typescript@5.9.3 tsc
   --allowJs --checkJs --noEmit --strict --target es2020 --lib dom,es2020
   src/sphinx_needs/libs/html/needstable.js
+  src/sphinx_needs/libs/html/sphinx_needs_collapse.js
 """
 cwd = "packages/sphinx-needs"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -643,8 +643,8 @@ env = { UV_PROJECT_ENVIRONMENT = ".venvs/typing" }
 #
 # ONE PATH PER LINE, so adding a script to the gate is one line -- which is the whole
 # extension story. Both of the package's browser scripts are here: `needstable.js` since
-# #1928, and `sphinx_needs_collapse.js` since #1922 ported it off jQuery and gave it the
-# `// @ts-check` header that makes `--strict` mean something.
+# #1928, and `sphinx_needs_collapse.js` since its port off jQuery (#1922), which gave it
+# the `// @ts-check` header that makes `--strict` mean something.
 #
 # No `package.json`, no `node_modules` and no second lock file: `npx -y -p` fetches the
 # pinned compiler into npm's cache for the run (23 MB unpacked, ~2 s cold, then cached).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -642,9 +642,9 @@ env = { UV_PROJECT_ENVIRONMENT = ".venvs/typing" }
 # passes the same file).
 #
 # ONE PATH PER LINE, so adding a script to the gate is one line -- which is the whole
-# extension story. Only `needstable.js` is here for now: `sphinx_needs_collapse.js` beside
-# it is jQuery-era, carries no `// @ts-check` and does not pass `--strict`, so #1922, which
-# ports it, is the pull request that adds the second line.
+# extension story. Both of the package's browser scripts are here: `needstable.js` since
+# #1928, and `sphinx_needs_collapse.js` since #1922 ported it off jQuery and gave it the
+# `// @ts-check` header that makes `--strict` mean something.
 #
 # No `package.json`, no `node_modules` and no second lock file: `npx -y -p` fetches the
 # pinned compiler into npm's cache for the run (23 MB unpacked, ~2 s cold, then cached).


### PR DESCRIPTION
The need's collapse button, the control that hides and shows a need's meta rows, was written against jQuery: `$(document).ready`, `$(...).closest(...)`, two `.each()` loops, about sixty lines. It is now **plain ES2020 with no dependencies**, type-checked through `// @ts-check` and JSDoc exactly as `needstable.js` is, and registered with **`defer`**, so it runs after the page is parsed instead of blocking it.

What it does is unchanged, deliberately: the same selectors, the same `collapse_is_hidden` class, the same initial state read from the `show`/`hide` part of the control's id, the same toggle on click, the same `a.no_link` default-prevention. Three things are worth naming for a reviewer:

- every lookup is scoped to the control's own `div[id^=SNCB-]` container, which is what the interpolated `#<container id> table …` selectors did. The id on the control is not unique: docutils writes `target__show__meta` on every need in that state, thirty-one times over on one test project's index page;
- a missing icon or row is now skipped rather than throwing. `--strict` type-checking asks for one or the other and a JSDoc cast would be a lie; nothing reaches it, and the browser tests assert on the classes either way;
- holding the container element rather than re-finding it by id string is the one difference that is not an error path: where two needs collide on the same eight-hex `SNCB-` id, the old lookup wrote both needs' state onto the first container, and the new one gives each need its own. Neither errors; the new behaviour is the correct one.

### What this does NOT do, and why

**`sphinxcontrib-jquery` stays.** After the port nothing in `src/sphinx_needs/` uses jQuery. But `sphinx-data-viewer`, a runtime dependency this extension sets up unconditionally for `needservice`'s debug output, ships `assets/jsonview_loader.js`:

```js
$(document).ready(function() {
  $("div.sdv-data").each(function(index){ ...
```

It adds that script to **every** HTML page from its own `env-updated` handler and declares no jQuery dependency of its own (`Requires-Dist: sphinx>=5`, plus docs/test extras). Our `app.setup_extension("sphinxcontrib.jquery")` is what has been satisfying it.

Measured rather than reasoned: with only that call removed, all four collapse browser cases fail with

```
E       AssertionError: the page raised: ['$ is not defined']
tests/test_sn_collapse_button.py:120: AssertionError
```

and a `needservice` debug block renders empty. Every page of every project would carry a console error. sphinx-data-viewer's newest release is 0.1.5 (2024-08-28), so there is no floor to raise either. On `sphinx-rtd-theme` the blocker does not exist, because that theme injects jQuery itself; everywhere else it does.

This is therefore #1922's first half, and the issue stays open. The removal needs a jQuery-free `jsonview_loader.js` upstream (it is twenty lines), a sphinx-data-viewer release, a floor bump here, and then the dependency, the `setup_extension` call and, as the fence, `jquery.js` / `_sphinx_javascript_frameworks_compat.js` absence assertions in `test_html_head_files` (written and measured: they fail against master today, which is how we know they bite).

Both places that were wrong about *why* the dependency is there now say what it is for: the trailing comment in `pyproject.toml`, and four lines above the `setup_extension` call.

**For projects that rely on Sphinx-Needs putting jQuery on the page**: nothing changes today. When it does go, such a project will need `sphinxcontrib-jquery` in its own dependencies and `sphinxcontrib.jquery` in its `extensions`.

### Tests

- The three existing browser cases pass **unchanged**. They are the fence, so they were mutation-tested before being relied on: with the `hide` branch stopped from hiding rows, `test_collapse_button_in_import_doc` fails at `tests/test_sn_collapse_button.py:103`.
- **New**: `test_no_link_anchor_does_not_navigate`, the one branch those three never reached. It gets a minimal project, `tests/doc_test/doc_collapse_no_link/`, whose page carries a raw-HTML `<a class="no_link">`, deliberately and explained in the page itself: no layout of this extension emits that class (`no_link=True` on the layout's `image()` writes `no-scaled-link` on the `<img>`), so the branch has no other markup to run on. With the `preventDefault` gone it fails `the click navigated`.
- `test_html_head_files` now asserts the `defer` attribute, by parsing the head rather than matching the `src`, for the collapse script as well as the table's, and that each is registered exactly once.

### CI

`typecheck-js-needs` (#1928) gains its second path line. The ported file passes `--strict --target es2020 --lib dom,es2020` under the pinned `typescript@5.9.3`; with a `string` passed where `setHidden` wants a `boolean` the task exits non-zero with `sphinx_needs_collapse.js(102,38): error TS2345`, so the gate reaches it.

### Changelog draft

As on #1919 and #1920, the entry is drafted here and the file is written at release time.

```rst
- ♻️ The need's collapse button is plain JavaScript, and no longer blocks the parser
  (:issue:`1922`, :pr:`NNNN`)

  ``sphinx_needs_collapse.js`` -- the control that hides and shows a need's meta rows --
  was written against jQuery. It is now plain ES2020 with no dependencies, type-checked
  through JSDoc as ``needstable.js`` is, and registered with ``defer``, so it runs after
  the page is parsed instead of blocking it. What it does is unchanged: the same initial
  state, the same toggle on click, the same classes.

  ``sphinxcontrib-jquery`` **remains a dependency**, so a project whose own scripts rely
  on Sphinx-Needs putting jQuery on the page still works. It can go once
  `sphinx-data-viewer <https://github.com/useblocks/sphinx-data-viewer>`__ -- which
  Sphinx-Needs sets up for :ref:`needservice`'s debug output, and which adds a jQuery
  loader script to every page while declaring no jQuery dependency of its own -- no
  longer needs it.
```

Part of #1922.
